### PR TITLE
feat(ios): context menus — graduated reset menu + long-press residue actions

### DIFF
--- a/modules/pymol/metal_pick.py
+++ b/modules/pymol/metal_pick.py
@@ -454,3 +454,33 @@ def pick_at(ndc_x, ndc_y, aspect):
 
     except Exception as e:
         print('metal_pick error: %s' % e)
+
+
+def pick_info_at(ndc_x, ndc_y, aspect):
+    """Identify the atom/residue under a long-press WITHOUT changing the
+    selection, and write its identity to <tmpdir>/pymol_longpress.json for the
+    iOS long-press context menu to read. Empty space -> {"hit": false}.
+
+    Mirrors pick_at's hit logic (shared _pick_atom) but is read-only: it never
+    touches 'sele', so opening the context menu doesn't perturb the scene."""
+    import json, os, tempfile
+    out = {"hit": False}
+    try:
+        best = _pick_atom(ndc_x, ndc_y, aspect)
+        if best is not None:
+            _, obj, chain, resi, resn, segi, name, _sx, _sy = best
+            # Residue-scoped selection the menu actions operate on (matches the
+            # residue expr pick_at builds for mouse_selection_mode 1).
+            sel = ('%s and chain %s and resi %s' % (obj, chain, resi)) if chain \
+                else ('%s and resi %s' % (obj, resi))
+            out = {"hit": True, "obj": obj, "chain": chain, "resi": resi,
+                   "resn": resn, "name": name, "sel": sel}
+    except Exception as e:
+        print('metal_pick pick_info error: %s' % e)
+        out = {"hit": False}
+    try:
+        path = os.path.join(tempfile.gettempdir(), 'pymol_longpress.json')
+        with open(path, 'w') as f:
+            json.dump(out, f)
+    except Exception:
+        pass

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -1923,19 +1923,10 @@ private struct SceneCard: View {
         .buttonStyle(.plain)
     }
 
-    // Effects-group defaults, from layer1/SettingInfo.h. The ~500ms scene-state
-    // poll re-syncs the toggles/sliders to these values after the sets land.
-    private func resetEffects() {
-        let defaults: [(String, String)] = [
-            ("metal_outline", "0"),
-            ("metal_outline_width", "1.4"),
-            ("metal_outline_color", "0x000000"),
-            ("metal_tonemap", "0"),
-            ("metal_exposure", "1.0"),
-            ("depth_cue", "1"),
-        ]
-        for (k, v) in defaults { engine.runCommand("set \(k), \(v)") }
-    }
+    // Defaults live on the engine (engine.resetEffects) so the iOS toolbar reset
+    // menu and this Inspector button share one source of truth. The ~500ms
+    // scene-state poll re-syncs the toggles/sliders after the sets land.
+    private func resetEffects() { engine.resetEffects() }
 
     // Dependent rows (dependsOn set) are hidden while their parent toggle is off.
     private func visible(_ p: SceneParam) -> Bool {

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -417,6 +417,8 @@ struct ContentView: View {
     @State private var selectedTab = 1
     @State private var showFetch = false
     @State private var fetchID = ""
+    // Confirmation for the destructive "Clear session" reset action.
+    @State private var showClearSessionConfirm = false
     // iPhone: the transport floats as a 1-line peek over the viewport and
     // expands in place to the full multi-row control. (Ignored on regular-width
     // iPad, where the bar is always full.)
@@ -559,7 +561,7 @@ struct ContentView: View {
                     }
                 }
             }
-            .toolbar { iosOpenToolbar; iosMeasureToolbar; iosThemeToolbar; iosPanelToggle; iosPadPanelMenu; iosExportToolbar }
+            .toolbar { iosOpenToolbar; iosMeasureToolbar; iosThemeToolbar; iosResetMenu; iosPanelToggle; iosPadPanelMenu; iosExportToolbar }
             .fileImporter(isPresented: $showFileImporter,
                           allowedContentTypes: iosImportTypes,
                           allowsMultipleSelection: false) { result in
@@ -572,6 +574,12 @@ struct ContentView: View {
                 Button("Cancel", role: .cancel) {}
             } message: {
                 Text("Download a structure from the RCSB PDB.")
+            }
+            .alert("Clear session?", isPresented: $showClearSessionConfirm) {
+                Button("Clear", role: .destructive) { engine.clearSessionAndAutosave() }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("Removes all loaded structures and resets the view, effects, and settings to defaults. This can’t be undone.")
             }
             .sheet(isPresented: $showGestureLegend) {
                 VStack(spacing: 16) {
@@ -1161,6 +1169,30 @@ struct ContentView: View {
                 Image(systemName: "circle.lefthalf.filled")
             }
             .accessibilityLabel("Theme studio")
+        }
+    }
+
+    // Graduated reset menu (iOS has no File menu, so this is the only escape
+    // hatch from a messed-up scene or a persisted bad state). Ordered by blast
+    // radius: recenter the camera, reset the post-processing effects, or wipe
+    // the whole session. Only the last is destructive → confirmation alert.
+    private var iosResetMenu: some ToolbarContent {
+        ToolbarItem(placement: .primaryAction) {
+            Menu {
+                Button { engine.runCommand("reset") } label: {
+                    Label("Reset view", systemImage: "arrow.counterclockwise")
+                }
+                Button { engine.resetEffects() } label: {
+                    Label("Reset effects", systemImage: "circle.lefthalf.filled")
+                }
+                Divider()
+                Button(role: .destructive) { showClearSessionConfirm = true } label: {
+                    Label("Clear session…", systemImage: "trash")
+                }
+            } label: {
+                Image(systemName: "arrow.counterclockwise.circle")
+            }
+            .accessibilityLabel("Reset")
         }
     }
 

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -419,6 +419,9 @@ struct ContentView: View {
     @State private var fetchID = ""
     // Confirmation for the destructive "Clear session" reset action.
     @State private var showClearSessionConfirm = false
+    // Long-press context menu: the color sub-sheet + the residue sel it colors.
+    @State private var showLongPressColor = false
+    @State private var longPressColorSel: String?
     // iPhone: the transport floats as a 1-line peek over the viewport and
     // expands in place to the full multi-row control. (Ignored on regular-width
     // iPad, where the bar is always full.)
@@ -580,6 +583,24 @@ struct ContentView: View {
                 Button("Cancel", role: .cancel) {}
             } message: {
                 Text("Removes all loaded structures and resets the view, effects, and settings to defaults. This can’t be undone.")
+            }
+            // Long-press context menu: a native action sheet for the atom/residue
+            // under the press (or scene-level actions on empty space). Presented
+            // when handleLongPress → engine.longPressPick sets engine.longPressHit.
+            .confirmationDialog(
+                engine.longPressHit?.title ?? "",
+                isPresented: Binding(get: { engine.longPressHit != nil },
+                                     set: { if !$0 { engine.longPressHit = nil } }),
+                titleVisibility: .visible,
+                presenting: engine.longPressHit
+            ) { hit in
+                longPressActions(hit)
+            }
+            // Color sub-sheet (confirmationDialog buttons can't nest, so "Color…"
+            // opens this second sheet for the residue captured in longPressColorSel).
+            .confirmationDialog("Color residue", isPresented: $showLongPressColor,
+                                titleVisibility: .visible) {
+                longPressColorActions()
             }
             .sheet(isPresented: $showGestureLegend) {
                 VStack(spacing: 16) {
@@ -1194,6 +1215,35 @@ struct ContentView: View {
             }
             .accessibilityLabel("Reset")
         }
+    }
+
+    // Buttons for the long-press context menu. Empty space → scene-level actions;
+    // a hit → residue-scoped actions on hit.sel (an obj/chain/resi selector).
+    @ViewBuilder
+    private func longPressActions(_ hit: LongPressHit) -> some View {
+        if hit.isEmpty {
+            Button("Reset view") { engine.runCommand("reset") }
+            Button("Deselect all") { engine.runCommand("deselect") }
+        } else {
+            Button("Zoom to residue") { engine.runCommand("zoom (\(hit.sel)), animate=1") }
+            Button("Select residue") { engine.runCommand("select sele, (?sele) or (\(hit.sel))\nenable sele") }
+            Button("Label residue") { engine.runCommand("label first (\(hit.sel)), '\(hit.resn)\(hit.resi)'") }
+            Button("Hide residue") { engine.runCommand("hide everything, (\(hit.sel))") }
+            Button("Center here") { engine.runCommand("center (\(hit.sel))") }
+            Button("Color…") { longPressColorSel = hit.sel; showLongPressColor = true }
+        }
+        Button("Cancel", role: .cancel) {}
+    }
+
+    // Color choices for the long-press "Color…" sub-sheet (a few presets + by-element).
+    @ViewBuilder
+    private func longPressColorActions() -> some View {
+        let sel = longPressColorSel ?? ""
+        ForEach(["red", "orange", "yellow", "green", "cyan", "blue", "magenta", "white"], id: \.self) { c in
+            Button(c.capitalized) { engine.runCommand("color \(c), (\(sel))") }
+        }
+        Button("By element") { engine.runCommand("python\nfrom pymol import util; util.cnc('(\(sel))')\npython end") }
+        Button("Cancel", role: .cancel) {}
     }
 
     private func iosHandleImport(_ result: Result<[URL], Error>) {

--- a/swiftui/PyMOLViewer/Shared/MetalViewport.swift
+++ b/swiftui/PyMOLViewer/Shared/MetalViewport.swift
@@ -802,16 +802,18 @@ extension MetalViewport {
         }
 
         @objc func handleLongPress(_ gesture: UILongPressGestureRecognizer) {
-            guard let view = mtkView else { return }
-            let location = gesture.location(in: view)
-            let pt = pymolPoint(in: view, at: location)
-
-            if gesture.state == .began {
-                // Long press = right click (context menu / translate)
-                engine?.button(PYMOL_BUTTON_RIGHT, state: PYMOL_BUTTON_DOWN, x: pt.0, y: pt.1, modifiers: 0)
-            } else if gesture.state == .ended || gesture.state == .cancelled {
-                engine?.button(PYMOL_BUTTON_RIGHT, state: PYMOL_BUTTON_UP, x: pt.0, y: pt.1, modifiers: 0)
-            }
+            guard gesture.state == .began, let engine = engine, let view = mtkView else { return }
+            // Identify the atom/residue under the press and let ContentView show
+            // a native context menu. NDC in point space with Y flipped (same as
+            // handleTap). This replaces the old right-click, which fired a PyMOL
+            // pop-up menu that this Metal backend never renders (internal_gui=0)
+            // — so long-press used to do nothing visible.
+            let p = gesture.location(in: view)
+            let w = view.bounds.width, h = view.bounds.height
+            guard w > 0, h > 0 else { return }
+            let ndcX = Float(p.x / w) * 2 - 1
+            let ndcY = 1 - Float(p.y / h) * 2
+            engine.longPressPick(ndcX: ndcX, ndcY: ndcY, aspect: Float(w / h))
         }
         #endif
     }

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -215,7 +215,7 @@ final class PyMOLEngine: ObservableObject {
         // cached/stale install) when verifying gesture-direction fixes. Bump the
         // tag whenever gesture behavior changes; it shows at the top of the log.
         DispatchQueue.main.async { [weak self] in
-            self?.feedbackLog.append(" [build] v33  (Movie export renders off the main thread — no UI freeze)")
+            self?.feedbackLog.append(" [build] v34  (iOS reset menu: Reset view / effects / Clear session)")
         }
 
         // `fetch` downloads into fetch_path. Use the temp directory: it's always
@@ -500,6 +500,18 @@ final class PyMOLEngine: ObservableObject {
         if let url = autosaveURL { try? FileManager.default.removeItem(at: url) }
         if let img = autosaveImageURL { try? FileManager.default.removeItem(at: img) }
         UserDefaults.standard.set(false, forKey: Self.autosaveDefaultsKey)
+    }
+
+    /// Full reset for the iOS "Clear session" action. clearSession() wipes the
+    /// scene + selections + camera and resets every setting to defaults (then
+    /// re-applies the theme); we ALSO delete the autosave here so a force-quit
+    /// immediately after the reset can't restore the cleared (or bad) state on
+    /// the next launch — the autosave otherwise only clears on a later
+    /// background-with-empty-scene cycle. This is the iOS escape hatch from a
+    /// persisted bad state (e.g. a stuck filmic tone-map).
+    func clearSessionAndAutosave() {
+        clearSession()
+        clearAutosave()
     }
 
     /// Snapshot the full session to the autosave .pse. Called when the app is
@@ -913,6 +925,21 @@ final class PyMOLEngine: ObservableObject {
         // access), then re-apply the RayMol theme.
         runPython("from pymol import cmd as _c; _c.set('fetch_path', '\(NSTemporaryDirectory())')")
         applyTheme(ThemeManager.shared.active)
+    }
+
+    /// Reset the Effects-group post-processing/stylization settings to their
+    /// SettingInfo.h defaults. Shared by the Inspector's "Reset effects" button
+    /// and the iOS toolbar reset menu. Non-destructive — keeps loaded structures.
+    func resetEffects() {
+        let defaults: [(String, String)] = [
+            ("metal_outline", "0"),
+            ("metal_outline_width", "1.4"),
+            ("metal_outline_color", "0x000000"),
+            ("metal_tonemap", "0"),
+            ("metal_exposure", "1.0"),
+            ("depth_cue", "1"),
+        ]
+        for (k, v) in defaults { runCommand("set \(k), \(v)") }
     }
 
     // MARK: - Theme studio live preview

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -31,6 +31,21 @@ struct SettingItem: Identifiable, Equatable, Codable {
     var id: String { name }
 }
 
+/// The atom/residue under a long-press, for the iOS context menu. `isEmpty`
+/// means the press landed on background (no atom) → scene-level actions.
+struct LongPressHit: Equatable, Identifiable {
+    let id = UUID()
+    var isEmpty: Bool
+    var obj = "", chain = "", resi = "", resn = "", name = "", sel = ""
+    /// Menu title, e.g. "ALA 42 · chain A" (or "Scene" for empty space).
+    var title: String {
+        if isEmpty { return "Scene" }
+        var t = resn.isEmpty ? resi : "\(resn) \(resi)"
+        if !chain.isEmpty { t += " · chain \(chain)" }
+        return t
+    }
+}
+
 final class PyMOLEngine: ObservableObject {
     static let shared = PyMOLEngine()
 
@@ -39,6 +54,9 @@ final class PyMOLEngine: ObservableObject {
     @Published var objects: [MoleculeObject] = []
     @Published var sequences: [SequenceObject] = []
     @Published var selectedResidueKeys: Set<String> = []
+    // Set when an iOS long-press identifies an atom/residue (or empty space);
+    // ContentView observes this to present the context menu, then clears it.
+    @Published var longPressHit: LongPressHit?
     @Published var isReady = false
     // Long-op ("Calculating…") overlay state. isBusy flips on only after a 2s
     // delay so quick ops never flash it; busyLabel describes the operation.
@@ -215,7 +233,7 @@ final class PyMOLEngine: ObservableObject {
         // cached/stale install) when verifying gesture-direction fixes. Bump the
         // tag whenever gesture behavior changes; it shows at the top of the log.
         DispatchQueue.main.async { [weak self] in
-            self?.feedbackLog.append(" [build] v34  (iOS reset menu: Reset view / effects / Clear session)")
+            self?.feedbackLog.append(" [build] v35  (Long-press context menu + iOS reset menu)")
         }
 
         // `fetch` downloads into fetch_path. Use the temp directory: it's always
@@ -1260,6 +1278,28 @@ final class PyMOLEngine: ObservableObject {
     func pick(ndcX: Float, ndcY: Float, aspect: Float) {
         guard let inst = instance else { return }
         PyMOLBridge_Pick(inst, ndcX, ndcY, aspect)
+    }
+
+    /// iOS long-press: identify the atom/residue under the press (read-only —
+    /// does NOT change the selection) and publish it so ContentView can show the
+    /// context menu. pick_info_at writes the hit JSON to the temp dir, which we
+    /// read back synchronously (this runs on the main thread from the gesture).
+    func longPressPick(ndcX: Float, ndcY: Float, aspect: Float) {
+        guard isReady else { return }
+        runPython("from pymol import metal_pick as _mp; _mp.pick_info_at(\(ndcX), \(ndcY), \(aspect))")
+        let path = (NSTemporaryDirectory() as NSString).appendingPathComponent("pymol_longpress.json")
+        guard let data = FileManager.default.contents(atPath: path),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return }
+        let hit = (root["hit"] as? Bool) ?? false
+        longPressHit = LongPressHit(
+            isEmpty: !hit,
+            obj: root["obj"] as? String ?? "",
+            chain: root["chain"] as? String ?? "",
+            resi: root["resi"] as? String ?? "",
+            resn: root["resn"] as? String ?? "",
+            name: root["name"] as? String ?? "",
+            sel: root["sel"] as? String ?? "")
     }
 
     // MARK: - Render loop hooks (called by MetalViewport)


### PR DESCRIPTION
iOS had two gaps around interacting with / recovering scene state. This adds both (supersedes #69, which was the reset-menu half on its own).

## 1. Graduated reset menu (`↺` toolbar)
iOS had no way to reset state — `clearSession()` was only reachable from the macOS File menu, so a messed-up scene or a persisted bad state (e.g. a stuck filmic tone-map restored from the autosave) had no escape on the phone.

- **Reset view** → recenter camera
- **Reset effects** → tone-map/exposure/outline/depth-cue → defaults (shares `engine.resetEffects()` with the Inspector button)
- **Clear session…** → destructive, confirmation alert → `clearSessionAndAutosave()` (reinitialize + re-apply theme + **delete the autosave**, so a force-quit right after can't restore the bad state)

## 2. Long-press context menu
The viewport long-press fired a PyMOL right-click that this Metal backend never renders as a menu (`internal_gui=0`), so "Menu — Long-press" did nothing visible. Replaced with a native context menu:

- `metal_pick.pick_info_at()` — read-only sibling of `pick_at` (reuses `_pick_atom`); identifies the atom/residue under the press WITHOUT touching `sele`, writes its identity to `<tmp>/pymol_longpress.json` (same temp-dir handoff the object-detail panel uses).
- `handleLongPress` → `engine.longPressPick()` → publishes `engine.longPressHit`.
- ContentView shows a `confirmationDialog`: **Zoom to / Select / Label / Hide / Center here / Color…** (Color opens a preset sheet + by-element), titled with the hit (e.g. "ALA 42 · chain A"). Empty-space press → **Reset view / Deselect all**.

## Verification
- Simulator + device builds succeed; the `↺` menu renders; the bundled `metal_pick.py` carries `pick_info_at`; `py_compile` clean.
- Both menus reuse already-tested code paths (`reset`, `resetEffects`, `clearSession`, `_pick_atom`). Banner bumped to v35.
- ⚠️ Long-press + tap gestures aren't automatable in-harness — the long-press menu was verified on-device (installed as v35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)