### PR TITLE
fix: offscreen export drops the molecular surface (transparent-alpha cutout + build race) (#22)

### DIFF
--- a/layerGraphics/metal/RendererMetal.mm
+++ b/layerGraphics/metal/RendererMetal.mm
@@ -557,9 +557,18 @@ fragment float4 post_tonemap(PostVOut in [[stage_in]],
 // exporting at 2x and downscaling anti-aliases the cutout.
 fragment float4 post_export_alpha(PostVOut in [[stage_in]],
     texture2d<float> src [[texture(0)]],
-    depth2d<float> depthTex [[texture(1)]], sampler s [[sampler(0)]]) {
+    depth2d<float> depthTex [[texture(1)]],
+    texture2d<float> revealTex [[texture(2)]], sampler s [[sampler(0)]]) {
   float d = depthTex.sample(s, in.uv);
-  float a = (d >= 0.99995) ? 0.0 : 1.0;   // far plane == cleared background
+  // Opaque geometry (depth < far) stays fully opaque; the far-plane background is
+  // cut out. BUT transparent reps (the molecular surface) render via weighted-
+  // blended OIT and do NOT write depth, so a depth-only cutout erases them from
+  // the exported alpha wherever the translucent shell overhangs the background —
+  // the surface vanishes from a transparent-background PNG while showing fine in
+  // the viewport (issue #22). Recover their coverage from the OIT transmittance
+  // (cover = 1 - reveal, matching oit_resolve) so the surface survives the matte.
+  float cover = 1.0 - revealTex.sample(s, in.uv).r;
+  float a = (d < 0.99995) ? 1.0 : cover;   // far plane == cleared background
   return float4(src.sample(s, in.uv).rgb, a);
 }
 
@@ -1762,6 +1771,7 @@ void RendererMetal::runPostChain()
     [ea setRenderPipelineState:_exportAlphaPipeline];
     [ea setFragmentTexture:sceneSrc atIndex:0];
     [ea setFragmentTexture:_sceneDepth atIndex:1];
+    [ea setFragmentTexture:_oitReveal atIndex:2];  // recover transparent (surface) coverage
     [ea setFragmentSamplerState:_postSampler atIndex:0];
     [ea drawPrimitives:MTLPrimitiveTypeTriangle vertexStart:0 vertexCount:3];
     [ea endEncoding];

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -396,10 +396,17 @@ final class PyMOLEngine: ObservableObject {
                     guard let self = self else { return }
                     // Re-assert the caller's explicit state last, so neither the
                     // persisted theme nor PYMOL_AUTOTHEME can clobber the requested
-                    // background between init and this render.
+                    // background between init and this render. Use runCommandCore
+                    // (NOT runCommand): runCommand routes heavy ops like `show
+                    // surface` to runHeavy, which defers them ~50ms off this turn,
+                    // so the synchronous render below would race the surface build
+                    // and export with the surface rep still unflagged/unbuilt — the
+                    // exported PNG then drops the surface (issue #22). runCommandCore
+                    // flags the reps synchronously here, so the offscreen render's
+                    // SceneUpdate builds them before the capture.
                     if let c = autoCmd {
                         for one in c.split(separator: ";") {
-                            self.runCommand(one.trimmingCharacters(in: .whitespaces))
+                            self.runCommandCore(one.trimmingCharacters(in: .whitespaces))
                         }
                     }
                     self.renderHiResPNG(parts[0], width: w, height: h, rayTraced: rt)


### PR DESCRIPTION
Fixes the surface missing from exported/copied images (#22). Investigation found **two distinct causes**; this branch fixes both. The cause documented in #22 (`renderOneOffscreen` skips `SceneUpdate`) is **not** it — `SceneRenderMetal` already calls `SceneUpdate`.

## Cause 1 (primary — the reported bug): transparent-background export cuts out the surface

`post_export_alpha` (the offscreen alpha-matte pass for `ray_opaque_background 0`) derives PNG alpha from **scene depth**: far-plane → alpha 0, geometry → alpha 1. But the transparent **surface** renders via weighted-blended **OIT and doesn't write depth**. So where the translucent shell overhangs the background, depth reads far-plane → the surface gets **alpha 0 and is cut out**, though its color is composited in. It shows in the live viewport but vanishes from a saved/copied **transparent** PNG; opaque-background exports were fine.

**Fix:** feed OIT transmittance (`_oitReveal`) into `post_export_alpha` — `alpha = opaque ? 1 : (1 - reveal)`, matching `oit_resolve`. **Verified** (transparent surface, `ray_opaque_background 0`, `rt=0`): before → surface cut out; after → translucent surface preserved (~142k partial-alpha pixels). Same-render A/B reproduces the exact bug by binarizing alpha.

## Cause 2 (secondary): AUTOEXPORT races the deferred surface build

`PYMOL_AUTOEXPORT` re-asserts via `runCommand`, which routes `show surface` to `runHeavy` (deferred ~50ms), so the synchronous export ran before the surface rep was flagged → `CoordSet::render` skipped it. **Fix:** re-assert via `runCommandCore` (synchronous). Verified against the headless harness.

## Ruled out (build-and-test)
Missing `SceneUpdate` (it's called), OIT-resolve skipped offscreen (it runs), VBO-upload gating (offscreen-safe), `ValidContext` (true offscreen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnX5reNtCwaVJ4a69N8jP9
