### PR TITLE
fix(ui): crash/data-loss batch — SequencePanel OOB, theme-preview scene loss, File-menu selectors (#53/#54/#55)

### DIFF
--- a/modules/pymol/appkit_menus.py
+++ b/modules/pymol/appkit_menus.py
@@ -258,19 +258,19 @@ def _add_file_menu(menubar):
     menu.setAutoenablesItems_(False)
 
     _menu_action(menu, "Open...", 'openFile:', 'o')
-    _menu_action(menu, "Get PDB...", 'fetchPDB_:', 'f', _CMD_SHIFT)
+    _menu_action(menu, "Get PDB...", 'fetchPDB:', 'f', _CMD_SHIFT)
     _sep(menu)
-    _menu_action(menu, "Save Session", 'saveSessionQuick_:', 's')
+    _menu_action(menu, "Save Session", 'saveSessionQuick:', 's')
     _menu_action(menu, "Save Session As...", 'saveSession:', 's', _CMD_SHIFT)
     _sep(menu)
 
     # Export Image As submenu
     export_img = _submenu(menu, "Export Image As")
-    _menu_action(export_img, "PNG...", 'exportPNG_:')
+    _menu_action(export_img, "PNG...", 'exportPNG:')
 
     _sep(menu)
 
-    _menu_action(menu, "Run Script...", 'runScript_:')
+    _menu_action(menu, "Run Script...", 'runScript:')
     _sep(menu)
 
     # Reinitialize submenu

--- a/modules/pymol/appkit_theme_preview.py
+++ b/modules/pymol/appkit_theme_preview.py
@@ -26,6 +26,13 @@ def begin(path):
     except Exception as e:
         _saved = None
         print("THEMEPREVIEW_ERR:snapshot:" + str(e))
+    # Never mutate the scene unless we hold a valid snapshot to restore from. If
+    # get_session failed (and we have no prior snapshot), bailing here keeps the
+    # user's real scene intact — otherwise disable("all") below would hide it with
+    # no way back (restore() with _saved is None only deletes the preview object).
+    if _saved is None:
+        print("THEMEPREVIEW_ERR:begin:no snapshot, scene left untouched")
+        return
     try:
         cmd.delete(OBJ)
         cmd.load(path, OBJ)

--- a/swiftui/PyMOLViewer/Panels/SequencePanel.swift
+++ b/swiftui/PyMOLViewer/Panels/SequencePanel.swift
@@ -245,9 +245,17 @@ struct SequencePanel: View {
         shift = mods.contains(.shift)
         ctrl = mods.contains(.control)
         #endif
-        if shift, let a = anchorIndex {
-            let lo = min(a, idx), hi = max(a, idx)
-            applyToggle(residues: Array(flat[lo...hi]), add: true)
+        if shift, let a = anchorIndex, !flat.isEmpty {
+            // `idx` is resolved against the current `flat`, but `a` was captured on
+            // an earlier click; if `flat` shrank since then (an object was removed/
+            // replaced), `a` can be >= flat.count. Clamp both ends so the range
+            // subscript can never trap out of bounds.
+            let n = flat.count
+            let lo = max(0, min(min(a, idx), n - 1))
+            let hi = max(0, min(max(a, idx), n - 1))
+            if lo <= hi {
+                applyToggle(residues: Array(flat[lo...hi]), add: true)
+            }
         } else {
             anchorIndex = idx
             let isSelected = engine.selectedResidueKeys.contains(r.selKey)


### PR DESCRIPTION
## Summary

Three small, surgical crash / data-loss fixes from the 2026-06-27 review (Tier A). Each is provably a no-op on its normal path and only changes the broken edge case.

### #54 — SequencePanel shift-click out-of-bounds crash *(SwiftUI app)*
`Array(flat[lo...hi])` mixed a **stale `anchorIndex`** with a freshly-resolved index. If the flattened residue list shrank (an object was removed/replaced) since the anchor click, the anchor could be `>= flat.count` and the range subscript **traps**. Now both ends are clamped to `[0, flat.count-1]` with a `lo <= hi` guard. In-bounds selection is byte-identical.

### #55 — Theme preview could hide the live scene unrecoverably *(SwiftUI Theme Studio)*
`begin()` snapshots the session, but on a `get_session` failure it set `_saved = None` and **still** ran `disable("all")` + showed only the preview — leaving the user's real scene hidden with no way back (`restore()` with `_saved is None` only deletes the preview object). Now it bails out before mutating the scene unless a valid snapshot is held. The normal flow (snapshot succeeds) is unchanged. Reachable from the SwiftUI Theme Studio (`PyMOLEngine.swift` → `appkit_theme_preview.begin/restore`).

### #53 — File-menu commands sent unrecognized selectors *(AppKit host)*
PyObjC maps a method's trailing `_` to a selector `:`; four action strings carried an **extra** underscore (`fetchPDB_:`, `saveSessionQuick_:`, `exportPNG_:`, `runScript_:`), naming non-existent selectors → `NSException` on click. Dropped the extra underscore to match the methods (mirrors the working `openFile:`/`saveSession:`).

> **Scope note:** `appkit_menus.setup_menus()` is invoked only from `layer5/main_appkit.mm` (the **AppKit host**). The shipping **SwiftUI app builds its File menu in `PyMOLApp.swift`**, so this code path is AppKit-host-only — the fix is correct there, but the SwiftUI app's menu was never affected. (Reachability caveat noted on #53.)

## Verification
- Python modules compile (`py_compile`) and re-bundle into `RayMol.app` (`fetchPDB_:` count = 0, theme-preview bail present).
- SwiftUI app builds clean and runs; reachability of each fix confirmed (SequencePanel used in `ContentView.swift`; theme preview called from `PyMOLEngine.swift`; appkit_menus only from `main_appkit.mm`).
- Each fix is a no-op on its normal path by construction, so existing behavior is preserved.

`+22 / −7` across `appkit_menus.py`, `appkit_theme_preview.py`, `SequencePanel.swift`.

Closes #54, #55. Partially addresses #53 (AppKit-host menu; see scope note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
