### PR TITLE
fix(release): render update notes as Markdown, not the GitHub web page

### DIFF
--- a/swiftui/publish_release.sh
+++ b/swiftui/publish_release.sh
@@ -8,11 +8,16 @@
 # is what installed RayMol.app polls (SUFeedURL in Info.plist).
 #
 # Usage:
-#   VERSION=1.1.0 BUILD=5 bash swiftui/publish_release.sh
+#   VERSION=1.1.0 BUILD=5 NOTES_FILE=docs/release-notes/v1.1.0.md \
+#     bash swiftui/publish_release.sh
 #
-# VERSION = marketing version (CFBundleShortVersionString)
-# BUILD   = CFBundleVersion (CURRENT_PROJECT_VERSION) — Sparkle compares on this,
-#           so it MUST increase every release.
+# VERSION   = marketing version (CFBundleShortVersionString)
+# BUILD     = CFBundleVersion (CURRENT_PROJECT_VERSION) — Sparkle compares on this,
+#             so it MUST increase every release.
+# NOTES_FILE = Markdown release notes. Embedded into the appcast as
+#             <description sparkle:format="markdown"> so Sparkle renders them
+#             natively in the update dialog (no GitHub web page), and also used
+#             as the GitHub release body. Optional; falls back to a short blurb.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -66,7 +71,6 @@ echo "  $SIGFRAG"
 
 URL="https://github.com/$REPO/releases/download/v$VERSION/RayMol-$VERSION.dmg"
 PUBDATE="$(date -u +"%a, %d %b %Y %H:%M:%S +0000")"
-NOTESLINK="https://github.com/$REPO/releases/tag/v$VERSION"
 
 echo "== Write appcast.xml =="
 cat > "$APPCAST" <<XML
@@ -79,7 +83,9 @@ cat > "$APPCAST" <<XML
     <language>en</language>
     <item>
       <title>RayMol $VERSION</title>
-      <sparkle:releaseNotesLink>$NOTESLINK</sparkle:releaseNotesLink>
+      <description xml:lang="en" sparkle:format="markdown"><![CDATA[
+__RELEASE_NOTES_CDATA__
+]]></description>
       <pubDate>$PUBDATE</pubDate>
       <sparkle:version>$BUILD</sparkle:version>
       <sparkle:shortVersionString>$VERSION</sparkle:shortVersionString>
@@ -89,6 +95,25 @@ cat > "$APPCAST" <<XML
   </channel>
 </rss>
 XML
+
+# Splice the release notes into the appcast's <description> as Markdown. This is
+# done here (not in the heredoc above) on purpose: the notes contain backticks
+# and may contain '$', which an unquoted heredoc would mangle. Python inserts the
+# bytes verbatim and guards the CDATA section against a literal ']]>'.
+python3 - "$APPCAST" "${NOTES_SNAPSHOT:-}" <<'PY'
+import sys
+appcast_path, notes_path = sys.argv[1], sys.argv[2]
+if notes_path:
+    with open(notes_path, encoding="utf-8") as f:
+        notes = f.read().strip()
+else:
+    notes = "Bug fixes and improvements. See the in-app release notes for details."
+notes = notes.replace("]]>", "]] >")  # CDATA cannot contain the literal ]]>
+with open(appcast_path, encoding="utf-8") as f:
+    xml = f.read()
+with open(appcast_path, "w", encoding="utf-8") as f:
+    f.write(xml.replace("__RELEASE_NOTES_CDATA__", notes))
+PY
 echo "  wrote $APPCAST"
 
 # Stable-named copy of the DMG so the website can link a FIXED url that always


### PR DESCRIPTION
## Problem

The Sparkle "A new version of RayMol is available!" dialog rendered the **entire GitHub release web page** — nav bar, "Sign in", Code/Issues/Pull-requests tabs — instead of clean release notes.

**Root cause:** `swiftui/publish_release.sh` set `<sparkle:releaseNotesLink>` to the GitHub release tag URL. Sparkle loads that URL in a web view, so the whole GitHub page chrome showed up.

## Fix

Embed the release notes directly in the appcast instead of linking out:

- Drop `<sparkle:releaseNotesLink>`.
- Write the `NOTES_FILE` Markdown into `<description xml:lang="en" sparkle:format="markdown">`.
- Splice the notes in with a small `python3` step rather than the shell heredoc, so backticks and `$` in the notes (e.g. `` `set grid_mode, 1` ``) aren't mangled by shell expansion; the CDATA is guarded against a literal `]]>`.

Sparkle 2.9.3 (already pinned) renders embedded Markdown natively into an `NSTextView` — auto-themed for light/dark, system font, headings/bold/lists/inline-code — so **no converter, CSS, or hosted HTML** is needed. RayMol requires macOS 13, and native Markdown needs macOS 12+, so it always applies.

## Verification

- **Appcast dry run** (real v1.2.1 notes): well-formed per `xmllint`; contains `sparkle:format="markdown"`; no `releaseNotesLink`; backticks/bold preserved.
- **Rendering** via the exact Foundation API Sparkle uses (`NSAttributedString(markdownString:options:nil)`): the notes parse into `header 2`, `unorderedList`, `listItem`, and `paragraph` presentation intents — real headings/bullets, not raw `##`/`-`.

## Follow-up (not in this PR)

The live feed still carries the old link for the current 1.2.1 release. To fix what already-installed users see immediately, re-publish so the uploaded `appcast.xml` is regenerated with embedded notes (DMG unchanged, same Ed25519 signature):

```bash
VERSION=1.2.1 BUILD=7 NOTES_FILE=docs/release-notes/v1.2.1.md \
  bash swiftui/publish_release.sh
```

Note: Sparkle drops the embedded notes if the enclosure signature doesn't validate (`SUAppcastItem.m:510`), so the notes only display once published with a valid signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnX5reNtCwaVJ4a69N8jP9
