### PR TITLE
iOS: auto-save session on background, resume on cold launch

### DIFF
--- a/swiftui/PyMOLViewer/Shared/PyMOLApp.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLApp.swift
@@ -24,6 +24,7 @@ struct PyMOLApp: App {
     @StateObject private var engine = PyMOLEngine.shared
     #if os(iOS)
     @UIApplicationDelegateAdaptor(OrientationLockDelegate.self) private var appDelegate
+    @Environment(\.scenePhase) private var scenePhase
     #endif
 
     init() {
@@ -64,7 +65,25 @@ struct PyMOLApp: App {
                 // the sanitized filename stem. Engine init runs in ContentView's
                 // .onAppear, so on a cold launch the URL may arrive before the
                 // engine is ready — loadOpenedFile retries briefly until it is.
-                .onOpenURL { url in loadOpenedFile(url, into: engine) }
+                .onOpenURL { url in
+                    #if os(iOS)
+                    // A launch-to-open-a-file takes precedence over the autosaved
+                    // scene: flag it before the (possibly retried) load so the
+                    // cold-launch restore doesn't merge the old session underneath.
+                    engine.launchOpenRequested = true
+                    #endif
+                    loadOpenedFile(url, into: engine)
+                }
+            #if os(iOS)
+                // iOS purges backgrounded apps to reclaim memory; persist the
+                // session on the way out so the next cold launch can resume it.
+                // .background (not .inactive) is the debounced signal — .inactive
+                // also fires for transient interruptions (app-switcher peek,
+                // Control Center) where we don't want to save.
+                .onChange(of: scenePhase) { phase in
+                    if phase == .background { engine.autosaveSession() }
+                }
+            #endif
         }
         #if os(macOS)
         .windowStyle(.titleBar)

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -4,6 +4,9 @@
 import Foundation
 import Combine
 import MetalKit
+#if os(iOS)
+import UIKit
+#endif
 
 /// Frequently-changing movie/timeline playback state, kept in its OWN
 /// ObservableObject so the ≈10/s frame ticks during playback re-render only the
@@ -160,6 +163,19 @@ final class PyMOLEngine: ObservableObject {
     private var pendingHeavyClearFrames = 0
     // Backstop that clears a stuck overlay if the render loop ever stalls.
     private var busyBackstop: DispatchWorkItem?
+
+    #if os(iOS)
+    // iOS session auto-save / resume. iOS purges backgrounded apps to reclaim
+    // memory (jetsam), and the whole session lives only in the in-memory core,
+    // so without this the user loses their work on the next cold launch. We
+    // snapshot a full .pse on background and silently reload it on cold launch.
+    // One-shot per process so a warm foreground (memory intact) never re-restores.
+    private var didRestoreAutosave = false
+    // Set by .onOpenURL: the app was launched to open a specific file, which
+    // takes precedence over the autosaved scene (don't merge the old session
+    // underneath the opened document).
+    var launchOpenRequested = false
+    #endif
 
     private init() {}
 
@@ -395,6 +411,17 @@ final class PyMOLEngine: ObservableObject {
             }
         }
 
+        #if os(iOS)
+        // Cold-launch resume: reload the session iOS purged when the app was
+        // backgrounded. Skipped when a test affordance scripts the scene
+        // (PYMOL_AUTOLOAD/PYMOL_AUTOCMD imply deterministic screenshot content)
+        // and when launched to open a specific file (handled by .onOpenURL).
+        let env = ProcessInfo.processInfo.environment
+        if env["PYMOL_AUTOLOAD"] == nil && env["PYMOL_AUTOCMD"] == nil {
+            restoreAutosaveIfAvailable()
+        }
+        #endif
+
         // Poll feedback every 100ms
         feedbackTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
             guard let self = self else { return }
@@ -422,6 +449,70 @@ final class PyMOLEngine: ObservableObject {
         instance = nil
         isReady = false
     }
+
+    #if os(iOS)
+    // MARK: - Session auto-save / resume (iOS)
+
+    private static let autosaveDefaultsKey = "raymol.autosave.present"
+
+    // Persistent home for the rolling autosave. A subfolder of Library survives
+    // across launches (unlike tmp, which iOS may purge) and isn't surfaced in
+    // the Files app. The directory name is intentionally space-free: the path is
+    // passed through PyMOL's `load`/`save` command parser, and the conventional
+    // "Application Support" location's space risks argument-splitting ambiguity.
+    // Created on first access.
+    private var autosaveURL: URL? {
+        guard let dir = FileManager.default.urls(
+            for: .libraryDirectory, in: .userDomainMask).first else { return nil }
+        let appDir = dir.appendingPathComponent("RayMolState", isDirectory: true)
+        try? FileManager.default.createDirectory(
+            at: appDir, withIntermediateDirectories: true)
+        return appDir.appendingPathComponent("autosave.pse")
+    }
+
+    private func clearAutosave() {
+        if let url = autosaveURL { try? FileManager.default.removeItem(at: url) }
+        UserDefaults.standard.set(false, forKey: Self.autosaveDefaultsKey)
+    }
+
+    /// Snapshot the full session to the autosave .pse. Called when the app is
+    /// backgrounded (scenePhase → .background), the point at which iOS may
+    /// subsequently terminate the process. An empty scene clears any prior
+    /// autosave so the user isn't resurrected into a scene they deliberately
+    /// cleared. The save runs synchronously on the main thread because the
+    /// embedded core's GIL model is not safe off-main (see runHeavy), and is
+    /// wrapped in a background-task assertion so a large session finishes
+    /// writing within iOS's background grace window.
+    func autosaveSession() {
+        guard isReady, let url = autosaveURL else { return }
+        guard !objects.isEmpty else { clearAutosave(); return }
+
+        let bgTask = UIApplication.shared.beginBackgroundTask(withName: "RayMolAutosave")
+        defer { if bgTask != .invalid { UIApplication.shared.endBackgroundTask(bgTask) } }
+
+        runPython("from pymol import cmd as _c; _c.save(r'''\(url.path)''')")
+        let saved = FileManager.default.fileExists(atPath: url.path)
+        UserDefaults.standard.set(saved, forKey: Self.autosaveDefaultsKey)
+    }
+
+    /// Reload the autosaved session on cold launch. One-shot per process, and
+    /// suppressed when the launch is opening a specific file. Routing through
+    /// runCommand("load …pse") reuses handleSessionViewport, which restores the
+    /// saved camera and letterbox aspect; refreshAfterRestore republishes the
+    /// panels. The .pse carries its own scene settings (bg_color, metal_*), so
+    /// we deliberately do NOT re-assert the active theme here — that would
+    /// override the saved scene and the goal is to resume it exactly. Loading
+    /// into the empty cold-launch scene reproduces the prior session exactly.
+    func restoreAutosaveIfAvailable() {
+        guard isReady, !didRestoreAutosave, !launchOpenRequested else { return }
+        guard UserDefaults.standard.bool(forKey: Self.autosaveDefaultsKey),
+              let url = autosaveURL,
+              FileManager.default.fileExists(atPath: url.path) else { return }
+        didRestoreAutosave = true
+        runCommand("load \(url.path)")
+        refreshAfterRestore()
+    }
+    #endif
 
     // MARK: - Commands
 


### PR DESCRIPTION
## Problem

On iOS/iPadOS, switching away from RayMol for a few minutes loses all work. iOS purges backgrounded apps to reclaim memory (jetsam), and RayMol's entire session (loaded structures, representations, colors, selections, camera, settings) lives **only in the in-memory PyMOL core**. Nothing persisted state across process death:

- Pure SwiftUI app with no background-save hook; `PyMOLEngine.shutdown()` is never called.
- The only wake handler (`MetalViewport.handleWake`) just repaints — fine for a warm resume, useless after a cold relaunch because the scene is gone.
- `@AppStorage` persists only UI/theme prefs, never the molecular session.

So after a purge the user relaunches to an empty viewport.

## Fix

Persist a full `.pse` when the app is backgrounded and silently reload it on the next cold launch, reusing the existing, tested save/load paths. iOS-only — macOS isn't purged and keeps its explicit Save Session flow.

- **`autosaveSession()`** — `cmd.save(...pse)` to `Library/RayMolState/autosave.pse`, guarded by a `UIApplication` background-task assertion so a large session finishes writing in the background grace window. An empty scene clears any prior autosave (don't resurrect a deliberately-cleared scene).
- **`restoreAutosaveIfAvailable()`** — load the `.pse` via the existing `runCommand("load …pse")` path, which already restores the camera + letterbox aspect through `handleSessionViewport`, then republishes the panels via `refreshAfterRestore()`. One-shot per process.
- **Lifecycle wiring** in `PyMOLApp.swift`: save on `scenePhase → .background` (the debounced signal, not `.inactive`); `.onOpenURL` sets `launchOpenRequested` so opening a file takes precedence over the autosaved scene.

### Design notes
- **Faithful resume:** the active theme is deliberately *not* re-asserted after restore — the `.pse` carries its own `bg_color`/`metal_*`, and overriding them would diverge from "resume exactly where you left off."
- **Space-free path:** `Library/RayMolState` (not "Application Support", whose space could trip PyMOL's `load`/`save` arg parser); same persistence + not-user-visible guarantees.
- Restore is suppressed under the screenshot harness (`PYMOL_AUTOLOAD`/`PYMOL_AUTOCMD`) so deterministic screenshots are preserved.

All changes are wrapped in `#if os(iOS)`.

## Verification

The iOS target needs Xcode (embedded PyMOL core), so it wasn't compiled/run in CI here — manual steps:

1. Build the iOS target; load a structure, set a distinctive camera/reps, background the app → confirm `Library/RayMolState/autosave.pse` is written.
2. Fully terminate (`xcrun simctl terminate`) and relaunch → objects, reps, colors, selections, camera, and letterbox aspect come back.
3. Empty scene → background → relaunch stays empty; autosave file removed.
4. With an autosave present, cold-launch by opening a file via "Open in RayMol" → opened file is shown, autosave not merged underneath.
5. macOS target still builds and behaves unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9HJQnHxQutaUVpKJCybHF)_