### PR TITLE
feat(metal): scene-panel outline color/width + MCP quick-connect pills

### DIFF
--- a/RayMol_Picking_Bug_Report.md
+++ b/RayMol_Picking_Bug_Report.md
@@ -1,0 +1,124 @@
+# Technical Investigation Report: CPU Screen-Space Picking Misalignment in RayMol
+
+## 🔍 Executive Summary
+A detailed visual frame-by-frame analysis of the screen recording (`Screen Recording 2026-06-18 at 12.04.12 PM.mov`) reveals two independent issues occurring simultaneously when clicking to select residues on the macOS Metal backend:
+1. **Vertical Flip/Mirror Bug:** Clicking on a residue selects a completely different residue in the vertically mirrored position of the viewport.
+2. **Console Error Noise Bug:** Clicking outputs a heavy C++ traceback in the dropdown terminal log (`Selector-Error: Invalid selection name "dist03"`).
+
+Both bugs originate from discrepancies between coordinates and types expected by the CPU unprojection picking system (`metal_pick.py` and `MetalViewport.swift`) and what is returned under SwiftUI layout hosting on macOS.
+
+---
+
+## 🐞 Bug 1: Vertical Offset / Flip (Coordinate Inversion)
+
+### 1. Symptoms & Visual Evidence
+* In **Frame 4**, the cursor clicks on the **bottom-left** of the protein (the green ribbon around coordinate `y = 630` in logical space). However, the resulting pink selection squares appear near the **top-left** of the protein (the orange ribbon around `y = 320`).
+* In **Frame 5**, the cursor clicks at the **bottom-center** (green ribbon, `y = 570`), but the new pink squares appear at the **top-center** (orange/green interface, `y = 310`).
+* In **Frame 6**, the cursor clicks on the blue helix near the **bottom-right** (`y = 570`), but the selection appears near the **top-right** of the helix (`y = 440`).
+
+### 2. Deep Root-Cause Analysis
+* **The File:** `swiftui/PyMOLViewer/Shared/MetalViewport.swift`
+* **The Code:**
+  ```swift
+  func handleMouseUp(_ event: NSEvent, in view: MTKView) {
+      let loc = view.convert(event.locationInWindow, from: nil)
+      // ...
+      let ndcX = Float(loc.x / w) * 2 - 1
+      let ndcY = Float(loc.y / h) * 2 - 1 // <--- Origin of the bug
+  ```
+* **The Explanation:**
+  1. Traditional macOS AppKit views (`NSView` / `MTKView`) are natively **bottom-up** (with `Y = 0` at the bottom and `Y = h` at the top).
+  2. However, because our `MTKView` is hosted inside SwiftUI (using `NSViewRepresentable`), SwiftUI wraps it in its own hosting hierarchy where `isFlipped` is `true` (standard top-down coordinates).
+  3. Under a flipped AppKit hierarchy, coordinate conversions like `view.convert(point, from: nil)` inherit the flipped state and return coordinates with a **top-left origin** (`Y = 0` is at the top of the viewport, increasing downwards).
+  4. The coordinate translation `Float(loc.y / h) * 2 - 1` assumes bottom-up coordinates. Under top-down coordinates, it **vertically mirrors the mouse position**:
+     * Clicking near the **top** (`loc.y ≈ 0`) maps to NDC `ndcY ≈ -1` (interpreted as the bottom).
+     * Clicking near the **bottom** (`loc.y ≈ h`) maps to NDC `ndcY ≈ 1` (interpreted as the top).
+
+---
+
+## 🐞 Bug 2: Selector-Error Console Noise
+
+### 1. Symptoms
+Every residue click triggers a verbose error block printed to the C++ terminal log:
+```text
+Selector-Error: Invalid selection name "dist03".
+( ( dist03 ) and ( rep spheres or rep sticks ...
+```
+
+### 2. Deep Root-Cause Analysis
+* **The File:** `modules/pymol/metal_pick.py`
+* **The Code:**
+  ```python
+  for obj in (cmd.get_names('objects', enabled_only=1) or []):
+      if obj.startswith('_'):
+          continue
+      try:
+          model = cmd.get_model('(%s) and (%s)' % (obj, _DRAWN_REPS))
+      except Exception:
+          continue
+  ```
+* **The Explanation:**
+  1. Inside the right sidebar panel of the video, several distance measurements (`dist03` and `dist04`) are checked/enabled.
+  2. `cmd.get_names('objects', enabled_only=1)` returns *all* enabled objects, which includes these distance measurements.
+  3. Distance measurements are of type `"object:measurement"`. They are not molecules and do not have coordinates or atoms in the selection system.
+  4. Passing `(dist03)` as a selection expression to `cmd.get_model` causes the C++ selection parser to fail with a `Selector-Error`, printing tracebacks and polluting internal C++ selection engine buffers.
+
+---
+
+# Proposed Fixes
+
+Here is the exact code architecture needed to resolve both issues permanently:
+
+### 1. Fixing Bug 1 (Vertical Flip) in `MetalViewport.swift`
+To resolve the coordinate flip under SwiftUI hosting, we must apply the same vertical Y-flip on macOS that we already do on iOS:
+
+#### A. Update the standard mouse-up NDC mapping:
+In `swiftui/PyMOLViewer/Shared/MetalViewport.swift` (around line 363), change `ndcY` to flip the top-down coordinates:
+```swift
+// FROM:
+let ndcY = Float(loc.y / h) * 2 - 1
+
+// TO:
+let ndcY = 1 - Float(loc.y / h) * 2
+```
+
+#### B. Update the debug click generator:
+In the test harness helper `debugClick` (around line 399), flip the Y coordinate as well so it converts the NDC bottom-up target correctly into top-down viewport points:
+```swift
+// FROM:
+let vp = CGPoint(x: (ndcX + 1) / 2 * w, y: (ndcY + 1) / 2 * h)
+
+// TO:
+let vp = CGPoint(x: (ndcX + 1) / 2 * w, y: (1 - ndcY) / 2 * h)
+```
+
+---
+
+### 2. Fixing Bug 2 (Selector-Error Noise) in `metal_pick.py`
+Before querying atoms of an enabled object, check if the object is actually a molecule (`"object:molecule"`). If it is a distance measurement (`"object:measurement"`) or group/map/volume, skip it entirely:
+
+In `modules/pymol/metal_pick.py` (inside the `_pick_atom` loop around line 118):
+```python
+# FROM:
+for obj in (cmd.get_names('objects', enabled_only=1) or []):
+    if obj.startswith('_'):
+        continue
+    try:
+        model = cmd.get_model('(%s) and (%s)' % (obj, _DRAWN_REPS))
+    except Exception:
+        continue
+
+# TO:
+for obj in (cmd.get_names('objects', enabled_only=1) or []):
+    if obj.startswith('_'):
+        continue
+    try:
+        if cmd.get_type(obj) != 'object:molecule':
+            continue
+    except Exception:
+        continue
+    try:
+        model = cmd.get_model('(%s) and (%s)' % (obj, _DRAWN_REPS))
+    except Exception:
+        continue
+```

--- a/RayMol_Sequence_Viewer_Report.md
+++ b/RayMol_Sequence_Viewer_Report.md
@@ -1,0 +1,105 @@
+# Investigation Report: RayMol Sequence Viewer Selection Logic vs. Vanilla PyMOL
+
+## 🔍 Overview
+Selecting residues in the AppKit/SwiftUI Sequence Viewer panel behaves differently than vanilla PyMOL. Specifically, clicking a residue in the panel:
+1. Hardcodes the selection name to `"sele"`, erasing any active custom selections.
+2. Overwrites the active selection entirely instead of toggling residues in/out of selection.
+3. Force-centers the camera on the clicked residue, which can cause jarring camera animations on simple selection changes.
+
+This report analyzes the underlying mechanics of both architectures and proposes a python-native solution for RayMol to mirror vanilla PyMOL's sequence selection capabilities.
+
+---
+
+## 🏛️ Architecture Comparison
+
+### 1. Vanilla PyMOL (`CSeeker` C++ Selection Engine)
+In standard PyMOL, clicking on sequence characters is handled by `SeekerClick` inside `layer3/Seeker.cpp` and `CSeeker` (inheriting from `CSeqHandler`):
+* **Respects Active Selection:** It checks the currently active selection via `ExecutiveGetActiveSeleName(G, name, ...)`. Clicking adds to or removes from this active selection instead of hardcoding `"sele"`.
+* **Additive/Subtractive Toggling:** It calls `SeekerSelectionToggle(G, rowVLA, row_num, col_num, ...)` to toggle individual residues. If a clicked residue is already highlighted, it is sliced out (`(active_sele) and not (residue)`); otherwise, it is joined (`(active_sele) or (residue)`).
+* **Multi-Select and Drag:** Dragging highlights continuous blocks, and Shift-clicks extend selections by executing a contiguous range query.
+* **No Forced Centering:** A simple left-click only modifies selection state. Camera centering is reserved for middle-clicks or double-clicks.
+
+### 2. RayMol Sequence Panel (`appkit_sequence_panel.py`)
+In RayMol, the sequence viewer is an AppKit horizontal scroll view composed of individual text button labels. Selection is intercepted in Python by **`SeqPanel_ClickTarget`** inside `modules/pymol/appkit_sequence_panel.py`:
+```python
+class SeqPanel_ClickTarget(AppKit.NSObject):
+    ...
+    @objc.typedSelector(b'v@:@')
+    def clicked_(self, sender):
+        try:
+            sel = self._obj_name
+            if self._chain:
+                sel += " and chain " + self._chain
+            if self._resi:
+                sel += " and resi " + str(self._resi)
+            self._cmd.select("sele", sel)              # 1. Hardcoded "sele" & Overwrite
+            self._cmd.center(sel, animate=-1)          # 2. Forced camera centering
+```
+
+---
+
+## 💡 Proposed Solution
+
+To align RayMol's sequence panel with the traditional PyMOL selection paradigm, the click target logic in `modules/pymol/appkit_sequence_panel.py` should be redesigned.
+
+### Features of the Proposed Solution:
+1. **Dynamic Active Selection:** Query the active named selection, falling back to `"sele"` only if none exists.
+2. **Residue-Level Toggling (Additive Selection):** Toggle the clicked residue in/out of the selection based on its current membership.
+3. **Configurable Camera Centering:** Remove or gate the forced `center` call (e.g. only center if holding `Control` or on double-clicks), matching the behavior of `metal_pick.py`.
+
+### Code Implementation Proposal
+Replace `clicked_` inside `SeqPanel_ClickTarget` with the following clean, PyMOL-idiomatic Python implementation:
+
+```python
+    @objc.typedSelector(b'v@:@')
+    def clicked_(self, sender):
+        try:
+            # 1. Build the specific residue selection expression
+            res_expr = self._obj_name
+            if self._chain:
+                res_expr += " and chain " + self._chain
+            if self._resi:
+                res_expr += " and resi " + str(self._resi)
+            res_expr = "(%s)" % res_expr
+
+            # 2. Determine target selection name (active selection, falling back to 'sele')
+            # Check for existing custom selections to see if one is currently active
+            all_sels = self._cmd.get_names('selections') or []
+            target_sele = "sele"
+            for s in all_sels:
+                # If there's an enabled custom selection, we target it
+                if self._cmd.get_setting_int('enabled', s) == 1:
+                    target_sele = s
+                    break
+
+            # 3. Additive / Subtractive Toggle
+            exists = target_sele in all_sels
+            # Check if this residue is already part of the active selection
+            already_selected = exists and self._cmd.count_atoms('(%s) and %s' % (target_sele, res_expr)) > 0
+
+            if already_selected:
+                # Subtractive selection: remove residue from active selection
+                self._cmd.select(target_sele, '(%s) and not %s' % (target_sele, res_expr))
+            else:
+                # Additive selection: join residue with active selection
+                self._cmd.select(target_sele, '(?%s) or %s' % (target_sele, res_expr))
+
+            self._cmd.enable(target_sele)
+
+            # 4. Optional: Only center on Ctrl+Click (matching Seeker's middle-click/modifier paradigm)
+            # In pure AppKit, we can check modifier keys via NSEvent:
+            # from AppKit import NSEvent, NSControlKeyMask
+            # if NSEvent.modifierFlags() & NSControlKeyMask:
+            #     self._cmd.center(res_expr, animate=-1)
+
+        except Exception as e:
+            print(f"SeqPanel click error: {e}")
+```
+
+---
+
+## 📈 Impact & Improvements
+By adopting this proposed solution:
+* **Peer Consistency:** The Sequence Viewer selections will interact seamlessly with selections created in the 3D viewport (via clicks) and the named selections sidebar.
+* **Complex Selections:** Users can select non-contiguous sets of residues across different chains and domains directly from the sequence bar.
+* **Viewport Stability:** The camera remains stable during sequential sequence selections, allowing users to build up a visual selection map without the viewport spinning/animating on every character click.

--- a/layer1/SceneRender.cpp
+++ b/layer1/SceneRender.cpp
@@ -2024,10 +2024,16 @@ void SceneRenderMetal(PyMOLGlobals* G)
     int tonemapEnabled = SettingGetGlobal_b(G, cSetting_metal_tonemap) ? 1 : 0;
     float exposure = SettingGetGlobal_f(G, cSetting_metal_exposure);
     int rtShadowEnabled = SettingGetGlobal_b(G, cSetting_metal_rt_shadows) ? 1 : 0;
+    // Outline contour color (resolved from the color setting, same ColorGet
+    // pattern as bg_rgb above) and thickness in px — both Scene-panel tunable.
+    const float* outlineCol =
+        ColorGet(G, SettingGetGlobal_color(G, cSetting_metal_outline_color));
+    float outlineWidth = SettingGetGlobal_f(G, cSetting_metal_outline_width);
     G->Renderer->setPostParams(fogEnabled, fogStart, fogEnd, bg[0], bg[1],
         bg[2], aoEnabled, shadowEnabled, aaEnabled, outlineEnabled, proj[10],
         proj[14], proj[0], proj[5], rtEnabled, tonemapEnabled, exposure,
-        rtShadowEnabled);
+        rtShadowEnabled, outlineCol[0], outlineCol[1], outlineCol[2],
+        outlineWidth);
     // Lighting model — the Metal lit shaders read these instead of hard-coded
     // constants, so the Scene-panel lighting sliders take effect.
     G->Renderer->setLightingParams(

--- a/layer1/SettingInfo.h
+++ b/layer1/SettingInfo.h
@@ -914,6 +914,8 @@ enum {
   REC_b( 804, metal_tonemap                           , global    , false ), /* Metal filmic (ACES) tone-mapping + exposure post pass */
   REC_f( 805, metal_exposure                          , global    , 1.0F ),  /* Metal tone-map exposure multiplier (1.0 = neutral) */
   REC_b( 806, metal_rt_shadows                         , global    , false ), /* Metal: trace hard shadow rays (needs metal_raytrace) instead of shadow-map PCF */
+  REC_c( 807, metal_outline_color                     , global    , "0x000000" ), /* Metal outline contour color (color setting, like ray_trace_color) */
+  REC_f( 808, metal_outline_width                     , global    , 1.4F ),  /* Metal outline thickness in pixels (post-pass neighbor sample step) */
 
 #ifdef SETTINGINFO_IMPLEMENTATION
 #undef SETTINGINFO_IMPLEMENTATION

--- a/layerGraphics/Renderer.h
+++ b/layerGraphics/Renderer.h
@@ -294,7 +294,8 @@ public:
       float bgR, float bgG, float bgB, int aoEnabled, int shadowEnabled,
       int aaEnabled, int outlineEnabled, float projA, float projB, float projX,
       float projY, int rtEnabled = 0, int tonemapEnabled = 0,
-      float exposure = 1.0f, int rtShadowEnabled = 0)
+      float exposure = 1.0f, int rtShadowEnabled = 0, float outlineR = 0.0f,
+      float outlineG = 0.0f, float outlineB = 0.0f, float outlineWidth = 1.4f)
   {
   }
 

--- a/layerGraphics/metal/RendererMetal.h
+++ b/layerGraphics/metal/RendererMetal.h
@@ -151,7 +151,9 @@ public:
       float bgG, float bgB, int aoEnabled, int shadowEnabled, int aaEnabled,
       int outlineEnabled, float projA, float projB, float projX,
       float projY, int rtEnabled, int tonemapEnabled = 0,
-      float exposure = 1.0f, int rtShadowEnabled = 0) override;
+      float exposure = 1.0f, int rtShadowEnabled = 0, float outlineR = 0.0f,
+      float outlineG = 0.0f, float outlineB = 0.0f,
+      float outlineWidth = 1.4f) override;
   void setLightingParams(float ambient, float direct, float reflect,
       float specular, float shininess) override;
 
@@ -398,6 +400,9 @@ private:
   int _shadowEnabled = 1;      // screen-space shadows (cSetting_metal_shadows)
   int _aaEnabled = 1;          // FXAA (cSetting_antialias_shader != 0)
   int _outlineEnabled = 0;     // silhouette outline (cSetting_metal_outline)
+  // Outline contour color + thickness in px (cSetting_metal_outline_color/_width).
+  float _outlineR = 0.f, _outlineG = 0.f, _outlineB = 0.f;
+  float _outlineWidth = 1.4f;
   id<MTLRenderPipelineState> _outlinePipeline = nil;
   // Filmic tone-map + exposure post pass (cSetting_metal_tonemap/_exposure).
   // Milestone 1: operates on the existing LDR scene color (no float promotion).

--- a/layerGraphics/metal/RendererMetal.mm
+++ b/layerGraphics/metal/RendererMetal.mm
@@ -1015,11 +1015,14 @@ void RendererMetal::setPostParams(int fogEnabled, float fogStart, float fogEnd,
     float bgR, float bgG, float bgB, int aoEnabled, int shadowEnabled,
     int aaEnabled, int outlineEnabled, float projA, float projB, float projX,
     float projY, int rtEnabled, int tonemapEnabled, float exposure,
-    int rtShadowEnabled)
+    int rtShadowEnabled, float outlineR, float outlineG, float outlineB,
+    float outlineWidth)
 {
   _tonemapEnabled = tonemapEnabled;
   _exposure = exposure;
   _rtShadowEnabled = rtShadowEnabled;
+  _outlineR = outlineR; _outlineG = outlineG; _outlineB = outlineB;
+  _outlineWidth = outlineWidth;
   _postFogEnabled = fogEnabled;
   _fogStart = fogStart;
   _fogEnd = fogEnd;
@@ -1709,8 +1712,8 @@ void RendererMetal::runPostChain()
     u.projA = _projA; u.projB = _projB;
     u.invW = (_rtW > 0) ? 1.0f / (float)_rtW : 0.0f;
     u.invH = (_rtH > 0) ? 1.0f / (float)_rtH : 0.0f;
-    u.colR = 0.0f; u.colG = 0.0f; u.colB = 0.0f;   // black contour
-    u.thickness = 1.4f;
+    u.colR = _outlineR; u.colG = _outlineG; u.colB = _outlineB;
+    u.thickness = _outlineWidth;
     MTLRenderPassDescriptor* pd = [[MTLRenderPassDescriptor alloc] init];
     pd.colorAttachments[0].texture = dst;
     pd.colorAttachments[0].loadAction = MTLLoadActionDontCare;

--- a/layerGraphics/metal/RendererMetal.mm
+++ b/layerGraphics/metal/RendererMetal.mm
@@ -557,9 +557,18 @@ fragment float4 post_tonemap(PostVOut in [[stage_in]],
 // exporting at 2x and downscaling anti-aliases the cutout.
 fragment float4 post_export_alpha(PostVOut in [[stage_in]],
     texture2d<float> src [[texture(0)]],
-    depth2d<float> depthTex [[texture(1)]], sampler s [[sampler(0)]]) {
+    depth2d<float> depthTex [[texture(1)]],
+    texture2d<float> revealTex [[texture(2)]], sampler s [[sampler(0)]]) {
   float d = depthTex.sample(s, in.uv);
-  float a = (d >= 0.99995) ? 0.0 : 1.0;   // far plane == cleared background
+  // Opaque geometry (depth < far) stays fully opaque; the far-plane background is
+  // cut out. BUT transparent reps (the molecular surface) render via weighted-
+  // blended OIT and do NOT write depth, so a depth-only cutout erases them from
+  // the exported alpha wherever the translucent shell overhangs the background —
+  // the surface vanishes from a transparent-background PNG while showing fine in
+  // the viewport (issue #22). Recover their coverage from the OIT transmittance
+  // (cover = 1 - reveal, matching oit_resolve) so the surface survives the matte.
+  float cover = 1.0 - revealTex.sample(s, in.uv).r;
+  float a = (d < 0.99995) ? 1.0 : cover;   // far plane == cleared background
   return float4(src.sample(s, in.uv).rgb, a);
 }
 
@@ -1762,6 +1771,7 @@ void RendererMetal::runPostChain()
     [ea setRenderPipelineState:_exportAlphaPipeline];
     [ea setFragmentTexture:sceneSrc atIndex:0];
     [ea setFragmentTexture:_sceneDepth atIndex:1];
+    [ea setFragmentTexture:_oitReveal atIndex:2];  // recover transparent (surface) coverage
     [ea setFragmentSamplerState:_postSampler atIndex:0];
     [ea drawPrimitives:MTLPrimitiveTypeTriangle vertexStart:0 vertexCount:3];
     [ea endEncoding];

--- a/modules/pymol/appkit_inspector.py
+++ b/modules/pymol/appkit_inspector.py
@@ -41,7 +41,8 @@ REP_COLOR = {
 }
 
 SCENE_SETTINGS = ['metal_raytrace', 'metal_rt_shadows', 'metal_shadows', 'metal_ssao',
-                  'metal_outline', 'metal_msaa', 'metal_tonemap', 'metal_exposure',
+                  'metal_outline', 'metal_outline_width', 'metal_msaa',
+                  'metal_tonemap', 'metal_exposure',
                   'depth_cue', 'fog', 'field_of_view', 'surface_quality',
                   'grid_mode', 'all_states', 'mouse_selection_mode',
                   'ambient', 'direct', 'reflect', 'specular', 'shininess',
@@ -86,26 +87,48 @@ def _rep_color(obj, setting):
 
 
 def _bg_rgb():
-    """bg_rgb may be a hex string ('0x000000') or an (r,g,b) tuple → [r,g,b] floats."""
+    """Background color → [r,g,b] floats. `bg_rgb` resolves to a hex string, an
+    (r,g,b) tuple, OR a named color / index — the last happens after the panel
+    runs `bg_color <name>` (cmd.get returns the name, e.g. '_bgcol'). Resolve it
+    the same robust way as any other color setting so the swatch never falls
+    back to black for a non-hex background."""
+    return _color_setting_rgb('bg_rgb')
+
+
+def _color_setting_rgb(setting, fallback=(0.0, 0.0, 0.0)):
+    """Resolve a color-type global setting (e.g. metal_outline_color) to [r,g,b]
+    floats in 0…1. Handles (r,g,b) tuples, '0xRRGGBB' hex, color names, and
+    numeric color indices."""
     try:
-        v = cmd.get('bg_rgb')
+        v = cmd.get(setting)
     except Exception:
-        return [0.0, 0.0, 0.0]
+        return list(fallback)
     if isinstance(v, (list, tuple)):
         try:
             return [float(x) for x in v][:3]
         except Exception:
-            return [0.0, 0.0, 0.0]
+            return list(fallback)
     s = str(v).strip()
-    if s[:2] in ('0x', '0X'):
-        s = s[2:]
-    if len(s) == 6:
+    if s[:2] in ('0x', '0X') and len(s) == 8:
         try:
-            return [int(s[0:2], 16) / 255.0, int(s[2:4], 16) / 255.0,
-                    int(s[4:6], 16) / 255.0]
+            return [int(s[2:4], 16) / 255.0, int(s[4:6], 16) / 255.0,
+                    int(s[6:8], 16) / 255.0]
         except Exception:
             pass
-    return [0.0, 0.0, 0.0]
+    try:
+        ci = int(float(s))
+    except Exception:
+        try:
+            ci = cmd.get_color_index(s)
+        except Exception:
+            return list(fallback)
+    try:
+        t = cmd.get_color_tuple(ci)
+    except Exception:
+        return list(fallback)
+    if not t or t == -1:
+        return list(fallback)
+    return [float(t[0]), float(t[1]), float(t[2])]
 
 
 def _build(objs):
@@ -125,6 +148,7 @@ def _build(objs):
         detail[o] = reps
     scene = {s: _num(s, '') for s in SCENE_SETTINGS}
     scene['bg'] = _bg_rgb()
+    scene['outline_rgb'] = _color_setting_rgb('metal_outline_color')
     # Per-object state metadata for the inspector STATE row: the effective
     # current state (the object's 'state' setting, which resolves to the global
     # frame's state when not pinned) and whether all states are overlaid.

--- a/swiftui/PyMOLViewer/Panels/MCPConnectSheet.swift
+++ b/swiftui/PyMOLViewer/Panels/MCPConnectSheet.swift
@@ -41,11 +41,20 @@ struct MCPConnectSheet: View {
                     .disabled(!mcp.isRunning)
             }
             if let port = mcp.port {
-                Text("Manual command:").font(.caption)
+                HStack {
+                    Text("Manual command:").font(.caption)
+                    Spacer()
+                    Button {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(manualCommand(port), forType: .string)
+                        result = "Connection details copied to clipboard."
+                    } label: {
+                        Label("Copy connection details", systemImage: "doc.on.doc")
+                    }
+                    .font(.caption).controlSize(.small)
+                }
                 ScrollView(.horizontal, showsIndicators: false) {
-                    Text("claude mcp add --transport http raymol "
-                        + "http://127.0.0.1:\(port)/mcp "
-                        + "--header \"Authorization: Bearer \(mcp.token)\" --scope user")
+                    Text(manualCommand(port))
                         .font(.system(.caption2, design: .monospaced))
                         .textSelection(.enabled).padding(8)
                 }
@@ -85,6 +94,12 @@ struct MCPConnectSheet: View {
             HStack { Spacer(); Button("Done") { dismiss() } }
         }
         .padding(20).frame(width: 470)
+    }
+
+    private func manualCommand(_ port: Int) -> String {
+        "claude mcp add --transport http raymol "
+            + "http://127.0.0.1:\(port)/mcp "
+            + "--header \"Authorization: Bearer \(mcp.token)\" --scope user"
     }
 }
 #endif

--- a/swiftui/PyMOLViewer/Panels/MCPStatusView.swift
+++ b/swiftui/PyMOLViewer/Panels/MCPStatusView.swift
@@ -37,6 +37,7 @@ struct MCPStatusView: View {
 
 private struct MCPStatusPopover: View {
     @EnvironmentObject var mcp: MCPServerManager
+    @State private var quickResult: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -72,12 +73,46 @@ private struct MCPStatusPopover: View {
                 .frame(maxHeight: 110)
             }
             Divider()
+            // One-click connect for the two common clients (skips the sheet).
+            // Both auto-trust the session (noteUserInitiatedConnect / pushTrusted).
+            Text("Quick connect").font(.caption).foregroundStyle(.secondary)
+            HStack(spacing: 6) {
+                Button {
+                    mcp.connectClaudeCode { msg in quickResult = msg }
+                } label: {
+                    HStack(spacing: 3) {
+                        Image(systemName: "terminal")
+                        Text("Claude Code")
+                        if mcp.claudeCLIPath != nil {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundStyle(.green).font(.caption2)
+                        }
+                    }
+                }
+                Button {
+                    mcp.noteUserInitiatedConnect()
+                    quickResult = MCPDesktopInstaller.installViaConfig().message
+                } label: {
+                    HStack(spacing: 3) {
+                        Image(systemName: "menubar.dock.rectangle")
+                        Text("Claude App")
+                    }
+                }
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .disabled(!mcp.isRunning)
+            if let quickResult {
+                Text(quickResult).font(.caption2).foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true).lineLimit(3)
+            }
+            Divider()
             Button("Connect an AI app…") {
                 NotificationCenter.default.post(name: .mcpOpenConnectSheet, object: nil)
             }
         }
         .padding(12)
-        .frame(width: 250)
+        .frame(width: 280)
     }
 }
 #endif

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -42,6 +42,7 @@ struct RepState: Equatable {
 struct SceneState: Equatable {
     var values: [String: Double] = [:]   // setting name → value (toggles 0/1)
     var bg: [Double] = [0, 0, 0]         // background r,g,b in 0…1
+    var outlineColor: [Double] = [0, 0, 0]  // metal_outline_color r,g,b in 0…1
 }
 
 /// Per-object state metadata for the inspector STATE row (multi-state objects).
@@ -177,6 +178,7 @@ enum SceneCatalog {
         SceneParam(setting: "metal_shadows", label: "Shadows", kind: .toggle, group: "Lighting & Quality"),
         SceneParam(setting: "metal_ssao",    label: "Ambient occlusion", kind: .toggle, group: "Lighting & Quality"),
         SceneParam(setting: "metal_outline", label: "Outline", kind: .toggle, group: "Lighting & Quality"),
+        SceneParam(setting: "metal_outline_width", label: "Outline width", kind: .slider, min: 0.5, max: 5.0, step: 0.1, decimals: 1, group: "Lighting & Quality"),
         SceneParam(setting: "metal_msaa",    label: "MSAA 4×", kind: .toggle, group: "Lighting & Quality"),
         SceneParam(setting: "metal_tonemap", label: "Filmic tone-map", kind: .toggle, group: "Lighting & Quality"),
         SceneParam(setting: "metal_exposure", label: "Exposure", kind: .slider, min: 0.2, max: 2.0, step: 0.05, decimals: 2, group: "Lighting & Quality"),
@@ -1719,6 +1721,18 @@ private struct SceneCard: View {
                         }
                         .disabled(rtUnavailable)
                         .opacity(rtUnavailable ? 0.45 : 1)
+                        // Keep the outline contour color directly under its toggle.
+                        if p.setting == "metal_outline" {
+                            sceneRow("Outline color") {
+                                ColorPicker("", selection: Binding(
+                                    get: { Color(.sRGB,
+                                                 red: engine.sceneState.outlineColor.count > 0 ? engine.sceneState.outlineColor[0] : 0,
+                                                 green: engine.sceneState.outlineColor.count > 1 ? engine.sceneState.outlineColor[1] : 0,
+                                                 blue: engine.sceneState.outlineColor.count > 2 ? engine.sceneState.outlineColor[2] : 0) },
+                                    set: { setOutlineColor($0) }))
+                                    .labelsHidden().frame(width: 28)
+                            }
+                        }
                     }
                     Button { showSettings = true } label: {
                         HStack(spacing: 6) {
@@ -1765,6 +1779,10 @@ private struct SceneCard: View {
 
     private func setBackground(_ color: Color) {
         engine.runCommand("set_color _bgcol, \(rgb01List(color))\nbg_color _bgcol")
+    }
+
+    private func setOutlineColor(_ color: Color) {
+        engine.runCommand("set_color _outlinecol, \(rgb01List(color))\nset metal_outline_color, _outlinecol")
     }
 
     @ViewBuilder

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -1417,6 +1417,8 @@ final class PyMOLEngine: ObservableObject {
             for (k, v) in sc {
                 if k == "bg", let arr = v as? [Any] {
                     scene.bg = arr.map { ($0 as? NSNumber)?.doubleValue ?? 0 }
+                } else if k == "outline_rgb", let arr = v as? [Any] {
+                    scene.outlineColor = arr.map { ($0 as? NSNumber)?.doubleValue ?? 0 }
                 } else {
                     scene.values[k] = (v as? NSNumber)?.doubleValue ?? 0
                 }

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -396,10 +396,17 @@ final class PyMOLEngine: ObservableObject {
                     guard let self = self else { return }
                     // Re-assert the caller's explicit state last, so neither the
                     // persisted theme nor PYMOL_AUTOTHEME can clobber the requested
-                    // background between init and this render.
+                    // background between init and this render. Use runCommandCore
+                    // (NOT runCommand): runCommand routes heavy ops like `show
+                    // surface` to runHeavy, which defers them ~50ms off this turn,
+                    // so the synchronous render below would race the surface build
+                    // and export with the surface rep still unflagged/unbuilt — the
+                    // exported PNG then drops the surface (issue #22). runCommandCore
+                    // flags the reps synchronously here, so the offscreen render's
+                    // SceneUpdate builds them before the capture.
                     if let c = autoCmd {
                         for one in c.split(separator: ";") {
-                            self.runCommand(one.trimmingCharacters(in: .whitespaces))
+                            self.runCommandCore(one.trimmingCharacters(in: .whitespaces))
                         }
                     }
                     self.renderHiResPNG(parts[0], width: w, height: h, rayTraced: rt)


### PR DESCRIPTION
## Summary
Adds RayMol (macOS SwiftUI+Metal) functionality. Note: this branch also carries the
pre-existing **#22 offscreen-export fixes** (not yet on master), so they appear here too.

### Metal outline — user-controllable color & width
- New settings `metal_outline_color` (color, default black) and `metal_outline_width`
  (float, default 1.4px). The Metal silhouette outline post-pass previously hardcoded
  black / 1.4px.
- Threaded `SceneRender` → `Renderer::setPostParams` → the outline pass.
- Scene panel: **Outline color** picker + **Outline width** slider, placed directly
  under the Outline toggle.

### Fix — background swatch went black for non-hex backgrounds
- `_bg_rgb()` only parsed `0x`-hex / RGB tuples, but the panel sets the background via
  `bg_color <name>`, so `cmd.get('bg_rgb')` returns a color *name* → black fallback.
  Now routed through the same name/index-aware resolver the outline color uses.

### MCP popover UX
- One-click **Claude Code** / **Claude App** quick-connect pills (auto-trusting).
- **Copy connection details** button in the Connect-an-AI-app sheet.

### Also on this branch (pre-existing)
- `82f51b10`, `5223b330` — #22 offscreen / transparent-background export surface fixes.
- Picking / Sequence-Viewer bug-report docs.

## Verification
- `libpymol_core.a` rebuilt + app relinked.
- New settings register with correct defaults and round-trip via `set`/`get`.
- Live Metal render uses the values (verified with a thick red outline on a surface).
- Background-swatch fix verified: a yellow named-color background now resolves correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
