### PR TITLE
fix(metal): deterministic + transparent offscreen export background — #19

### DIFF
--- a/layerGraphics/metal/RendererMetal.h
+++ b/layerGraphics/metal/RendererMetal.h
@@ -403,6 +403,10 @@ private:
   int _tonemapEnabled = 0;
   float _exposure = 1.0f;
   id<MTLRenderPipelineState> _tonemapPipeline = nil;
+  // Offscreen-export-only pass: rewrites the framebuffer alpha from scene depth
+  // (background = far -> alpha 0) so a transparent-background PNG can be written
+  // on the Metal fast path. Gated on _offscreen && transparent clear (_clearA<0.5).
+  id<MTLRenderPipelineState> _exportAlphaPipeline = nil;
   // PyMOL lighting model (cSetting_ambient/direct/reflect/specular/shininess),
   // set per frame by SceneRenderMetal and uploaded into each lit shader's
   // uniform so the Scene-panel lighting sliders actually affect the render.

--- a/layerGraphics/metal/RendererMetal.mm
+++ b/layerGraphics/metal/RendererMetal.mm
@@ -549,6 +549,20 @@ fragment float4 post_tonemap(PostVOut in [[stage_in]],
   return float4(saturate(c), 1.0);
 }
 
+// Offscreen transparent export: keep the fully post-processed RGB but rewrite
+// alpha from scene depth so the background (depth at the far plane) becomes
+// transparent and geometry stays opaque. Runs only for the offscreen PNG path
+// when a transparent background was requested (ray_opaque_background 0); the
+// live view never uses it. Alpha is binary (no matte fringing toward bg_rgb);
+// exporting at 2x and downscaling anti-aliases the cutout.
+fragment float4 post_export_alpha(PostVOut in [[stage_in]],
+    texture2d<float> src [[texture(0)]],
+    depth2d<float> depthTex [[texture(1)]], sampler s [[sampler(0)]]) {
+  float d = depthTex.sample(s, in.uv);
+  float a = (d >= 0.99995) ? 0.0 : 1.0;   // far plane == cleared background
+  return float4(src.sample(s, in.uv).rgb, a);
+}
+
 // Weighted-blended OIT resolve: composite accumulated transparent color over
 // the (already post-processed) opaque color. reveal = Π(1-α) = transmittance.
 fragment float4 oit_resolve(PostVOut in [[stage_in]],
@@ -980,6 +994,7 @@ void RendererMetal::buildPostPipelines()
   };
   _blitPipeline = mkpipe(@"post_blit");
   _tonemapPipeline = mkpipe(@"post_tonemap");
+  _exportAlphaPipeline = mkpipe(@"post_export_alpha");
   _fxaaPipeline = mkpipe(@"post_fxaa");
   _ssaoPipeline = mkpipe(@"post_ssao_fog");
   _oitResolvePipeline = mkpipe(@"oit_resolve");
@@ -1727,6 +1742,29 @@ void RendererMetal::runPostChain()
     [et setFragmentBytes:&u length:sizeof(u) atIndex:0];
     [et drawPrimitives:MTLPrimitiveTypeTriangle vertexStart:0 vertexCount:3];
     [et endEncoding];
+    sceneSrc = dst;
+  }
+
+  // Transparent-export alpha (offscreen only). When a transparent background was
+  // requested (ray_opaque_background 0 -> clear alpha 0), rewrite the captured
+  // alpha from scene depth so the background is cut out while geometry stays
+  // opaque. The post passes above all emit alpha=1, so this restores a usable
+  // matte regardless of which of them ran. Live rendering (to a drawable) never
+  // takes this path — its layer is opaque.
+  if (_offscreen && _clearA < 0.5f && _exportAlphaPipeline && _sceneDepth) {
+    id<MTLTexture> dst = (sceneSrc == _sceneColor) ? _postColor : _sceneColor;
+    MTLRenderPassDescriptor* pd = [[MTLRenderPassDescriptor alloc] init];
+    pd.colorAttachments[0].texture = dst;
+    pd.colorAttachments[0].loadAction = MTLLoadActionDontCare;
+    pd.colorAttachments[0].storeAction = MTLStoreActionStore;
+    id<MTLRenderCommandEncoder> ea =
+        [_cmdBuffer renderCommandEncoderWithDescriptor:pd];
+    [ea setRenderPipelineState:_exportAlphaPipeline];
+    [ea setFragmentTexture:sceneSrc atIndex:0];
+    [ea setFragmentTexture:_sceneDepth atIndex:1];
+    [ea setFragmentSamplerState:_postSampler atIndex:0];
+    [ea drawPrimitives:MTLPrimitiveTypeTriangle vertexStart:0 vertexCount:3];
+    [ea endEncoding];
     sceneSrc = dst;
   }
 

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -1454,21 +1454,18 @@ struct ContentView: View {
 
     private var rtFlag: Int { exportRayTraced ? 1 : 0 }
 
-    // Render a PNG to `path`. Transparent → CPU ray-trace (honors
-    // ray_opaque_background; the Metal fast path bakes the bg color via its post
-    // chain). Else the Metal fast path with the background color.
-    // Renders through runHeavy so the "Calculating…" overlay shows during the
-    // (slow, ray-traced) render; `done` runs on the main thread once written.
+    // Render a PNG to `path` via the Metal fast path. `ray_opaque_background`
+    // selects an opaque vs transparent background: when transparent, the
+    // offscreen post chain rewrites alpha from depth (background → cut out), so a
+    // straight-alpha PNG is produced without falling back to the slow CPU
+    // ray-tracer. `rtFlag` still selects hardware-RT AO/shadows for the export.
+    // Renders through runHeavy so the "Calculating…" overlay shows; `done` runs
+    // on the main thread once written.
     private func renderExportPNG(_ path: String, _ w: Int, _ h: Int,
                                  done: @escaping () -> Void = {}) {
         engine.runHeavy("Rendering image…") {
-            if exportTransparent {
-                engine.runCommand("set ray_opaque_background, 0")
-                engine.runCommand("png \(path), width=\(w), height=\(h), ray=1")
-            } else {
-                engine.runCommand("set ray_opaque_background, 1")
-                engine.renderHiResPNG(path, width: w, height: h, rayTraced: rtFlag)
-            }
+            engine.runCommand("set ray_opaque_background, \(exportTransparent ? 0 : 1)")
+            engine.renderHiResPNG(path, width: w, height: h, rayTraced: rtFlag)
             done()
         }
     }

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -364,12 +364,32 @@ final class PyMOLEngine: ObservableObject {
         // Test affordance: exercise the Export menu's GPU hi-res render path with
         // an explicit ray-traced flag — the exact call Save Image / Copy make.
         // Format: "path,W,H[,rt]" (rt: -1 WYSIWYG default, 0 off, 1 force on).
+        //
+        // Determinism (GitHub issue #19): the exported background must reflect the
+        // caller's requested bg_rgb on every run. Three things set the background
+        // at launch — PYMOL_AUTOCMD (synchronous, at init), the persisted theme
+        // (applied from ContentView.onAppear), and PYMOL_AUTOTHEME (at +2.5s) —
+        // so a fixed-delay export raced them and captured navy/cream/peach
+        // depending on ordering. We therefore (1) fire AFTER the theme paths have
+        // settled and (2) re-assert PYMOL_AUTOCMD synchronously on the same
+        // main-thread turn as the (synchronous) render, so the caller's explicit
+        // settings — bg_color included — are authoritative at scene-clear time.
         if let e = ProcessInfo.processInfo.environment["PYMOL_AUTOEXPORT"] {
             let parts = e.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
             if parts.count >= 3, let w = Int(parts[1]), let h = Int(parts[2]) {
                 let rt = parts.count >= 4 ? (Int(parts[3]) ?? -1) : -1
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) { [weak self] in
-                    self?.renderHiResPNG(parts[0], width: w, height: h, rayTraced: rt)
+                let autoCmd = ProcessInfo.processInfo.environment["PYMOL_AUTOCMD"]
+                DispatchQueue.main.asyncAfter(deadline: .now() + 4.0) { [weak self] in
+                    guard let self = self else { return }
+                    // Re-assert the caller's explicit state last, so neither the
+                    // persisted theme nor PYMOL_AUTOTHEME can clobber the requested
+                    // background between init and this render.
+                    if let c = autoCmd {
+                        for one in c.split(separator: ";") {
+                            self.runCommand(one.trimmingCharacters(in: .whitespaces))
+                        }
+                    }
+                    self.renderHiResPNG(parts[0], width: w, height: h, rayTraced: rt)
                     NSLog("PYMOL_AUTOEXPORT: \(parts[0]) \(w)x\(h) rt=\(rt)")
                 }
             }


### PR DESCRIPTION
Addresses #19. Two related fixes to the offscreen Metal PNG export (`PYMOL_AUTOEXPORT` / Save Image, `rt=0`).

## 1 — Deterministic background (ask 1)

The export produced a different background on nearly every run and ignored `bg_color`. Root cause: a **race** between the three things that set the background at launch — `PYMOL_AUTOCMD` (synchronous, at init), the persisted theme (`ContentView.onAppear`), and `PYMOL_AUTOTHEME` (+2.5s) — against the export, which also fired at a fixed +2.5s. Whichever ran last won.

**Fix:** fire the export after the theme paths settle and **re-assert `PYMOL_AUTOCMD` synchronously on the same main-thread turn as the render**, so the caller's explicit `bg_color` is authoritative at scene-clear time.

Verified (rt=0, tonemap off, corner pixel), exact + byte-identical across runs:

| `bg_color` | exported corner |
|---|---|
| `orange` (1.0,0.5,0.0) | `(255,128,0)` |
| `white` | `(255,255,255)` |
| `marine` (0.0,0.5,1.0) | `(0,128,255)` |

> Note: the reporter's repro used `bg_color peach`, but PyMOL has no color named `peach` (`get_color_tuple -> None`), so that command was a silent no-op — part of why the background looked unrelated to the request.

## 2 — Transparent background on the fast path (ask 2)

The fast path forced output alpha to 1.0 (the SSAO/RT/fog passes composite over `bg_rgb`, tonemap/OIT emit alpha 1), so `ray_opaque_background 0` gave a fully opaque PNG and transparency needed the slow CPU ray-tracer.

**Fix:** a final offscreen-only pass (`post_export_alpha`) rewrites alpha from scene depth — background (far plane) -> alpha 0, geometry -> alpha 1 — keeping the fully post-processed RGB. Runs only when offscreen **and** a transparent background was requested (`ray_opaque_background 0` -> clear alpha 0); the live view is untouched. The interactive "Transparent background" export now uses this fast path too.

Verified (rt=0, 1200x1320, marine bg, 1ubq cartoon):
- `ray_opaque_background 0` -> corner alpha **0**; ~87% transparent, geometry opaque; composites cleanly onto a checkerboard.
- `ray_opaque_background 1` -> 100% opaque (unchanged; no regression).

Alpha is binary (no matte fringing toward `bg_rgb`); export at 2x and downscale to anti-alias the cutout. A coverage-based (smooth) alpha is left as a follow-up.

## 3 — `metal_outline` honoring `bg_rgb` (ask 3): already resolved

Investigated and found **no code path that ties the background to `metal_outline`** — the `post_outline` shader only composites edge contours over the existing scene color. The "light-grey background" in the report was the **theme** background: `raymol_theme.set_palette` sets `bg` and `metal_outline` together, so a light preset (e.g. Paper) enabled outline *and* a grey bg, which then raced the export exactly like ask 1.

Verified with the determinism fix in place:
- `set metal_outline,1; bg_color marine` -> corner `(0,128,255)` (marine honored, outline contours render).

So ask 3 is covered by the ask-1 determinism fix; no separate change is needed.

## Build note

`RendererMetal.mm`/`RendererMetal.h` are part of `libpymol_core.a` (built via CMake), so verifying these required rebuilding the core target (`cmake --build build_macos_swiftui --target pymol_core`) in addition to the Xcode app target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
