### PR TITLE
macOS: Grid toggle + global "all" controls; fix Scene-toggle flicker

### DIFF
--- a/modules/pymol/appkit_inspector.py
+++ b/modules/pymol/appkit_inspector.py
@@ -43,7 +43,7 @@ REP_COLOR = {
 SCENE_SETTINGS = ['metal_raytrace', 'metal_rt_shadows', 'metal_shadows', 'metal_ssao',
                   'metal_outline', 'metal_msaa', 'metal_tonemap', 'metal_exposure',
                   'depth_cue', 'fog', 'field_of_view', 'surface_quality',
-                  'all_states', 'mouse_selection_mode',
+                  'grid_mode', 'all_states', 'mouse_selection_mode',
                   'ambient', 'direct', 'reflect', 'specular', 'shininess',
                   'ray_opaque_background']
 

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -181,6 +181,10 @@ enum SceneCatalog {
         SceneParam(setting: "metal_tonemap", label: "Filmic tone-map", kind: .toggle, group: "Lighting & Quality"),
         SceneParam(setting: "metal_exposure", label: "Exposure", kind: .slider, min: 0.2, max: 2.0, step: 0.05, decimals: 2, group: "Lighting & Quality"),
         SceneParam(setting: "depth_cue",     label: "Depth cue / fog", kind: .toggle, group: "Lighting & Quality"),
+        // grid_mode is an int (0=off, 1=by object, 2=by state); the toggle maps
+        // off→0 / on→1 and reads on for any non-zero mode. Lays each object out
+        // in its own viewport cell (Metal grid support added in 1.2.0).
+        SceneParam(setting: "grid_mode",     label: "Grid", kind: .toggle, group: "Lighting & Quality"),
         SceneParam(setting: "all_states",    label: "Overlay all states", kind: .toggle, group: "Lighting & Quality"),
         // Lighting (made real-time on Metal in Phase 3; tunable here in Phase 2).
         SceneParam(setting: "ambient",   label: "Ambient",  kind: .slider, min: 0, max: 1, step: 0.01, decimals: 2, group: "Lighting & Quality"),
@@ -491,10 +495,46 @@ private func runActionCommand(_ key: String, name: String, engine: PyMOLEngine) 
         return
     case "copy":               cmd = "copy \(n)_copy, \(n)"
     case "delete":             cmd = "delete \(n)"
+    // Global ("all" row) actions
+    case "deselect":           cmd = "deselect"
+    case "hide_everything":    cmd = "hide everything, \(n)"
+    case "reset_view":         cmd = "reset"
     default:                   return
     }
     engine.runCommand(cmd)
 }
+
+/// Action ("A") menu for the global "all" row — a focused, scene-wide subset.
+/// Reuses the per-object action keys (all valid with name "all"); deliberately
+/// omits per-object items (Rename / Duplicate / Delete) and adds global ones
+/// (Deselect, Hide everything, Reset camera).
+private let allActionMenuItems: [ActionMenuItem] = [
+    .action(label: "Zoom",          key: "zoom"),
+    .action(label: "Orient",        key: "orient"),
+    .action(label: "Center",        key: "center"),
+    .action(label: "Reset camera",  key: "reset_view"),
+    .separator,
+    .action(label: "Deselect",      key: "deselect"),
+    .action(label: "Hide everything", key: "hide_everything"),
+    .separator,
+    .action(label: "Assign Sec. Struc.", key: "dss"),
+    .action(label: "Remove Waters",      key: "remove_waters"),
+    .submenu(label: "Hydrogens", children: [
+        .action(label: "add",        key: "h_add"),
+        .action(label: "add polar",  key: "h_add_polar"),
+        .action(label: "remove",     key: "h_remove"),
+    ]),
+    .submenu(label: "Find", children: [
+        .action(label: "polar contacts (any)", key: "find_polar_any"),
+        .action(label: "salt bridges",         key: "find_salt_bridge"),
+    ]),
+    .submenu(label: "Preset", children: [
+        .action(label: "pretty",         key: "preset_pretty"),
+        .action(label: "technical",      key: "preset_technical"),
+        .action(label: "ball and stick", key: "preset_ball_and_stick"),
+        .action(label: "default",        key: "preset_default"),
+    ]),
+]
 
 // MARK: - Theme
 
@@ -584,6 +624,9 @@ struct ObjectPanel: View {
 
                     // Objects section — each is an expandable inspector card
                     if !objects.isEmpty {
+                        // Global "all" controls (A/S/H/L/C on the whole scene),
+                        // pinned above the per-object cards.
+                        AllControlsRow()
                         ForEach(Array(objects.enumerated()), id: \.element.id) { index, obj in
                             ObjectCard(entry: obj, isAlt: index % 2 == 1)
                         }
@@ -720,6 +763,49 @@ private struct ObjectRowView: View {
         } else {
             engine.runCommand("enable \(entry.name)")
         }
+    }
+}
+
+// MARK: - Global "all" controls row
+
+/// Pinned row above the object list giving the same A/S/H/L/C controls as an
+/// object row but acting on the whole scene (selection "all") — mirrors desktop
+/// PyMOL's "all" row for quick global Show/Hide/Label/Color and scene actions.
+/// Show/Hide/Label/Color reuse the per-object menus with name "all"; the Action
+/// (A) menu uses the global subset `allActionMenuItems`.
+private struct AllControlsRow: View {
+    @EnvironmentObject var engine: PyMOLEngine
+
+    var body: some View {
+        HStack(spacing: 2) {
+            // No enable checkbox — "all" is a selection, not a toggleable object.
+            Spacer().frame(width: kGutterW)
+            Text("all")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(PanelTheme.textColor)
+                .lineLimit(1)
+            Spacer(minLength: 4)
+            Menu {
+                actionMenuContent(allActionMenuItems, name: "all", engine: engine)
+            } label: {
+                Text("A")
+                    .frame(width: kActBtnW, height: kActBtnH)
+                    .background(PanelTheme.buttonBackground)
+                    .cornerRadius(2)
+                    .contentShape(Rectangle())
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            ShowButton(name: "all")
+            HideButton(name: "all")
+            LabelMenuButton(name: "all")
+            ColorMenuButton(name: "all")
+        }
+        .padding(.horizontal, 4)
+        .padding(.vertical, 2)
+        .frame(height: kRowH)
+        .background(PanelTheme.rowBackground)
+        .contextMenu { actionMenuContent(allActionMenuItems, name: "all", engine: engine) }
     }
 }
 
@@ -1094,12 +1180,28 @@ private struct SegmentedSetting: View {
 private struct ToggleSetting: View {
     let value: Double
     let onToggle: (Bool) -> Void
+    // Optimistic local state. Previously the switch derived its position directly
+    // from `value` (a ~500ms-lagged poll) on EVERY re-render, so it flickered /
+    // snapped back: opening the panel, a rotation-driven refresh, or the gap
+    // between a tap and the next poll would re-render with the stale value and
+    // flip the switch (and its tint) back. Driving the switch from local @State
+    // that changes ONLY on a user flip or a genuine polled-value change makes a
+    // re-render with an unchanged value a no-op for the switch.
+    @State private var isOn = false
     var body: some View {
-        Toggle("", isOn: Binding(get: { value > 0.5 }, set: { onToggle($0) }))
+        Toggle("", isOn: $isOn)
             .labelsHidden()
             .toggleStyle(.switch)
             .controlSize(.mini)
             .tint(PanelTheme.selectionTextColor)
+            .onAppear { isOn = value > 0.5 }
+            .onChange(of: value) { v in
+                let want = v > 0.5
+                if want != isOn { isOn = want }          // adopt real external changes
+            }
+            .onChange(of: isOn) { on in
+                if on != (value > 0.5) { onToggle(on) }   // user flip → push once
+            }
     }
 }
 


### PR DESCRIPTION
Three Scene/Objects-panel changes for **1.2.0**, from on-device feedback.

### 1. Fix Scene-panel toggle/color flicker
`ToggleSetting` derived its switch position straight from the ~500 ms poll on every re-render, so toggles (and their tint) flickered/snapped back when the panel opened/closed, the molecule rotated (a poll-driven refresh), or in the gap between a tap and the next poll. Now the switch is driven by optimistic local `@State` that changes only on a user flip or a genuine polled-value change — a re-render with an unchanged value is a no-op. Fixes all four `ToggleSetting` call sites (scene, rep-show, rep-property, overlay-all).

### 2. Grid on/off toggle (SCENE panel)
`grid_mode` added to `appkit_inspector.SCENE_SETTINGS` (so it's polled) and a `SceneParam` toggle in **Lighting & Quality**. on→`set grid_mode,1` / off→`0`; shown on for any non-zero mode. Drives the Metal grid layout shipped in #30.

### 3. Global "all" controls row
A pinned row above the object list with the same **A / S / H / L / C** controls acting on selection `all` — mirrors desktop PyMOL. Show/Hide/Label/Color reuse the per-object menus with `name = "all"`; the Action (A) menu is a global subset (Zoom / Orient / Center / Reset camera, Deselect, Hide everything, Assign SS, Remove waters, Hydrogens, Find, Preset) and omits per-object Rename/Duplicate/Delete. New `runActionCommand` keys: `deselect`, `hide_everything`, `reset_view`.

### Verification
- macOS app builds clean (Swift + bundled Python; core lib unchanged).
- The scene poll now includes `grid_mode` (reads `1.0` after `set grid_mode, 1`) — the value the new toggle binds to.
- The panel visuals (toggle present, no flicker on rotate, "all" row) are SwiftUI chrome that can't be captured headlessly; confirmed interactively on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PAYCZJD3624SDAJfJGFJiZ