### PR TITLE
build(release): harden publish/notarize against the 1.2.1 failure modes

### DIFF
--- a/swiftui/make_dmg.sh
+++ b/swiftui/make_dmg.sh
@@ -41,6 +41,26 @@ VERSION="${VERSION:-1.0.0}"
 : "${DEVID:?Set DEVID to your 'Developer ID Application: NAME (TEAMID)' identity}"
 NOTARY_PROFILE="${NOTARY_PROFILE:-RayMol-notary}"
 
+# --- Preflight (hardening after the 1.2.1 build got tripped up) ---------------
+# Keep the Mac awake for the whole run. This script has two multi-minute Apple
+# notarization waits; a sleep/lock cycle during one of them locked the keychain
+# and evicted the notary credential, so the 2nd notarization failed AFTER the
+# app was already built, signed, and notarized. -w $$ stops caffeinate on exit.
+caffeinate -dims -w "$$" &
+
+# Verify the notary credential is reachable BEFORE the long build + first
+# notarization, so a missing/locked profile fails in seconds instead of ~40 min
+# in. (notarytool reads the profile from the keychain; this also surfaces a
+# locked keychain immediately.)
+if ! xcrun notarytool history --keychain-profile "$NOTARY_PROFILE" >/dev/null 2>&1; then
+  echo "ERROR: notary profile '$NOTARY_PROFILE' is not reachable (missing or keychain locked)."
+  echo "  Re-store it:  xcrun notarytool store-credentials $NOTARY_PROFILE \\"
+  echo "                  --apple-id <id> --team-id VT99UQUQ89 --password <app-specific-pw>"
+  echo "  Then verify:  xcrun notarytool history --keychain-profile $NOTARY_PROFILE"
+  exit 1
+fi
+# ------------------------------------------------------------------------------
+
 echo "== 1/8  Build Release app (unsigned; we Developer-ID-sign below) =="
 xcodebuild -project "$SWIFTUI/PyMOLViewer.xcodeproj" -scheme PyMOLViewer_macOS \
   -configuration Release -destination 'platform=macOS,arch=arm64' \

--- a/swiftui/publish_release.sh
+++ b/swiftui/publish_release.sh
@@ -28,6 +28,36 @@ APPCAST="$ROOT/appcast.xml"
 SIGN_UPDATE="$(find "$HOME/Library/Developer/Xcode/DerivedData" -path '*Sparkle/bin/sign_update' 2>/dev/null | head -1)"
 [ -x "$SIGN_UPDATE" ] || { echo "ERROR: sign_update not found; run 'xcodebuild -resolvePackageDependencies' first"; exit 1; }
 
+# --- Preflight (hardening after the 1.2.1 publish got tripped up) -------------
+# 1. Keep the Mac awake for the whole run. A sleep/lock cycle mid-publish can
+#    evict the keychain credentials sign_update needs and force a fresh, easily-
+#    missed authorization prompt (sign_update then hangs). -w $$ ties caffeinate's
+#    lifetime to this script, so it stops automatically when we exit.
+caffeinate -dims -w "$$" &
+
+# 2. The login keychain must be unlocked — sign_update reads the Sparkle EdDSA
+#    key from it. Fail fast with a clear message instead of hanging deep in the
+#    run on an unattended keychain prompt.
+if ! security show-keychain-info "$HOME/Library/Keychains/login.keychain-db" >/dev/null 2>&1; then
+  echo "ERROR: login keychain is locked. Unlock it and re-run, e.g.:"
+  echo "  security unlock-keychain \"\$HOME/Library/Keychains/login.keychain-db\""
+  exit 1
+fi
+
+# 3. Snapshot the release notes NOW, before the long sign/upload. The GitHub
+#    release is created at the END of this script; if the working tree changes
+#    in between (a branch switch or checkout — which is exactly what broke the
+#    1.2.1 create), NOTES_FILE can vanish. Copy it to a stable temp path up front
+#    and create the release from that, independent of the live checkout.
+NOTES_SNAPSHOT=""
+if [ -n "${NOTES_FILE:-}" ]; then
+  [ -f "$NOTES_FILE" ] || { echo "ERROR: NOTES_FILE not found: $NOTES_FILE"; exit 1; }
+  NOTES_SNAPSHOT="$(mktemp -t raymol-relnotes)"
+  cp "$NOTES_FILE" "$NOTES_SNAPSHOT"
+  echo "  notes snapshot → $NOTES_SNAPSHOT"
+fi
+# ------------------------------------------------------------------------------
+
 echo "== EdDSA-sign the DMG =="
 # sign_update prints an attribute fragment, e.g.:
 #   sparkle:edSignature="…" length="12345"
@@ -72,9 +102,9 @@ echo "== Publish GitHub release v$VERSION =="
 if gh release view "v$VERSION" -R "$REPO" >/dev/null 2>&1; then
   gh release upload "v$VERSION" "$DMG" "$STABLE_DMG" "$APPCAST" -R "$REPO" --clobber
 else
-  if [ -n "${NOTES_FILE:-}" ]; then
+  if [ -n "$NOTES_SNAPSHOT" ]; then
     gh release create "v$VERSION" "$DMG" "$STABLE_DMG" "$APPCAST" -R "$REPO" \
-      --title "RayMol $VERSION" --notes-file "$NOTES_FILE"
+      --title "RayMol $VERSION" --notes-file "$NOTES_SNAPSHOT"
   else
     gh release create "v$VERSION" "$DMG" "$STABLE_DMG" "$APPCAST" -R "$REPO" \
       --title "RayMol $VERSION" \


### PR DESCRIPTION
Guards against the two snags that hit the 1.2.1 release:

1. **Notes snapshot** — `publish_release.sh` creates the GitHub release at the *end*, but read `NOTES_FILE` from the live checkout. When the repo was switched to another branch mid-publish, the notes file disappeared and `gh release create` failed (after signing). Now it snapshots `NOTES_FILE` to a temp path up front and creates the release from that.
2. **Keychain robustness** — a sleep/lock cycle during the long Apple notarization waits evicted the notary credential and forced a fresh, easily-missed `sign_update` prompt. Both scripts now `caffeinate -dims -w $$` for their lifetime, and preflight: `make_dmg` verifies the notary profile is reachable (fail in seconds, not ~40 min in); `publish_release` verifies the login keychain is unlocked. Clear remediation messages on failure.

No behavior change on the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PAYCZJD3624SDAJfJGFJiZ