### PR TITLE
RayMol 1.2.1

### DIFF
--- a/docs/release-notes/v1.2.1.md
+++ b/docs/release-notes/v1.2.1.md
@@ -1,0 +1,7 @@
+## RayMol 1.2.1
+
+A patch release fixing AI control.
+
+- **Fixed AI driving when measurements are present.** `get_session_state` — the first thing the Claude app calls to see your scene — crashed whenever the session held a non-molecule object (H-bond/distance measurements, maps, CGOs, or groups), leaving the assistant unable to read the scene. It now reports those objects correctly instead of erroring.
+
+Built on the open-source PyMOL engine. Updates install automatically via the in-app updater (**Check for Updates…** in the app menu).

--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -806,7 +806,7 @@
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -820,7 +820,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.2.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -836,7 +836,7 @@
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -850,7 +850,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.2.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -867,7 +867,7 @@
 				CODE_SIGN_ENTITLEMENTS = PyMOLViewer/RayMol.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = VT99UQUQ89;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -883,7 +883,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.2.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -920,7 +920,7 @@
 				CODE_SIGN_ENTITLEMENTS = PyMOLViewer/RayMol.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = VT99UQUQ89;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -936,7 +936,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.2.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;

--- a/swiftui/project.yml
+++ b/swiftui/project.yml
@@ -52,8 +52,8 @@ targets:
         PRODUCT_NAME: RayMol
         PRODUCT_BUNDLE_IDENTIFIER: io.raymol.RayMol
         INFOPLIST_GENERATION_MODE: GeneratedFile
-        MARKETING_VERSION: "1.2.0"
-        CURRENT_PROJECT_VERSION: 6
+        MARKETING_VERSION: "1.2.1"
+        CURRENT_PROJECT_VERSION: 7
         GENERATE_INFOPLIST_FILE: YES
         # Generate a launch screen so iOS renders at the device's NATIVE
         # resolution. Without it the app is letterboxed at a legacy size on

--- a/swiftui/publish_release.sh
+++ b/swiftui/publish_release.sh
@@ -61,15 +61,22 @@ cat > "$APPCAST" <<XML
 XML
 echo "  wrote $APPCAST"
 
+# Stable-named copy of the DMG so the website can link a FIXED url that always
+# serves the newest release: https://github.com/$REPO/releases/latest/download/RayMol.dmg
+# (the versioned RayMol-$VERSION.dmg name changes every release, so it can't be
+# used with the /latest/ redirect). Same notarized+stapled bytes, second name.
+STABLE_DMG="$ROOT/RayMol.dmg"
+cp "$DMG" "$STABLE_DMG"
+
 echo "== Publish GitHub release v$VERSION =="
 if gh release view "v$VERSION" -R "$REPO" >/dev/null 2>&1; then
-  gh release upload "v$VERSION" "$DMG" "$APPCAST" -R "$REPO" --clobber
+  gh release upload "v$VERSION" "$DMG" "$STABLE_DMG" "$APPCAST" -R "$REPO" --clobber
 else
   if [ -n "${NOTES_FILE:-}" ]; then
-    gh release create "v$VERSION" "$DMG" "$APPCAST" -R "$REPO" \
+    gh release create "v$VERSION" "$DMG" "$STABLE_DMG" "$APPCAST" -R "$REPO" \
       --title "RayMol $VERSION" --notes-file "$NOTES_FILE"
   else
-    gh release create "v$VERSION" "$DMG" "$APPCAST" -R "$REPO" \
+    gh release create "v$VERSION" "$DMG" "$STABLE_DMG" "$APPCAST" -R "$REPO" \
       --title "RayMol $VERSION" \
       --notes "${NOTES:-Automatic updates are here. RayMol now checks for new versions and installs them with one click — no more manual DMG downloads. Built on the open-source PyMOL engine.}"
   fi


### PR DESCRIPTION
Patch release **1.2.1** (build 7).

## Included

- **#32 — fix(mcp): don't crash `get_session_state` on non-molecule objects.** The Claude app calls `get_session_state` first to orient itself; it crashed whenever the session held a measurement/map/CGO/group object (their names aren't valid atom-selections, so `count_atoms` raised `Invalid selection name` and aborted the whole call). Now gated on `object:molecule`.

## Version bump

- `swiftui/project.yml` + `swiftui/PyMOLViewer.xcodeproj/project.pbxproj`: `MARKETING_VERSION` 1.2.0 → 1.2.1, `CURRENT_PROJECT_VERSION` 6 → 7.
- `docs/release-notes/v1.2.1.md` added.

## Remaining (manual, post-merge)

Build + notarize the DMG, then `VERSION=1.2.1 BUILD=7 bash swiftui/publish_release.sh` to EdDSA-sign, regenerate `appcast.xml`, and publish the GitHub release. (appcast.xml is intentionally not touched here — `publish_release.sh` regenerates it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnX5reNtCwaVJ4a69N8jP9