### PR TITLE
fix(mcp): thread-safety & input robustness — marshal core calls onto the main thread (#52)

### DIFF
--- a/modules/raymol_mcp/mainthread.py
+++ b/modules/raymol_mcp/mainthread.py
@@ -1,0 +1,70 @@
+"""Main-thread marshalling for the in-process MCP server.
+
+MCP tool handlers run on http.server request-handler threads. In the embedded
+Metal build ``pymol._pymol.glutThread`` is never set, so ``is_gui_thread()`` is
+True on every thread and a ``cmd`` call made on a handler thread runs
+synchronously OFF the main thread, racing the main thread's ``SceneRenderMetal``
+(which drives the core natively, not via the cmd API). The app documents that
+off-main core access corrupts the interpreter state, so this races/crashes.
+
+``run_on_main(fn)`` hands ``fn`` to the app's MAIN thread and blocks the calling
+handler until the result (or exception) is ready. The app drains the queue once
+per ~100ms Timer tick by calling ``drain_main_thread_queue()`` (on the main
+thread, via PyMOLBridge_RunPython). This is the same "all core access on main"
+invariant the SwiftUI app's ``runHeavy`` already relies on.
+
+Stdlib-only (queue + threading) so this imports without a built PyMOL.
+"""
+
+import queue
+import threading
+
+_main_q = queue.Queue()
+_main_ident = None        # thread id of the draining (main) thread; set on first drain
+_TIMEOUT = 30.0           # seconds; longer than the slowest CPU ray-trace
+
+
+def run_on_main(fn, timeout=_TIMEOUT):
+    """Run ``fn()`` on the app's main thread and return its result.
+
+    Called from an MCP request-handler thread: enqueues the work and blocks
+    until the main thread drains it (or ``timeout`` elapses). Any exception
+    ``fn`` raised is re-raised here (with its original traceback). If we are
+    already ON the main thread (re-entrancy — a queued fn called us back), run
+    ``fn`` inline: the draining thread is the only consumer, so enqueuing would
+    self-deadlock.
+    """
+    if _main_ident is not None and threading.get_ident() == _main_ident:
+        return fn()
+    box = {}
+    done = threading.Event()
+    _main_q.put((fn, box, done))
+    if not done.wait(timeout):
+        raise TimeoutError(
+            "RayMol main thread did not process the request within %ss "
+            "(is the app rendering / responsive?)" % timeout)
+    if "exc" in box:
+        raise box["exc"]
+    return box.get("val")
+
+
+def drain_main_thread_queue():
+    """Run all queued work on the MAIN thread, then return.
+
+    Called once per Timer tick from PyMOLEngine.pollFeedback (main thread, via
+    PyMOLBridge_RunPython). Each item's result/exception is recorded and its
+    waiter signalled. Must never raise (it runs inside the app's feedback pump).
+    """
+    global _main_ident
+    _main_ident = threading.get_ident()
+    while True:
+        try:
+            fn, box, done = _main_q.get_nowait()
+        except queue.Empty:
+            break
+        try:
+            box["val"] = fn()
+        except BaseException as e:  # propagate to the waiting handler thread
+            box["exc"] = e
+        finally:
+            done.set()

--- a/modules/raymol_mcp/server.py
+++ b/modules/raymol_mcp/server.py
@@ -35,12 +35,17 @@ INSTRUCTIONS = (
 SESSION_TTL = 300.0
 SWEEP_INTERVAL = 20.0
 
-_lock = threading.Lock()
+_lock = threading.Lock()            # guards server lifecycle (start/stop)
 _httpd = None
 _thread = None
 _port = None
 _token = None
 _sessions = {}  # sid -> last_seen (monotonic)
+# Guards _sessions, mutated from request-handler threads + the sweeper thread.
+# Lock rules: never hold it across events.* (which does blocking stdout I/O) or
+# httpd.shutdown(); if both locks are needed, take _lock first (never nest _lock
+# inside _sessions_lock) — request handlers only ever take _sessions_lock.
+_sessions_lock = threading.Lock()
 _trusted = False
 _stop_sweeper = threading.Event()
 _sweeper = None
@@ -51,16 +56,15 @@ def set_trusted(value):
     _trusted = bool(value)
 
 
-def _touch(sid):
-    if sid:
-        _sessions[sid] = time.monotonic()
-
-
 def _prune_idle(now=None):
     now = time.monotonic() if now is None else now
-    dead = [s for s, t in list(_sessions.items()) if now - t > SESSION_TTL]
+    with _sessions_lock:
+        dead = [s for s, t in _sessions.items() if now - t > SESSION_TTL]
+        for s in dead:
+            _sessions.pop(s, None)
+    # Emit OUTSIDE the lock (events.* does blocking stdout I/O). pop-then-emit
+    # means each sid disconnects exactly once even if do_DELETE races us.
     for s in dead:
-        _sessions.pop(s, None)
         events.client_disconnected(s)
     return dead
 
@@ -162,13 +166,19 @@ class _Handler(BaseHTTPRequestHandler):
         is_init = isinstance(message, dict) and message.get("method") == "initialize"
         if is_init:
             session_id = uuid.uuid4().hex
-            _sessions[session_id] = time.monotonic()
+            with _sessions_lock:
+                _sessions[session_id] = time.monotonic()
             # Skip the connect event (which raises the "Allow" prompt) when
             # auto-trust is on for testing — there is nothing to approve.
             if not _trusted:
                 events.client_connected(session_id)
-        elif session_id and session_id in _sessions:
-            _touch(session_id)
+        elif session_id:
+            # Atomic check-and-touch: refresh last_seen only for a KNOWN session,
+            # under one lock so a concurrent sweep can't prune between the
+            # membership test and the update (which would resurrect the session).
+            with _sessions_lock:
+                if session_id in _sessions:
+                    _sessions[session_id] = time.monotonic()
 
         response = handle_jsonrpc(message, session_id or "")
 
@@ -191,8 +201,13 @@ class _Handler(BaseHTTPRequestHandler):
         if not self._authed():
             return self._reject(401, "unauthorized")
         session_id = self.headers.get("Mcp-Session-Id")
-        if session_id and session_id in _sessions:
-            _sessions.pop(session_id, None)
+        # Atomic pop-once so a concurrent sweep can't also pop+emit for this sid
+        # (double client_disconnected). Emit outside the lock (blocking I/O).
+        existed = False
+        if session_id:
+            with _sessions_lock:
+                existed = _sessions.pop(session_id, None) is not None
+        if existed:
             events.client_disconnected(session_id)
         self.send_response(204)
         self.send_header("Content-Length", "0")
@@ -231,8 +246,9 @@ def stop():
         if _httpd is None:
             return
         _stop_sweeper.set()
-        sids = list(_sessions.keys())
-        _sessions = {}                      # cleared first: a waking sweeper finds nothing
+        with _sessions_lock:                # cleared first: a waking sweeper finds nothing
+            sids = list(_sessions.keys())
+            _sessions.clear()
         _httpd.shutdown()
         _httpd.server_close()
         worker = _thread
@@ -246,10 +262,13 @@ def stop():
             worker.join(timeout=2)
         if sweeper is not None:
             sweeper.join(timeout=2)
-        for s in sids:
-            events.client_disconnected(s)
-        events.server_stopped()
+    # Emit disconnects/stopped OUTSIDE both locks (events.* does blocking I/O).
+    for s in sids:
+        events.client_disconnected(s)
+    events.server_stopped()
 
 
 def status():
-    return {"running": _httpd is not None, "port": _port, "clients": len(_sessions)}
+    with _sessions_lock:
+        n = len(_sessions)
+    return {"running": _httpd is not None, "port": _port, "clients": n}

--- a/modules/raymol_mcp/tools.py
+++ b/modules/raymol_mcp/tools.py
@@ -1,13 +1,15 @@
 """MCP tool definitions + dispatcher for the RayMol MCP server.
 
-Tools call PyMOL's ``cmd`` API directly, imported LAZILY inside functions so this
-module imports standalone (for unit tests) without a built PyMOL. They run on the
-MCP server's Python thread (a real threading.Thread), so cmd's API lock serialises
-access safely -- the same model the old Raymond worker used. Never call the C
-bridge (PyMOLBridge_*) from here; only the Python ``cmd`` API.
+Tools call PyMOL's ``cmd`` API, imported LAZILY inside functions so this module
+imports standalone (for unit tests) without a built PyMOL. Handlers run on the
+MCP server's HTTP request-handler threads, but every ``cmd``-touching body is
+run via ``mainthread.run_on_main`` so it executes on the app's MAIN thread — the
+only thread where the embedded core is safe to touch (it races
+``SceneRenderMetal`` otherwise; see mainthread.py). Never call the C bridge
+(PyMOLBridge_*) from here; only the Python ``cmd`` API.
 
-``capture_viewport`` renders with the CPU ray-tracer (cmd.ray) because cmd.png
-without ray reads a GL framebuffer the Metal app does not have.
+``capture_viewport`` renders with the CPU ray-tracer (cmd.png ray=1) because
+cmd.png without ray reads a GL framebuffer the Metal app does not have.
 """
 
 import base64
@@ -20,6 +22,8 @@ import threading
 import traceback
 import urllib.parse
 import urllib.request
+
+from raymol_mcp.mainthread import run_on_main
 
 # Persistent namespace for run_python; seeded on first use.
 _py_ns = None
@@ -60,11 +64,15 @@ def _run_pymol_command(args):
     cmd_str = args.get("command", "")
     if not cmd_str:
         return _error("missing 'command'")
-    from pymol import cmd
-    try:
+
+    def _body():
+        from pymol import cmd
         cmd.do(cmd_str)
         cmd.sync()
         return _text("ok")
+
+    try:
+        return run_on_main(_body)
     except Exception:
         return _error(traceback.format_exc())
 
@@ -73,22 +81,29 @@ def _run_python(args):
     code = args.get("code", "")
     if not code:
         return _error("missing 'code'")
-    ns = _namespace()
-    buf = io.StringIO()
+
+    def _body():
+        ns = _namespace()
+        buf = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(buf):
+                exec(code, ns)
+            from pymol import cmd
+            cmd.sync()
+            out = buf.getvalue()
+            return _text(out if out else "ok")
+        except Exception:
+            return _error(buf.getvalue() + "\n" + traceback.format_exc())
+
     try:
-        with contextlib.redirect_stdout(buf):
-            exec(code, ns)
-        from pymol import cmd
-        cmd.sync()
-        out = buf.getvalue()
-        return _text(out if out else "ok")
+        return run_on_main(_body)
     except Exception:
-        return _error(buf.getvalue() + "\n" + traceback.format_exc())
+        return _error(traceback.format_exc())
 
 
 def _get_session_state(args):
-    from pymol import cmd
-    try:
+    def _body():
+        from pymol import cmd
         objects = []
         for name in cmd.get_names("objects"):
             otype = cmd.get_type(name)
@@ -110,22 +125,32 @@ def _get_session_state(args):
             "n_frames": cmd.count_frames(),
         }
         return _text(json.dumps(state, indent=2))
+
+    try:
+        return run_on_main(_body)
     except Exception:
         return _error(traceback.format_exc())
 
 
 def _capture_viewport(args):
-    from pymol import cmd
     path = None
     try:
-        width = int(args.get("width", 640))
-        height = int(args.get("height", 480))
+        # Clamp to a sane maximum: width/height come straight from the caller and
+        # feed a CPU ray-trace, so an unbounded size is a multi-minute / OOM DoS.
+        width = max(1, min(int(args.get("width", 640)), 2048))
+        height = max(1, min(int(args.get("height", 480)), 2048))
         fd, path = tempfile.mkstemp(suffix=".png", prefix="raymol_mcp_capture_")
         os.close(fd)
+
         # ray=1 ray-traces and writes the PNG in one synchronous call. A separate
         # cmd.ray + cmd.png(prior=1) fails with "no prior image available" when
-        # driven from the MCP server thread.
-        cmd.png(path, width=width, height=height, ray=1)
+        # driven from the MCP server thread. Runs on the main thread (touches the
+        # scene/renderer); the tempfile create/read/cleanup stay off-main.
+        def _render():
+            from pymol import cmd
+            cmd.png(path, width=width, height=height, ray=1)
+        run_on_main(_render)
+
         with open(path, "rb") as f:
             data = base64.b64encode(f.read()).decode("ascii")
         return {"content": [{"type": "image", "data": data,

--- a/swiftui/PyMOLViewer/Shared/MCPBridge.swift
+++ b/swiftui/PyMOLViewer/Shared/MCPBridge.swift
@@ -8,7 +8,16 @@ import Foundation
 
 enum MCPBridge {
     private static let protocolVersion = "2025-06-18"
+    // sessionId is written from the URLSession completion queue and read on the
+    // run() loop thread, so guard it with a lock for safe cross-thread visibility.
     private static var sessionId: String? = nil
+    private static let sessionIdLock = NSLock()
+    private static func getSessionId() -> String? {
+        sessionIdLock.lock(); defer { sessionIdLock.unlock() }; return sessionId
+    }
+    private static func setSessionId(_ s: String) {
+        sessionIdLock.lock(); sessionId = s; sessionIdLock.unlock()
+    }
 
     static func run() {
         while let line = readLine(strippingNewline: true) {
@@ -27,7 +36,7 @@ enum MCPBridge {
         // Claude closed our stdin (it quit) — tell the server to terminate our
         // session so the connected-client count updates immediately instead of
         // waiting for the idle sweep.
-        if let sid = sessionId, let h = handoff(),
+        if let sid = getSessionId(), let h = handoff(),
            let url = URL(string: "http://127.0.0.1:\(h.port)/mcp") {
             var req = URLRequest(url: url)
             req.httpMethod = "DELETE"
@@ -62,18 +71,24 @@ enum MCPBridge {
         req.httpBody = raw
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
         req.setValue("Bearer \(h.token)", forHTTPHeaderField: "Authorization")
-        if let sid = sessionId { req.setValue(sid, forHTTPHeaderField: "Mcp-Session-Id") }
+        if let sid = getSessionId() { req.setValue(sid, forHTTPHeaderField: "Mcp-Session-Id") }
         let sem = DispatchSemaphore(value: 0)
         var out: Data? = nil
         let task = URLSession.shared.dataTask(with: req) { body, resp, _ in
             if let http = resp as? HTTPURLResponse {
-                if let sid = http.value(forHTTPHeaderField: "Mcp-Session-Id") { sessionId = sid }
+                if let sid = http.value(forHTTPHeaderField: "Mcp-Session-Id") { setSessionId(sid) }
                 out = (http.statusCode == 202) ? Data() : (body ?? Data())
             }
             sem.signal()
         }
         task.resume()
-        _ = sem.wait(timeout: .now() + 120)
+        if sem.wait(timeout: .now() + 120) == .timedOut {
+            // Cancel so the abandoned task's completion can't write `out`/sessionId
+            // off-thread later; don't read `out` here (it could be racing). On
+            // success the completion ran fully before signaling, so `out` is safe.
+            task.cancel()
+            return nil
+        }
         return out
     }
 

--- a/swiftui/PyMOLViewer/Shared/MCPServerManager.swift
+++ b/swiftui/PyMOLViewer/Shared/MCPServerManager.swift
@@ -230,9 +230,14 @@ final class MCPServerManager: ObservableObject {
         let pipe = Pipe()
         proc.standardOutput = pipe
         proc.standardError = pipe
-        do { try proc.run(); proc.waitUntilExit() } catch { return (-1, "\(error)") }
+        do { try proc.run() } catch { return (-1, "\(error)") }
+        // Drain the pipe to EOF BEFORE waiting. stdout+stderr share one pipe, so a
+        // chatty child can fill the ~64KB buffer and block on write while we block
+        // in waitUntilExit() — a classic deadlock. readDataToEndOfFile() returns
+        // when the child closes the pipe (i.e. exits), so read first, then wait.
         let out = String(data: pipe.fileHandleForReading.readDataToEndOfFile(),
                          encoding: .utf8) ?? ""
+        proc.waitUntilExit()
         return (proc.terminationStatus, out)
     }
 

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -436,6 +436,7 @@ final class PyMOLEngine: ObservableObject {
         feedbackTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
             guard let self = self else { return }
             self.pollFeedback()
+            self.drainMCPMainQueue()
             self.pollObjects()
             // While the core is advancing frames, mirror the frame counter at
             // the full 100ms tick so the scrubber tracks playback smoothly.
@@ -1058,11 +1059,17 @@ final class PyMOLEngine: ObservableObject {
     // creating a lasting selection. Emits SELPREVIEW:<n> (or :err). The caller
     // debounces. Uses a throwaway '_pv' selection.
     func previewSelection(_ expr: String) {
-        let e = expr.replacingOccurrences(of: "\\", with: "")
+        // Pass the expression as base64 and decode in Python, so a selection
+        // string containing quotes / ''' / backslashes can neither break the
+        // literal nor inject code (the old strip-backslashes + r'''…''' was both
+        // lossy and injectable via an embedded ''').
+        let b64 = Data(expr.utf8).base64EncodedString()
         runPython(
-            "from pymol import cmd as _c\n"
+            "import base64 as _b64\n"
+            + "from pymol import cmd as _c\n"
+            + "_e = _b64.b64decode('\(b64)').decode('utf-8')\n"
             + "try:\n"
-            + "    _n = _c.select('_pv', r'''\(e)''')\n"
+            + "    _n = _c.select('_pv', _e)\n"
             + "    print('SELPREVIEW:%d' % int(_n))\n"
             + "    _c.delete('_pv')\n"
             + "except Exception:\n"
@@ -1071,17 +1078,24 @@ final class PyMOLEngine: ObservableObject {
 
     // Create/overwrite a named selection and enable it.
     func createSelection(name: String, expr: String) {
-        let n = name.replacingOccurrences(of: "'", with: "")
-        let e = expr.replacingOccurrences(of: "\\", with: "")
-        runPython("from pymol import cmd as _c\n_c.select(r'''\(n)''', r'''\(e)''', enable=1)")
+        // base64 the name + expression (see previewSelection): injection-safe.
+        let nb = Data(name.utf8).base64EncodedString()
+        let eb = Data(expr.utf8).base64EncodedString()
+        runPython("import base64 as _b64\nfrom pymol import cmd as _c\n"
+            + "_c.select(_b64.b64decode('\(nb)').decode('utf-8'), "
+            + "_b64.b64decode('\(eb)').decode('utf-8'), enable=1)")
     }
 
     // Rename an object/selection.
     func renameObject(_ old: String, to newName: String) {
-        let o = old.replacingOccurrences(of: "'", with: "")
-        let n = newName.replacingOccurrences(of: "'", with: "")
-        guard !n.isEmpty else { return }
-        runPython("from pymol import cmd as _c\n_c.set_name(r'''\(o)''', r'''\(n)''')")
+        guard !newName.isEmpty else { return }
+        // base64 both names (see previewSelection): injection-safe. The C core
+        // sanitizes the decoded name via ObjectMakeValidName.
+        let ob = Data(old.utf8).base64EncodedString()
+        let nb = Data(newName.utf8).base64EncodedString()
+        runPython("import base64 as _b64\nfrom pymol import cmd as _c\n"
+            + "_c.set_name(_b64.b64decode('\(ob)').decode('utf-8'), "
+            + "_b64.b64decode('\(nb)').decode('utf-8'))")
     }
 
     // MARK: - Interactive measurement
@@ -1111,9 +1125,12 @@ final class PyMOLEngine: ObservableObject {
     }
 
     func setSetting(_ name: String, _ value: String) {
-        let n = name.replacingOccurrences(of: "'", with: "")
-        let v = value.replacingOccurrences(of: "'", with: "")
-        runPython("from pymol import appkit_settings as _as\n_as.set_value(r'''\(n)''', r'''\(v)''')")
+        // base64 the name + value (see previewSelection): injection-safe.
+        let nb = Data(name.utf8).base64EncodedString()
+        let vb = Data(value.utf8).base64EncodedString()
+        runPython("import base64 as _b64\nfrom pymol import appkit_settings as _as\n"
+            + "_as.set_value(_b64.b64decode('\(nb)').decode('utf-8'), "
+            + "_b64.b64decode('\(vb)').decode('utf-8'))")
     }
 
     // Read the settings catalog JSON the bridge wrote to the temp dir.
@@ -1346,6 +1363,21 @@ final class PyMOLEngine: ObservableObject {
                 }
             }
         }
+    }
+
+    // Run MCP tool work queued from the in-process server's HTTP request threads
+    // on THIS (main) thread — the only thread where touching the embedded core is
+    // safe (off-main cmd calls race SceneRenderMetal / corrupt the interpreter).
+    // raymol_mcp.mainthread.run_on_main enqueues from the handler thread and blocks
+    // until we drain here, once per ~100ms Timer tick. Gated on the server running
+    // so there's no per-tick bridge call when MCP is off. A queued op runs
+    // synchronously (it can block this tick — the same on-main invariant runHeavy
+    // relies on); when idle the drain is an instant empty-queue check.
+    private func drainMCPMainQueue() {
+        #if os(macOS) && !RAYMOL_MAS_RESTRICTED
+        guard isReady, MCPServerManager.shared.isRunning else { return }
+        PyMOLBridge_RunPython("import raymol_mcp.mainthread as _mt; _mt.drain_main_thread_queue()")
+        #endif
     }
 
     private var objectPollCounter = 0


### PR DESCRIPTION
## Summary

Fixes the MCP thread-safety + robustness issues in #52. The in-process MCP server's tool handlers ran on `http.server` request threads; in the embedded Metal build `is_gui_thread()` is True on every thread, so `cmd.do` / `cmd.png(ray=1)` / `exec` executed **synchronously off the main thread**, racing `SceneRenderMetal` (which drives the core natively, bypassing the cmd API). Off-main core access corrupts the interpreter → sporadic native crashes whenever the MCP/AI-copilot drove the core while the view rendered (worst under `cmd.png(ray=1)`).

## H-7 — main-thread marshalling (core fix)
- **New `raymol_mcp/mainthread.py`**: `run_on_main(fn)` enqueues work and blocks the handler thread on an `Event`; `drain_main_thread_queue()` runs the queued work on the **main thread** and signals waiters. Hardenings: inline-on-main re-entrancy guard, `finally: event.set()`, bounded 30s timeout.
- **`tools.py`**: every cmd-touching handler body runs via `run_on_main` (`run_pymol_command`, `run_python`, `get_session_state`, `capture_viewport`); `search_pdb` stays off-main (pure HTTP).
- **`PyMOLEngine.swift`**: `drainMCPMainQueue()` pumps the queue once per ~100ms feedback Timer tick (main thread, PAutoBlock), gated on the server running.

Long ops (`cmd.png ray=1`) run on main and briefly block the UI — the same on-main invariant `runHeavy` already relies on; correctness over responsiveness.

## Robustness
- **L-51** `capture_viewport` clamps `width`/`height` to `[1, 2048]` (was an unbounded ray-trace DoS).
- **L-50** `server.py` adds `_sessions_lock` around all `_sessions` access; `client_*` events emitted **outside** the lock; `do_DELETE`/`_prune_idle` pop-once so each session disconnects exactly once even when a handler races the sweeper.
- **L-56** `PyMOLEngine.swift` selection/name interpolation (`previewSelection`, `createSelection`, `renameObject`, `setSetting`) now **base64-encodes in Swift → b64decodes in Python** (was strip-quotes + `r'''…'''`, injectable via an embedded `'''`).
- **M-25** `MCPServerManager.runClaude` reads the pipe to EOF **before** `waitUntilExit` (merged stdout+stderr could fill the 64KB buffer and deadlock).
- **L-57** `MCPBridge.proxy` cancels the URLSession task on the 120s timeout and serializes the static `sessionId` with a lock (late off-thread write race).

## Verification
- Marshalling unit-tested standalone (value / exception propagation / re-entrancy-inline / timeout — **4/4**).
- App builds; **driving real MCP tool calls against the live app while it renders no longer crashes**: `fetch 1ubq`, `show surface` + `set transparency` + `metal_shadows`, ray-traced `capture_viewport`, and a `run_python` turn+refresh loop — all marshalled to main, **0 crashes**, leaks at baseline.
- L-51: a `99999×99999` capture request is clamped to `2048×2048` and returns promptly (no OOM/hang).
- Clean teardown crash-free (exercises the `stop()` / L-50 path).

`+229 / −63` across the 5 modified files + new `mainthread.py`.

Closes #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
