### PR TITLE
Fix: animated camera actions on Metal + enable/disable-all from the "all" row

### DIFF
--- a/layer1/SceneRender.cpp
+++ b/layer1/SceneRender.cpp
@@ -1957,6 +1957,14 @@ void SceneRenderMetal(PyMOLGlobals* G)
   ExecutiveUpdateSceneMembers(G);
   SceneUpdate(G, false);
 
+  // Advance any in-progress view animation (zoom/orient/center/set_view with
+  // animate, scene transitions, etc.) BEFORE deriving the matrices from
+  // I->m_view below. The GL SceneRender path does this; without it the Metal
+  // renderer set up animations that never ticked, so animated camera commands
+  // appeared to do nothing. The MTKView renders continuously, so the animation
+  // plays out across frames from here.
+  SceneUpdateAnimation(G);
+
   // --- Matrix setup ---
   auto aspRat = SceneGetAspectRatio(G);
 

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -776,14 +776,26 @@ private struct ObjectRowView: View {
 private struct AllControlsRow: View {
     @EnvironmentObject var engine: PyMOLEngine
 
+    // The objects shown in the panel (selections excluded) — "all current objects".
+    private var objects: [ObjectEntry] { engine.objects.filter { !$0.isSelection } }
+    private var allEnabled: Bool { !objects.isEmpty && objects.allSatisfy { $0.isEnabled } }
+
     var body: some View {
         HStack(spacing: 2) {
-            // No enable checkbox — "all" is a selection, not a toggleable object.
-            Spacer().frame(width: kGutterW)
+            // Enable/disable ALL objects at once (mirrors desktop PyMOL's "all" row).
+            Button(action: { toggleAll() }) {
+                Image(systemName: allEnabled ? "checkmark.square.fill" : "square")
+                    .font(.system(size: 12))
+                    .foregroundColor(allEnabled ? PanelTheme.textColor : PanelTheme.disabledColor)
+            }
+            .buttonStyle(.plain)
+            .frame(width: kGutterW)
             Text("all")
                 .font(.system(size: 11, weight: .semibold))
                 .foregroundColor(PanelTheme.textColor)
                 .lineLimit(1)
+                .contentShape(Rectangle())
+                .onTapGesture { toggleAll() }
             Spacer(minLength: 4)
             Menu {
                 actionMenuContent(allActionMenuItems, name: "all", engine: engine)
@@ -806,6 +818,17 @@ private struct AllControlsRow: View {
         .frame(height: kRowH)
         .background(PanelTheme.rowBackground)
         .contextMenu { actionMenuContent(allActionMenuItems, name: "all", engine: engine) }
+    }
+
+    // Enable or disable every object in one shot. Iterating get_names('objects')
+    // targets exactly the current objects (not the "all" atom-selection), so it
+    // works regardless of how enable/disable interpret the "all" keyword.
+    private func toggleAll() {
+        let action = allEnabled ? "disable" : "enable"
+        engine.runPython(
+            "from pymol import cmd as _c\n"
+            + "for _o in (_c.get_names('objects') or []):\n"
+            + "    _c.\(action)(_o)\n")
     }
 }
 


### PR DESCRIPTION
Two Objects-panel bugs (macOS + iOS), each with its own issue.

### #37 — Zoom/Orient/Center do nothing on the Metal renderer
These Action-menu commands use `animate=-1` (animated camera move), advanced each frame by `SceneUpdateAnimation()`. The GL `SceneRender` path calls it; **`SceneRenderMetal` never did**, so the animation was created but never ticked and the camera stayed put. Fix: call `SceneUpdateAnimation(G)` in `SceneRenderMetal` after `SceneUpdate`, before the projection/modelview are derived from `I->m_view`. Fixes *all* animated view changes on Metal (console `zoom`/`orient`, scenes, scripts), not just the menu. (`origin` has no visible move by design.)

### #36 — Clicking the "all" row doesn't enable/disable all objects
The global `all` row had no enable control. Added a checkbox (mirroring `ObjectRowView`): checked when all objects are enabled; tapping enables all / disables all by iterating `get_names('objects')` (targets exactly the current objects, not the `all` atom-selection).

### Verified (macOS build)
- Animated `zoom <subset>, animate=1` now plays to its target on Metal (confirmed by capturing a single-residue zoom; `get_view` right after the command is still the start, so reaching the target proves the animation advanced).
- `toggleAll`: enabled `[ala,trp]` → disable-all `[]` → enable-all `[ala,trp]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PAYCZJD3624SDAJfJGFJiZ