### PR TITLE
Metal: support grid_mode (side-by-side object cells)

### DIFF
--- a/layer1/SceneRender.cpp
+++ b/layer1/SceneRender.cpp
@@ -1884,6 +1884,40 @@ static glm::mat4 SceneBuildLightViewProjEye(PyMOLGlobals* G)
  * render() methods dispatch CGO draws through CGORenderGL which
  * already routes VBOs to RendererMetal via drawVBOViaMetal().
  *========================================================================*/
+
+/**
+ * Point the Metal renderer's viewport + scissor at grid cell `slot` within the
+ * scene viewport rect `vp` (Metal top-left backing px), and set grid->slot /
+ * cur_viewport_size accordingly. Cell (col,row): col runs left→right, row 0 is
+ * at the TOP, matching the GL grid layout. Integer scaling on the cell
+ * boundaries avoids 1-px gaps between adjacent cells. Shared by the geometry
+ * pass (SceneRenderMetal) and the selection overlay (SceneRenderMetalSelections)
+ * so the per-cell math lives in exactly one place.
+ */
+static void SceneSetMetalGridCell(
+    PyMOLGlobals* G, GridInfo* grid, const Rect2D& vp, int slot)
+{
+  int abs_slot = slot - grid->first_slot; // 0-based
+  int col = abs_slot % grid->n_col;
+  int row = abs_slot / grid->n_col;
+  int vpX = vp.offset.x;
+  int vpY = vp.offset.y;
+  int vpW = static_cast<int>(vp.extent.width);
+  int vpH = static_cast<int>(vp.extent.height);
+  int x0 = vpX + (col * vpW) / grid->n_col;
+  int x1 = vpX + ((col + 1) * vpW) / grid->n_col;
+  int y0 = vpY + (row * vpH) / grid->n_row;
+  int y1 = vpY + ((row + 1) * vpH) / grid->n_row;
+  int cw = x1 - x0;
+  int ch = y1 - y0;
+  G->Renderer->viewport(x0, y0, cw, ch);
+  G->Renderer->enable(pymol::Capability::ScissorTest);
+  G->Renderer->scissor(x0, y0, cw, ch);
+  grid->slot = slot;
+  grid->cur_viewport_size = Extent2D{
+      static_cast<std::uint32_t>(cw), static_cast<std::uint32_t>(ch)};
+}
+
 void SceneRenderMetal(PyMOLGlobals* G)
 {
   if (!G->Renderer)
@@ -1925,6 +1959,23 @@ void SceneRenderMetal(PyMOLGlobals* G)
 
   // --- Matrix setup ---
   auto aspRat = SceneGetAspectRatio(G);
+
+  // Grid layout (grid_mode): compute the cell layout BEFORE the projection so
+  // the per-cell aspect ratio (aspRat *= asp_adjust) feeds both the projection
+  // matrix AND the post-process params (proj[0]/[5]). This mirrors the GL
+  // SceneRender path (which does the same aspRat *= grid.asp_adjust). All cells
+  // share one projection — only the viewport changes per slot — because every
+  // cell has identical dimensions (window / n_col x n_row).
+  auto grid_mode = SettingGet<GridMode>(G, cSetting_grid_mode);
+  if (grid_mode != GridMode::NoGrid) {
+    int grid_size = SceneGetGridSize(G, grid_mode);
+    GridUpdate(&I->grid, aspRat, grid_mode, grid_size);
+    if (I->grid.active)
+      aspRat *= I->grid.asp_adjust;
+  } else {
+    I->grid.active = false;
+  }
+
   SceneProjectionMatrix(
       G, I->m_view.m_clipSafe().m_front, I->m_view.m_clipSafe().m_back, aspRat);
   ScenePrepareMatrix(G, 0);
@@ -2013,15 +2064,6 @@ void SceneRenderMetal(PyMOLGlobals* G)
   auto scene_extent = SceneGetExtent(G);
   auto context = ScenePrepareUnitContext(scene_extent);
 
-  // Grid (usually inactive for simple scenes)
-  auto grid_mode = SettingGet<GridMode>(G, cSetting_grid_mode);
-  if (grid_mode != GridMode::NoGrid) {
-    int grid_size = SceneGetGridSize(G, grid_mode);
-    GridUpdate(&I->grid, aspRat, grid_mode, grid_size);
-  } else {
-    I->grid.active = false;
-  }
-
   // Transparency alpha CGO
   if (SettingGet<bool>(G, cSetting_transparency_global_sort) &&
       SettingGet<bool>(G, cSetting_transparency_mode)) {
@@ -2035,7 +2077,11 @@ void SceneRenderMetal(PyMOLGlobals* G)
   // into the depth map, so the post pass can PCF-sample real cast shadows. The
   // light VP is loaded as PROJECTION (camera MODELVIEW kept), the renderer
   // routes draws to depth-only pipelines, then restores the scene pass. ---
-  if (SettingGetGlobal_b(G, cSetting_metal_shadows)) {
+  // Skipped in grid mode: the shadow map is a single global texture, so it
+  // can't be made per-cell, and a shared map would leak shadows between cells
+  // (an object visible only in cell B darkening an object in cell A). Grid mode
+  // therefore renders unshadowed (geometry-only parity for now).
+  if (!I->grid.active && SettingGetGlobal_b(G, cSetting_metal_shadows)) {
     glm::mat4 lightVP_eye = SceneBuildLightViewProjEye(G);
     const float* mvp = SceneGetModelViewMatrixPtr(G);
     G->Renderer->setLightViewProjEye(glm::value_ptr(lightVP_eye));
@@ -2057,14 +2103,54 @@ void SceneRenderMetal(PyMOLGlobals* G)
   // --- Render objects: opaque first, then transparent via order-independent
   // transparency (weighted-blended). The transparent pass accumulates into the
   // OIT targets between begin/endTransparentOIT; endFrame resolves them. ---
-  for (auto pass : {RenderPass::Opaque, RenderPass::Antialias}) {
-    SceneRenderAll(G, &context, normal, nullptr, pass, false, 0.0f,
-        &I->grid, 0, SceneRenderWhich::All, SceneRenderOrder::GadgetsLast);
+  if (I->grid.active) {
+    // Grid mode: lay each slot's object(s) out in its own viewport cell.
+    // SceneRenderAll already filters objects by grid->slot (SceneGetDrawFlag),
+    // so we just set grid->slot + the cell viewport/scissor per iteration and
+    // replay the same passes. Scissor clips each cell so nothing bleeds across
+    // borders. Post-effects (SSAO/outline/OIT-resolve/FXAA) stay global — they
+    // run once over the whole frame in endFrame; minor seams at cell edges are
+    // acceptable for this geometry-first parity pass.
+    int vpX = 0, vpY = 0, vpW = I->Width, vpH = I->Height;
+    G->Renderer->getViewportRect(vpX, vpY, vpW, vpH);
+    Rect2D sceneVP{vpX, vpY, static_cast<std::uint32_t>(vpW),
+        static_cast<std::uint32_t>(vpH)};
+    I->grid.cur_view = sceneVP;
+
+    for (int slot = I->grid.first_slot; slot <= I->grid.last_slot; ++slot) {
+      SceneSetMetalGridCell(G, &I->grid, sceneVP, slot);
+      for (auto pass : {RenderPass::Opaque, RenderPass::Antialias}) {
+        SceneRenderAll(G, &context, normal, nullptr, pass, false, 0.0f,
+            &I->grid, 0, SceneRenderWhich::All, SceneRenderOrder::GadgetsLast);
+      }
+    }
+    // Transparent OIT wraps every cell: all cells accumulate into the
+    // full-frame OIT targets, resolved once in endFrame.
+    G->Renderer->beginTransparentOIT();
+    for (int slot = I->grid.first_slot; slot <= I->grid.last_slot; ++slot) {
+      SceneSetMetalGridCell(G, &I->grid, sceneVP, slot);
+      SceneRenderAll(G, &context, normal, nullptr, RenderPass::Transparent,
+          false, 0.0f, &I->grid, 0, SceneRenderWhich::All,
+          SceneRenderOrder::GadgetsLast);
+    }
+    G->Renderer->endTransparentOIT();
+
+    // Restore the full scene viewport and drop the scissor so the fullscreen
+    // post chain in endFrame (OIT resolve, SSAO, outline, FXAA) covers the
+    // whole frame instead of being clipped to the last cell.
+    G->Renderer->disable(pymol::Capability::ScissorTest);
+    G->Renderer->viewport(vpX, vpY, vpW, vpH);
+    I->grid.slot = 0;
+  } else {
+    for (auto pass : {RenderPass::Opaque, RenderPass::Antialias}) {
+      SceneRenderAll(G, &context, normal, nullptr, pass, false, 0.0f,
+          &I->grid, 0, SceneRenderWhich::All, SceneRenderOrder::GadgetsLast);
+    }
+    G->Renderer->beginTransparentOIT();
+    SceneRenderAll(G, &context, normal, nullptr, RenderPass::Transparent, false,
+        0.0f, &I->grid, 0, SceneRenderWhich::All, SceneRenderOrder::GadgetsLast);
+    G->Renderer->endTransparentOIT();
   }
-  G->Renderer->beginTransparentOIT();
-  SceneRenderAll(G, &context, normal, nullptr, RenderPass::Transparent, false,
-      0.0f, &I->grid, 0, SceneRenderWhich::All, SceneRenderOrder::GadgetsLast);
-  G->Renderer->endTransparentOIT();
 
   // --- Render selection indicators ---
   // Collect selected atom positions and draw them as pink points
@@ -2075,31 +2161,54 @@ void SceneRenderMetal(PyMOLGlobals* G)
     SceneRenderMetalSelections(G);
 }
 
+// Draw a batch of selection-indicator points (overlay, no depth test) at the
+// given world coordinates with the active theme's selection color.
+static void SceneDrawMetalSelectionPoints(
+    PyMOLGlobals* G, const std::vector<float>& coords)
+{
+  if (coords.empty())
+    return;
+  int nPoints = (int)(coords.size() / 3);
+  G->Renderer->disable(pymol::Capability::DepthTest);
+  G->Renderer->pointSize(12.0f); // Retina: need ~2x for visible size
+  G->Renderer->beginBatch(pymol::PrimitiveType::Points);
+  G->Renderer->batchColor4f(G->Renderer->selColor[0], G->Renderer->selColor[1],
+      G->Renderer->selColor[2], 1.0f);
+  for (int i = 0; i < nPoints; i++)
+    G->Renderer->batchVertex3f(coords[i * 3], coords[i * 3 + 1], coords[i * 3 + 2]);
+  G->Renderer->endBatch();
+  G->Renderer->enable(pymol::Capability::DepthTest);
+}
+
 void SceneRenderMetalSelections(PyMOLGlobals* G)
 {
   if (!G->Renderer || !G->Renderer->isRenderReady())
     return;
 
-  // Collect selected atom coordinates via Executive helper
+  CScene* I = G->Scene;
+
+  if (I->grid.active) {
+    // Grid mode: draw each cell's selection markers inside that cell's viewport.
+    // ExecutiveGetSelectionCoords filters by the current grid->slot (via
+    // SceneGetDrawFlagGrid), so per slot it returns only that cell object's
+    // selected atoms — projected with the same camera into the cell viewport.
+    int vpX = 0, vpY = 0, vpW = I->Width, vpH = I->Height;
+    G->Renderer->getViewportRect(vpX, vpY, vpW, vpH);
+    Rect2D sceneVP{vpX, vpY, static_cast<std::uint32_t>(vpW),
+        static_cast<std::uint32_t>(vpH)};
+    for (int slot = I->grid.first_slot; slot <= I->grid.last_slot; ++slot) {
+      SceneSetMetalGridCell(G, &I->grid, sceneVP, slot);
+      std::vector<float> coords;
+      ExecutiveGetSelectionCoords(G, coords);
+      SceneDrawMetalSelectionPoints(G, coords);
+    }
+    G->Renderer->disable(pymol::Capability::ScissorTest);
+    G->Renderer->viewport(vpX, vpY, vpW, vpH);
+    I->grid.slot = 0;
+    return;
+  }
+
   std::vector<float> coords;
   ExecutiveGetSelectionCoords(G, coords);
-
-  if (coords.empty())
-    return;
-
-  int nPoints = (int)(coords.size() / 3);
-
-  // Render selection indicators as squares (overlay, no depth test). Color is
-  // the active theme's selection color (Renderer::selColor; defaults to pink).
-  G->Renderer->disable(pymol::Capability::DepthTest);
-  G->Renderer->pointSize(12.0f);  // Retina: need ~2x for visible size
-
-  G->Renderer->beginBatch(pymol::PrimitiveType::Points);
-  G->Renderer->batchColor4f(G->Renderer->selColor[0], G->Renderer->selColor[1],
-                            G->Renderer->selColor[2], 1.0f);
-  for (int i = 0; i < nPoints; i++)
-    G->Renderer->batchVertex3f(coords[i*3], coords[i*3+1], coords[i*3+2]);
-  G->Renderer->endBatch();
-
-  G->Renderer->enable(pymol::Capability::DepthTest);
+  SceneDrawMetalSelectionPoints(G, coords);
 }

--- a/layer3/Executive.cpp
+++ b/layer3/Executive.cpp
@@ -8616,6 +8616,12 @@ void ExecutiveGetSelectionCoords(PyMOLGlobals* G, std::vector<float>& coords)
       if (rec1.type != cExecObject || rec1.obj->type != cObjectMolecule)
         continue;
 
+      // In grid mode, only collect coords for objects belonging to the cell
+      // currently being rendered (G->Scene->grid.slot). When grid is inactive
+      // this returns true for every object, so the non-grid path is unchanged.
+      if (!SceneGetDrawFlagGrid(G, &G->Scene->grid, rec1.obj->grid_slot))
+        continue;
+
       auto* obj = static_cast<ObjectMolecule*>(rec1.obj);
       int curState = obj->getCurrentState();
       if (curState < 0) curState = 0;

--- a/layerGraphics/Renderer.h
+++ b/layerGraphics/Renderer.h
@@ -68,6 +68,14 @@ public:
 
   // Viewport and clear
   virtual void viewport(int x, int y, int w, int h) = 0;
+  // Reports the renderer's current viewport rect (the one last set by
+  // viewport()). SceneRenderMetal needs this to subdivide the scene viewport
+  // into grid_mode cells. Default: report nothing (GL path reads GL_VIEWPORT
+  // itself). Returns true if x/y/w/h were filled.
+  virtual bool getViewportRect(int& x, int& y, int& w, int& h) const
+  {
+    return false;
+  }
   virtual void clear(bool color, bool depth, bool stencil) = 0;
   virtual void clearColor(float r, float g, float b, float a) = 0;
   virtual void scissor(int x, int y, int w, int h) = 0;

--- a/layerGraphics/metal/RendererMetal.h
+++ b/layerGraphics/metal/RendererMetal.h
@@ -36,6 +36,7 @@ public:
 
   // Viewport and clear
   void viewport(int x, int y, int w, int h) override;
+  bool getViewportRect(int& x, int& y, int& w, int& h) const override;
   void clear(bool color, bool depth, bool stencil) override;
   void clearColor(float r, float g, float b, float a) override;
   void scissor(int x, int y, int w, int h) override;

--- a/layerGraphics/metal/RendererMetal.mm
+++ b/layerGraphics/metal/RendererMetal.mm
@@ -1959,6 +1959,15 @@ void RendererMetal::viewport(int x, int y, int w, int h)
   }
 }
 
+bool RendererMetal::getViewportRect(int& x, int& y, int& w, int& h) const
+{
+  x = static_cast<int>(_viewport.originX);
+  y = static_cast<int>(_viewport.originY);
+  w = static_cast<int>(_viewport.width);
+  h = static_cast<int>(_viewport.height);
+  return true;
+}
+
 void RendererMetal::clear(bool color, bool depth, bool stencil)
 {
   // In Metal, clears happen via the render pass descriptor's load actions.

--- a/modules/pymol/metal_pick.py
+++ b/modules/pymol/metal_pick.py
@@ -67,6 +67,77 @@ def _pickdbg(ndc_x, ndc_y, aspect, best, ncand):
         pass
 
 
+def _grid_layout(size, aspect):
+    """Choose (n_col, n_row) for `size` grid cells at window aspect (W/H).
+    Mirrors the C++ GridUpdate (layer1/Scene.cpp) exactly so picking agrees with
+    what the Metal renderer drew."""
+    if size < 1:
+        return (1, 1)
+    n_row = n_col = 1
+    while (n_row * n_col) < size:
+        asp1 = aspect * (n_row + 1.0) / n_col
+        asp2 = aspect * n_row / (n_col + 1.0)
+        if asp1 < 1.0:
+            asp1 = 1.0 / asp1
+        if asp2 < 1.0:
+            asp2 = 1.0 / asp2
+        if abs(asp1) > abs(asp2):
+            n_col += 1
+        else:
+            n_row += 1
+    while (n_col - 1) * n_row >= size and size:
+        n_col -= 1
+    while (n_row - 1) * n_col >= size and size:
+        n_row -= 1
+    return (n_col, n_row)
+
+
+def _grid_pick_context(ndc_x, ndc_y, aspect):
+    """When grid_mode=1 (by-object) is active with 2+ objects, map a full-window
+    click NDC to its grid cell and return
+    (target_obj, cell_ndc_x, cell_ndc_y, cell_aspect):
+      - target_obj: the object laid out in the clicked cell ('' if none).
+      - cell_ndc_x/y: the click re-expressed in that cell's NDC.
+      - cell_aspect: that cell's aspect (window_aspect * n_row/n_col).
+    Returns None when grid isn't cell-mapped (caller projects the whole window).
+
+    The slot→object mapping mirrors the core: grid-eligible enabled objects take
+    slots in scene order, cell layout is GridUpdate, cells run col left→right and
+    row 0 at the TOP. (By-object only; grid_mode 2/3 fall through to whole-window
+    picking, and disabled-object/group gaps aren't modeled — the common case is
+    all-enabled objects.)"""
+    from pymol import cmd
+    try:
+        if int(cmd.get_setting_int('grid_mode')) != 1:
+            return None
+    except Exception:
+        return None
+    objs = [o for o in (cmd.get_names('objects', enabled_only=1) or [])
+            if not o.startswith('_')]
+    size = len(objs)
+    try:
+        grid_max = int(cmd.get_setting_int('grid_max'))
+    except Exception:
+        grid_max = -1
+    if grid_max >= 0:
+        size = min(size, grid_max)
+    if size < 2 or aspect <= 0.0:
+        return None
+    n_col, n_row = _grid_layout(size, aspect)
+    if n_col < 1 or n_row < 1:
+        return None
+    u = (ndc_x + 1.0) * 0.5 * n_col        # [0, n_col), x: +1 = right
+    t = (1.0 - ndc_y) * 0.5 * n_row        # [0, n_row), 0 = top row
+    col = min(max(int(u), 0), n_col - 1)
+    row = min(max(int(t), 0), n_row - 1)
+    slot = row * n_col + col               # 0-based, matches abs_grid_slot
+    cell_ndc_x = (u - col) * 2.0 - 1.0
+    cell_ndc_y = 1.0 - (t - row) * 2.0
+    cell_aspect = aspect * (float(n_row) / float(n_col))
+    target = objs[slot] if 0 <= slot < len(objs) else ''
+    return (target, cell_ndc_x, cell_ndc_y, cell_aspect)
+
+
 def _pick_atom(ndc_x, ndc_y, aspect):
     """Project all DRAWN atoms and return the front-most atom under the click as
     (screen_d2, obj, chain, resi, resn, segi, name, sx, sy), or None for empty
@@ -115,12 +186,27 @@ def _pick_atom(ndc_x, ndc_y, aspect):
         if tan_half <= 0.0:
             return
 
+        # Grid mode (by-object): the renderer draws each object in its own
+        # viewport cell, so a full-window projection wouldn't line up with what
+        # the user sees. Map the click to its cell, restrict the search to that
+        # cell's object, and project with the cell's NDC + aspect. tan_half is
+        # aspect-independent (FOV only), so reassigning `aspect` below is safe.
+        pick_objs = None
+        gctx = _grid_pick_context(ndc_x, ndc_y, aspect)
+        if gctx is not None:
+            target_obj, ndc_x, ndc_y, aspect = gctx
+            if not target_obj:
+                return None  # empty cell → treat as empty-space click
+            pick_objs = [target_obj]
+
         best = None  # (screen_d2, obj, chain, resi, resn, segi, name, sx, sy)
         cands = []   # (d2, depth, obj, chain, resi, resn, segi, name, sx, sy)
         ncand = 0    # atoms whose projection fell within the pick radius
         _ext = [1e9, -1e9, 1e9, -1e9]  # projected-NDC extent: sx_min,sx_max,sy_min,sy_max
 
-        for obj in (cmd.get_names('objects', enabled_only=1) or []):
+        if pick_objs is None:
+            pick_objs = (cmd.get_names('objects', enabled_only=1) or [])
+        for obj in pick_objs:
             if obj.startswith('_'):
                 continue
             # Skip non-molecule objects (distance/angle measurements, maps, CGOs,

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -737,17 +737,10 @@ final class PyMOLEngine: ObservableObject {
     private func handleSessionViewport(for command: String) {
         let lower = command.lowercased()
         if lower.contains(".pse"), let path = sessionPath(from: command) {
-            // grid_mode (objects laid out in side-by-side cells) is not yet
-            // supported by the Metal renderer — it renders a single viewport, so a
-            // grid session would show NOTHING (only the selection overlay, which
-            // ignores grid). Reset it so the session renders (objects overlaid)
-            // and tell the user. See GitHub issue: grid-mode Metal support.
-            runPython(
-                "from pymol import cmd as _g\n"
-                + "if int(_g.get('grid_mode') or 0):\n"
-                + "    _g.set('grid_mode', 0)\n"
-                + "    print('RayMol: grid_mode is not supported yet — disabled so the "
-                + "session renders (objects overlaid).')\n")
+            // grid_mode (objects laid out in side-by-side cells) is now rendered
+            // natively by the Metal renderer (per-slot viewport loop in
+            // SceneRenderMetal), so the session keeps whatever grid_mode it saved
+            // — no reset needed. See GitHub issue: grid-mode Metal support.
             // Read the session's 'main' [W,H] (→ letterbox via SESSIONVP) AND fix
             // the camera: modern .pse files store a 25-float SceneViewType, but
             // our embedded core is 18-float and mis-restores it (front/back


### PR DESCRIPTION
Closes #10.

RayMol's Metal renderer didn't implement PyMOL's `grid_mode`, so a grid session (e.g. a side-by-side comparison `.pse`) rendered **blank** — only the selection overlay showed. The shipped workaround reset `grid_mode` to 0 on `.pse` load so objects rendered overlaid. This PR renders grid natively.

## Root cause
`SceneRenderMetal` called `SceneRenderAll` once with `grid->slot` fixed at 0, so the by-object draw-flag filter (`SceneGetDrawFlag`) rejected every object. All the grid machinery (`GridUpdate`, per-slot viewport, the slot loop) lived only in the GL `SceneRender`, which the Metal path early-returns past.

## Approach
Reuse PyMOL's backend-agnostic grid math (`GridUpdate` / `SceneGetGridSize` / `SceneGetDrawFlag`) and add the missing per-slot loop to the Metal path.

- **`layer1/SceneRender.cpp`** — compute the grid layout before the projection (`aspRat *= grid.asp_adjust`, matching the GL path), then loop the slots: set each cell's `MTLViewport` + scissor and `grid->slot`, replay the Opaque/Antialias passes per cell; the Transparent (OIT) pass wraps all cells. Shadow pre-pass is skipped in grid mode (a single global shadow map would leak shadows between cells). Full viewport/scissor is restored before the fullscreen post chain so SSAO/outline/OIT-resolve/FXAA stay global. New shared `SceneSetMetalGridCell` helper; `SceneRenderMetalSelections` made grid-aware.
- **`layerGraphics/Renderer.h`, `metal/RendererMetal.{h,mm}`** — add `getViewportRect()` to subdivide the scene viewport into cells.
- **`layer3/Executive.cpp`** — `ExecutiveGetSelectionCoords` filters by the current grid slot (no-op when grid is inactive).
- **`modules/pymol/metal_pick.py`** — grid-aware picking: map a click to its cell, restrict the search to that cell's object, project with the cell's NDC + aspect.
- **`swiftui/.../PyMOLEngine.swift`** — drop the `.pse`-load `grid_mode=0` reset; sessions keep their saved `grid_mode`.

## Verification (native macOS build)
- 2-cell, 2×2, and 3-cell renders each place an object in its own viewport cell, correct row/column order.
- A `grid_mode=1` `.pse` reloads with `grid_mode` still `1` and renders as a grid (workaround gone).
- Selection markers draw only in the selected object's cell.
- `pick_at` sweep: left-cell clicks resolve only to the left object, right-cell only to the right — never the neighbor (plus a passing unit test of the cell mapping).

## Scope / follow-ups (by-object first, per the issue)
- Post-effects are global, not per-cell (minor SSAO/outline seams possible at cell borders).
- Shadows are disabled in grid mode.
- Picking covers `grid_mode 1` for enabled objects; modes 2/3 fall through to whole-window picking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PAYCZJD3624SDAJfJGFJiZ