### PR TITLE
fix(metal): surfaces render black (bind LightU on indexed VBO path)

### DIFF
--- a/layerGraphics/metal/RendererMetal.mm
+++ b/layerGraphics/metal/RendererMetal.mm
@@ -3839,6 +3839,12 @@ void RendererMetal::drawVBOIndexed(PrimitiveType mode, int indexCount,
   matrices.pointSize = _pointSize > 0.0f ? _pointSize : 1.0f;
   matrices._pad[0] = matrices._pad[1] = matrices._pad[2] = 0.0f;
   [_encoder setVertexBytes:&matrices length:sizeof(matrices) atIndex:1];
+  // Lighting (Scene sliders) for the lit vbo_fragment at fragment buffer(0).
+  // Without this, indexed lit geometry (molecular surfaces) reads an unbound
+  // LightU (ambient/direct = 0) and renders black. Mirrors drawVBO.
+  { struct { float a, d, r, s, sh; } _lt = { _lightAmbient, _lightDirect,
+      _lightReflect, _lightSpecular, _lightShininess };
+    [_encoder setFragmentBytes:&_lt length:sizeof(_lt) atIndex:0]; }
 
   // Flat (uniform-colored) geometry reads its color from buffer 2 — see drawVBO.
   if (flat) {


### PR DESCRIPTION
## Problem
Molecular **surfaces render as a flat black silhouette** (reported on iOS; reproduced on macOS). Geometry is correct but the surface has no color/lighting.

## Root cause
`RendererMetal::drawVBOIndexed` never bound the lighting uniform to **fragment buffer(0)**, unlike `drawVBO`. The lit fragment shader `vbo_fragment` reads `LightU [[buffer(0)]]`. Surfaces are drawn as **indexed** triangles, so they read an unbound `LightU` (ambient = direct = 0) → `baseColor × 0 = black`.

This explains the full symptom set:
- Surface **alone** → fully black (buffer 0 never set).
- Surface **with cartoon/sticks** → partially lit/grey, because a preceding *non-indexed* draw left a valid `LightU` in buffer 0 that the surface draw inherited.
- Independent of AO/shadows/tonemap (black persists with all effects off) and of vertex data (VBO color verified correct, grey80 Float4).

## Fix
Bind `LightU` at fragment buffer(0) in `drawVBOIndexed` before the draw call, mirroring `drawVBO`.

## Verification
Rebuilt macOS; the surface-alone case (previously fully black) now renders lit with proper depth/highlights and CPK colors. iOS shares this renderer, so it's fixed there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)