### PR TITLE
fix(metal): resolution-relative DoF aperture + outline width for WYSIWYG hi-res export (#48)

### DIFF
--- a/layerGraphics/metal/RendererMetal.h
+++ b/layerGraphics/metal/RendererMetal.h
@@ -321,6 +321,15 @@ private:
   MTLRenderPassDescriptor* _scenePassDesc = nil;
   MTLRenderPassDescriptor* _screenPassDesc = nil;
   NSUInteger _rtW = 0, _rtH = 0;
+  // Live render-target height, captured in setDrawable. Pixel-radius post passes
+  // (DoF aperture, outline thickness) are authored against the live resolution;
+  // offscreen exports run at a higher _rtH, so scaling those radii by
+  // _rtH/_liveRefH keeps the effect resolution-relative (WYSIWYG). 0 until the
+  // first live frame, where the scale is 1 (live appearance unchanged).
+  NSUInteger _liveRefH = 0;
+  float pixelRadiusScale() const {
+    return (_liveRefH > 0) ? (float)_rtH / (float)_liveRefH : 1.0f;
+  }
   id<MTLRenderPipelineState> _blitPipeline = nil;
   id<MTLRenderPipelineState> _ssaoPipeline = nil;
   id<MTLRenderPipelineState> _fxaaPipeline = nil;

--- a/layerGraphics/metal/RendererMetal.mm
+++ b/layerGraphics/metal/RendererMetal.mm
@@ -441,6 +441,11 @@ void RendererMetal::setDrawable(
   if (rw < 1) rw = 1;
   if (rh < 1) rh = 1;
   ensurePostTargets(rw, rh);
+  // Remember the live render height so pixel-radius post passes (DoF/outline)
+  // scale up for hi-res offscreen exports (which size _rtH directly via
+  // beginOffscreen and never touch _liveRefH). On the live path this keeps
+  // pixelRadiusScale()==1, so the on-screen appearance is unchanged.
+  _liveRefH = rh;
   _passDesc = _scenePassDesc;
 }
 
@@ -2030,7 +2035,10 @@ void RendererMetal::runPostChain()
     u.invH = (_rtH > 0) ? 1.0f / (float)_rtH : 0.0f;
     u.focusDist = _dofFocus;
     u.focusRange = (_dofRange > 0.01f) ? _dofRange : 14.0f;
-    u.maxRadiusPx = (_dofAperture > 0.0f) ? _dofAperture : 14.0f;
+    // Resolution-relative: the aperture is authored in px at the live resolution,
+    // so scale it for hi-res exports (pixelRadiusScale()==1 on the live view) —
+    // otherwise the bokeh nearly vanishes in 2x/4K Copy/Save output (#48).
+    u.maxRadiusPx = ((_dofAperture > 0.0f) ? _dofAperture : 14.0f) * pixelRadiusScale();
     u._pad = 0.0f;
     MTLRenderPassDescriptor* pd = [MTLRenderPassDescriptor renderPassDescriptor];
     pd.colorAttachments[0].texture = dst;
@@ -2059,7 +2067,9 @@ void RendererMetal::runPostChain()
     u.invW = (_rtW > 0) ? 1.0f / (float)_rtW : 0.0f;
     u.invH = (_rtH > 0) ? 1.0f / (float)_rtH : 0.0f;
     u.colR = _outlineR; u.colG = _outlineG; u.colB = _outlineB;
-    u.thickness = _outlineWidth;
+    // Resolution-relative thickness so outlines aren't hairline-thin in hi-res
+    // exports (pixelRadiusScale()==1 on the live view; see #48).
+    u.thickness = _outlineWidth * pixelRadiusScale();
     MTLRenderPassDescriptor* pd = [MTLRenderPassDescriptor renderPassDescriptor];
     pd.colorAttachments[0].texture = dst;
     pd.colorAttachments[0].loadAction = MTLLoadActionDontCare;


### PR DESCRIPTION
## Summary

Fixes #48: the Metal DoF bokeh and outline thickness did not match between the live viewport and Copy/Save exports — exports came out razor-sharp / hairline-thin.

**Root cause:** `metal_dof_aperture` (blur radius) and `metal_outline_width` are absolute **pixel** counts applied at the render-target resolution. Offscreen export renders larger than the live drawable (`copyImageToClipboard` uses `exportSize(scale: 2)`; Save offers up to 4K), so a fixed ~19px blur spans a much smaller fraction of the image → the bokeh nearly vanishes and outlines go thin. Not WYSIWYG.

**Fix:** make the pixel-radius post passes resolution-relative via `pixelRadiusScale() = _rtH / _liveRefH`:
- `setDrawable` records the **live** render height in `_liveRefH`; `beginOffscreen` sizes `_rtH` to the export resolution and never touches `_liveRefH`.
- `runPostChain` multiplies DoF `maxRadiusPx` and outline `thickness` by the ratio.

On the live view `_rtH == _liveRefH` → scale **1.0** (appearance byte-identical); a 2× export → scale **2.0**, exactly compensating the resolution so the effect matches. (SSAO's `aoRadiusPx` was already `_rtH`-relative, so it's untouched. Any future px-radius pass can call `pixelRadiusScale()`.)

`+21 / −2` in `RendererMetal.{h,mm}`.

## Verification
- Two-stage build clean (core `build_macos.sh` + xcodebuild).
- **Live view confirmed unchanged**: with `metal_dof` on (aperture 40) and `metal_outline` on, the on-screen render still shows the bokeh + outline (scale = 1).
- **Export scaling confirmed by code path**: `beginOffscreen` sets `_rtH` to the 2× export size via `ensurePostTargets` and leaves `_liveRefH` at the live height, so `pixelRadiusScale()` returns 2 during export → aperture 40→80, outline 2.5→5.
- App stable, clean teardown, no crashes.
- Note: a pixel-level capture of the 2× export wasn't automated here (the Copy Image / Save panel paths resist System-Events driving in this harness); it's trivial to eyeball via Export ▸ Copy Image.

Closes #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
