### PR TITLE
feat(ios): graduated reset menu (Reset view / effects / Clear session)

### DIFF
--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -1923,19 +1923,10 @@ private struct SceneCard: View {
         .buttonStyle(.plain)
     }
 
-    // Effects-group defaults, from layer1/SettingInfo.h. The ~500ms scene-state
-    // poll re-syncs the toggles/sliders to these values after the sets land.
-    private func resetEffects() {
-        let defaults: [(String, String)] = [
-            ("metal_outline", "0"),
-            ("metal_outline_width", "1.4"),
-            ("metal_outline_color", "0x000000"),
-            ("metal_tonemap", "0"),
-            ("metal_exposure", "1.0"),
-            ("depth_cue", "1"),
-        ]
-        for (k, v) in defaults { engine.runCommand("set \(k), \(v)") }
-    }
+    // Defaults live on the engine (engine.resetEffects) so the iOS toolbar reset
+    // menu and this Inspector button share one source of truth. The ~500ms
+    // scene-state poll re-syncs the toggles/sliders after the sets land.
+    private func resetEffects() { engine.resetEffects() }
 
     // Dependent rows (dependsOn set) are hidden while their parent toggle is off.
     private func visible(_ p: SceneParam) -> Bool {

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -417,6 +417,8 @@ struct ContentView: View {
     @State private var selectedTab = 1
     @State private var showFetch = false
     @State private var fetchID = ""
+    // Confirmation for the destructive "Clear session" reset action.
+    @State private var showClearSessionConfirm = false
     // iPhone: the transport floats as a 1-line peek over the viewport and
     // expands in place to the full multi-row control. (Ignored on regular-width
     // iPad, where the bar is always full.)
@@ -559,7 +561,7 @@ struct ContentView: View {
                     }
                 }
             }
-            .toolbar { iosOpenToolbar; iosMeasureToolbar; iosThemeToolbar; iosPanelToggle; iosPadPanelMenu; iosExportToolbar }
+            .toolbar { iosOpenToolbar; iosMeasureToolbar; iosThemeToolbar; iosResetMenu; iosPanelToggle; iosPadPanelMenu; iosExportToolbar }
             .fileImporter(isPresented: $showFileImporter,
                           allowedContentTypes: iosImportTypes,
                           allowsMultipleSelection: false) { result in
@@ -572,6 +574,12 @@ struct ContentView: View {
                 Button("Cancel", role: .cancel) {}
             } message: {
                 Text("Download a structure from the RCSB PDB.")
+            }
+            .alert("Clear session?", isPresented: $showClearSessionConfirm) {
+                Button("Clear", role: .destructive) { engine.clearSessionAndAutosave() }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("Removes all loaded structures and resets the view, effects, and settings to defaults. This can’t be undone.")
             }
             .sheet(isPresented: $showGestureLegend) {
                 VStack(spacing: 16) {
@@ -1161,6 +1169,30 @@ struct ContentView: View {
                 Image(systemName: "circle.lefthalf.filled")
             }
             .accessibilityLabel("Theme studio")
+        }
+    }
+
+    // Graduated reset menu (iOS has no File menu, so this is the only escape
+    // hatch from a messed-up scene or a persisted bad state). Ordered by blast
+    // radius: recenter the camera, reset the post-processing effects, or wipe
+    // the whole session. Only the last is destructive → confirmation alert.
+    private var iosResetMenu: some ToolbarContent {
+        ToolbarItem(placement: .primaryAction) {
+            Menu {
+                Button { engine.runCommand("reset") } label: {
+                    Label("Reset view", systemImage: "arrow.counterclockwise")
+                }
+                Button { engine.resetEffects() } label: {
+                    Label("Reset effects", systemImage: "circle.lefthalf.filled")
+                }
+                Divider()
+                Button(role: .destructive) { showClearSessionConfirm = true } label: {
+                    Label("Clear session…", systemImage: "trash")
+                }
+            } label: {
+                Image(systemName: "arrow.counterclockwise.circle")
+            }
+            .accessibilityLabel("Reset")
         }
     }
 

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -215,7 +215,7 @@ final class PyMOLEngine: ObservableObject {
         // cached/stale install) when verifying gesture-direction fixes. Bump the
         // tag whenever gesture behavior changes; it shows at the top of the log.
         DispatchQueue.main.async { [weak self] in
-            self?.feedbackLog.append(" [build] v33  (Movie export renders off the main thread — no UI freeze)")
+            self?.feedbackLog.append(" [build] v34  (iOS reset menu: Reset view / effects / Clear session)")
         }
 
         // `fetch` downloads into fetch_path. Use the temp directory: it's always
@@ -500,6 +500,18 @@ final class PyMOLEngine: ObservableObject {
         if let url = autosaveURL { try? FileManager.default.removeItem(at: url) }
         if let img = autosaveImageURL { try? FileManager.default.removeItem(at: img) }
         UserDefaults.standard.set(false, forKey: Self.autosaveDefaultsKey)
+    }
+
+    /// Full reset for the iOS "Clear session" action. clearSession() wipes the
+    /// scene + selections + camera and resets every setting to defaults (then
+    /// re-applies the theme); we ALSO delete the autosave here so a force-quit
+    /// immediately after the reset can't restore the cleared (or bad) state on
+    /// the next launch — the autosave otherwise only clears on a later
+    /// background-with-empty-scene cycle. This is the iOS escape hatch from a
+    /// persisted bad state (e.g. a stuck filmic tone-map).
+    func clearSessionAndAutosave() {
+        clearSession()
+        clearAutosave()
     }
 
     /// Snapshot the full session to the autosave .pse. Called when the app is
@@ -913,6 +925,21 @@ final class PyMOLEngine: ObservableObject {
         // access), then re-apply the RayMol theme.
         runPython("from pymol import cmd as _c; _c.set('fetch_path', '\(NSTemporaryDirectory())')")
         applyTheme(ThemeManager.shared.active)
+    }
+
+    /// Reset the Effects-group post-processing/stylization settings to their
+    /// SettingInfo.h defaults. Shared by the Inspector's "Reset effects" button
+    /// and the iOS toolbar reset menu. Non-destructive — keeps loaded structures.
+    func resetEffects() {
+        let defaults: [(String, String)] = [
+            ("metal_outline", "0"),
+            ("metal_outline_width", "1.4"),
+            ("metal_outline_color", "0x000000"),
+            ("metal_tonemap", "0"),
+            ("metal_exposure", "1.0"),
+            ("depth_cue", "1"),
+        ]
+        for (k, v) in defaults { runCommand("set \(k), \(v)") }
     }
 
     // MARK: - Theme studio live preview


### PR DESCRIPTION
## Gap

iOS had **no way to reset app state**. The engine's `clearSession()` (reinitialize → wipe scene/selections/camera + reset all settings to defaults, then re-apply the theme) was solid but only reachable from the **macOS File ▸ Clear Session** menu. So a messed-up scene — or a persisted bad state restored from the autosave, like the stuck filmic tone-map this session chased — had no escape on the phone short of reinstalling.

## What this adds

A graduated **`↺` reset menu** in the iOS toolbar, ordered by blast radius:

| Action | Does | Destructive? |
|---|---|---|
| **Reset view** | `cmd "reset"` (recenter camera) | no |
| **Reset effects** | tone-map / exposure / outline / depth-cue → defaults | no |
| **Clear session…** | reinitialize + re-apply theme + **clear the autosave** | yes → confirmation alert |

### Engine
- **`resetEffects()`** — the Effects-group defaults, now a shared method so the Inspector's "Reset effects" button (#67) and this menu use one source of truth.
- **`clearSessionAndAutosave()`** (iOS) — `clearSession()` **plus** delete the autosave, so a force-quit right after the reset can't restore the cleared/bad state on next launch (the autosave otherwise only clears on a later background-with-empty-scene cycle). This is the actual escape hatch.

Only "Clear session" is destructive and it confirms first; the two light actions reuse already-tested commands.

## Verification
- Simulator build succeeds; the `↺` menu renders in the toolbar (between the theme ◐ and panel/share icons), no toolbar crowding.
- Actions reuse `reset` / `resetEffects` / `clearSession` (the same path macOS uses) + a file delete — low risk. Worth a quick on-device tap-through of Clear session (confirm → empty scene → relaunch stays clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)