### PR TITLE
fix(metal): stop tone-map/exposure silently muddling the render; guard MetalFX on the iOS Simulator

### DIFF
--- a/layerGraphics/metal/RendererMetal.mm
+++ b/layerGraphics/metal/RendererMetal.mm
@@ -1,7 +1,11 @@
 #include "RendererMetal.h"
 
 #import <simd/simd.h>
+#include <TargetConditionals.h>
+#if !TARGET_OS_SIMULATOR
 #import <MetalFX/MetalFX.h>   // MTLFXSpatialScaler (metal_upscale); macOS 13 / iOS 16+
+                              // — absent from the iOS Simulator SDK, so guarded.
+#endif
 #include <algorithm>
 #include <cmath>
 #include "MyPNG.h"
@@ -452,6 +456,12 @@ void RendererMetal::setDrawable(
 void RendererMetal::ensureUpscaler(NSUInteger inW, NSUInteger inH,
                                    NSUInteger outW, NSUInteger outH)
 {
+#if TARGET_OS_SIMULATOR
+  // MetalFX is absent from the iOS Simulator SDK — force the bilinear fallback.
+  _metalfxSupported = 0;
+  (void)inW; (void)inH; (void)outW; (void)outH;
+  return;
+#else
   if (_metalfxSupported == 0)
     return;  // known-unsupported device: caller uses the bilinear fallback
   if (inW == 0 || inH == 0 || outW == 0 || outH == 0)
@@ -486,6 +496,7 @@ void RendererMetal::ensureUpscaler(NSUInteger inW, NSUInteger inH,
   } else {
     _metalfxSupported = 0;
   }
+#endif  // !TARGET_OS_SIMULATOR
 }
 
 // ---------------------------------------------------------------------------
@@ -2171,6 +2182,7 @@ void RendererMetal::runPostChain()
     bool doUpscale = (_upscaleEnabled && _renderScale < 0.999f && sceneSrc && drawTex);
     if (doUpscale)
       ensureUpscaler(sceneSrc.width, sceneSrc.height, drawTex.width, drawTex.height);
+#if !TARGET_OS_SIMULATOR
     if (doUpscale && _upscaler) {
       if (@available(macOS 13.0, iOS 16.0, *)) {
         id<MTLFXSpatialScaler> sc = (id<MTLFXSpatialScaler>)_upscaler;
@@ -2178,7 +2190,9 @@ void RendererMetal::runPostChain()
         sc.outputTexture = drawTex;
         [sc encodeToCommandBuffer:_cmdBuffer];  // NOT a render-encoder pass
       }
-    } else {
+    } else
+#endif  // !TARGET_OS_SIMULATOR — sim has no MetalFX; always takes the blit path
+    {
       id<MTLRenderPipelineState> finalPipe =
           (_fxaaPipeline && _aaEnabled && !noAA) ? _fxaaPipeline : _blitPipeline;
       id<MTLRenderCommandEncoder> enc =

--- a/swiftui/PyMOLBridge.xcconfig
+++ b/swiftui/PyMOLBridge.xcconfig
@@ -61,8 +61,12 @@ PYMOL_LIB_PATH_FLAGS[sdk=iphonesimulator*] = -L$(PYMOL_BUILD_IOS) -L$(PYMOL_IOS_
 PYMOL_PYTHON_DYLIB[sdk=iphoneos*] = $(SRCROOT)/../deps_ios/Python.xcframework/ios-arm64/Python.framework/Python
 PYMOL_PYTHON_DYLIB[sdk=iphonesimulator*] = $(SRCROOT)/../deps_ios/Python.xcframework/ios-arm64_x86_64-simulator/Python.framework/Python
 
-// Core library (always linked)
-PYMOL_CORE_LDFLAGS = -lpymol_core -framework Metal -framework MetalKit -framework CoreVideo -framework MetalFX
+// Core library (always linked). MetalFX (metal_upscale) is absent from the iOS
+// Simulator SDK, so link it only for device + macOS; the renderer's
+// !TARGET_OS_SIMULATOR guard drops all MetalFX usage on the simulator.
+METALFX_LDFLAGS = -framework MetalFX
+METALFX_LDFLAGS[sdk=iphonesimulator*] =
+PYMOL_CORE_LDFLAGS = -lpymol_core -framework Metal -framework MetalKit -framework CoreVideo $(METALFX_LDFLAGS)
 
 // macOS: full dependency set. libomp.a is linked STATICALLY (by absolute path,
 // so the linker uses the archive, not the .dylib) to resolve the OpenMP symbols

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -239,8 +239,12 @@ enum SceneCatalog {
                    help: "Thickness of the outline, in pixels."),
         SceneParam(setting: "metal_tonemap", label: "Filmic tone-map", kind: .toggle, group: "Effects",
                    help: "ACES filmic tone-mapping for a cinematic look with a softer highlight rolloff."),
-        SceneParam(setting: "metal_exposure", label: "Exposure", kind: .slider, min: 0.2, max: 2.0, step: 0.05, decimals: 2, group: "Effects", dependsOn: "metal_tonemap",
-                   help: "Brightness multiplier applied by the tone-map. 1.0 = neutral."),
+        // Always shown (NOT gated behind metal_tonemap): the renderer applies
+        // exposure independently of the tone-map toggle (RendererMetal runs the
+        // pass whenever exposure != 1), so hiding the slider when tone-map is off
+        // could strand a dimmed value with no way to fix it in the UI.
+        SceneParam(setting: "metal_exposure", label: "Exposure", kind: .slider, min: 0.2, max: 2.0, step: 0.05, decimals: 2, group: "Effects",
+                   help: "Brightness multiplier (1.0 = neutral). Applies whether or not filmic tone-map is on."),
         SceneParam(setting: "depth_cue",  label: "Depth cue / fog", kind: .toggle, group: "Effects",
                    help: "Fade distant parts of the scene into the background to convey depth."),
 
@@ -1875,8 +1879,42 @@ private struct SceneCard: View {
                 ForEach(SceneCatalog.params.filter { $0.group == group }) { p in
                     if visible(p) { paramRow(p) }
                 }
+                if group == "Effects" { resetEffectsButton }
             }
         }
+    }
+
+    // One-tap restore of the Effects group to its built-in defaults. Filmic
+    // tone-map (white → ~80% grey via ACES) and a dimmed exposure muddle the
+    // whole frame, and the iOS autosave persists that look across launches with
+    // no obvious cause — this gives an obvious way back to a neutral render.
+    private var resetEffectsButton: some View {
+        Button { resetEffects() } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "arrow.counterclockwise")
+                Text("Reset effects to defaults")
+                Spacer()
+            }
+            .font(.system(size: 12, weight: .medium))
+            .foregroundColor(PanelTheme.selectionTextColor)
+            .padding(.leading, 10).padding(.vertical, 3)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    // Effects-group defaults, from layer1/SettingInfo.h. The ~500ms scene-state
+    // poll re-syncs the toggles/sliders to these values after the sets land.
+    private func resetEffects() {
+        let defaults: [(String, String)] = [
+            ("metal_outline", "0"),
+            ("metal_outline_width", "1.4"),
+            ("metal_outline_color", "0x000000"),
+            ("metal_tonemap", "0"),
+            ("metal_exposure", "1.0"),
+            ("depth_cue", "1"),
+        ]
+        for (k, v) in defaults { engine.runCommand("set \(k), \(v)") }
     }
 
     // Dependent rows (dependsOn set) are hidden while their parent toggle is off.

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -206,7 +206,7 @@ final class PyMOLEngine: ObservableObject {
         // cached/stale install) when verifying gesture-direction fixes. Bump the
         // tag whenever gesture behavior changes; it shows at the top of the log.
         DispatchQueue.main.async { [weak self] in
-            self?.feedbackLog.append(" [build] v30  (Live-RT grain fix + Calculating overlay + immediate inspector poll)")
+            self?.feedbackLog.append(" [build] v31  (Reset-effects button + always-visible exposure; sim MetalFX guard)")
         }
 
         // `fetch` downloads into fetch_path. Use the temp directory: it's always


### PR DESCRIPTION
## Problem

On iOS the render looked **muddled with "white looking greyish"**, while the identical scene rendered correctly on macOS. Root-caused to the Metal exposure + filmic tone-map post pass (`RendererMetal.mm`, `post_tonemap`): it runs over **every pixel** whenever `metal_tonemap` is on **or** `metal_exposure != 1.0`, and

- ACES maps pure white `1.0 → 2.54/3.16 = 0.804` (≈ 205/255 grey) and compresses/desaturates midtones, and
- `c = src * exposure` is applied **unconditionally** (even with tone-map off).

Both settings default to off / 1.0, so a fresh render is correct — but the **iOS autosave bakes them into the restored `.pse`**, so a single accidental toggle in the Inspector silently greys + muddles every later session with no obvious cause.

Reproduced in the iPhone 17 Pro simulator (identical 1ubq scene, Paper white theme):

| Setting | White background renders as |
|---|---|
| Defaults (tone-map off, exposure 1.0) | **(255, 255, 255)** |
| `metal_tonemap` ON | **(205, 205, 205)** grey |
| `metal_exposure` 0.6 | **(153, 153, 153)** grey |

## Changes

**Effects persistence / discoverability**
- Add a **"Reset effects to defaults"** button to the Inspector → Effects group — one tap restores tone-map off / exposure 1.0 / outline off / etc., giving an obvious way back to a neutral render. (Persistence behavior is unchanged — sessions still resume exactly as saved.)
- **Always show the Exposure slider** (removed `dependsOn: metal_tonemap`). The renderer applies exposure independently of the tone-map toggle, so hiding the slider when tone-map was off could strand a dimmed value with no UI control to fix it.

**MetalFX on the iOS Simulator**
- Guard `#import <MetalFX/MetalFX.h>` and all `MTLFXSpatialScaler` usage behind `#if !TARGET_OS_SIMULATOR` (the iphonesimulator SDK ships no MetalFX); the simulator falls back to the existing bilinear blit.
- `PyMOLBridge.xcconfig` now links `-framework MetalFX` only for device + macOS (`METALFX_LDFLAGS` is empty for `[sdk=iphonesimulator*]`). This replaces ad-hoc command-line build workarounds with a proper source fix, so a vanilla simulator build works.

Build banner bumped to `[build] v31`.

## Verification

- **Simulator** (vanilla, no workarounds): `BUILD SUCCEEDED`; `nm` shows zero MetalFX symbols and the link line has no `-framework MetalFX`.
- **macOS**: `BUILD SUCCEEDED`; `nm` shows `MTLFXSpatialScalerDescriptor` present and `-framework MetalFX` linked (the `#else` branch still compiles/links).
- **iOS device** (iPhone 15 Pro): device core + signed app build pass, `-framework MetalFX` in the device link line, installed on-device.
- In-simulator A/B confirms white renders 255 at defaults vs 205 with tone-map on (matching the ACES math).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
