### PR TITLE
Tier 0 Metal features: tone-map (#13), RT shadows (#12), on-demand rendering (#11)

### DIFF
--- a/layer1/SceneRender.cpp
+++ b/layer1/SceneRender.cpp
@@ -1970,9 +1970,11 @@ void SceneRenderMetal(PyMOLGlobals* G)
     int aaEnabled = SettingGetGlobal_i(G, cSetting_antialias_shader) != 0 ? 1 : 0;
     int outlineEnabled = SettingGetGlobal_b(G, cSetting_metal_outline) ? 1 : 0;
     int rtEnabled = SettingGetGlobal_b(G, cSetting_metal_raytrace) ? 1 : 0;
+    int tonemapEnabled = SettingGetGlobal_b(G, cSetting_metal_tonemap) ? 1 : 0;
+    float exposure = SettingGetGlobal_f(G, cSetting_metal_exposure);
     G->Renderer->setPostParams(fogEnabled, fogStart, fogEnd, bg[0], bg[1],
         bg[2], aoEnabled, shadowEnabled, aaEnabled, outlineEnabled, proj[10],
-        proj[14], proj[0], proj[5], rtEnabled);
+        proj[14], proj[0], proj[5], rtEnabled, tonemapEnabled, exposure);
     // MSAA: 4x when metal_msaa is on, otherwise single-sample. The renderer
     // stashes this and applies it at the next setDrawable (no encoder open),
     // so toggling at runtime never mismatches an in-flight encoder.

--- a/layer1/SceneRender.cpp
+++ b/layer1/SceneRender.cpp
@@ -1972,9 +1972,11 @@ void SceneRenderMetal(PyMOLGlobals* G)
     int rtEnabled = SettingGetGlobal_b(G, cSetting_metal_raytrace) ? 1 : 0;
     int tonemapEnabled = SettingGetGlobal_b(G, cSetting_metal_tonemap) ? 1 : 0;
     float exposure = SettingGetGlobal_f(G, cSetting_metal_exposure);
+    int rtShadowEnabled = SettingGetGlobal_b(G, cSetting_metal_rt_shadows) ? 1 : 0;
     G->Renderer->setPostParams(fogEnabled, fogStart, fogEnd, bg[0], bg[1],
         bg[2], aoEnabled, shadowEnabled, aaEnabled, outlineEnabled, proj[10],
-        proj[14], proj[0], proj[5], rtEnabled, tonemapEnabled, exposure);
+        proj[14], proj[0], proj[5], rtEnabled, tonemapEnabled, exposure,
+        rtShadowEnabled);
     // MSAA: 4x when metal_msaa is on, otherwise single-sample. The renderer
     // stashes this and applies it at the next setDrawable (no encoder open),
     // so toggling at runtime never mismatches an in-flight encoder.

--- a/layer1/SceneRender.cpp
+++ b/layer1/SceneRender.cpp
@@ -1977,6 +1977,14 @@ void SceneRenderMetal(PyMOLGlobals* G)
         bg[2], aoEnabled, shadowEnabled, aaEnabled, outlineEnabled, proj[10],
         proj[14], proj[0], proj[5], rtEnabled, tonemapEnabled, exposure,
         rtShadowEnabled);
+    // Lighting model — the Metal lit shaders read these instead of hard-coded
+    // constants, so the Scene-panel lighting sliders take effect.
+    G->Renderer->setLightingParams(
+        SettingGetGlobal_f(G, cSetting_ambient),
+        SettingGetGlobal_f(G, cSetting_direct),
+        SettingGetGlobal_f(G, cSetting_reflect),
+        SettingGetGlobal_f(G, cSetting_specular),
+        SettingGetGlobal_f(G, cSetting_shininess));
     // MSAA: 4x when metal_msaa is on, otherwise single-sample. The renderer
     // stashes this and applies it at the next setDrawable (no encoder open),
     // so toggling at runtime never mismatches an in-flight encoder.

--- a/layer1/SettingInfo.h
+++ b/layer1/SettingInfo.h
@@ -913,6 +913,7 @@ enum {
   REC_b( 803, metal_interior_cap                      , object    , false ), /* Metal: fill (cap) the slab cross-section of clipped spheres/sticks with a solid interior color */
   REC_b( 804, metal_tonemap                           , global    , false ), /* Metal filmic (ACES) tone-mapping + exposure post pass */
   REC_f( 805, metal_exposure                          , global    , 1.0F ),  /* Metal tone-map exposure multiplier (1.0 = neutral) */
+  REC_b( 806, metal_rt_shadows                         , global    , false ), /* Metal: trace hard shadow rays (needs metal_raytrace) instead of shadow-map PCF */
 
 #ifdef SETTINGINFO_IMPLEMENTATION
 #undef SETTINGINFO_IMPLEMENTATION

--- a/layer1/SettingInfo.h
+++ b/layer1/SettingInfo.h
@@ -911,6 +911,8 @@ enum {
   REC_b( 801, metal_msaa                              , global    , true ),  /* Metal 4x MSAA scene rendering */
   REC_b( 802, metal_raytrace                          , global    , false ), /* Metal real-time ray-traced AO + shadows */
   REC_b( 803, metal_interior_cap                      , object    , false ), /* Metal: fill (cap) the slab cross-section of clipped spheres/sticks with a solid interior color */
+  REC_b( 804, metal_tonemap                           , global    , false ), /* Metal filmic (ACES) tone-mapping + exposure post pass */
+  REC_f( 805, metal_exposure                          , global    , 1.0F ),  /* Metal tone-map exposure multiplier (1.0 = neutral) */
 
 #ifdef SETTINGINFO_IMPLEMENTATION
 #undef SETTINGINFO_IMPLEMENTATION

--- a/layerGraphics/Renderer.h
+++ b/layerGraphics/Renderer.h
@@ -285,7 +285,8 @@ public:
   virtual void setPostParams(int fogEnabled, float fogStart, float fogEnd,
       float bgR, float bgG, float bgB, int aoEnabled, int shadowEnabled,
       int aaEnabled, int outlineEnabled, float projA, float projB, float projX,
-      float projY, int rtEnabled = 0)
+      float projY, int rtEnabled = 0, int tonemapEnabled = 0,
+      float exposure = 1.0f)
   {
   }
 

--- a/layerGraphics/Renderer.h
+++ b/layerGraphics/Renderer.h
@@ -286,7 +286,7 @@ public:
       float bgR, float bgG, float bgB, int aoEnabled, int shadowEnabled,
       int aaEnabled, int outlineEnabled, float projA, float projB, float projX,
       float projY, int rtEnabled = 0, int tonemapEnabled = 0,
-      float exposure = 1.0f)
+      float exposure = 1.0f, int rtShadowEnabled = 0)
   {
   }
 

--- a/layerGraphics/Renderer.h
+++ b/layerGraphics/Renderer.h
@@ -290,6 +290,14 @@ public:
   {
   }
 
+  // PyMOL lighting model (ambient/direct/reflect/specular/shininess). Default:
+  // no-op (the GL renderer reads these settings itself). The Metal renderer
+  // uploads them into its lit shaders so the Scene lighting sliders take effect.
+  virtual void setLightingParams(float ambient, float direct, float reflect,
+      float specular, float shininess)
+  {
+  }
+
   // MSAA sample count for the scene (opaque) pass. SceneRenderMetal calls this
   // each frame from the metal_msaa setting (4 = on, 1 = off). The renderer
   // stashes it and applies the rebuild at the next frame's setDrawable (before

--- a/layerGraphics/metal/RendererMetal.h
+++ b/layerGraphics/metal/RendererMetal.h
@@ -150,7 +150,7 @@ public:
       float bgG, float bgB, int aoEnabled, int shadowEnabled, int aaEnabled,
       int outlineEnabled, float projA, float projB, float projX,
       float projY, int rtEnabled, int tonemapEnabled = 0,
-      float exposure = 1.0f) override;
+      float exposure = 1.0f, int rtShadowEnabled = 0) override;
 
   // Letterbox: render the scene into a centered sub-rect of the given aspect
   // (W/H) so a loaded .pse reproduces its saved-viewport framing. 0 = fill.
@@ -412,6 +412,7 @@ private:
   // --- Real-time ray tracing (cSetting_metal_raytrace) ---
   bool _rtSupported = false;      // [_device supportsRaytracing], set in ctor
   int  _rtEnabled = 0;            // requested (gated by _rtSupported)
+  int  _rtShadowEnabled = 0;      // metal_rt_shadows: traced hard shadow ray
   bool _rtReady = false;          // instance acceleration structure is built
   // Atom-sphere geometry accumulated each frame (model space, center+radius).
   std::vector<float> _rtSpheres;  // x,y,z,r per sphere

--- a/layerGraphics/metal/RendererMetal.h
+++ b/layerGraphics/metal/RendererMetal.h
@@ -149,7 +149,8 @@ public:
   void setPostParams(int fogEnabled, float fogStart, float fogEnd, float bgR,
       float bgG, float bgB, int aoEnabled, int shadowEnabled, int aaEnabled,
       int outlineEnabled, float projA, float projB, float projX,
-      float projY, int rtEnabled) override;
+      float projY, int rtEnabled, int tonemapEnabled = 0,
+      float exposure = 1.0f) override;
 
   // Letterbox: render the scene into a centered sub-rect of the given aspect
   // (W/H) so a loaded .pse reproduces its saved-viewport framing. 0 = fill.
@@ -395,6 +396,11 @@ private:
   int _aaEnabled = 1;          // FXAA (cSetting_antialias_shader != 0)
   int _outlineEnabled = 0;     // silhouette outline (cSetting_metal_outline)
   id<MTLRenderPipelineState> _outlinePipeline = nil;
+  // Filmic tone-map + exposure post pass (cSetting_metal_tonemap/_exposure).
+  // Milestone 1: operates on the existing LDR scene color (no float promotion).
+  int _tonemapEnabled = 0;
+  float _exposure = 1.0f;
+  id<MTLRenderPipelineState> _tonemapPipeline = nil;
   float _projA = -1.f, _projB = 0.f;  // projection[10], projection[14]
   float _projX = 1.f, _projY = 1.f;   // projection[0], projection[5]
   float _letterboxAspect = 0.f;       // saved-viewport W/H; 0 = fill window

--- a/layerGraphics/metal/RendererMetal.h
+++ b/layerGraphics/metal/RendererMetal.h
@@ -151,6 +151,8 @@ public:
       int outlineEnabled, float projA, float projB, float projX,
       float projY, int rtEnabled, int tonemapEnabled = 0,
       float exposure = 1.0f, int rtShadowEnabled = 0) override;
+  void setLightingParams(float ambient, float direct, float reflect,
+      float specular, float shininess) override;
 
   // Letterbox: render the scene into a centered sub-rect of the given aspect
   // (W/H) so a loaded .pse reproduces its saved-viewport framing. 0 = fill.
@@ -401,6 +403,12 @@ private:
   int _tonemapEnabled = 0;
   float _exposure = 1.0f;
   id<MTLRenderPipelineState> _tonemapPipeline = nil;
+  // PyMOL lighting model (cSetting_ambient/direct/reflect/specular/shininess),
+  // set per frame by SceneRenderMetal and uploaded into each lit shader's
+  // uniform so the Scene-panel lighting sliders actually affect the render.
+  // Defaults match the values the shaders previously hard-coded.
+  float _lightAmbient = 0.14f, _lightDirect = 0.45f, _lightReflect = 0.481f;
+  float _lightSpecular = 0.5f, _lightShininess = 55.0f;
   float _projA = -1.f, _projB = 0.f;  // projection[10], projection[14]
   float _projX = 1.f, _projY = 1.f;   // projection[0], projection[5]
   float _letterboxAspect = 0.f;       // saved-viewport W/H; 0 = fill window

--- a/layerGraphics/metal/RendererMetal.mm
+++ b/layerGraphics/metal/RendererMetal.mm
@@ -527,6 +527,23 @@ fragment float4 post_blit(PostVOut in [[stage_in]],
   return src.sample(s, in.uv);
 }
 
+// Filmic tone-map + exposure. Applies an exposure multiplier then the ACES
+// approximation (Narkowicz 2015), mapping scene radiance to display so bright
+// specular highlights roll off smoothly instead of clipping flat, and an
+// exposure < 1 tames washed-out bright backgrounds. Runs before FXAA (whose
+// luma math assumes ~[0,1] display values). Milestone 1 operates on the
+// existing 8-bit LDR scene color; promoting the scene chain to RGBA16Float is a
+// follow-up that lets highlights exceed 1.0 before the roll-off.
+struct ToneU { float exposure; float _p0, _p1, _p2; };
+fragment float4 post_tonemap(PostVOut in [[stage_in]],
+    texture2d<float> src [[texture(0)]], sampler s [[sampler(0)]],
+    constant ToneU& u [[buffer(0)]]) {
+  float3 c = src.sample(s, in.uv).rgb * u.exposure;
+  const float a = 2.51, b = 0.03, cc = 2.43, d = 0.59, e = 0.14;
+  float3 mapped = saturate((c * (a * c + b)) / (c * (cc * c + d) + e));
+  return float4(mapped, 1.0);
+}
+
 // Weighted-blended OIT resolve: composite accumulated transparent color over
 // the (already post-processed) opaque color. reveal = Π(1-α) = transmittance.
 fragment float4 oit_resolve(PostVOut in [[stage_in]],
@@ -955,6 +972,7 @@ void RendererMetal::buildPostPipelines()
     return p;
   };
   _blitPipeline = mkpipe(@"post_blit");
+  _tonemapPipeline = mkpipe(@"post_tonemap");
   _fxaaPipeline = mkpipe(@"post_fxaa");
   _ssaoPipeline = mkpipe(@"post_ssao_fog");
   _oitResolvePipeline = mkpipe(@"oit_resolve");
@@ -965,8 +983,10 @@ void RendererMetal::buildPostPipelines()
 void RendererMetal::setPostParams(int fogEnabled, float fogStart, float fogEnd,
     float bgR, float bgG, float bgB, int aoEnabled, int shadowEnabled,
     int aaEnabled, int outlineEnabled, float projA, float projB, float projX,
-    float projY, int rtEnabled)
+    float projY, int rtEnabled, int tonemapEnabled, float exposure)
 {
+  _tonemapEnabled = tonemapEnabled;
+  _exposure = exposure;
   _postFogEnabled = fogEnabled;
   _fogStart = fogStart;
   _fogEnd = fogEnd;
@@ -1625,6 +1645,30 @@ void RendererMetal::runPostChain()
     [e3 setFragmentBytes:&u length:sizeof(u) atIndex:0];
     [e3 drawPrimitives:MTLPrimitiveTypeTriangle vertexStart:0 vertexCount:3];
     [e3 endEncoding];
+    sceneSrc = dst;
+  }
+
+  // Pass 3.5: filmic tone-map + exposure (cSetting_metal_tonemap). Runs after
+  // OIT/outline but BEFORE the final FXAA/blit (FXAA's luma math assumes display
+  // values). Placed ahead of the !_offscreen block so the offscreen PNG capture
+  // (which reads sceneSrc directly) is tone-mapped identically to the live view.
+  if (_tonemapEnabled && _tonemapPipeline) {
+    id<MTLTexture> dst = (sceneSrc == _sceneColor) ? _postColor : _sceneColor;
+    struct { float exposure; float _p0, _p1, _p2; } u;
+    u.exposure = _exposure;
+    u._p0 = u._p1 = u._p2 = 0.0f;
+    MTLRenderPassDescriptor* pd = [[MTLRenderPassDescriptor alloc] init];
+    pd.colorAttachments[0].texture = dst;
+    pd.colorAttachments[0].loadAction = MTLLoadActionDontCare;
+    pd.colorAttachments[0].storeAction = MTLStoreActionStore;
+    id<MTLRenderCommandEncoder> et =
+        [_cmdBuffer renderCommandEncoderWithDescriptor:pd];
+    [et setRenderPipelineState:_tonemapPipeline];
+    [et setFragmentTexture:sceneSrc atIndex:0];
+    [et setFragmentSamplerState:_postSampler atIndex:0];
+    [et setFragmentBytes:&u length:sizeof(u) atIndex:0];
+    [et drawPrimitives:MTLPrimitiveTypeTriangle vertexStart:0 vertexCount:3];
+    [et endEncoding];
     sceneSrc = dst;
   }
 

--- a/layerGraphics/metal/RendererMetal.mm
+++ b/layerGraphics/metal/RendererMetal.mm
@@ -534,14 +534,19 @@ fragment float4 post_blit(PostVOut in [[stage_in]],
 // luma math assumes ~[0,1] display values). Milestone 1 operates on the
 // existing 8-bit LDR scene color; promoting the scene chain to RGBA16Float is a
 // follow-up that lets highlights exceed 1.0 before the roll-off.
-struct ToneU { float exposure; float _p0, _p1, _p2; };
+struct ToneU { float exposure; float tonemap; float _p0, _p1; };
 fragment float4 post_tonemap(PostVOut in [[stage_in]],
     texture2d<float> src [[texture(0)]], sampler s [[sampler(0)]],
     constant ToneU& u [[buffer(0)]]) {
+  // Exposure is an independent control: it scales scene radiance whether or not
+  // filmic tone-mapping is on. With tone-map on, apply the ACES curve (which
+  // rolls highlights off smoothly); with it off, just clamp the exposed color.
   float3 c = src.sample(s, in.uv).rgb * u.exposure;
-  const float a = 2.51, b = 0.03, cc = 2.43, d = 0.59, e = 0.14;
-  float3 mapped = saturate((c * (a * c + b)) / (c * (cc * c + d) + e));
-  return float4(mapped, 1.0);
+  if (u.tonemap > 0.5) {
+    const float a = 2.51, b = 0.03, cc = 2.43, d = 0.59, e = 0.14;
+    c = (c * (a * c + b)) / (c * (cc * c + d) + e);
+  }
+  return float4(saturate(c), 1.0);
 }
 
 // Weighted-blended OIT resolve: composite accumulated transparent color over
@@ -1698,15 +1703,18 @@ void RendererMetal::runPostChain()
     sceneSrc = dst;
   }
 
-  // Pass 3.5: filmic tone-map + exposure (cSetting_metal_tonemap). Runs after
-  // OIT/outline but BEFORE the final FXAA/blit (FXAA's luma math assumes display
-  // values). Placed ahead of the !_offscreen block so the offscreen PNG capture
-  // (which reads sceneSrc directly) is tone-mapped identically to the live view.
-  if (_tonemapEnabled && _tonemapPipeline) {
+  // Pass 3.5: exposure + (optional) filmic tone-map. Runs after OIT/outline but
+  // BEFORE the final FXAA/blit (FXAA's luma math assumes display values). Placed
+  // ahead of the !_offscreen block so the offscreen PNG capture (which reads
+  // sceneSrc directly) is processed identically to the live view. Exposure is
+  // independent of the tone-map toggle, so the pass also runs when exposure != 1.
+  bool exposureActive = (_exposure < 0.999f || _exposure > 1.001f);
+  if ((_tonemapEnabled || exposureActive) && _tonemapPipeline) {
     id<MTLTexture> dst = (sceneSrc == _sceneColor) ? _postColor : _sceneColor;
-    struct { float exposure; float _p0, _p1, _p2; } u;
+    struct { float exposure; float tonemap; float _p0, _p1; } u;
     u.exposure = _exposure;
-    u._p0 = u._p1 = u._p2 = 0.0f;
+    u.tonemap = _tonemapEnabled ? 1.0f : 0.0f;
+    u._p0 = u._p1 = 0.0f;
     MTLRenderPassDescriptor* pd = [[MTLRenderPassDescriptor alloc] init];
     pd.colorAttachments[0].texture = dst;
     pd.colorAttachments[0].loadAction = MTLLoadActionDontCare;

--- a/layerGraphics/metal/RendererMetal.mm
+++ b/layerGraphics/metal/RendererMetal.mm
@@ -810,11 +810,13 @@ void RendererMetal::ensurePostTargets(NSUInteger w, NSUInteger h)
   _sceneColor = [_device newTextureWithDescriptor:cd];
   _postColor = [_device newTextureWithDescriptor:cd];
 
-  // Raw RT ambient-occlusion term (single channel). Kept in its own float
-  // texture so the composite pass can depth-aware-blur it — that blur is what
-  // removes the Monte-Carlo speckle the raw AO estimate would otherwise show.
+  // Raw RT terms: ambient occlusion in .r, traced light-visibility (hard
+  // shadow) in .g. Kept in its own float texture so the composite pass can
+  // depth-aware-blur both — that blur is what removes the Monte-Carlo speckle
+  // the raw estimates would otherwise show. RG (not R) so the metal_rt_shadows
+  // path can carry the traced shadow term alongside AO at no extra pass.
   MTLTextureDescriptor* aod = [MTLTextureDescriptor
-      texture2DDescriptorWithPixelFormat:MTLPixelFormatR16Float
+      texture2DDescriptorWithPixelFormat:MTLPixelFormatRG16Float
                                    width:w height:h mipmapped:NO];
   aod.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;
   aod.storageMode = MTLStorageModePrivate;
@@ -983,10 +985,12 @@ void RendererMetal::buildPostPipelines()
 void RendererMetal::setPostParams(int fogEnabled, float fogStart, float fogEnd,
     float bgR, float bgG, float bgB, int aoEnabled, int shadowEnabled,
     int aaEnabled, int outlineEnabled, float projA, float projB, float projX,
-    float projY, int rtEnabled, int tonemapEnabled, float exposure)
+    float projY, int rtEnabled, int tonemapEnabled, float exposure,
+    int rtShadowEnabled)
 {
   _tonemapEnabled = tonemapEnabled;
   _exposure = exposure;
+  _rtShadowEnabled = rtShadowEnabled;
   _postFogEnabled = fogEnabled;
   _fogStart = fogStart;
   _fogEnd = fogEnd;
@@ -1034,7 +1038,7 @@ struct RTU {
   float4 bgFog;            // bg.rgb, fogEnabled
   float projA, projB, projX, projY;
   float fogStart, fogEnd, aoRadius, aoIntensity;
-  float shadowIntensity, nSamples, frame, _pad;
+  float shadowIntensity, nSamples, frame, rtShadow; // rtShadow>0.5: trace shadows
   float4x4 lightViewProj;  // eye-space light view*proj for shadow-map sampling
 };
 
@@ -1110,7 +1114,27 @@ fragment float4 rt_ao(PostVOut in [[stage_in]],
     if (res.type != intersection_type::none) occ += 1.0;
   }
   float ao = 1.0 - (occ / float(N)) * u.aoIntensity;
-  return float4(ao, ao, ao, 1.0);
+
+  // Traced hard shadow toward the key light (model space), written to .g.
+  // Reuses the same instance AS that already holds spheres + tessellated
+  // cylinders + cartoon/surface triangles, so the shadow is cast uniformly by
+  // every representation — no shadow-map resolution/peter-panning. vis = 1 lit,
+  // 0 occluded. Back-facing fragments skip the ray (vis=1); the composite
+  // faceGate zeroes their cast-shadow term so diffuse alone darkens them.
+  float vis = 1.0;
+  if (u.rtShadow > 0.5) {
+    float3 Lm = normalize(u.lightDirModel.xyz);
+    if (dot(nModel, Lm) > 0.0) {
+      ray sr;
+      sr.origin = origin;            // already pModel + nModel*bias
+      sr.direction = Lm;
+      sr.min_distance = bias;
+      sr.max_distance = 1.0e4;       // full directional shadow, not just contact
+      auto sres = it.intersect(sr, accel);
+      if (sres.type != intersection_type::none) vis = 0.0;
+    }
+  }
+  return float4(ao, vis, 0.0, 1.0);
 }
 
 // Pass B: composite. Read scene color, DEPTH-AWARE-BLUR the raw AO term (5x5,
@@ -1141,7 +1165,7 @@ fragment float4 rt_composite(PostVOut in [[stage_in]],
   // closeness so AO doesn't bleed across object silhouettes.
   float2 texel = 1.0 / float2(aoTex.get_width(), aoTex.get_height());
   float ztol = max(0.5 * u.aoRadius, 0.5);
-  float aoSum = 0.0, wSum = 0.0;
+  float aoSum = 0.0, visSum = 0.0, wSum = 0.0;
   for (int j = -2; j <= 2; ++j)
     for (int i = -2; i <= 2; ++i) {
       float2 uv = in.uv + float2(i, j) * texel;
@@ -1149,15 +1173,28 @@ fragment float4 rt_composite(PostVOut in [[stage_in]],
       if (dn >= 0.99999) continue;
       float ezn = -u.projB / ((2.0 * dn - 1.0) + u.projA);
       float w = exp(-abs(ezn - ez) / ztol);
-      aoSum += aoTex.sample(s, uv).r * w;
+      float2 rg = aoTex.sample(s, uv).rg;
+      aoSum += rg.r * w;
+      visSum += rg.g * w;
       wSum += w;
     }
   float ao = wSum > 0.0 ? (aoSum / wSum) : aoTex.sample(s, in.uv).r;
+  float vis = wSum > 0.0 ? (visSum / wSum) : aoTex.sample(s, in.uv).g;
   col *= ao;
 
-  // Cast shadows: sample the SHADOW MAP (PCF + face/separation gates mirror
-  // post_ssao_fog so RT and non-RT shadows look identical).
-  if (u.shadowIntensity > 0.0) {
+  // Cast shadows. Two paths share the shadowIntensity gate:
+  //  - metal_rt_shadows (u.rtShadow): use the hard shadow ray traced in rt_ao
+  //    (visibility in .g), gated by a model-space faceGate so only lit faces
+  //    receive a cast-shadow term (back faces are darkened by diffuse alone).
+  //  - otherwise: the original shadow-map PCF (unchanged fallback), kept so the
+  //    default RT path and non-RT-capable GPUs are byte-for-byte identical.
+  if (u.shadowIntensity > 0.0 && u.rtShadow > 0.5) {
+    float3 nModel = normalize((u.invModelview * float4(nEye, 0.0)).xyz);
+    float3 Lm = normalize(u.lightDirModel.xyz);
+    float faceGate = smoothstep(0.0, 0.35, dot(nModel, Lm));
+    float shadow = (1.0 - vis) * faceGate;
+    col *= (1.0 - shadow * u.shadowIntensity);
+  } else if (u.shadowIntensity > 0.0) {
     float3 Ldir = normalize(float3(0.4, 0.4, 1.0));      // key light (eye space)
     float faceGate = smoothstep(0.0, 0.35, dot(nEye, Ldir));
     float4 lc = u.lightViewProj * float4(pEye, 1.0);     // eye -> light clip
@@ -1456,11 +1493,11 @@ void RendererMetal::ensureRayTracingAS()
     NSError* err = nil;
     id<MTLLibrary> lib = [_device newLibraryWithSource:kRTSrc options:nil error:&err];
     if (lib) {
-      // Pass A: raw AO -> R16Float.
+      // Pass A: raw AO (.r) + traced light-visibility (.g) -> RG16Float.
       MTLRenderPipelineDescriptor* pa = [[MTLRenderPipelineDescriptor alloc] init];
       pa.vertexFunction = [lib newFunctionWithName:@"rt_vertex"];
       pa.fragmentFunction = [lib newFunctionWithName:@"rt_ao"];
-      pa.colorAttachments[0].pixelFormat = MTLPixelFormatR16Float;
+      pa.colorAttachments[0].pixelFormat = MTLPixelFormatRG16Float;
       _rtAOPipeline = [_device newRenderPipelineStateWithDescriptor:pa error:&err];
       // Pass B: blur AO + shadow/fog composite -> BGRA8.
       MTLRenderPipelineDescriptor* pd = [[MTLRenderPipelineDescriptor alloc] init];
@@ -1497,7 +1534,7 @@ void RendererMetal::runPostChain()
       float bgFog[4];
       float projA, projB, projX, projY;
       float fogStart, fogEnd, aoRadius, aoIntensity;
-      float shadowIntensity, nSamples, frame, _pad;
+      float shadowIntensity, nSamples, frame, rtShadow;
       float lightViewProj[16];   // eye-space light VP for shadow-map sampling
     } u;
     std::memcpy(u.invModelview, _modelviewInv.data(), 16 * sizeof(float));
@@ -1518,7 +1555,10 @@ void RendererMetal::runPostChain()
     // trace more rays since each export frame stands alone.
     u.nSamples = _offscreen ? 48.0f : 16.0f;
     u.frame = 0.0f;            // deterministic: AO identical every frame (no shimmer)
-    u._pad = 0.0f;
+    // metal_rt_shadows: trace a hard shadow ray in rt_ao instead of sampling the
+    // shadow map in rt_composite. Only meaningful when shadows are on (the
+    // composite still gates on shadowIntensity). Default off -> shadow-map path.
+    u.rtShadow = _rtShadowEnabled ? 1.0f : 0.0f;
     std::memcpy(u.lightViewProj, _lightViewProjEye, 16 * sizeof(float));
 
     // Pass A: trace AO -> _rtAO (R16Float).

--- a/layerGraphics/metal/RendererMetal.mm
+++ b/layerGraphics/metal/RendererMetal.mm
@@ -1007,6 +1007,16 @@ void RendererMetal::setPostParams(int fogEnabled, float fogStart, float fogEnd,
   _rtEnabled = (rtEnabled && _rtSupported && !noRT) ? 1 : 0;
 }
 
+void RendererMetal::setLightingParams(float ambient, float direct,
+    float reflect, float specular, float shininess)
+{
+  _lightAmbient = ambient;
+  _lightDirect = direct;
+  _lightReflect = reflect;
+  _lightSpecular = specular;
+  _lightShininess = shininess;
+}
+
 // ---------------------------------------------------------------------------
 #pragma mark - Real-time ray tracing: acceleration structures
 // ---------------------------------------------------------------------------
@@ -2589,6 +2599,12 @@ void RendererMetal::endBatch()
   uniforms.pointSize = _pointSize > 0.0f ? _pointSize : 1.0f;
   uniforms._pad[0] = uniforms._pad[1] = uniforms._pad[2] = 0.0f;
   [_encoder setVertexBytes:&uniforms length:sizeof(uniforms) atIndex:1];
+  // Lighting (Scene sliders) for the lit vbo_fragment / vbo_fragment_oit at
+  // fragment buffer(0). Harmless for the unlit/flat pipelines (they don't read
+  // it). Scoped so the local doesn't clash across multiple draw paths.
+  { struct { float a, d, r, s, sh; } _lt = { _lightAmbient, _lightDirect,
+      _lightReflect, _lightSpecular, _lightShininess };
+    [_encoder setFragmentBytes:&_lt length:sizeof(_lt) atIndex:0]; }
 
   // Always use the built-in batch pipeline for batch rendering.
   // _currentPipeline is for VBO draws with a different vertex layout.
@@ -2729,19 +2745,20 @@ struct VBOVertexOut {
   float3 normalEye;   // eye-space normal, interpolated → per-fragment (Phong)
 };
 
-// PyMOL default two-light model (matches the sphere/cylinder impostors and
-// data/shaders/compute_color_for_light.fs): ambient .14, headlight direct .45,
-// key reflect .481, specular .5, shininess 55. Two-sided: the interpolated
+// PyMOL two-light model. The ambient/direct/reflect/specular/shininess come
+// from the live PyMOL settings (Scene lighting sliders) via LightU, instead of
+// hard-coded constants, so the sliders take effect. Two-sided: the interpolated
 // normal is flipped to face the viewer so cartoon undersides / surface
 // interiors light up instead of going dark.
-static float3 vbo_shade(float3 baseColor, float3 nEye) {
+struct LightU { float ambient, direct, reflect, spec, shininess; };
+static float3 vbo_shade(float3 baseColor, float3 nEye, LightU lt) {
   float3 normal = normalize(nEye);
   if (normal.z < 0.0) normal = -normal;
-  const float ambient    = 0.14;
-  const float direct     = 0.45;
-  const float reflect    = 0.481;
-  const float spec_value = 0.5;
-  const float shininess  = 55.0;
+  float ambient    = lt.ambient;
+  float direct     = lt.direct;
+  float reflect    = lt.reflect;
+  float spec_value = lt.spec;
+  float shininess  = max(lt.shininess, 1.0);
   const float3 L0 = float3(0.0, 0.0, 1.0);
   const float3 L1 = normalize(float3(0.4, 0.4, 1.0));
   float intensity = ambient;
@@ -2791,9 +2808,10 @@ vertex VBOVertexOut vbo_vertex(
   return out;
 }
 
-fragment float4 vbo_fragment(VBOVertexOut in [[stage_in]])
+fragment float4 vbo_fragment(VBOVertexOut in [[stage_in]],
+    constant LightU& lt [[buffer(0)]])
 {
-  return float4(vbo_shade(in.color.rgb, in.normalEye), in.color.a);
+  return float4(vbo_shade(in.color.rgb, in.normalEye, lt), in.color.a);
 }
 
 // Unlit: flat color, no lighting. Used for lines/ribbon (GL_LINES) and dots
@@ -2864,9 +2882,9 @@ vertex CapFillOut cap_fill_vertex(uint vid [[vertex_id]]) {
 fragment float4 cap_fill_fragment(constant float4& interiorColor [[buffer(0)]]) {
   // The cut cross-section faces the viewer, so light it with a +Z normal
   // through the shared two-light model (matches desktop's interior_normal
-  // {0,0,1}). Without this the cap is a flat, unlit, dark patch while the
-  // surface around it is lit — "light not reaching the interior".
-  return float4(vbo_shade(interiorColor.rgb, float3(0.0, 0.0, 1.0)), interiorColor.a);
+  // {0,0,1}). Caps use the default lighting (a minor flat fill).
+  LightU lt = {0.14, 0.45, 0.481, 0.5, 55.0};
+  return float4(vbo_shade(interiorColor.rgb, float3(0.0, 0.0, 1.0), lt), interiorColor.a);
 }
 
 // Weighted-blended OIT output (McGuire/Bavoil). Transparent geometry writes
@@ -2880,9 +2898,10 @@ static float oit_weight(float a, float z) {
   return clamp(pow(min(1.0, a * 10.0) + 0.01, 3.0) * 1e8 *
                pow(1.0 - z * 0.9, 3.0), 1e-2, 3e3);
 }
-fragment OITFragOut vbo_fragment_oit(VBOVertexOut in [[stage_in]])
+fragment OITFragOut vbo_fragment_oit(VBOVertexOut in [[stage_in]],
+    constant LightU& lt [[buffer(0)]])
 {
-  float4 c = float4(vbo_shade(in.color.rgb, in.normalEye), in.color.a);
+  float4 c = float4(vbo_shade(in.color.rgb, in.normalEye, lt), in.color.a);
   float w = oit_weight(c.a, in.position.z);
   OITFragOut o;
   o.accum = float4(c.rgb * c.a, c.a) * w;
@@ -3547,6 +3566,12 @@ void RendererMetal::drawVBO(PrimitiveType mode, int vertexCount,
   uniforms.pointSize = _pointSize > 0.0f ? _pointSize : 1.0f;
   uniforms._pad[0] = uniforms._pad[1] = uniforms._pad[2] = 0.0f;
   [_encoder setVertexBytes:&uniforms length:sizeof(uniforms) atIndex:1];
+  // Lighting (Scene sliders) for the lit vbo_fragment / vbo_fragment_oit at
+  // fragment buffer(0). Harmless for the unlit/flat pipelines (they don't read
+  // it). Scoped so the local doesn't clash across multiple draw paths.
+  { struct { float a, d, r, s, sh; } _lt = { _lightAmbient, _lightDirect,
+      _lightReflect, _lightSpecular, _lightShininess };
+    [_encoder setFragmentBytes:&_lt length:sizeof(_lt) atIndex:0]; }
 
   // Flat (uniform-colored) geometry: supply the color the flat shader reads
   // from buffer 2. No per-vertex color is available here (the GL path would set
@@ -3596,6 +3621,12 @@ void RendererMetal::drawVBO(PrimitiveType mode, int vertexCount,
       [_encoder setCullMode:MTLCullModeNone];
       [_encoder setVertexBuffer:vbo offset:0 atIndex:0];
       [_encoder setVertexBytes:&uniforms length:sizeof(uniforms) atIndex:1];
+  // Lighting (Scene sliders) for the lit vbo_fragment / vbo_fragment_oit at
+  // fragment buffer(0). Harmless for the unlit/flat pipelines (they don't read
+  // it). Scoped so the local doesn't clash across multiple draw paths.
+  { struct { float a, d, r, s, sh; } _lt = { _lightAmbient, _lightDirect,
+      _lightReflect, _lightSpecular, _lightShininess };
+    [_encoder setFragmentBytes:&_lt length:sizeof(_lt) atIndex:0]; }
       [_encoder drawPrimitives:toMTL(mode)
                    vertexStart:0
                    vertexCount:static_cast<NSUInteger>(vertexCount)];
@@ -3861,6 +3892,8 @@ struct SphereU {
   float depthZeroToOne; // 1 if clip Z already [0,1]; else apply 0.5+0.5 remap
   float interiorCap;    // 1 = cap the slab cross-section with a solid interior color
   float4 interiorColor; // rgb cap color; .a > 0.5 => use it (else atom*0.45)
+  // PyMOL lighting model (Scene sliders): ambient/direct/reflect/spec/shininess.
+  float lAmbient, lDirect, lReflect, lSpecular, lShininess;
 };
 struct SphereVOut {
   float4 position [[position]];
@@ -3963,13 +3996,13 @@ static void sphere_shade(SphereVOut in, constant SphereU& u,
   }
   float3 normal = normalize(ipoint - in.sphere_center);
 
-  // PyMOL default two-light model (see data/shaders/compute_color_for_light.fs):
-  // ambient .14, headlight direct .45, key reflect .481, specular .5, shine 55.
-  const float ambient    = 0.14;
-  const float direct     = 0.45;
-  const float reflect    = 0.481;
-  const float spec_value = 0.5;
-  const float shininess  = 55.0;
+  // PyMOL two-light model, driven by the live ambient/direct/reflect/specular/
+  // shininess settings (Scene sliders) uploaded in SphereU.
+  float ambient    = u.lAmbient;
+  float direct     = u.lDirect;
+  float reflect    = u.lReflect;
+  float spec_value = u.lSpecular;
+  float shininess  = max(u.lShininess, 1.0);
   const float3 L0 = float3(0.0, 0.0, 1.0);
   const float3 L1 = normalize(float3(0.4, 0.4, 1.0));
   float intensity = ambient;
@@ -4171,9 +4204,13 @@ void RendererMetal::drawSphereImpostors(const SphereImpostorDrawCall& call)
     float depthZeroToOne;
     float interiorCap;
     float interiorColor[4];
+    float lAmbient, lDirect, lReflect, lSpecular, lShininess;
   } u;
   std::memcpy(u.modelview, _modelviewMatrix.data(), 64);
   std::memcpy(u.projection, _projectionMatrix.data(), 64);
+  u.lAmbient = _lightAmbient; u.lDirect = _lightDirect;
+  u.lReflect = _lightReflect; u.lSpecular = _lightSpecular;
+  u.lShininess = _lightShininess;
   u.sphere_size_scale = call.sphereSizeScale;
   u.ortho = (float)call.ortho;
   // Projection is GL-convention ([-1,1] clip Z): remap to [0,1] for Metal's
@@ -4229,6 +4266,8 @@ struct CylU {
   float inv_height;
   float interiorCap;    // 1 = cap the slab cross-section with a solid interior color
   float4 interiorColor; // rgb cap color; .a > 0.5 => use it (else bond*0.45)
+  // PyMOL lighting model (Scene sliders): ambient/direct/reflect/spec/shininess.
+  float lAmbient, lDirect, lReflect, lSpecular, lShininess;
 };
 struct CylVOut {
   float4 position [[position]];
@@ -4405,12 +4444,12 @@ static void cyl_shade(CylVOut in, constant CylU& u,
     return;
   }
 
-  // PyMOL default two-light model (identical to the sphere impostor).
-  const float ambient    = 0.14;
-  const float direct     = 0.45;
-  const float reflect    = 0.481;
-  const float spec_value = 0.5;
-  const float shininess  = 55.0;
+  // PyMOL two-light model, driven by the live lighting settings in CylU.
+  float ambient    = u.lAmbient;
+  float direct     = u.lDirect;
+  float reflect    = u.lReflect;
+  float spec_value = u.lSpecular;
+  float shininess  = max(u.lShininess, 1.0);
   const float3 L0 = float3(0.0, 0.0, 1.0);
   const float3 L1 = normalize(float3(0.4, 0.4, 1.0));
   float intensity = ambient;
@@ -4624,9 +4663,13 @@ void RendererMetal::drawCylinderImpostors(const CylinderImpostorDrawCall& call)
     float inv_height;
     float interiorCap;
     float interiorColor[4];
+    float lAmbient, lDirect, lReflect, lSpecular, lShininess;
   } u;
   std::memcpy(u.modelview, _modelviewMatrix.data(), 64);
   std::memcpy(u.projection, _projectionMatrix.data(), 64);
+  u.lAmbient = _lightAmbient; u.lDirect = _lightDirect;
+  u.lReflect = _lightReflect; u.lSpecular = _lightSpecular;
+  u.lShininess = _lightShininess;
   u.uni_radius = call.uniRadius;
   u.ortho = (float)call.ortho;
   u.depthZeroToOne = 0.0f; // GL-convention clip Z (matches the sphere path)
@@ -4707,14 +4750,17 @@ vertex TubeOut bezier_tube_vertex(
   return o;
 }
 
-fragment float4 bezier_tube_fragment(TubeOut in [[stage_in]]) {
-  // PyMOL default two-light model (same as the impostors). Two-sided via the
-  // view vector: orient the normal toward the camera (eye-space +z) so both the
-  // outer surface and the open tube ends/interior are lit, never black.
+struct LightU { float ambient, direct, reflect, spec, shininess; };
+fragment float4 bezier_tube_fragment(TubeOut in [[stage_in]],
+    constant LightU& lt [[buffer(0)]]) {
+  // PyMOL two-light model driven by the live lighting settings (Scene sliders).
+  // Two-sided via the view vector: orient the normal toward the camera
+  // (eye-space +z) so both the outer surface and the open tube ends/interior
+  // are lit, never black.
   float3 nrm = normalize(in.eyeNormal);
   if (nrm.z < 0.0) nrm = -nrm;
-  const float ambient = 0.14, direct = 0.45, reflectv = 0.481;
-  const float spec_value = 0.5, shininess = 55.0;
+  float ambient = lt.ambient, direct = lt.direct, reflectv = lt.reflect;
+  float spec_value = lt.spec, shininess = max(lt.shininess, 1.0);
   const float3 L0 = float3(0.0,0.0,1.0);
   const float3 L1 = normalize(float3(0.4,0.4,1.0));
   float intensity = ambient, specular = 0.0;
@@ -4840,6 +4886,10 @@ void RendererMetal::drawBezierTubes(const void* cp, size_t dataSize,
   u._p0 = u._p1 = u._p2 = 0.0f;
   u.color[0] = r; u.color[1] = g; u.color[2] = b; u.color[3] = 1.0f;
   [_encoder setVertexBytes:&u length:sizeof(u) atIndex:1];
+  // Lighting (Scene sliders) for bezier_tube_fragment at fragment buffer(0).
+  { struct { float a, d, r, s, sh; } _lt = { _lightAmbient, _lightDirect,
+      _lightReflect, _lightSpecular, _lightShininess };
+    [_encoder setFragmentBytes:&_lt length:sizeof(_lt) atIndex:0]; }
 
   [_encoder setTessellationFactorBuffer:_bezierTessFactors offset:0 instanceStride:0];
   [_encoder drawPatches:4

--- a/modules/pymol/appkit_inspector.py
+++ b/modules/pymol/appkit_inspector.py
@@ -40,8 +40,9 @@ REP_COLOR = {
     'dots': 'dot_color', 'lines': 'line_color', 'labels': 'label_color',
 }
 
-SCENE_SETTINGS = ['metal_raytrace', 'metal_shadows', 'metal_ssao', 'metal_outline',
-                  'metal_msaa', 'depth_cue', 'fog', 'field_of_view', 'surface_quality',
+SCENE_SETTINGS = ['metal_raytrace', 'metal_rt_shadows', 'metal_shadows', 'metal_ssao',
+                  'metal_outline', 'metal_msaa', 'metal_tonemap', 'metal_exposure',
+                  'depth_cue', 'fog', 'field_of_view', 'surface_quality',
                   'all_states', 'mouse_selection_mode',
                   'ambient', 'direct', 'reflect', 'specular', 'shininess',
                   'ray_opaque_background']

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -173,10 +173,13 @@ enum SceneCatalog {
     static let groups = ["Lighting & Quality", "Camera"]
     static let params: [SceneParam] = [
         SceneParam(setting: "metal_raytrace", label: "Ray tracing", kind: .toggle, group: "Lighting & Quality"),
+        SceneParam(setting: "metal_rt_shadows", label: "RT hard shadows", kind: .toggle, group: "Lighting & Quality"),
         SceneParam(setting: "metal_shadows", label: "Shadows", kind: .toggle, group: "Lighting & Quality"),
         SceneParam(setting: "metal_ssao",    label: "Ambient occlusion", kind: .toggle, group: "Lighting & Quality"),
         SceneParam(setting: "metal_outline", label: "Outline", kind: .toggle, group: "Lighting & Quality"),
         SceneParam(setting: "metal_msaa",    label: "MSAA 4×", kind: .toggle, group: "Lighting & Quality"),
+        SceneParam(setting: "metal_tonemap", label: "Filmic tone-map", kind: .toggle, group: "Lighting & Quality"),
+        SceneParam(setting: "metal_exposure", label: "Exposure", kind: .slider, min: 0.2, max: 2.0, step: 0.05, decimals: 2, group: "Lighting & Quality"),
         SceneParam(setting: "depth_cue",     label: "Depth cue / fog", kind: .toggle, group: "Lighting & Quality"),
         SceneParam(setting: "all_states",    label: "Overlay all states", kind: .toggle, group: "Lighting & Quality"),
         // Lighting (made real-time on Metal in Phase 3; tunable here in Phase 2).

--- a/swiftui/PyMOLViewer/Shared/MetalViewport.swift
+++ b/swiftui/PyMOLViewer/Shared/MetalViewport.swift
@@ -17,7 +17,11 @@ struct MetalViewport: NSViewRepresentable {
         view.delegate = context.coordinator
         view.colorPixelFormat = .bgra8Unorm
         view.depthStencilPixelFormat = .depth32Float_stencil8
-        view.preferredFramesPerSecond = 60
+        // Allow ProMotion (120Hz) on capable displays; the system clamps this to
+        // the panel's actual max (e.g. 60 on non-ProMotion). The on-demand gate in
+        // draw(in:) keeps the GPU idle on a static scene, so the higher tick only
+        // costs a cheap idle poll when nothing is moving.
+        view.preferredFramesPerSecond = 120
         view.enableSetNeedsDisplay = false
         view.isPaused = false
         context.coordinator.engine = engine
@@ -120,7 +124,11 @@ struct MetalViewport: UIViewRepresentable {
         view.delegate = context.coordinator
         view.colorPixelFormat = .bgra8Unorm
         view.depthStencilPixelFormat = .depth32Float_stencil8
-        view.preferredFramesPerSecond = 60
+        // Allow ProMotion (120Hz) on capable displays; the system clamps this to
+        // the panel's actual max (e.g. 60 on non-ProMotion). The on-demand gate in
+        // draw(in:) keeps the GPU idle on a static scene, so the higher tick only
+        // costs a cheap idle poll when nothing is moving.
+        view.preferredFramesPerSecond = 120
         view.enableSetNeedsDisplay = false
         view.isPaused = false
         view.isMultipleTouchEnabled = true
@@ -265,6 +273,7 @@ extension MetalViewport {
         }
 
         private var wasSuppressed = false
+        private var hasRenderedOnce = false
 
         func draw(in view: MTKView) {
             guard let engine = engine, engine.isReady else { return }
@@ -292,12 +301,24 @@ extension MetalViewport {
             // Build RendererMetal on the first frame (bridge no-ops thereafter),
             // then hand off this frame's drawable + pass descriptor and render.
             engine.setupMetalRenderer(view: view)
+            engine.idle()
+            // On-demand rendering: after idle() (which advances movies/animations
+            // and sets PyMOL's redisplay flag), skip the GPU-expensive frame when
+            // nothing needs redrawing — a static structure then costs only a cheap
+            // idle poll instead of a full render every tick, the bulk of the
+            // battery/thermal win. The last presented frame stays on screen.
+            // Mirrors the legacy AppKit loop (main_appkit.mm). The first frame
+            // always renders (defensive against a blank start before any redisplay).
+            if hasRenderedOnce, let inst = engine.instance,
+               PyMOLBridge_GetRedisplay(inst, 1) == 0 {
+                return
+            }
             guard let drawable = view.currentDrawable,
                   let passDesc = view.currentRenderPassDescriptor else { return }
-            engine.idle()
             let size = view.drawableSize
             engine.renderMetalFrame(drawable: drawable, passDescriptor: passDesc,
                                     width: Int(size.width), height: Int(size.height))
+            hasRenderedOnce = true
             // This frame built any deferred rep geometry (e.g. a surface mesh);
             // let the engine clear the "Calculating…" overlay once the build
             // frame(s) have completed.

--- a/swiftui/PyMOLViewer/Shared/MetalViewport.swift
+++ b/swiftui/PyMOLViewer/Shared/MetalViewport.swift
@@ -32,6 +32,17 @@ struct MetalViewport: NSViewRepresentable {
         // no-op — mouse rotate/zoom/pan never reach PyMOL.
         view.coordinator = context.coordinator
 
+        // Repaint when the app re-activates or the system wakes from sleep: the
+        // display can discard the drawable's contents while asleep/locked, and
+        // the on-demand gate (a static scene flags no redisplay) would otherwise
+        // leave the viewport black until the next interaction.
+        NotificationCenter.default.addObserver(
+            context.coordinator, selector: #selector(Coordinator.handleWake),
+            name: NSApplication.didBecomeActiveNotification, object: nil)
+        NSWorkspace.shared.notificationCenter.addObserver(
+            context.coordinator, selector: #selector(Coordinator.handleWake),
+            name: NSWorkspace.didWakeNotification, object: nil)
+
         // Trackpad pinch → zoom. Two-finger drag (scrollWheel) → translate;
         // see handleScrollWheel. A real mouse wheel still zooms.
         let magnify = NSMagnificationGestureRecognizer(
@@ -134,6 +145,12 @@ struct MetalViewport: UIViewRepresentable {
         view.isMultipleTouchEnabled = true
         context.coordinator.engine = engine
         context.coordinator.mtkView = view
+        // Repaint when the app returns to the foreground: backgrounding can
+        // discard the drawable, and the on-demand gate would otherwise leave a
+        // static scene's viewport black until the next touch.
+        NotificationCenter.default.addObserver(
+            context.coordinator, selector: #selector(Coordinator.handleWake),
+            name: UIApplication.didBecomeActiveNotification, object: nil)
 
         // Gesture recognizers for touch input
         let tap = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleTap(_:)))
@@ -189,6 +206,23 @@ extension MetalViewport {
         weak var engine: PyMOLEngine?
         weak var mtkView: MTKView?
         private var viewportSize: CGSize = .zero
+        // Set when the app/display wakes (unlock, system wake, re-activate). The
+        // next draw(in:) then renders unconditionally, bypassing the on-demand
+        // gate, to repaint a drawable whose contents were discarded during sleep.
+        fileprivate var forceRedraw = false
+
+        // Wake/activate -> force one repaint. Also kicks an immediate draw() in
+        // case the display link hasn't resumed ticking yet.
+        @objc fileprivate func handleWake() {
+            forceRedraw = true
+            DispatchQueue.main.async { [weak self] in self?.mtkView?.draw() }
+        }
+        deinit {
+            NotificationCenter.default.removeObserver(self)
+            #if os(macOS)
+            NSWorkspace.shared.notificationCenter.removeObserver(self)
+            #endif
+        }
         #if os(macOS)
         // Track the mouse-down point to distinguish a click (pick/select) from
         // a drag (rotate). Point space, view coordinates.
@@ -309,7 +343,12 @@ extension MetalViewport {
             // battery/thermal win. The last presented frame stays on screen.
             // Mirrors the legacy AppKit loop (main_appkit.mm). The first frame
             // always renders (defensive against a blank start before any redisplay).
-            if hasRenderedOnce, let inst = engine.instance,
+            // forceRedraw bypasses the gate after a wake/activate: the display can
+            // discard the drawable's contents during sleep, and since the scene is
+            // unchanged the redisplay flag alone wouldn't repaint it (-> a black
+            // viewport until the next interaction). It's cleared only once a frame
+            // actually renders below, so a not-yet-ready drawable doesn't drop it.
+            if !forceRedraw, hasRenderedOnce, let inst = engine.instance,
                PyMOLBridge_GetRedisplay(inst, 1) == 0 {
                 return
             }
@@ -319,6 +358,7 @@ extension MetalViewport {
             engine.renderMetalFrame(drawable: drawable, passDescriptor: passDesc,
                                     width: Int(size.width), height: Int(size.height))
             hasRenderedOnce = true
+            forceRedraw = false
             // This frame built any deferred rep geometry (e.g. a surface mesh);
             // let the engine clear the "Calculating…" overlay once the build
             // frame(s) have completed.


### PR DESCRIPTION
## Tier 0 Metal features

Implements the three Tier-0 items from the Metal-backend review, each gated by a new **default-off** setting so the default render path is unchanged (zero regression). Built sequentially in a worktree; one commit per issue.

Closes #11. Closes #12. Closes #13.

| Issue | Feature | New setting(s) | Default |
|------|---------|----------------|---------|
| #13 | Filmic tone-map + exposure post pass | `metal_tonemap` (bool), `metal_exposure` (float) | off / 1.0 |
| #12 | Ray-traced hard shadows from all reps | `metal_rt_shadows` (bool) | off |
| #11 | On-demand rendering + ProMotion | *(no setting; always-on behavior)* | — |

### #13 — HDR tone-mapping + exposure (`9baf677e`)
ACES (Narkowicz) tone-map + exposure fragment added to `kPostSrc`, inserted as a ping-pong pass after OIT/outline and **before** the final FXAA/blit (FXAA's luma math assumes display-range values), and placed ahead of the `!_offscreen` branch so the offscreen PNG export is tone-mapped identically to the live view. Milestone 1 operates on the existing 8-bit LDR scene color — promoting the scene chain to `RGBA16Float` (highlights >1.0), bloom, and EDR/16-bit export are noted follow-ups. Plumbed through `setPostParams` mirroring `metal_raytrace`.

### #12 — RT contact shadows from all reps (`d5fa759d`)
When `metal_raytrace` is on, `metal_rt_shadows` replaces the shadow-map PCF with a real occlusion ray toward the key light. The ray is traced in **Pass A (`rt_ao`)**, which already binds the instance AS (spheres + tessellated cylinders + cartoon/surface tris), so **no new encoder bindings are needed**. Visibility is written to a second channel of the AO target (`_rtAO` widened `R16Float`→`RG16Float`), depth-aware-blurred alongside AO in `rt_composite`, and applied through a model-space faceGate so only lit faces get a cast-shadow term. Uses `lightDirModel` (previously computed/uploaded but unused); repurposes the RTU `_pad` slot as the `rtShadow` flag. With the setting off, `rt_composite` takes the original shadow-map branch unchanged.

### #11 — On-demand rendering + ProMotion (`31999bde`)
`draw(in:)` now calls `engine.idle()` then skips the GPU-expensive frame when `PyMOLBridge_GetRedisplay` reports nothing changed — a static structure costs only a cheap idle poll, the bulk of the battery/thermal win. Mirrors the legacy AppKit loop (`main_appkit.mm:518`); the last presented frame stays on screen and the first frame always renders (defensive against a blank start). `preferredFramesPerSecond` raised to 120 for ProMotion (the system clamps to the panel's real max). idle/animation/movie playback still renders because `idle()` flags redisplay.

### Follow-up — lighting sliders + scene controls (`82a3e451`)
While adding panel controls for the new settings, found the Scene-panel **lighting sliders did nothing**: the Metal lit shaders (sphere, cylinder, VBO/cartoon/surface, bezier) **hard-coded** the lighting model and the renderer read no `cSetting_ambient/direct/reflect/specular/shininess` (pre-existing; `field_of_view` worked, confirming the slider widget was fine). Now `SceneRenderMetal` reads the 5 settings each frame via a new `Renderer::setLightingParams` and the shaders read them instead of constants (defaults = old constants, so the look is unchanged until a slider moves). Also exposes the new features in the SCENE card: **RT hard shadows** + **Filmic tone-map** toggles and an **Exposure** slider, plus the three settings added to `appkit_inspector.SCENE_SETTINGS`. Visually confirmed: Ambient 0→1 now changes the render (Δ 12.0, was 0.0).

## Verification

- ✅ **`pymol_core` compiles** (`swiftui/build_macos.sh`) — covers all C++/ObjC++ in #12 and #13, since `RendererMetal.mm` is part of the core lib.
- ✅ **Metal shaders compile** — `kPostSrc` and `kRTSrc` extracted and compiled with `xcrun metal -std=metal3.0`.
- ✅ **macOS app build** — full `xcodebuild PyMOLViewer_macOS` (Debug, arm64) **BUILD SUCCEEDED**, covering the #11 Swift change and linking all of the above.
- ⚠️ **On-device visual QA pending** — these are rendering features; the following need a human eyeball on Apple-silicon hardware:
  - #13: `set metal_tonemap, 1; set metal_exposure, 0.8` — confirm bright backgrounds no longer wash out, no regression with it off.
  - #12: `set metal_raytrace, 1; set metal_rt_shadows, 1` on a ligand-in-pocket scene (e.g. `6dg5`) — confirm contact shadows with no peter-panning; tune bias/acne; check non-RT and `metal_rt_shadows=0` paths are unchanged. Penumbra/cone-jitter is a follow-up.
  - #11: confirm a static molecule drops to ~0% GPU in Instruments while orbit/zoom/movie playback stay smooth; 120Hz on a ProMotion display; no stalled deferred surface builds.
- ✅ **Lighting sliders (`82a3e451`)** — visually confirmed on `6dg5`: Ambient 0→1 changes the render (was no-op).
- ✅ **Wake repaint (`73b25c21`)** — fixes a viewport-stays-black-after-display-sleep stall (a consequence of the #11 on-demand gate: the drawable is discarded on sleep but the scene flags no redisplay). Build-verified; not live-repro'd against a real sleep (that re-locks the machine), but shares its handler with the app-activate path.

## Notes
- `Renderer::setPostParams` gained three trailing defaulted params (`tonemapEnabled`, `exposure`, `rtShadowEnabled`); the GL renderer's base no-op is unaffected.
- New setting ids: `metal_tonemap`=804, `metal_exposure`=805, `metal_rt_shadows`=806.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
