### PR TITLE
Release 1.2.0: macOS polish (single-window, Clear Session, About links, drag-and-drop, banner) + Claude/MCP support page

### DIFF
--- a/docs/raymol.io/support.md
+++ b/docs/raymol.io/support.md
@@ -2,7 +2,9 @@
 
 **RayMol** is a native molecular visualization app for macOS, iPad, and iPhone —
 real-time Metal rendering (cartoon, sticks, spheres, surfaces), hardware ray
-tracing, themes, measurements, movies, and PyMOL scripting.
+tracing, themes, measurements, movies, PyMOL scripting, and — on macOS —
+control by your own Claude (Claude Code or the Claude app) via a built-in MCP
+server.
 
 ## Getting help
 
@@ -16,9 +18,12 @@ version (Settings shows it), and the steps to reproduce.
 
 - **Opening structures:** use **Open File** for local `.pdb`/`.cif`/`.pse` and
   related formats, or **Fetch from PDB** to download by 4-letter PDB ID.
-- **The AI assistant (Raymond):** optional and off by default. Enable it in
-  Settings → Experimental; it requires your own API key (Anthropic or Google
-  Vertex AI), stored securely in your device Keychain.
+- **Drive RayMol with Claude (macOS):** RayMol has a built-in MCP server, so you
+  can control it from your own Claude — either Claude Code or the Claude desktop
+  app. It's off by default; turn it on under the **Connect** menu, then choose
+  **Connect an AI app…** to link Claude. No API key is required — it uses your
+  existing Claude. The server is local-only (127.0.0.1), token-protected, and
+  asks you to approve each connection before it can drive the app.
 - **Privacy:** see the [Privacy Policy](https://raymol.io/privacy).
 
 ---

--- a/docs/release-notes/v1.2.0.md
+++ b/docs/release-notes/v1.2.0.md
@@ -6,6 +6,11 @@ As always, it's **off by default**, **local-only** (127.0.0.1), **token-protecte
 
 **Also in this release**
 
+- **Drag and drop** structures and sessions — `.pdb`, `.cif`, `.pse`, and more — straight onto the window to open them.
+- **Clear Session** added to the File menu.
+- **Website and GitHub links** in the About panel.
+- The "Claude is controlling RayMol" banner now stays on screen long enough to read.
+- New windows no longer duplicate the current one — RayMol runs as a single window for now (independent windows are on the way).
 - The connected-client indicator now clears correctly when a client disconnects (the Claude desktop app reports it the moment it quits; Claude Code clears on idle).
 - Internal cleanups and reliability fixes.
 

--- a/docs/release-notes/v1.2.0.md
+++ b/docs/release-notes/v1.2.0.md
@@ -1,0 +1,12 @@
+## RayMol 1.2.0
+
+**Drive RayMol from the Claude desktop app.** RayMol's built-in MCP server now works with the Claude Mac app — not just Claude Code. Open **Connect ▸ Connect an AI app…** and install it for Claude in one click.
+
+As always, it's **off by default**, **local-only** (127.0.0.1), **token-protected**, and **asks you to approve** each connection before it can drive the app — no API key needed, it uses your existing Claude.
+
+**Also in this release**
+
+- The connected-client indicator now clears correctly when a client disconnects (the Claude desktop app reports it the moment it quits; Claude Code clears on idle).
+- Internal cleanups and reliability fixes.
+
+Built on the open-source PyMOL engine. Updates install automatically via the in-app updater (**Check for Updates…** in the app menu).

--- a/docs/release-notes/v1.2.0.md
+++ b/docs/release-notes/v1.2.0.md
@@ -6,6 +6,9 @@ As always, it's **off by default**, **local-only** (127.0.0.1), **token-protecte
 
 **Also in this release**
 
+- **Grid mode** — view multiple structures side by side, each in its own cell. Toggle **Grid** in the Scene panel (or `set grid_mode, 1`); picking and selections work per cell. Sessions saved with grid mode now open as a grid.
+- **Global “all” controls** — a new row above the object list to Show / Hide / Label / Color or run actions (zoom, orient, deselect, hide everything, …) on everything at once.
+- Fixed Scene-panel toggles flickering or snapping back while rotating or reopening the panel — they now hold the state you set.
 - **Drag and drop** structures and sessions — `.pdb`, `.cif`, `.pse`, and more — straight onto the window to open them.
 - **Clear Session** added to the File menu.
 - **Website and GitHub links** in the About panel.

--- a/layer1/SceneRender.cpp
+++ b/layer1/SceneRender.cpp
@@ -1884,6 +1884,40 @@ static glm::mat4 SceneBuildLightViewProjEye(PyMOLGlobals* G)
  * render() methods dispatch CGO draws through CGORenderGL which
  * already routes VBOs to RendererMetal via drawVBOViaMetal().
  *========================================================================*/
+
+/**
+ * Point the Metal renderer's viewport + scissor at grid cell `slot` within the
+ * scene viewport rect `vp` (Metal top-left backing px), and set grid->slot /
+ * cur_viewport_size accordingly. Cell (col,row): col runs left→right, row 0 is
+ * at the TOP, matching the GL grid layout. Integer scaling on the cell
+ * boundaries avoids 1-px gaps between adjacent cells. Shared by the geometry
+ * pass (SceneRenderMetal) and the selection overlay (SceneRenderMetalSelections)
+ * so the per-cell math lives in exactly one place.
+ */
+static void SceneSetMetalGridCell(
+    PyMOLGlobals* G, GridInfo* grid, const Rect2D& vp, int slot)
+{
+  int abs_slot = slot - grid->first_slot; // 0-based
+  int col = abs_slot % grid->n_col;
+  int row = abs_slot / grid->n_col;
+  int vpX = vp.offset.x;
+  int vpY = vp.offset.y;
+  int vpW = static_cast<int>(vp.extent.width);
+  int vpH = static_cast<int>(vp.extent.height);
+  int x0 = vpX + (col * vpW) / grid->n_col;
+  int x1 = vpX + ((col + 1) * vpW) / grid->n_col;
+  int y0 = vpY + (row * vpH) / grid->n_row;
+  int y1 = vpY + ((row + 1) * vpH) / grid->n_row;
+  int cw = x1 - x0;
+  int ch = y1 - y0;
+  G->Renderer->viewport(x0, y0, cw, ch);
+  G->Renderer->enable(pymol::Capability::ScissorTest);
+  G->Renderer->scissor(x0, y0, cw, ch);
+  grid->slot = slot;
+  grid->cur_viewport_size = Extent2D{
+      static_cast<std::uint32_t>(cw), static_cast<std::uint32_t>(ch)};
+}
+
 void SceneRenderMetal(PyMOLGlobals* G)
 {
   if (!G->Renderer)
@@ -1925,6 +1959,23 @@ void SceneRenderMetal(PyMOLGlobals* G)
 
   // --- Matrix setup ---
   auto aspRat = SceneGetAspectRatio(G);
+
+  // Grid layout (grid_mode): compute the cell layout BEFORE the projection so
+  // the per-cell aspect ratio (aspRat *= asp_adjust) feeds both the projection
+  // matrix AND the post-process params (proj[0]/[5]). This mirrors the GL
+  // SceneRender path (which does the same aspRat *= grid.asp_adjust). All cells
+  // share one projection — only the viewport changes per slot — because every
+  // cell has identical dimensions (window / n_col x n_row).
+  auto grid_mode = SettingGet<GridMode>(G, cSetting_grid_mode);
+  if (grid_mode != GridMode::NoGrid) {
+    int grid_size = SceneGetGridSize(G, grid_mode);
+    GridUpdate(&I->grid, aspRat, grid_mode, grid_size);
+    if (I->grid.active)
+      aspRat *= I->grid.asp_adjust;
+  } else {
+    I->grid.active = false;
+  }
+
   SceneProjectionMatrix(
       G, I->m_view.m_clipSafe().m_front, I->m_view.m_clipSafe().m_back, aspRat);
   ScenePrepareMatrix(G, 0);
@@ -2013,15 +2064,6 @@ void SceneRenderMetal(PyMOLGlobals* G)
   auto scene_extent = SceneGetExtent(G);
   auto context = ScenePrepareUnitContext(scene_extent);
 
-  // Grid (usually inactive for simple scenes)
-  auto grid_mode = SettingGet<GridMode>(G, cSetting_grid_mode);
-  if (grid_mode != GridMode::NoGrid) {
-    int grid_size = SceneGetGridSize(G, grid_mode);
-    GridUpdate(&I->grid, aspRat, grid_mode, grid_size);
-  } else {
-    I->grid.active = false;
-  }
-
   // Transparency alpha CGO
   if (SettingGet<bool>(G, cSetting_transparency_global_sort) &&
       SettingGet<bool>(G, cSetting_transparency_mode)) {
@@ -2035,7 +2077,11 @@ void SceneRenderMetal(PyMOLGlobals* G)
   // into the depth map, so the post pass can PCF-sample real cast shadows. The
   // light VP is loaded as PROJECTION (camera MODELVIEW kept), the renderer
   // routes draws to depth-only pipelines, then restores the scene pass. ---
-  if (SettingGetGlobal_b(G, cSetting_metal_shadows)) {
+  // Skipped in grid mode: the shadow map is a single global texture, so it
+  // can't be made per-cell, and a shared map would leak shadows between cells
+  // (an object visible only in cell B darkening an object in cell A). Grid mode
+  // therefore renders unshadowed (geometry-only parity for now).
+  if (!I->grid.active && SettingGetGlobal_b(G, cSetting_metal_shadows)) {
     glm::mat4 lightVP_eye = SceneBuildLightViewProjEye(G);
     const float* mvp = SceneGetModelViewMatrixPtr(G);
     G->Renderer->setLightViewProjEye(glm::value_ptr(lightVP_eye));
@@ -2057,14 +2103,54 @@ void SceneRenderMetal(PyMOLGlobals* G)
   // --- Render objects: opaque first, then transparent via order-independent
   // transparency (weighted-blended). The transparent pass accumulates into the
   // OIT targets between begin/endTransparentOIT; endFrame resolves them. ---
-  for (auto pass : {RenderPass::Opaque, RenderPass::Antialias}) {
-    SceneRenderAll(G, &context, normal, nullptr, pass, false, 0.0f,
-        &I->grid, 0, SceneRenderWhich::All, SceneRenderOrder::GadgetsLast);
+  if (I->grid.active) {
+    // Grid mode: lay each slot's object(s) out in its own viewport cell.
+    // SceneRenderAll already filters objects by grid->slot (SceneGetDrawFlag),
+    // so we just set grid->slot + the cell viewport/scissor per iteration and
+    // replay the same passes. Scissor clips each cell so nothing bleeds across
+    // borders. Post-effects (SSAO/outline/OIT-resolve/FXAA) stay global — they
+    // run once over the whole frame in endFrame; minor seams at cell edges are
+    // acceptable for this geometry-first parity pass.
+    int vpX = 0, vpY = 0, vpW = I->Width, vpH = I->Height;
+    G->Renderer->getViewportRect(vpX, vpY, vpW, vpH);
+    Rect2D sceneVP{vpX, vpY, static_cast<std::uint32_t>(vpW),
+        static_cast<std::uint32_t>(vpH)};
+    I->grid.cur_view = sceneVP;
+
+    for (int slot = I->grid.first_slot; slot <= I->grid.last_slot; ++slot) {
+      SceneSetMetalGridCell(G, &I->grid, sceneVP, slot);
+      for (auto pass : {RenderPass::Opaque, RenderPass::Antialias}) {
+        SceneRenderAll(G, &context, normal, nullptr, pass, false, 0.0f,
+            &I->grid, 0, SceneRenderWhich::All, SceneRenderOrder::GadgetsLast);
+      }
+    }
+    // Transparent OIT wraps every cell: all cells accumulate into the
+    // full-frame OIT targets, resolved once in endFrame.
+    G->Renderer->beginTransparentOIT();
+    for (int slot = I->grid.first_slot; slot <= I->grid.last_slot; ++slot) {
+      SceneSetMetalGridCell(G, &I->grid, sceneVP, slot);
+      SceneRenderAll(G, &context, normal, nullptr, RenderPass::Transparent,
+          false, 0.0f, &I->grid, 0, SceneRenderWhich::All,
+          SceneRenderOrder::GadgetsLast);
+    }
+    G->Renderer->endTransparentOIT();
+
+    // Restore the full scene viewport and drop the scissor so the fullscreen
+    // post chain in endFrame (OIT resolve, SSAO, outline, FXAA) covers the
+    // whole frame instead of being clipped to the last cell.
+    G->Renderer->disable(pymol::Capability::ScissorTest);
+    G->Renderer->viewport(vpX, vpY, vpW, vpH);
+    I->grid.slot = 0;
+  } else {
+    for (auto pass : {RenderPass::Opaque, RenderPass::Antialias}) {
+      SceneRenderAll(G, &context, normal, nullptr, pass, false, 0.0f,
+          &I->grid, 0, SceneRenderWhich::All, SceneRenderOrder::GadgetsLast);
+    }
+    G->Renderer->beginTransparentOIT();
+    SceneRenderAll(G, &context, normal, nullptr, RenderPass::Transparent, false,
+        0.0f, &I->grid, 0, SceneRenderWhich::All, SceneRenderOrder::GadgetsLast);
+    G->Renderer->endTransparentOIT();
   }
-  G->Renderer->beginTransparentOIT();
-  SceneRenderAll(G, &context, normal, nullptr, RenderPass::Transparent, false,
-      0.0f, &I->grid, 0, SceneRenderWhich::All, SceneRenderOrder::GadgetsLast);
-  G->Renderer->endTransparentOIT();
 
   // --- Render selection indicators ---
   // Collect selected atom positions and draw them as pink points
@@ -2075,31 +2161,54 @@ void SceneRenderMetal(PyMOLGlobals* G)
     SceneRenderMetalSelections(G);
 }
 
+// Draw a batch of selection-indicator points (overlay, no depth test) at the
+// given world coordinates with the active theme's selection color.
+static void SceneDrawMetalSelectionPoints(
+    PyMOLGlobals* G, const std::vector<float>& coords)
+{
+  if (coords.empty())
+    return;
+  int nPoints = (int)(coords.size() / 3);
+  G->Renderer->disable(pymol::Capability::DepthTest);
+  G->Renderer->pointSize(12.0f); // Retina: need ~2x for visible size
+  G->Renderer->beginBatch(pymol::PrimitiveType::Points);
+  G->Renderer->batchColor4f(G->Renderer->selColor[0], G->Renderer->selColor[1],
+      G->Renderer->selColor[2], 1.0f);
+  for (int i = 0; i < nPoints; i++)
+    G->Renderer->batchVertex3f(coords[i * 3], coords[i * 3 + 1], coords[i * 3 + 2]);
+  G->Renderer->endBatch();
+  G->Renderer->enable(pymol::Capability::DepthTest);
+}
+
 void SceneRenderMetalSelections(PyMOLGlobals* G)
 {
   if (!G->Renderer || !G->Renderer->isRenderReady())
     return;
 
-  // Collect selected atom coordinates via Executive helper
+  CScene* I = G->Scene;
+
+  if (I->grid.active) {
+    // Grid mode: draw each cell's selection markers inside that cell's viewport.
+    // ExecutiveGetSelectionCoords filters by the current grid->slot (via
+    // SceneGetDrawFlagGrid), so per slot it returns only that cell object's
+    // selected atoms — projected with the same camera into the cell viewport.
+    int vpX = 0, vpY = 0, vpW = I->Width, vpH = I->Height;
+    G->Renderer->getViewportRect(vpX, vpY, vpW, vpH);
+    Rect2D sceneVP{vpX, vpY, static_cast<std::uint32_t>(vpW),
+        static_cast<std::uint32_t>(vpH)};
+    for (int slot = I->grid.first_slot; slot <= I->grid.last_slot; ++slot) {
+      SceneSetMetalGridCell(G, &I->grid, sceneVP, slot);
+      std::vector<float> coords;
+      ExecutiveGetSelectionCoords(G, coords);
+      SceneDrawMetalSelectionPoints(G, coords);
+    }
+    G->Renderer->disable(pymol::Capability::ScissorTest);
+    G->Renderer->viewport(vpX, vpY, vpW, vpH);
+    I->grid.slot = 0;
+    return;
+  }
+
   std::vector<float> coords;
   ExecutiveGetSelectionCoords(G, coords);
-
-  if (coords.empty())
-    return;
-
-  int nPoints = (int)(coords.size() / 3);
-
-  // Render selection indicators as squares (overlay, no depth test). Color is
-  // the active theme's selection color (Renderer::selColor; defaults to pink).
-  G->Renderer->disable(pymol::Capability::DepthTest);
-  G->Renderer->pointSize(12.0f);  // Retina: need ~2x for visible size
-
-  G->Renderer->beginBatch(pymol::PrimitiveType::Points);
-  G->Renderer->batchColor4f(G->Renderer->selColor[0], G->Renderer->selColor[1],
-                            G->Renderer->selColor[2], 1.0f);
-  for (int i = 0; i < nPoints; i++)
-    G->Renderer->batchVertex3f(coords[i*3], coords[i*3+1], coords[i*3+2]);
-  G->Renderer->endBatch();
-
-  G->Renderer->enable(pymol::Capability::DepthTest);
+  SceneDrawMetalSelectionPoints(G, coords);
 }

--- a/layer3/Executive.cpp
+++ b/layer3/Executive.cpp
@@ -8616,6 +8616,12 @@ void ExecutiveGetSelectionCoords(PyMOLGlobals* G, std::vector<float>& coords)
       if (rec1.type != cExecObject || rec1.obj->type != cObjectMolecule)
         continue;
 
+      // In grid mode, only collect coords for objects belonging to the cell
+      // currently being rendered (G->Scene->grid.slot). When grid is inactive
+      // this returns true for every object, so the non-grid path is unchanged.
+      if (!SceneGetDrawFlagGrid(G, &G->Scene->grid, rec1.obj->grid_slot))
+        continue;
+
       auto* obj = static_cast<ObjectMolecule*>(rec1.obj);
       int curState = obj->getCurrentState();
       if (curState < 0) curState = 0;

--- a/layerGraphics/Renderer.h
+++ b/layerGraphics/Renderer.h
@@ -68,6 +68,14 @@ public:
 
   // Viewport and clear
   virtual void viewport(int x, int y, int w, int h) = 0;
+  // Reports the renderer's current viewport rect (the one last set by
+  // viewport()). SceneRenderMetal needs this to subdivide the scene viewport
+  // into grid_mode cells. Default: report nothing (GL path reads GL_VIEWPORT
+  // itself). Returns true if x/y/w/h were filled.
+  virtual bool getViewportRect(int& x, int& y, int& w, int& h) const
+  {
+    return false;
+  }
   virtual void clear(bool color, bool depth, bool stencil) = 0;
   virtual void clearColor(float r, float g, float b, float a) = 0;
   virtual void scissor(int x, int y, int w, int h) = 0;

--- a/layerGraphics/metal/RendererMetal.h
+++ b/layerGraphics/metal/RendererMetal.h
@@ -36,6 +36,7 @@ public:
 
   // Viewport and clear
   void viewport(int x, int y, int w, int h) override;
+  bool getViewportRect(int& x, int& y, int& w, int& h) const override;
   void clear(bool color, bool depth, bool stencil) override;
   void clearColor(float r, float g, float b, float a) override;
   void scissor(int x, int y, int w, int h) override;

--- a/layerGraphics/metal/RendererMetal.mm
+++ b/layerGraphics/metal/RendererMetal.mm
@@ -1959,6 +1959,15 @@ void RendererMetal::viewport(int x, int y, int w, int h)
   }
 }
 
+bool RendererMetal::getViewportRect(int& x, int& y, int& w, int& h) const
+{
+  x = static_cast<int>(_viewport.originX);
+  y = static_cast<int>(_viewport.originY);
+  w = static_cast<int>(_viewport.width);
+  h = static_cast<int>(_viewport.height);
+  return true;
+}
+
 void RendererMetal::clear(bool color, bool depth, bool stencil)
 {
   // In Metal, clears happen via the render pass descriptor's load actions.

--- a/modules/pymol/appkit_inspector.py
+++ b/modules/pymol/appkit_inspector.py
@@ -43,7 +43,7 @@ REP_COLOR = {
 SCENE_SETTINGS = ['metal_raytrace', 'metal_rt_shadows', 'metal_shadows', 'metal_ssao',
                   'metal_outline', 'metal_msaa', 'metal_tonemap', 'metal_exposure',
                   'depth_cue', 'fog', 'field_of_view', 'surface_quality',
-                  'all_states', 'mouse_selection_mode',
+                  'grid_mode', 'all_states', 'mouse_selection_mode',
                   'ambient', 'direct', 'reflect', 'specular', 'shininess',
                   'ray_opaque_background']
 

--- a/modules/pymol/metal_pick.py
+++ b/modules/pymol/metal_pick.py
@@ -67,6 +67,77 @@ def _pickdbg(ndc_x, ndc_y, aspect, best, ncand):
         pass
 
 
+def _grid_layout(size, aspect):
+    """Choose (n_col, n_row) for `size` grid cells at window aspect (W/H).
+    Mirrors the C++ GridUpdate (layer1/Scene.cpp) exactly so picking agrees with
+    what the Metal renderer drew."""
+    if size < 1:
+        return (1, 1)
+    n_row = n_col = 1
+    while (n_row * n_col) < size:
+        asp1 = aspect * (n_row + 1.0) / n_col
+        asp2 = aspect * n_row / (n_col + 1.0)
+        if asp1 < 1.0:
+            asp1 = 1.0 / asp1
+        if asp2 < 1.0:
+            asp2 = 1.0 / asp2
+        if abs(asp1) > abs(asp2):
+            n_col += 1
+        else:
+            n_row += 1
+    while (n_col - 1) * n_row >= size and size:
+        n_col -= 1
+    while (n_row - 1) * n_col >= size and size:
+        n_row -= 1
+    return (n_col, n_row)
+
+
+def _grid_pick_context(ndc_x, ndc_y, aspect):
+    """When grid_mode=1 (by-object) is active with 2+ objects, map a full-window
+    click NDC to its grid cell and return
+    (target_obj, cell_ndc_x, cell_ndc_y, cell_aspect):
+      - target_obj: the object laid out in the clicked cell ('' if none).
+      - cell_ndc_x/y: the click re-expressed in that cell's NDC.
+      - cell_aspect: that cell's aspect (window_aspect * n_row/n_col).
+    Returns None when grid isn't cell-mapped (caller projects the whole window).
+
+    The slot→object mapping mirrors the core: grid-eligible enabled objects take
+    slots in scene order, cell layout is GridUpdate, cells run col left→right and
+    row 0 at the TOP. (By-object only; grid_mode 2/3 fall through to whole-window
+    picking, and disabled-object/group gaps aren't modeled — the common case is
+    all-enabled objects.)"""
+    from pymol import cmd
+    try:
+        if int(cmd.get_setting_int('grid_mode')) != 1:
+            return None
+    except Exception:
+        return None
+    objs = [o for o in (cmd.get_names('objects', enabled_only=1) or [])
+            if not o.startswith('_')]
+    size = len(objs)
+    try:
+        grid_max = int(cmd.get_setting_int('grid_max'))
+    except Exception:
+        grid_max = -1
+    if grid_max >= 0:
+        size = min(size, grid_max)
+    if size < 2 or aspect <= 0.0:
+        return None
+    n_col, n_row = _grid_layout(size, aspect)
+    if n_col < 1 or n_row < 1:
+        return None
+    u = (ndc_x + 1.0) * 0.5 * n_col        # [0, n_col), x: +1 = right
+    t = (1.0 - ndc_y) * 0.5 * n_row        # [0, n_row), 0 = top row
+    col = min(max(int(u), 0), n_col - 1)
+    row = min(max(int(t), 0), n_row - 1)
+    slot = row * n_col + col               # 0-based, matches abs_grid_slot
+    cell_ndc_x = (u - col) * 2.0 - 1.0
+    cell_ndc_y = 1.0 - (t - row) * 2.0
+    cell_aspect = aspect * (float(n_row) / float(n_col))
+    target = objs[slot] if 0 <= slot < len(objs) else ''
+    return (target, cell_ndc_x, cell_ndc_y, cell_aspect)
+
+
 def _pick_atom(ndc_x, ndc_y, aspect):
     """Project all DRAWN atoms and return the front-most atom under the click as
     (screen_d2, obj, chain, resi, resn, segi, name, sx, sy), or None for empty
@@ -115,12 +186,27 @@ def _pick_atom(ndc_x, ndc_y, aspect):
         if tan_half <= 0.0:
             return
 
+        # Grid mode (by-object): the renderer draws each object in its own
+        # viewport cell, so a full-window projection wouldn't line up with what
+        # the user sees. Map the click to its cell, restrict the search to that
+        # cell's object, and project with the cell's NDC + aspect. tan_half is
+        # aspect-independent (FOV only), so reassigning `aspect` below is safe.
+        pick_objs = None
+        gctx = _grid_pick_context(ndc_x, ndc_y, aspect)
+        if gctx is not None:
+            target_obj, ndc_x, ndc_y, aspect = gctx
+            if not target_obj:
+                return None  # empty cell → treat as empty-space click
+            pick_objs = [target_obj]
+
         best = None  # (screen_d2, obj, chain, resi, resn, segi, name, sx, sy)
         cands = []   # (d2, depth, obj, chain, resi, resn, segi, name, sx, sy)
         ncand = 0    # atoms whose projection fell within the pick radius
         _ext = [1e9, -1e9, 1e9, -1e9]  # projected-NDC extent: sx_min,sx_max,sy_min,sy_max
 
-        for obj in (cmd.get_names('objects', enabled_only=1) or []):
+        if pick_objs is None:
+            pick_objs = (cmd.get_names('objects', enabled_only=1) or [])
+        for obj in pick_objs:
             if obj.startswith('_'):
                 continue
             # Skip non-molecule objects (distance/angle measurements, maps, CGOs,

--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -113,7 +113,7 @@
 		F2078076B68D28457409F7A5 /* RayMol.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RayMol.entitlements; sourceTree = "<group>"; };
 		F607D204A410CA38B84223BE /* RayMolUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RayMolUpdater.swift; sourceTree = "<group>"; };
 		FB1304C662D9011F7C4505FC /* MCPStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPStatusView.swift; sourceTree = "<group>"; };
-		"TEMP_5002B105-2B8E-4D61-8547-43F4466B8862" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
+		"TEMP_5CD9B1A3-3A99-4D7F-81D8-BAABA047A399" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -225,10 +225,10 @@
 			path = Bridge;
 			sourceTree = "<group>";
 		};
-		"TEMP_B15D54CB-8CE4-471F-87BB-0E95DACC381C" /* swiftui */ = {
+		"TEMP_6C17689C-9A96-4B72-A478-1AEE7393F5DD" /* swiftui */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_5002B105-2B8E-4D61-8547-43F4466B8862" /* PyMOLBridge.xcconfig */,
+				"TEMP_5CD9B1A3-3A99-4D7F-81D8-BAABA047A399" /* PyMOLBridge.xcconfig */,
 			);
 			path = swiftui;
 			sourceTree = "<group>";
@@ -806,7 +806,7 @@
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -820,7 +820,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.2.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -836,7 +836,7 @@
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -850,7 +850,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.2.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -867,7 +867,7 @@
 				CODE_SIGN_ENTITLEMENTS = PyMOLViewer/RayMol.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = VT99UQUQ89;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -883,7 +883,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.2.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -920,7 +920,7 @@
 				CODE_SIGN_ENTITLEMENTS = PyMOLViewer/RayMol.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = VT99UQUQ89;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -936,7 +936,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.2.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -948,7 +948,7 @@
 		};
 		76B7E9DB75E073D1E60928FA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_5002B105-2B8E-4D61-8547-43F4466B8862" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_5CD9B1A3-3A99-4D7F-81D8-BAABA047A399" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1033,7 +1033,7 @@
 		};
 		D8F44FDFF036013D2F03BA83 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_5002B105-2B8E-4D61-8547-43F4466B8862" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_5CD9B1A3-3A99-4D7F-81D8-BAABA047A399" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -181,6 +181,10 @@ enum SceneCatalog {
         SceneParam(setting: "metal_tonemap", label: "Filmic tone-map", kind: .toggle, group: "Lighting & Quality"),
         SceneParam(setting: "metal_exposure", label: "Exposure", kind: .slider, min: 0.2, max: 2.0, step: 0.05, decimals: 2, group: "Lighting & Quality"),
         SceneParam(setting: "depth_cue",     label: "Depth cue / fog", kind: .toggle, group: "Lighting & Quality"),
+        // grid_mode is an int (0=off, 1=by object, 2=by state); the toggle maps
+        // off→0 / on→1 and reads on for any non-zero mode. Lays each object out
+        // in its own viewport cell (Metal grid support added in 1.2.0).
+        SceneParam(setting: "grid_mode",     label: "Grid", kind: .toggle, group: "Lighting & Quality"),
         SceneParam(setting: "all_states",    label: "Overlay all states", kind: .toggle, group: "Lighting & Quality"),
         // Lighting (made real-time on Metal in Phase 3; tunable here in Phase 2).
         SceneParam(setting: "ambient",   label: "Ambient",  kind: .slider, min: 0, max: 1, step: 0.01, decimals: 2, group: "Lighting & Quality"),
@@ -491,10 +495,46 @@ private func runActionCommand(_ key: String, name: String, engine: PyMOLEngine) 
         return
     case "copy":               cmd = "copy \(n)_copy, \(n)"
     case "delete":             cmd = "delete \(n)"
+    // Global ("all" row) actions
+    case "deselect":           cmd = "deselect"
+    case "hide_everything":    cmd = "hide everything, \(n)"
+    case "reset_view":         cmd = "reset"
     default:                   return
     }
     engine.runCommand(cmd)
 }
+
+/// Action ("A") menu for the global "all" row — a focused, scene-wide subset.
+/// Reuses the per-object action keys (all valid with name "all"); deliberately
+/// omits per-object items (Rename / Duplicate / Delete) and adds global ones
+/// (Deselect, Hide everything, Reset camera).
+private let allActionMenuItems: [ActionMenuItem] = [
+    .action(label: "Zoom",          key: "zoom"),
+    .action(label: "Orient",        key: "orient"),
+    .action(label: "Center",        key: "center"),
+    .action(label: "Reset camera",  key: "reset_view"),
+    .separator,
+    .action(label: "Deselect",      key: "deselect"),
+    .action(label: "Hide everything", key: "hide_everything"),
+    .separator,
+    .action(label: "Assign Sec. Struc.", key: "dss"),
+    .action(label: "Remove Waters",      key: "remove_waters"),
+    .submenu(label: "Hydrogens", children: [
+        .action(label: "add",        key: "h_add"),
+        .action(label: "add polar",  key: "h_add_polar"),
+        .action(label: "remove",     key: "h_remove"),
+    ]),
+    .submenu(label: "Find", children: [
+        .action(label: "polar contacts (any)", key: "find_polar_any"),
+        .action(label: "salt bridges",         key: "find_salt_bridge"),
+    ]),
+    .submenu(label: "Preset", children: [
+        .action(label: "pretty",         key: "preset_pretty"),
+        .action(label: "technical",      key: "preset_technical"),
+        .action(label: "ball and stick", key: "preset_ball_and_stick"),
+        .action(label: "default",        key: "preset_default"),
+    ]),
+]
 
 // MARK: - Theme
 
@@ -584,6 +624,9 @@ struct ObjectPanel: View {
 
                     // Objects section — each is an expandable inspector card
                     if !objects.isEmpty {
+                        // Global "all" controls (A/S/H/L/C on the whole scene),
+                        // pinned above the per-object cards.
+                        AllControlsRow()
                         ForEach(Array(objects.enumerated()), id: \.element.id) { index, obj in
                             ObjectCard(entry: obj, isAlt: index % 2 == 1)
                         }
@@ -720,6 +763,49 @@ private struct ObjectRowView: View {
         } else {
             engine.runCommand("enable \(entry.name)")
         }
+    }
+}
+
+// MARK: - Global "all" controls row
+
+/// Pinned row above the object list giving the same A/S/H/L/C controls as an
+/// object row but acting on the whole scene (selection "all") — mirrors desktop
+/// PyMOL's "all" row for quick global Show/Hide/Label/Color and scene actions.
+/// Show/Hide/Label/Color reuse the per-object menus with name "all"; the Action
+/// (A) menu uses the global subset `allActionMenuItems`.
+private struct AllControlsRow: View {
+    @EnvironmentObject var engine: PyMOLEngine
+
+    var body: some View {
+        HStack(spacing: 2) {
+            // No enable checkbox — "all" is a selection, not a toggleable object.
+            Spacer().frame(width: kGutterW)
+            Text("all")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(PanelTheme.textColor)
+                .lineLimit(1)
+            Spacer(minLength: 4)
+            Menu {
+                actionMenuContent(allActionMenuItems, name: "all", engine: engine)
+            } label: {
+                Text("A")
+                    .frame(width: kActBtnW, height: kActBtnH)
+                    .background(PanelTheme.buttonBackground)
+                    .cornerRadius(2)
+                    .contentShape(Rectangle())
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            ShowButton(name: "all")
+            HideButton(name: "all")
+            LabelMenuButton(name: "all")
+            ColorMenuButton(name: "all")
+        }
+        .padding(.horizontal, 4)
+        .padding(.vertical, 2)
+        .frame(height: kRowH)
+        .background(PanelTheme.rowBackground)
+        .contextMenu { actionMenuContent(allActionMenuItems, name: "all", engine: engine) }
     }
 }
 
@@ -1094,12 +1180,28 @@ private struct SegmentedSetting: View {
 private struct ToggleSetting: View {
     let value: Double
     let onToggle: (Bool) -> Void
+    // Optimistic local state. Previously the switch derived its position directly
+    // from `value` (a ~500ms-lagged poll) on EVERY re-render, so it flickered /
+    // snapped back: opening the panel, a rotation-driven refresh, or the gap
+    // between a tap and the next poll would re-render with the stale value and
+    // flip the switch (and its tint) back. Driving the switch from local @State
+    // that changes ONLY on a user flip or a genuine polled-value change makes a
+    // re-render with an unchanged value a no-op for the switch.
+    @State private var isOn = false
     var body: some View {
-        Toggle("", isOn: Binding(get: { value > 0.5 }, set: { onToggle($0) }))
+        Toggle("", isOn: $isOn)
             .labelsHidden()
             .toggleStyle(.switch)
             .controlSize(.mini)
             .tint(PanelTheme.selectionTextColor)
+            .onAppear { isOn = value > 0.5 }
+            .onChange(of: value) { v in
+                let want = v > 0.5
+                if want != isOn { isOn = want }          // adopt real external changes
+            }
+            .onChange(of: isOn) { on in
+                if on != (value > 0.5) { onToggle(on) }   // user flip → push once
+            }
     }
 }
 

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -43,6 +43,7 @@ enum RayMolBuild {
 extension Notification.Name {
     static let raymolOpenFile     = Notification.Name("raymol.menu.openFile")
     static let raymolFetch        = Notification.Name("raymol.menu.fetch")
+    static let raymolClearSession = Notification.Name("raymol.menu.clearSession")
     static let raymolSaveSession  = Notification.Name("raymol.menu.saveSession")
     static let raymolExportImage  = Notification.Name("raymol.menu.exportImage")
     static let mcpOpenConnectSheet = Notification.Name("raymol.mcp.openConnectSheet")
@@ -71,6 +72,8 @@ struct ContentView: View {
     // NSOpenPanel directly, so it needs no presentation state).
     @State private var showMacFetch = false
     @State private var macFetchID = ""
+    // Drag-and-drop: true while a file is hovered over the viewport (draws a border).
+    @State private var isViewportDropTargeted = false
     #endif
     #if os(macOS) && !RAYMOL_MAS_RESTRICTED
     @EnvironmentObject private var mcpManager: MCPServerManager
@@ -240,6 +243,19 @@ struct ContentView: View {
                 }
                 // Empty-state CTA when nothing is loaded (mirrors the iOS overlay).
                 .overlay { if engine.objects.isEmpty && !showThemeStudio { macEmptyState } }
+                // Drag a .pdb/.cif/.pse/etc. onto the viewport to load it (same
+                // path as File ▸ Open / Finder "Open With"). Highlight while hovered.
+                .onDrop(of: [.fileURL], isTargeted: $isViewportDropTargeted) { providers in
+                    handleViewportDrop(providers)
+                }
+                .overlay {
+                    if isViewportDropTargeted {
+                        RoundedRectangle(cornerRadius: 6)
+                            .strokeBorder(themeManager.active.tabTint.color, lineWidth: 3)
+                            .padding(2)
+                            .allowsHitTesting(false)
+                    }
+                }
             }
 
             // Right column: objects + (chat). Only exists (and only occupies its
@@ -287,6 +303,7 @@ struct ContentView: View {
         // Native File-menu commands → reuse the same actions as the toolbar.
         .onReceive(NotificationCenter.default.publisher(for: .raymolOpenFile)) { _ in macOpenFile() }
         .onReceive(NotificationCenter.default.publisher(for: .raymolFetch)) { _ in macFetchID = ""; showMacFetch = true }
+        .onReceive(NotificationCenter.default.publisher(for: .raymolClearSession)) { _ in engine.clearSession() }
         .onReceive(NotificationCenter.default.publisher(for: .raymolSaveSession)) { _ in saveSession() }
         .onReceive(NotificationCenter.default.publisher(for: .raymolExportImage)) { _ in saveImage(size: exportSize(scale: 2)) }
         #if !RAYMOL_MAS_RESTRICTED
@@ -345,6 +362,22 @@ struct ContentView: View {
                     "xyz", "pdbqt", "pqr", "mae", "pse", "ccp4", "mrc", "map",
                     "dx", "mtz", "fasta", "pir"]
         return exts.compactMap { UTType(filenameExtension: $0) } + [.data]
+    }
+
+    // Drag-and-drop: load each dropped file URL through the same path as the Open
+    // menu / Finder "Open With" — loadOpenedFile handles security scope, temp copy,
+    // name sanitizing, and engine-not-ready retry. A dropped .pse restores a session.
+    private func handleViewportDrop(_ providers: [NSItemProvider]) -> Bool {
+        let engine = self.engine
+        var accepted = false
+        for provider in providers where provider.canLoadObject(ofClass: URL.self) {
+            accepted = true
+            _ = provider.loadObject(ofClass: URL.self) { url, _ in
+                guard let url, url.isFileURL else { return }
+                Task { @MainActor in loadOpenedFile(url, into: engine) }
+            }
+        }
+        return accepted
     }
 
     // Open a molecule/session via NSOpenPanel and load it. PyMOL infers the format

--- a/swiftui/PyMOLViewer/Shared/MCPServerManager.swift
+++ b/swiftui/PyMOLViewer/Shared/MCPServerManager.swift
@@ -18,6 +18,14 @@ final class MCPServerManager: ObservableObject {
     private let preferredPort = 51737
     private weak var engine: PyMOLEngine?
     private var pulseWork: DispatchWorkItem?
+    // When the "Claude is controlling RayMol" banner first appeared in the current
+    // burst of tool activity — used to keep it on screen long enough to read even
+    // when a tool call finishes almost instantly (see scheduleClearBanner).
+    private var activeToolShownAt: Date?
+    // Minimum on-screen time from first appearance, plus a short trailing linger
+    // after the last tool call ends, so quick actions don't flash past.
+    private let bannerMinVisible: TimeInterval = 2.5
+    private let bannerTrailingLinger: TimeInterval = 1.0
     private var trustedThisSession = false
     private var userInitiatedConnectAt: Date?
 
@@ -112,10 +120,13 @@ final class MCPServerManager: ObservableObject {
         case "action":
             lastAction = detail
             logLine(detail)
+            if !activeTool { activeToolShownAt = Date() }
             activeTool = true
-            pulse()
+            // A tool call is in progress — keep the banner up and re-arm the
+            // backstop in case the matching "actionend" never arrives.
+            scheduleBannerBackstop()
         case "actionend":
-            activeTool = false
+            scheduleClearBanner()
         default:
             break
         }
@@ -126,13 +137,30 @@ final class MCPServerManager: ObservableObject {
         if activityLog.count > 200 { activityLog.removeFirst(activityLog.count - 200) }
     }
 
-    // Hold activeTool true briefly so the pulse is visible; a backstop in case an
-    // actionend line is ever missed.
-    private func pulse() {
+    // Backstop: if an "actionend" is ever missed, clear the banner a few seconds
+    // after the last "action". Re-armed on every "action".
+    private func scheduleBannerBackstop() {
         pulseWork?.cancel()
-        let w = DispatchWorkItem { [weak self] in self?.activeTool = false }
+        let w = DispatchWorkItem { [weak self] in self?.clearActiveTool() }
         pulseWork = w
         DispatchQueue.main.asyncAfter(deadline: .now() + 5, execute: w)
+    }
+
+    // On "actionend", keep the banner visible until it's been shown at least
+    // bannerMinVisible (so an instant tool call doesn't just flash) and at least
+    // bannerTrailingLinger past the last action (so it doesn't vanish mid-glance).
+    private func scheduleClearBanner() {
+        pulseWork?.cancel()
+        let shown = activeToolShownAt.map { Date().timeIntervalSince($0) } ?? bannerMinVisible
+        let remaining = max(bannerMinVisible - shown, bannerTrailingLinger)
+        let w = DispatchWorkItem { [weak self] in self?.clearActiveTool() }
+        pulseWork = w
+        DispatchQueue.main.asyncAfter(deadline: .now() + remaining, execute: w)
+    }
+
+    private func clearActiveTool() {
+        activeTool = false
+        activeToolShownAt = nil
     }
 
     // MARK: Connect (Claude Code)

--- a/swiftui/PyMOLViewer/Shared/PyMOLApp.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLApp.swift
@@ -45,8 +45,25 @@ struct PyMOLApp: App {
     }
 
     var body: some Scene {
-        WindowGroup {
-            ContentView()
+        #if os(macOS)
+        // Single, unique window (`Window`, not `WindowGroup`): RayMol's engine is
+        // one shared PyMOL session, so a second window would only duplicate the
+        // same view and stay in sync. `Window` drops the "New Window" command and
+        // re-focuses the existing window instead. Per-window sessions: issue #29.
+        Window("RayMol", id: "raymol-main") { rootView }
+            .windowStyle(.titleBar)
+            .defaultSize(width: 1200, height: 800)
+            .commands { macCommands }
+        #else
+        WindowGroup { rootView }
+        #endif
+    }
+
+    // Content of the single window, shared by the macOS `Window` and iOS
+    // `WindowGroup`: engine/theme injection, OS file-open, and the iOS
+    // orientation + scene-phase hooks.
+    @ViewBuilder private var rootView: some View {
+        ContentView()
                 .environmentObject(engine)
                 .environmentObject(engine.playback)
                 .environmentObject(ThemeManager.shared)
@@ -99,13 +116,17 @@ struct PyMOLApp: App {
                 }
             #endif
         }
-        #if os(macOS)
-        .windowStyle(.titleBar)
-        .defaultSize(width: 1200, height: 800)
-        // Native File menu: Open / Fetch / Save Session / Export Image, with
-        // standard shortcuts. Buttons post notifications that ContentView's macOS
-        // layout handles (reusing the toolbar's open/save/export logic).
-        .commands {
+    #if os(macOS)
+    // Native menus (macOS only). File: Open / Fetch / Save / Export. App menu:
+    // website + GitHub links, plus Check for Updates on the Developer-ID build.
+    // Connect: MCP server control. Buttons post notifications ContentView's macOS
+    // layout observes (reusing the toolbar's open/save/export logic).
+    @CommandsBuilder private var macCommands: some Commands {
+            // Custom About panel: standard panel with clickable website + GitHub
+            // links in the credits (replaces the default About menu item).
+            CommandGroup(replacing: .appInfo) {
+                Button("About RayMol") { showAboutPanel() }
+            }
             #if os(macOS) && !RAYMOL_MAS_RESTRICTED
             // Sparkle auto-update (Developer-ID/DMG build only; the Mac App Store
             // build updates through Apple). Placed in the app menu next to About.
@@ -127,6 +148,10 @@ struct PyMOLApp: App {
                 Button("Export Image…") {
                     NotificationCenter.default.post(name: .raymolExportImage, object: nil)
                 }.keyboardShortcut("e", modifiers: [.command, .shift])
+                Divider()
+                Button("Clear Session") {
+                    NotificationCenter.default.post(name: .raymolClearSession, object: nil)
+                }
             }
             #if os(macOS) && !RAYMOL_MAS_RESTRICTED
             CommandMenu("Connect") {
@@ -154,8 +179,30 @@ struct PyMOLApp: App {
             }
             #endif
         }
-        #endif
+
+    // Standard About panel with clickable website + GitHub links in the credits.
+    private func showAboutPanel() {
+        let para = NSMutableParagraphStyle()
+        para.alignment = .center
+        let base: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 11),
+            .foregroundColor: NSColor.secondaryLabelColor,
+            .paragraphStyle: para,
+        ]
+        func link(_ text: String, _ urlString: String) -> NSAttributedString {
+            var attrs = base
+            if let url = URL(string: urlString) { attrs[.link] = url }
+            return NSAttributedString(string: text, attributes: attrs)
+        }
+        let credits = NSMutableAttributedString(
+            string: "Molecular visualization built on the open-source PyMOL engine.\n\n",
+            attributes: base)
+        credits.append(link("raymol.io", "https://raymol.io"))
+        credits.append(NSAttributedString(string: "      ·      ", attributes: base))
+        credits.append(link("GitHub", "https://github.com/javierbq/RayMol"))
+        NSApplication.shared.orderFrontStandardAboutPanel(options: [.credits: credits])
     }
+    #endif
 
     #if os(iOS)
     private static func forceOrientationIfRequested() {
@@ -183,7 +230,7 @@ struct PyMOLApp: App {
 // inbox), so copy it into the temp dir before handing the path to PyMOL, which
 // infers the format from the extension. The object name is the sanitized stem.
 @MainActor
-private func loadOpenedFile(_ url: URL, into engine: PyMOLEngine, attempt: Int = 0) {
+func loadOpenedFile(_ url: URL, into engine: PyMOLEngine, attempt: Int = 0) {
     guard engine.isReady else {
         guard attempt < 40 else { return }   // ~10s cap (40 × 250ms)
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -737,17 +737,10 @@ final class PyMOLEngine: ObservableObject {
     private func handleSessionViewport(for command: String) {
         let lower = command.lowercased()
         if lower.contains(".pse"), let path = sessionPath(from: command) {
-            // grid_mode (objects laid out in side-by-side cells) is not yet
-            // supported by the Metal renderer — it renders a single viewport, so a
-            // grid session would show NOTHING (only the selection overlay, which
-            // ignores grid). Reset it so the session renders (objects overlaid)
-            // and tell the user. See GitHub issue: grid-mode Metal support.
-            runPython(
-                "from pymol import cmd as _g\n"
-                + "if int(_g.get('grid_mode') or 0):\n"
-                + "    _g.set('grid_mode', 0)\n"
-                + "    print('RayMol: grid_mode is not supported yet — disabled so the "
-                + "session renders (objects overlaid).')\n")
+            // grid_mode (objects laid out in side-by-side cells) is now rendered
+            // natively by the Metal renderer (per-slot viewport loop in
+            // SceneRenderMetal), so the session keeps whatever grid_mode it saved
+            // — no reset needed. See GitHub issue: grid-mode Metal support.
             // Read the session's 'main' [W,H] (→ letterbox via SESSIONVP) AND fix
             // the camera: modern .pse files store a 25-float SceneViewType, but
             // our embedded core is 18-float and mis-restores it (front/back

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -867,6 +867,17 @@ final class PyMOLEngine: ObservableObject {
         runPython("from pymol import raymol_theme as _rt; _rt.apply_to('\(clean)')")
     }
 
+    /// Clear the whole session (File ▸ Clear Session): wipe all objects, selections,
+    /// and camera via `reinitialize`, then re-apply RayMol's theme defaults
+    /// (bg/palette/render toggles) so the empty viewport keeps the app's look
+    /// instead of PyMOL's bare defaults. The objects panel refreshes on the next
+    /// poll tick.
+    func clearSession() {
+        guard isReady else { return }
+        runCommand("reinitialize")
+        applyTheme(ThemeManager.shared.active)
+    }
+
     // MARK: - Theme studio live preview
     //
     // While the Theme studio is open we snapshot the full session in memory and

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -875,6 +875,11 @@ final class PyMOLEngine: ObservableObject {
     func clearSession() {
         guard isReady else { return }
         runCommand("reinitialize")
+        // reinitialize also resets engine settings to defaults — restore the
+        // fetch_path that initialize() set (the writable temp dir) so a post-clear
+        // `fetch` doesn't fall back to cwd (which can fail or prompt for file
+        // access), then re-apply the RayMol theme.
+        runPython("from pymol import cmd as _c; _c.set('fetch_path', '\(NSTemporaryDirectory())')")
         applyTheme(ThemeManager.shared.active)
     }
 

--- a/swiftui/project.yml
+++ b/swiftui/project.yml
@@ -52,8 +52,8 @@ targets:
         PRODUCT_NAME: RayMol
         PRODUCT_BUNDLE_IDENTIFIER: io.raymol.RayMol
         INFOPLIST_GENERATION_MODE: GeneratedFile
-        MARKETING_VERSION: "1.1.0"
-        CURRENT_PROJECT_VERSION: 5
+        MARKETING_VERSION: "1.2.0"
+        CURRENT_PROJECT_VERSION: 6
         GENERATE_INFOPLIST_FILE: YES
         # Generate a launch screen so iOS renders at the device's NATIVE
         # resolution. Without it the app is letterboxed at a legacy size on

--- a/swiftui/publish_release.sh
+++ b/swiftui/publish_release.sh
@@ -65,9 +65,14 @@ echo "== Publish GitHub release v$VERSION =="
 if gh release view "v$VERSION" -R "$REPO" >/dev/null 2>&1; then
   gh release upload "v$VERSION" "$DMG" "$APPCAST" -R "$REPO" --clobber
 else
-  gh release create "v$VERSION" "$DMG" "$APPCAST" -R "$REPO" \
-    --title "RayMol $VERSION" \
-    --notes "Automatic updates are here. RayMol now checks for new versions and installs them with one click — no more manual DMG downloads. Built on the open-source PyMOL engine."
+  if [ -n "${NOTES_FILE:-}" ]; then
+    gh release create "v$VERSION" "$DMG" "$APPCAST" -R "$REPO" \
+      --title "RayMol $VERSION" --notes-file "$NOTES_FILE"
+  else
+    gh release create "v$VERSION" "$DMG" "$APPCAST" -R "$REPO" \
+      --title "RayMol $VERSION" \
+      --notes "${NOTES:-Automatic updates are here. RayMol now checks for new versions and installs them with one click — no more manual DMG downloads. Built on the open-source PyMOL engine.}"
+  fi
 fi
 
 echo "DONE → https://github.com/$REPO/releases/tag/v$VERSION"


### PR DESCRIPTION
Release 1.2.0 for the macOS Developer-ID (Sparkle) build.

## Version
- `MARKETING_VERSION` 1.2.0, `CURRENT_PROJECT_VERSION` 6 (pbxproj regenerated).

## macOS features / fixes
- **Single window** — macOS now uses the singleton `Window` scene instead of `WindowGroup`, so "New Window" no longer duplicates the single shared PyMOL session into a second, synced window. iOS keeps `WindowGroup`. True per-window sessions tracked in #29.
- **Clear Session** — File menu item; `reinitialize` + re-apply theme + restore `fetch_path`.
- **About panel** — clickable raymol.io + GitHub links in the credits.
- **Drag-and-drop** — drop `.pdb`/`.cif`/`.pse`/etc. onto the viewport to load it (reuses the Open / "Open With" path).
- **MCP "driving" banner** — stays on screen long enough to read (was clearing the instant a fast tool call ended).

## Docs
- Support page rewritten (MCP/Claude, stale Raymond text dropped); `docs/release-notes/v1.2.0.md`; `publish_release.sh` parameterized via `NOTES_FILE`.

## Verification
- macOS Developer-ID build: **BUILD SUCCEEDED** (0 errors/warnings in changed files).
- macOS Mac App Store build (`RAYMOL_MAS_RESTRICTED`): **BUILD SUCCEEDED**.
- Fresh-eyes code review: **SHIP**, no Critical/compile-blocking issues.
- Not built here: iOS (the change is macOS-gated; the iOS path is the unchanged content relocated into `rootView`). Verify on next iOS build.

## Manual checks suggested before publishing
- Cmd-W with the singleton window (confirm the app re-opens the window from the dock / Window menu).
- A dropped `.pse` restores cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnX5reNtCwaVJ4a69N8jP9
