### PR TITLE
fix(mcp): don't crash get_session_state on non-molecule objects

### DIFF
--- a/modules/raymol_mcp/tools.py
+++ b/modules/raymol_mcp/tools.py
@@ -91,10 +91,16 @@ def _get_session_state(args):
     try:
         objects = []
         for name in cmd.get_names("objects"):
+            otype = cmd.get_type(name)
+            # Only molecule objects are valid atom-selections. A measurement,
+            # map, CGO or group name fed to count_atoms('(name)') raises a C++
+            # "Invalid selection name" Selector-Error (same gotcha metal_pick.py
+            # documents), which would otherwise abort the whole call.
             objects.append({
                 "name": name,
-                "type": cmd.get_type(name),
-                "atoms": cmd.count_atoms("(%s)" % name),
+                "type": otype,
+                "atoms": (cmd.count_atoms("(%s)" % name)
+                          if otype == "object:molecule" else 0),
             })
         state = {
             "objects": objects,

--- a/testing/tests/test_mcp_tools.py
+++ b/testing/tests/test_mcp_tools.py
@@ -1,6 +1,70 @@
+import json
+import sys
+import types
 import unittest
 
 import raymol_mcp.tools as tools
+
+
+class _FakeCmd:
+    """Minimal ``cmd`` stand-in for get_session_state.
+
+    A measurement object (``hb_x``) raises on ``count_atoms`` exactly the way
+    PyMOL's selector rejects a non-molecule object name with "Invalid selection
+    name" (verified against the live app). A molecule (``mol1``) counts fine.
+    """
+
+    _TYPES = {"mol1": "object:molecule", "hb_x": "object:measurement"}
+
+    def get_names(self, kind):
+        return ["mol1", "hb_x"] if kind == "objects" else ["sele1"]
+
+    def get_type(self, name):
+        return self._TYPES[name]
+
+    def count_atoms(self, selection):
+        if "hb_x" in selection:
+            raise Exception('Error: Invalid selection name "hb_x".')
+        return 100
+
+    def get_view(self):
+        return tuple(float(i) for i in range(18))
+
+    def get_frame(self):
+        return 3
+
+    def count_frames(self):
+        return 5
+
+
+class TestGetSessionStateNonMolecule(unittest.TestCase):
+    """get_session_state must not blow up when the session holds objects that
+    aren't molecules (measurements, maps, CGOs, groups) -- their names aren't
+    valid atom-selections, so count_atoms('(name)') raises. Regression for the
+    Claude-driving crash where an hb_* H-bond object aborted the whole call."""
+
+    def setUp(self):
+        self._saved = sys.modules.get("pymol")
+        fake = types.ModuleType("pymol")
+        fake.cmd = _FakeCmd()
+        sys.modules["pymol"] = fake
+
+    def tearDown(self):
+        if self._saved is not None:
+            sys.modules["pymol"] = self._saved
+        else:
+            sys.modules.pop("pymol", None)
+
+    def test_non_molecule_object_does_not_error(self):
+        res = tools._get_session_state({})
+        self.assertFalse(res["isError"], res["content"][0]["text"])
+        state = json.loads(res["content"][0]["text"])
+        objs = {o["name"]: o for o in state["objects"]}
+        self.assertEqual(objs["mol1"]["atoms"], 100)
+        # measurement object is still listed, just not atom-counted
+        self.assertEqual(objs["hb_x"]["type"], "object:measurement")
+        self.assertEqual(objs["hb_x"]["atoms"], 0)
+        self.assertEqual(state["selections"], ["sele1"])
 
 
 class TestMcpToolsRegistry(unittest.TestCase):


### PR DESCRIPTION
## Problem

The Claude app calls `get_session_state` first to orient itself in a scene. It crashed whenever the session contained a **non-molecule object** — measurement/distance objects (`hb_*` H-bond contacts), maps, CGOs, or groups — leaving Claude driving blind.

**Root cause:** `_get_session_state` called `cmd.count_atoms("(%s)" % name)` on *every* object from `get_names("objects")`. Non-molecule object names aren't valid atom-selections, so PyMOL's C++ selector raises `Invalid selection name`. Because the `try` wrapped the whole loop, a single bad object aborted the entire call:

```
File ".../raymol_mcp/tools.py", line 97, in _get_session_state
    "atoms": cmd.count_atoms("(%s)" % name),
File ".../pymol/querying.py", line 1435, in count_atoms
    r = _cmd.select(_self._COb,"_count_tmp","("+str(selection)+")",1,...)
pymol.CmdException:  Error: Invalid selection name "hb_APB27970".
( ( hb_APB27970 ) )<--
```

Reproduced live (created an `object:measurement`, called the tool, got the identical error) and confirmed against the bridge log at `~/Library/Logs/Claude/mcp-server-raymol.log`.

## Fix

Gate `count_atoms` on `type == "object:molecule"` — the same filter `metal_pick.py` already uses for this exact gotcha. Non-molecule objects are still listed with their type, just reported as `0` atoms instead of crashing.

## Testing

Added `TestGetSessionStateNonMolecule` to `testing/tests/test_mcp_tools.py` using a `cmd` stand-in whose measurement object raises on `count_atoms` (faithful to the verified live behavior). TDD: watched it fail at the exact production line, applied the fix, watched it pass. All 15 MCP tests green, no regressions.

## Note

Out of scope here: the separate `socketserver` "Exception occurred during processing of request" traceback is a harmless client-disconnect (BrokenPipe/ConnectionReset) when the bridge drops the connection mid-response — not caused by this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnX5reNtCwaVJ4a69N8jP9