### PR TITLE
fix(cleanup): Metal/SwiftUI-app items from the 2026-06-27 review (Tab completion, log truncation, capture race) (#59)

### DIFF
--- a/layerGraphics/metal/RendererMetal.h
+++ b/layerGraphics/metal/RendererMetal.h
@@ -487,7 +487,6 @@ private:
   float _letterboxAspect = 0.f;       // saved-viewport W/H; 0 = fill window
   int _lbOriginX = 0, _lbOriginY = 0; // letterbox sub-rect origin (backing px)
   std::string _capturePath;           // pending png ray=0 capture (empty = none)
-  id<MTLTexture> _captureTex = nil;   // CPU-readable copy for readback
   bool _offscreen = false;            // hi-res offscreen render (no drawable)
 
   // --- Real-time ray tracing (cSetting_metal_raytrace) ---

--- a/layerGraphics/metal/RendererMetal.mm
+++ b/layerGraphics/metal/RendererMetal.mm
@@ -357,7 +357,7 @@ RendererMetal::~RendererMetal()
   [_sceneColorMS release];   [_sceneDepthMS release];
   [_oitAccum release];       [_oitReveal release];
   [_rtAO release];           [_rtAOHistory release];    [_rtAOAccum release];
-  [_shadowDepth release];    [_captureTex release];     [_labelAtlas release];
+  [_shadowDepth release];    [_labelAtlas release];
 
   // Render-pass descriptors ([[MTLRenderPassDescriptor alloc] init], +1).
   [_scenePassDesc release];  [_oitPassDesc release];    [_shadowPassDesc release];
@@ -2196,30 +2196,31 @@ void RendererMetal::runPostChain()
   // GPU completes. Captures at the current render resolution.
   if (!_capturePath.empty() && sceneSrc) {
     NSUInteger cw = sceneSrc.width, ch = sceneSrc.height;
-    if (!_captureTex || _captureTex.width != cw || _captureTex.height != ch) {
-      MTLTextureDescriptor* d = [MTLTextureDescriptor
-          texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm
-                                       width:cw height:ch mipmapped:NO];
-      d.usage = MTLTextureUsageShaderRead;
-      d.storageMode = MTLStorageModeShared;
-      // MRC: release the previous-size capture copy before reallocating. The
-      // completion handler below captures the old texture into `capTex`, and the
-      // copied block holds its own retain, so this release is safe.
-      [_captureTex release];
-      _captureTex = [_device newTextureWithDescriptor:d];
-    }
+    // Allocate a FRESH staging texture per capture (not a shared ivar): two
+    // captures a frame or two apart would otherwise blit into the same texture
+    // while the prior completion handler is still reading it off the GPU thread
+    // — a data race producing a torn/garbled PNG.
+    MTLTextureDescriptor* d = [MTLTextureDescriptor
+        texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm
+                                     width:cw height:ch mipmapped:NO];
+    d.usage = MTLTextureUsageShaderRead;
+    d.storageMode = MTLStorageModeShared;
+    id<MTLTexture> capTex = [_device newTextureWithDescriptor:d];  // +1 (owned here)
     id<MTLBlitCommandEncoder> be = [_cmdBuffer blitCommandEncoder];
     [be copyFromTexture:sceneSrc sourceSlice:0 sourceLevel:0
            sourceOrigin:MTLOriginMake(0, 0, 0) sourceSize:MTLSizeMake(cw, ch, 1)
-              toTexture:_captureTex destinationSlice:0 destinationLevel:0
+              toTexture:capTex destinationSlice:0 destinationLevel:0
       destinationOrigin:MTLOriginMake(0, 0, 0)];
     [be endEncoding];
     std::string path = _capturePath;
     _capturePath.clear();
-    id<MTLTexture> capTex = _captureTex;
     [_cmdBuffer addCompletedHandler:^(id<MTLCommandBuffer> cb) {
       rtWriteTextureToPNG(capTex, path);
     }];
+    // MRC: the copied handler block retained capTex and releases it when the
+    // block is destroyed (after it runs), so drop our +1 now — the texture stays
+    // alive for exactly this capture's handler and is then freed once.
+    [capTex release];
   }
 }
 

--- a/modules/pymol/appkit_command_panel.py
+++ b/modules/pymol/appkit_command_panel.py
@@ -103,14 +103,25 @@ def _append_log(text):
     full_text = storage.string()
     lines = full_text.split("\n")
     if len(lines) > _MAX_LINES:
-        # Find the character index where we keep from
-        keep_from = 0
         remove_count = len(lines) - _TRUNCATE_TO
-        for i in range(remove_count):
-            keep_from += len(lines[i]) + 1  # +1 for newline
-        storage.beginEditing()
-        storage.deleteCharactersInRange_((0, keep_from))
-        storage.endEditing()
+        # Compute the cut point in NSString (UTF-16) units, NOT Python code-point
+        # lengths: a non-BMP char (emoji) is 1 in Python len() but 2 UTF-16 units,
+        # so summing len(line) would under-count and deleteCharactersInRange_ would
+        # cut mid-character and garble the log. Walk the NSString's own newlines.
+        ns = storage.string()
+        total = ns.length()
+        keep_from = 0
+        found = 0
+        while found < remove_count:
+            r = ns.rangeOfString_options_range_("\n", 0, (keep_from, total - keep_from))
+            if r.length == 0:  # no more newlines
+                break
+            keep_from = r.location + 1
+            found += 1
+        if keep_from > 0:
+            storage.beginEditing()
+            storage.deleteCharactersInRange_((0, keep_from))
+            storage.endEditing()
 
     # Auto-scroll to bottom
     _log_text_view.scrollRangeToVisible_((storage.length(), 0))
@@ -179,15 +190,19 @@ class CommandInputDelegate(AppKit.NSObject):
             return True
 
         if sel == b'insertTab:' or sel_name == 'insertTab:':
-            # Basic tab completion placeholder
+            # Tab completion. cmd has no .complete(); the parser does, and it
+            # returns the COMPLETED STRING (or None), printing the options to the
+            # feedback log itself when there are several. (The old _cmd.complete()
+            # raised AttributeError that the bare except swallowed → Tab did nothing.)
             text = control.stringValue()
             if text:
                 try:
-                    completions = _cmd.complete(text)
-                    if completions and len(completions) == 1:
-                        control.setStringValue_(completions[0])
-                    elif completions:
-                        _append_log("  ".join(completions) + "\n")
+                    completed = _cmd._parser.complete(text)
+                    if completed and completed != text:
+                        control.setStringValue_(completed)
+                        editor = control.currentEditor()
+                        if editor:
+                            editor.moveToEndOfDocument_(None)
                 except Exception:
                     pass
             return True


### PR DESCRIPTION
Fixes the #59 cleanup items that actually affect the shipping **Metal/SwiftUI app** (the rest are GL-desktop / Linux-OpenMP / informational and never run here).

- **L-46** — command-panel **Tab completion did nothing**: it called `cmd.complete()` (doesn't exist) and the `AttributeError` was swallowed. Now uses `cmd._parser.complete(text)` (returns the completed string; prints options to the log) and moves the caret to the end.
- **L-47** — log auto-truncation summed **Python code-point** lengths but `deleteCharactersInRange_` uses **UTF-16** units, so an emoji misaligned the delete and garbled the log. Now walks the NSString's own newlines in UTF-16 units.
- **L-38** — PNG capture reused a single `_captureTex` ivar → two captures a frame apart could blit into it while the prior completion handler was still reading it (torn PNG). Now a **fresh per-capture Shared texture** owned by the handler block (block retains; we drop our +1 after `addCompletedHandler`). Removed the now-dead `_captureTex` ivar + its dtor release.

**Verified:** core + app build clean; `py_compile` clean; app launches, renders, clean teardown, no crashes. (Capture-block / Tab runtime triggers weren't exercised — MCP client disconnected + command-field keystroke automation is unreliable in this harness — but the builds are clean and the MRC block-capture pattern is the standard no-double-free one.)

**Out of scope** (GL-desktop / Linux / info-only, not run in the Metal app): L-24, L-33, L-36, L-54, L-55, L-35, I-61/62/63/65.

Closes #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)