### PR TITLE
iOS UX refinement: Settings/Scenes/Movie tabs, landscape Dynamic-Island handling, content-aware panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ build_ios_dd/
 /*.dmg
 /build_dmg/
 /swiftui/build_*/
+build_mac_verify/
+swiftui/DerivedData_iOS/
+swiftui/DerivedData/
+RayMol-1.3.1-portable-test.zip

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # RayMol
 
+[![Join Slack](https://img.shields.io/badge/Slack-Join_Community-4A154B?logo=slack&logoColor=white)](https://raymol-slack-invite-production.up.railway.app)
+
 **RayMol** is a native **macOS · iPad · iPhone** reimagining of the
 [PyMOL](https://pymol.org) molecular visualization system — a SwiftUI front end
 driving the real PyMOL engine through **Metal**, with an embedded CPython

--- a/swiftui/PyMOLViewer/Panels/MovieBuilderSheet.swift
+++ b/swiftui/PyMOLViewer/Panels/MovieBuilderSheet.swift
@@ -1,15 +1,22 @@
 // MovieBuilderSheet.swift — author camera / state / scene-loop movies (the
 // desktop "Movie ▸ Program" builders), native and neutral-labeled. Writes
 // mset/mview via appkit_movie.make_movie and plays the result on the TransportBar.
+//
+// The controls live in the reusable MovieBuilderControls view so they can be
+// embedded both in this sheet (transport overflow · SceneCard "Scene loop →")
+// and inline in the Movie content tab (MoviePane).
 
 import SwiftUI
 
-struct MovieBuilderSheet: View {
+// MARK: - Reusable controls
+
+struct MovieBuilderControls: View {
     @EnvironmentObject var engine: PyMOLEngine
-    @Environment(\.dismiss) private var dismiss
 
     /// Which tab to open on (SceneCard "Scene loop →" opens .scenes).
     var initialTab: Tab = .camera
+    /// Called after a successful Build (the sheet dismisses; the pane no-ops).
+    var onBuilt: (() -> Void)? = nil
 
     enum Tab: String, CaseIterable, Identifiable {
         case camera = "Camera", states = "States", scenes = "Scenes"
@@ -45,60 +52,31 @@ struct MovieBuilderSheet: View {
     @State private var sceneLoop = true
 
     var body: some View {
-        VStack(spacing: 0) {
-            header
+        VStack(alignment: .leading, spacing: 16) {
             Picker("", selection: $tab) {
                 ForEach(Tab.allCases) { Text($0.rawValue).tag($0) }
             }
             .pickerStyle(.segmented)
-            .padding(.horizontal, 16).padding(.bottom, 8)
 
-            ScrollView {
-                VStack(alignment: .leading, spacing: 18) {
-                    switch tab {
-                    case .camera: cameraTab
-                    case .states: statesTab
-                    case .scenes: scenesTab
-                    }
-                    Divider()
-                    commonActions
-                }
-                .padding(16)
+            switch tab {
+            case .camera: cameraTab
+            case .states: statesTab
+            case .scenes: scenesTab
             }
 
-            buildBar
-        }
-        .onAppear { tab = initialTab }
-        #if os(iOS)
-        .presentationDetents([.medium, .large])
-        #else
-        .frame(width: 420, height: 520)
-        #endif
-    }
+            Divider()
+            commonActions
 
-    // MARK: Header / footer
-
-    private var header: some View {
-        HStack {
-            Text("Make Movie").font(.headline)
-            Spacer()
-            Button("Done") { dismiss() }
-        }
-        .padding(16)
-    }
-
-    private var buildBar: some View {
-        HStack {
-            Spacer()
             Button(action: build) {
                 Label("Build & Play", systemImage: "play.fill")
                     .font(.system(size: 14, weight: .semibold))
-                    .padding(.horizontal, 18).padding(.vertical, 8)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
             }
             .buttonStyle(.borderedProminent)
             .tint(TimelineTheme.accent)
         }
-        .padding(16)
+        .onAppear { tab = initialTab }
     }
 
     // MARK: Tabs
@@ -209,7 +187,7 @@ struct MovieBuilderSheet: View {
         }
         // Let the build settle, then start playback on the transport bar.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { engine.play() }
-        dismiss()
+        onBuilt?()
     }
 
     // MARK: Helpers
@@ -227,6 +205,36 @@ struct MovieBuilderSheet: View {
             ForEach(opts, id: \.1) { Text($0.0).tag($0.1) }
         }
         .pickerStyle(.segmented)
+    }
+}
+
+// MARK: - Sheet wrapper
+
+struct MovieBuilderSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    /// Which tab to open on (SceneCard "Scene loop →" opens .scenes).
+    var initialTab: MovieBuilderControls.Tab = .camera
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Make Movie").font(.headline)
+                Spacer()
+                Button("Done") { dismiss() }
+            }
+            .padding(16)
+
+            ScrollView {
+                MovieBuilderControls(initialTab: initialTab, onBuilt: { dismiss() })
+                    .padding(16)
+            }
+        }
+        #if os(iOS)
+        .presentationDetents([.medium, .large])
+        #else
+        .frame(width: 420, height: 520)
+        #endif
     }
 }
 

--- a/swiftui/PyMOLViewer/Panels/MovieBuilderSheet.swift
+++ b/swiftui/PyMOLViewer/Panels/MovieBuilderSheet.swift
@@ -173,25 +173,39 @@ struct MovieBuilderControls: View {
 
     // MARK: Helpers
 
-    // Compact labelled dropdown — several sit side-by-side in a row to save
-    // vertical space (vs full-width segmented controls stacked one per row).
+    // Compact labelled dropdown — several sit side-by-side in a row. Built from a
+    // Menu with a custom label (NOT Picker(.menu)) so the value is forced to a
+    // single line that shrinks-to-fit rather than wrapping ("R / oll") when the
+    // column is narrow (e.g. when the Dynamic Island insets the landscape panel).
     @ViewBuilder
     private func menuPicker<T: Hashable>(_ title: String, _ value: Binding<T>,
                                          _ opts: [(String, T)]) -> some View {
+        let current = opts.first(where: { $0.1 == value.wrappedValue })?.0 ?? ""
         VStack(alignment: .leading, spacing: 3) {
             Text(title.uppercased())
                 .font(.system(size: 9, weight: .semibold))
                 .foregroundStyle(.secondary)
-            Picker(title, selection: value) {
-                ForEach(opts, id: \.1) { Text($0.0).tag($0.1) }
+                .lineLimit(1)
+            Menu {
+                ForEach(opts, id: \.1) { opt in
+                    Button(opt.0) { value.wrappedValue = opt.1 }
+                }
+            } label: {
+                HStack(spacing: 3) {
+                    Text(current)
+                        .font(.system(size: 14, weight: .medium))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.6)
+                    Spacer(minLength: 0)
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.system(size: 9, weight: .semibold))
+                }
+                .foregroundStyle(TimelineTheme.accent)
+                .padding(.horizontal, 8).padding(.vertical, 6)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(RoundedRectangle(cornerRadius: 8).fill(Color.gray.opacity(0.13)))
+                .contentShape(Rectangle())
             }
-            .pickerStyle(.menu)
-            .font(.system(size: 13, weight: .medium))   // compact so 4 fit one row
-            .tint(TimelineTheme.accent)
-            .lineLimit(1)
-            .padding(.horizontal, 7).padding(.vertical, 5)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(RoundedRectangle(cornerRadius: 8).fill(Color.gray.opacity(0.13)))
         }
         .frame(maxWidth: .infinity)
     }

--- a/swiftui/PyMOLViewer/Panels/MovieBuilderSheet.swift
+++ b/swiftui/PyMOLViewer/Panels/MovieBuilderSheet.swift
@@ -58,11 +58,16 @@ struct MovieBuilderControls: View {
             }
             .pickerStyle(.segmented)
 
-            switch tab {
-            case .camera: cameraTab
-            case .states: statesTab
-            case .scenes: scenesTab
+            // Fixed-height content area so Build & Play sits at the SAME spot
+            // for every tab (Camera / States / Scenes), not jumping by content.
+            Group {
+                switch tab {
+                case .camera: cameraTab
+                case .states: statesTab
+                case .scenes: scenesTab
+                }
             }
+            .frame(minHeight: 156, alignment: .top)
 
             Divider()
             commonActions
@@ -121,8 +126,6 @@ struct MovieBuilderControls: View {
                 Text("No scenes saved. Store scenes in the Scenes tab first.")
                     .font(.caption).foregroundStyle(.secondary)
             } else {
-                Text("Scenes (tap to include; none = all)")
-                    .font(.caption).foregroundStyle(.secondary)
                 FlowChips(items: engine.sceneNames, selected: selectedScenes) { name in
                     if selectedScenes.contains(name) { selectedScenes.remove(name) }
                     else { selectedScenes.insert(name) }
@@ -131,9 +134,9 @@ struct MovieBuilderControls: View {
             HStack(alignment: .top, spacing: 12) {
                 menuPicker("Seconds / scene", $sceneSeconds, [("2 s", 2), ("4 s", 4), ("8 s", 8), ("12 s", 12)])
             }
-            Toggle("Loop", isOn: $sceneLoop).tint(TimelineTheme.accent)
-            Text("Strings scenes into a movie with interpolated camera transitions.")
-                .font(.caption).foregroundStyle(.secondary)
+            Toggle("Loop  ·  tap scenes to include (none = all)", isOn: $sceneLoop)
+                .font(.system(size: 15))
+                .tint(TimelineTheme.accent)
         }
     }
 

--- a/swiftui/PyMOLViewer/Panels/MovieBuilderSheet.swift
+++ b/swiftui/PyMOLViewer/Panels/MovieBuilderSheet.swift
@@ -92,9 +92,9 @@ struct MovieBuilderControls: View {
             HStack(alignment: .top, spacing: 12) {
                 menuPicker("Motion", $motion, CameraMotion.allCases.map { ($0.rawValue, $0) })
                 menuPicker("Duration", $duration, [("4 s", 4), ("8 s", 8), ("16 s", 16), ("32 s", 32)])
-                if motion.needsAngle {
-                    menuPicker("Angle", $angle, [("30°", 30), ("60°", 60), ("90°", 90), ("120°", 120)])
-                }
+                // Always shown (rock/nutate use it; roll ignores it) so the row
+                // is consistent across motions.
+                menuPicker("Angle", $angle, [("30°", 30), ("60°", 60), ("90°", 90), ("120°", 120)])
             }
             Toggle("Seamless loop", isOn: $cameraLoop).tint(TimelineTheme.accent)
             Text("A 360° camera \(motion.rawValue.lowercased()) authored as interpolated keyframes.")
@@ -106,7 +106,7 @@ struct MovieBuilderControls: View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(alignment: .top, spacing: 12) {
                 menuPicker("Mode", $stateMode, StateMode.allCases.map { ($0.rawValue, $0) })
-                menuPicker("Speed", $speedFactor, [("1×", 1), ("½×", 2), ("¼×", 4), ("⅛×", 8)])
+                menuPicker("Speed", $speedFactor, [("1×", 1), ("½×", 2), ("⅓×", 3), ("¼×", 4), ("⅛×", 8), ("1⁄16×", 16)])
                 menuPicker("Pause", $statePause, [("0 s", 0), ("1 s", 1), ("2 s", 2), ("4 s", 4)])
             }
             Toggle("Seamless loop", isOn: $stateLoop).tint(TimelineTheme.accent)
@@ -135,13 +135,13 @@ struct MovieBuilderControls: View {
     }
 
     private var commonActions: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        HStack(spacing: 16) {
             Button {
                 engine.captureKeyframe()
             } label: {
-                Label("Capture camera keyframe @ frame \(engine.playback.currentFrame)",
-                      systemImage: "camera.viewfinder")
+                Label("Capture keyframe", systemImage: "camera.viewfinder")
             }
+            Spacer(minLength: 0)
             Button(role: .destructive) {
                 engine.clearMovie()
             } label: {

--- a/swiftui/PyMOLViewer/Panels/MovieBuilderSheet.swift
+++ b/swiftui/PyMOLViewer/Panels/MovieBuilderSheet.swift
@@ -32,6 +32,7 @@ struct MovieBuilderControls: View {
         var needsAngle: Bool { self != .roll }
     }
     @State private var motion: CameraMotion = .roll
+    @State private var axis: String = "y"
     @State private var duration: Double = 8
     @State private var angle: Double = 30
     @State private var cameraLoop = true
@@ -88,17 +89,19 @@ struct MovieBuilderControls: View {
     // MARK: Tabs
 
     private var cameraTab: some View {
+        // 2×2 grid: Motion · Axis / Duration · Angle — roomy enough that values
+        // don't wrap, and still fits the pinned content height.
         VStack(alignment: .leading, spacing: 12) {
             HStack(alignment: .top, spacing: 12) {
                 menuPicker("Motion", $motion, CameraMotion.allCases.map { ($0.rawValue, $0) })
+                menuPicker("Axis", $axis, [("X", "x"), ("Y", "y"), ("Z", "z")])
+            }
+            HStack(alignment: .top, spacing: 12) {
                 menuPicker("Duration", $duration, [("4 s", 4), ("8 s", 8), ("16 s", 16), ("32 s", 32)])
-                // Always shown (rock/nutate use it; roll ignores it) so the row
-                // is consistent across motions.
+                // Angle always shown (rock/nutate use it; roll ignores it).
                 menuPicker("Angle", $angle, [("30°", 30), ("60°", 60), ("90°", 90), ("120°", 120)])
             }
             Toggle("Seamless loop", isOn: $cameraLoop).tint(TimelineTheme.accent)
-            Text("A 360° camera \(motion.rawValue.lowercased()) authored as interpolated keyframes.")
-                .font(.caption).foregroundStyle(.secondary)
         }
     }
 
@@ -158,7 +161,7 @@ struct MovieBuilderControls: View {
     private func build() {
         switch tab {
         case .camera:
-            engine.buildMovie(kind: motion.kind, duration: duration, angle: angle, loop: cameraLoop)
+            engine.buildMovie(kind: motion.kind, duration: duration, angle: angle, axis: axis, loop: cameraLoop)
         case .states:
             engine.buildMovie(kind: stateMode == .loop ? "state_loop" : "state_sweep",
                               loop: stateLoop, factor: speedFactor, pause: statePause)

--- a/swiftui/PyMOLViewer/Panels/MovieBuilderSheet.swift
+++ b/swiftui/PyMOLViewer/Panels/MovieBuilderSheet.swift
@@ -53,15 +53,15 @@ struct MovieBuilderControls: View {
     @State private var sceneLoop = true
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 11) {
             Picker("", selection: $tab) {
                 ForEach(Tab.allCases) { Text($0.rawValue).tag($0) }
             }
             .pickerStyle(.segmented)
 
-            // Fixed-height content area so Build & Play sits at the SAME spot
-            // for every tab (Camera / States / Scenes). Pinned to the Camera
-            // tab's natural height; the other tabs are sized to fit within it.
+            // Fixed-height content area so Build & Play sits at the SAME spot for
+            // every tab. Kept tight (single dropdown row + toggle + caption) so the
+            // whole builder — including Build & Play — fits the short landscape panel.
             Group {
                 switch tab {
                 case .camera: cameraTab
@@ -69,7 +69,7 @@ struct MovieBuilderControls: View {
                 case .scenes: scenesTab
                 }
             }
-            .frame(height: 156, alignment: .top)
+            .frame(height: 116, alignment: .top)
 
             Divider()
             commonActions
@@ -89,16 +89,13 @@ struct MovieBuilderControls: View {
     // MARK: Tabs
 
     private var cameraTab: some View {
-        // 2×2 grid: Motion · Axis / Duration · Angle — roomy enough that values
-        // don't wrap, and still fits the pinned content height.
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .top, spacing: 12) {
+        // All four controls on one row (compact dropdowns) so the builder stays
+        // short enough that Build & Play fits the landscape panel.
+        VStack(alignment: .leading, spacing: 11) {
+            HStack(alignment: .top, spacing: 8) {
                 menuPicker("Motion", $motion, CameraMotion.allCases.map { ($0.rawValue, $0) })
                 menuPicker("Axis", $axis, [("X", "x"), ("Y", "y"), ("Z", "z")])
-            }
-            HStack(alignment: .top, spacing: 12) {
                 menuPicker("Duration", $duration, [("4 s", 4), ("8 s", 8), ("16 s", 16), ("32 s", 32)])
-                // Angle always shown (rock/nutate use it; roll ignores it).
                 menuPicker("Angle", $angle, [("30°", 30), ("60°", 60), ("90°", 90), ("120°", 120)])
             }
             Toggle("Seamless loop", isOn: $cameraLoop).tint(TimelineTheme.accent)
@@ -106,34 +103,32 @@ struct MovieBuilderControls: View {
     }
 
     private var statesTab: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .top, spacing: 12) {
+        VStack(alignment: .leading, spacing: 11) {
+            HStack(alignment: .top, spacing: 8) {
                 menuPicker("Mode", $stateMode, StateMode.allCases.map { ($0.rawValue, $0) })
                 menuPicker("Speed", $speedFactor, [("1×", 1), ("½×", 2), ("⅓×", 3), ("¼×", 4), ("⅛×", 8), ("1⁄16×", 16)])
                 menuPicker("Pause", $statePause, [("0 s", 0), ("1 s", 1), ("2 s", 2), ("4 s", 4)])
             }
             Toggle("Seamless loop", isOn: $stateLoop).tint(TimelineTheme.accent)
-            // Single caption (no extra top note) so the height matches Camera.
-            Text(engine.playback.frameCount <= 1 && stateMaxStates <= 1
-                 ? "Needs a multi-state object (NMR / trajectory)."
-                 : (stateMode == .loop ? "Steps through all states once per cycle."
-                                       : "Sweeps forward and back through all states."))
-                .font(.caption).foregroundStyle(.secondary)
+            if engine.playback.frameCount <= 1 && stateMaxStates <= 1 {
+                Text("Needs a multi-state object (NMR / trajectory).")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
         }
     }
 
     private var scenesTab: some View {
         // Same 3-row shape as Camera/States (dropdown · toggle · caption) so the
         // height matches. Uses all saved scenes; manage them in the Scenes tab.
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .top, spacing: 12) {
+        VStack(alignment: .leading, spacing: 11) {
+            HStack(alignment: .top, spacing: 8) {
                 menuPicker("Seconds / scene", $sceneSeconds, [("2 s", 2), ("4 s", 4), ("8 s", 8), ("12 s", 12)])
             }
             Toggle("Loop", isOn: $sceneLoop).tint(TimelineTheme.accent)
-            Text(engine.sceneNames.isEmpty
-                 ? "No scenes saved — store scenes in the Scenes tab first."
-                 : "Strings all \(engine.sceneNames.count) saved scenes into a movie.")
-                .font(.caption).foregroundStyle(.secondary)
+            if engine.sceneNames.isEmpty {
+                Text("No scenes saved — store scenes in the Scenes tab first.")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
         }
     }
 
@@ -191,8 +186,10 @@ struct MovieBuilderControls: View {
                 ForEach(opts, id: \.1) { Text($0.0).tag($0.1) }
             }
             .pickerStyle(.menu)
+            .font(.system(size: 13, weight: .medium))   // compact so 4 fit one row
             .tint(TimelineTheme.accent)
-            .padding(.horizontal, 10).padding(.vertical, 4)
+            .lineLimit(1)
+            .padding(.horizontal, 7).padding(.vertical, 5)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(RoundedRectangle(cornerRadius: 8).fill(Color.gray.opacity(0.13)))
         }

--- a/swiftui/PyMOLViewer/Panels/MovieBuilderSheet.swift
+++ b/swiftui/PyMOLViewer/Panels/MovieBuilderSheet.swift
@@ -82,18 +82,12 @@ struct MovieBuilderControls: View {
     // MARK: Tabs
 
     private var cameraTab: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            labeled("Motion") {
-                Picker("", selection: $motion) {
-                    ForEach(CameraMotion.allCases) { Text($0.rawValue).tag($0) }
-                }.pickerStyle(.segmented)
-            }
-            labeled("Duration") {
-                presetPicker($duration, [("4 s", 4), ("8 s", 8), ("16 s", 16), ("32 s", 32)])
-            }
-            if motion.needsAngle {
-                labeled("Angle") {
-                    presetPicker($angle, [("30°", 30), ("60°", 60), ("90°", 90), ("120°", 120)])
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 12) {
+                menuPicker("Motion", $motion, CameraMotion.allCases.map { ($0.rawValue, $0) })
+                menuPicker("Duration", $duration, [("4 s", 4), ("8 s", 8), ("16 s", 16), ("32 s", 32)])
+                if motion.needsAngle {
+                    menuPicker("Angle", $angle, [("30°", 30), ("60°", 60), ("90°", 90), ("120°", 120)])
                 }
             }
             Toggle("Seamless loop", isOn: $cameraLoop).tint(TimelineTheme.accent)
@@ -103,23 +97,15 @@ struct MovieBuilderControls: View {
     }
 
     private var statesTab: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 12) {
             if engine.playback.frameCount <= 1 && stateMaxStates <= 1 {
                 Text("Load a multi-state object (NMR ensemble or trajectory) to animate states.")
                     .font(.caption).foregroundStyle(.secondary)
             }
-            labeled("Mode") {
-                Picker("", selection: $stateMode) {
-                    ForEach(StateMode.allCases) { Text($0.rawValue).tag($0) }
-                }.pickerStyle(.segmented)
-            }
-            labeled("Speed") {
-                presetPicker(Binding(get: { Double(speedFactor) },
-                                     set: { speedFactor = Int($0) }),
-                             [("1×", 1), ("½×", 2), ("¼×", 4), ("⅛×", 8)])
-            }
-            labeled("Pause") {
-                presetPicker($statePause, [("0 s", 0), ("1 s", 1), ("2 s", 2), ("4 s", 4)])
+            HStack(alignment: .top, spacing: 12) {
+                menuPicker("Mode", $stateMode, StateMode.allCases.map { ($0.rawValue, $0) })
+                menuPicker("Speed", $speedFactor, [("1×", 1), ("½×", 2), ("¼×", 4), ("⅛×", 8)])
+                menuPicker("Pause", $statePause, [("0 s", 0), ("1 s", 1), ("2 s", 2), ("4 s", 4)])
             }
             Toggle("Seamless loop", isOn: $stateLoop).tint(TimelineTheme.accent)
             Text(stateMode == .loop
@@ -130,9 +116,9 @@ struct MovieBuilderControls: View {
     }
 
     private var scenesTab: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 12) {
             if engine.sceneNames.isEmpty {
-                Text("No scenes saved. Store scenes from the SCENE card first.")
+                Text("No scenes saved. Store scenes in the Scenes tab first.")
                     .font(.caption).foregroundStyle(.secondary)
             } else {
                 Text("Scenes (tap to include; none = all)")
@@ -142,8 +128,8 @@ struct MovieBuilderControls: View {
                     else { selectedScenes.insert(name) }
                 }
             }
-            labeled("Seconds / scene") {
-                presetPicker($sceneSeconds, [("2 s", 2), ("4 s", 4), ("8 s", 8), ("12 s", 12)])
+            HStack(alignment: .top, spacing: 12) {
+                menuPicker("Seconds / scene", $sceneSeconds, [("2 s", 2), ("4 s", 4), ("8 s", 8), ("12 s", 12)])
             }
             Toggle("Loop", isOn: $sceneLoop).tint(TimelineTheme.accent)
             Text("Strings scenes into a movie with interpolated camera transitions.")
@@ -192,19 +178,25 @@ struct MovieBuilderControls: View {
 
     // MARK: Helpers
 
+    // Compact labelled dropdown — several sit side-by-side in a row to save
+    // vertical space (vs full-width segmented controls stacked one per row).
     @ViewBuilder
-    private func labeled<C: View>(_ title: String, @ViewBuilder _ content: () -> C) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(title).font(.system(size: 12, weight: .medium)).foregroundStyle(.secondary)
-            content()
+    private func menuPicker<T: Hashable>(_ title: String, _ value: Binding<T>,
+                                         _ opts: [(String, T)]) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title.uppercased())
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(.secondary)
+            Picker(title, selection: value) {
+                ForEach(opts, id: \.1) { Text($0.0).tag($0.1) }
+            }
+            .pickerStyle(.menu)
+            .tint(TimelineTheme.accent)
+            .padding(.horizontal, 10).padding(.vertical, 7)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(RoundedRectangle(cornerRadius: 8).fill(Color.gray.opacity(0.13)))
         }
-    }
-
-    private func presetPicker(_ value: Binding<Double>, _ opts: [(String, Double)]) -> some View {
-        Picker("", selection: value) {
-            ForEach(opts, id: \.1) { Text($0.0).tag($0.1) }
-        }
-        .pickerStyle(.segmented)
+        .frame(maxWidth: .infinity)
     }
 }
 

--- a/swiftui/PyMOLViewer/Panels/MovieBuilderSheet.swift
+++ b/swiftui/PyMOLViewer/Panels/MovieBuilderSheet.swift
@@ -59,7 +59,8 @@ struct MovieBuilderControls: View {
             .pickerStyle(.segmented)
 
             // Fixed-height content area so Build & Play sits at the SAME spot
-            // for every tab (Camera / States / Scenes), not jumping by content.
+            // for every tab (Camera / States / Scenes). Pinned to the Camera
+            // tab's natural height; the other tabs are sized to fit within it.
             Group {
                 switch tab {
                 case .camera: cameraTab
@@ -67,7 +68,7 @@ struct MovieBuilderControls: View {
                 case .scenes: scenesTab
                 }
             }
-            .frame(minHeight: 156, alignment: .top)
+            .frame(height: 156, alignment: .top)
 
             Divider()
             commonActions
@@ -103,40 +104,33 @@ struct MovieBuilderControls: View {
 
     private var statesTab: some View {
         VStack(alignment: .leading, spacing: 12) {
-            if engine.playback.frameCount <= 1 && stateMaxStates <= 1 {
-                Text("Load a multi-state object (NMR ensemble or trajectory) to animate states.")
-                    .font(.caption).foregroundStyle(.secondary)
-            }
             HStack(alignment: .top, spacing: 12) {
                 menuPicker("Mode", $stateMode, StateMode.allCases.map { ($0.rawValue, $0) })
                 menuPicker("Speed", $speedFactor, [("1×", 1), ("½×", 2), ("¼×", 4), ("⅛×", 8)])
                 menuPicker("Pause", $statePause, [("0 s", 0), ("1 s", 1), ("2 s", 2), ("4 s", 4)])
             }
             Toggle("Seamless loop", isOn: $stateLoop).tint(TimelineTheme.accent)
-            Text(stateMode == .loop
-                 ? "Steps through all states once per cycle."
-                 : "Sweeps forward and back through all states.")
+            // Single caption (no extra top note) so the height matches Camera.
+            Text(engine.playback.frameCount <= 1 && stateMaxStates <= 1
+                 ? "Needs a multi-state object (NMR / trajectory)."
+                 : (stateMode == .loop ? "Steps through all states once per cycle."
+                                       : "Sweeps forward and back through all states."))
                 .font(.caption).foregroundStyle(.secondary)
         }
     }
 
     private var scenesTab: some View {
+        // Same 3-row shape as Camera/States (dropdown · toggle · caption) so the
+        // height matches. Uses all saved scenes; manage them in the Scenes tab.
         VStack(alignment: .leading, spacing: 12) {
-            if engine.sceneNames.isEmpty {
-                Text("No scenes saved. Store scenes in the Scenes tab first.")
-                    .font(.caption).foregroundStyle(.secondary)
-            } else {
-                FlowChips(items: engine.sceneNames, selected: selectedScenes) { name in
-                    if selectedScenes.contains(name) { selectedScenes.remove(name) }
-                    else { selectedScenes.insert(name) }
-                }
-            }
             HStack(alignment: .top, spacing: 12) {
                 menuPicker("Seconds / scene", $sceneSeconds, [("2 s", 2), ("4 s", 4), ("8 s", 8), ("12 s", 12)])
             }
-            Toggle("Loop  ·  tap scenes to include (none = all)", isOn: $sceneLoop)
-                .font(.system(size: 15))
-                .tint(TimelineTheme.accent)
+            Toggle("Loop", isOn: $sceneLoop).tint(TimelineTheme.accent)
+            Text(engine.sceneNames.isEmpty
+                 ? "No scenes saved — store scenes in the Scenes tab first."
+                 : "Strings all \(engine.sceneNames.count) saved scenes into a movie.")
+                .font(.caption).foregroundStyle(.secondary)
         }
     }
 

--- a/swiftui/PyMOLViewer/Panels/MovieBuilderSheet.swift
+++ b/swiftui/PyMOLViewer/Panels/MovieBuilderSheet.swift
@@ -183,7 +183,7 @@ struct MovieBuilderControls: View {
     @ViewBuilder
     private func menuPicker<T: Hashable>(_ title: String, _ value: Binding<T>,
                                          _ opts: [(String, T)]) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: 3) {
             Text(title.uppercased())
                 .font(.system(size: 9, weight: .semibold))
                 .foregroundStyle(.secondary)
@@ -192,7 +192,7 @@ struct MovieBuilderControls: View {
             }
             .pickerStyle(.menu)
             .tint(TimelineTheme.accent)
-            .padding(.horizontal, 10).padding(.vertical, 7)
+            .padding(.horizontal, 10).padding(.vertical, 4)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(RoundedRectangle(cornerRadius: 8).fill(Color.gray.opacity(0.13)))
         }

--- a/swiftui/PyMOLViewer/Panels/MovieExportSheet.swift
+++ b/swiftui/PyMOLViewer/Panels/MovieExportSheet.swift
@@ -261,11 +261,13 @@ final class MovieExporter: ObservableObject {
     }
 }
 
-// MARK: - Sheet
+// MARK: - Reusable controls
 
-struct MovieExportSheet: View {
+// The export form, reused by both the MovieExportSheet and the Movie content
+// tab's MoviePane. Self-contained (owns its MovieExporter); each embedding gets
+// its own instance.
+struct MovieExportControls: View {
     @EnvironmentObject var engine: PyMOLEngine
-    @Environment(\.dismiss) private var dismiss
     @StateObject private var exporter = MovieExporter()
 
     private struct SizePreset: Identifiable { let id = UUID(); let name: String; let w: Int; let h: Int }
@@ -280,77 +282,69 @@ struct MovieExportSheet: View {
     @State private var rayMode = false
 
     var body: some View {
-        VStack(spacing: 0) {
-            HStack {
-                Text("Export Movie").font(.headline)
-                Spacer()
-                Button("Done") { dismiss() }
-            }.padding(16)
-
-            ScrollView {
-                VStack(alignment: .leading, spacing: 18) {
-                    labeled("Format") {
-                        Picker("", selection: $format) {
-                            ForEach(MovieExporter.Format.allCases) { Text($0.rawValue).tag($0) }
-                        }.pickerStyle(.segmented)
+        VStack(alignment: .leading, spacing: 18) {
+            labeled("Format") {
+                Picker("", selection: $format) {
+                    ForEach(MovieExporter.Format.allCases) { Text($0.rawValue).tag($0) }
+                }.pickerStyle(.segmented)
+            }
+            labeled("Size") {
+                Picker("", selection: $presetIdx) {
+                    ForEach(presets.indices, id: \.self) { i in
+                        Text("\(presets[i].name)  ·  \(presets[i].w)×\(presets[i].h)").tag(i)
                     }
-                    labeled("Size") {
-                        Picker("", selection: $presetIdx) {
-                            ForEach(presets.indices, id: \.self) { i in
-                                Text("\(presets[i].name)  ·  \(presets[i].w)×\(presets[i].h)").tag(i)
-                            }
-                        }.pickerStyle(.segmented)
-                    }
-                    labeled("Frames") {
-                        HStack(spacing: 12) {
-                            Stepper("First: \(first)", value: $first, in: 1...max(engine.playback.frameCount, 1))
-                            Stepper("Last: \(last)", value: $last, in: 1...max(engine.playback.frameCount, 1))
-                        }.font(.system(size: 13))
-                    }
-                    Toggle(isOn: $rayMode) {
-                        Label("Ray-traced frames (slow)", systemImage: "sparkles")
-                    }.tint(TimelineTheme.accent)
-                    if rayMode {
-                        Text("Ray-tracing every frame is much slower — use a short range first.")
-                            .font(.caption).foregroundStyle(.orange)
-                    }
-
-                    if exporter.isExporting {
-                        VStack(alignment: .leading, spacing: 6) {
-                            ProgressView(value: exporter.progress)
-                                .tint(TimelineTheme.accent)
-                            Text("Rendering frame \(Int(exporter.progress * Double(max(last - first + 1, 1))))/\(max(last - first + 1, 1))…")
-                                .font(.caption).foregroundStyle(.secondary)
-                        }
-                    }
-                    if let err = exporter.errorText {
-                        Text(err).font(.caption).foregroundStyle(.red)
-                    }
-                }.padding(16)
+                }.pickerStyle(.segmented)
+            }
+            labeled("Frames") {
+                HStack(spacing: 12) {
+                    Stepper("First: \(first)", value: $first, in: 1...max(engine.playback.frameCount, 1))
+                    Stepper("Last: \(last)", value: $last, in: 1...max(engine.playback.frameCount, 1))
+                }.font(.system(size: 13))
+            }
+            Toggle(isOn: $rayMode) {
+                Label("Ray-traced frames (slow)", systemImage: "sparkles")
+            }.tint(TimelineTheme.accent)
+            if rayMode {
+                Text("Ray-tracing every frame is much slower — use a short range first.")
+                    .font(.caption).foregroundStyle(.orange)
+            }
+            if engine.playback.frameCount <= 1 {
+                Text("Nothing to export yet — author an animation above (a camera roll works from a single structure).")
+                    .font(.caption).foregroundStyle(.secondary)
             }
 
-            HStack {
-                Spacer()
-                Button(action: runExport) {
-                    Label(exporter.isExporting ? "Rendering…" : "Render & Export",
-                          systemImage: "film")
-                        .font(.system(size: 14, weight: .semibold))
-                        .padding(.horizontal, 18).padding(.vertical, 8)
+            if exporter.isExporting {
+                VStack(alignment: .leading, spacing: 6) {
+                    ProgressView(value: exporter.progress)
+                        .tint(TimelineTheme.accent)
+                    Text("Rendering frame \(Int(exporter.progress * Double(max(last - first + 1, 1))))/\(max(last - first + 1, 1))…")
+                        .font(.caption).foregroundStyle(.secondary)
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(TimelineTheme.accent)
-                .disabled(exporter.isExporting || engine.playback.frameCount <= 1)
-            }.padding(16)
+            }
+            if let err = exporter.errorText {
+                Text(err).font(.caption).foregroundStyle(.red)
+            }
+
+            Button(action: runExport) {
+                Label(exporter.isExporting ? "Rendering…" : "Render & Export",
+                      systemImage: "film")
+                    .font(.system(size: 14, weight: .semibold))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(TimelineTheme.accent)
+            .disabled(exporter.isExporting || engine.playback.frameCount <= 1)
         }
         .onAppear { last = max(engine.playback.frameCount, 1); first = 1 }
+        .onChange(of: engine.playback.frameCount) { n in
+            // Keep the range valid as the timeline appears/changes (e.g. after a
+            // camera roll is built from the Animate section just above).
+            last = max(n, 1); first = min(first, last)
+        }
         .onChange(of: exporter.finishedURL) { url in
             if let url = url { deliver(url) }
         }
-        #if os(iOS)
-        .presentationDetents([.medium, .large])
-        #else
-        .frame(width: 420, height: 480)
-        #endif
     }
 
     private func runExport() {
@@ -394,5 +388,68 @@ struct MovieExportSheet: View {
             Text(title).font(.system(size: 12, weight: .medium)).foregroundStyle(.secondary)
             content()
         }
+    }
+}
+
+// MARK: - Sheet wrapper
+
+struct MovieExportSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Export Movie").font(.headline)
+                Spacer()
+                Button("Done") { dismiss() }
+            }.padding(16)
+
+            ScrollView {
+                MovieExportControls().padding(16)
+            }
+        }
+        #if os(iOS)
+        .presentationDetents([.medium, .large])
+        #else
+        .frame(width: 420, height: 480)
+        #endif
+    }
+}
+
+// MARK: - Movie content tab
+
+// The unified Movie flow as an in-panel content tab (iPhone bottom tab bar):
+// "1 · Animate" (author a camera/state/scene movie) flows straight into
+// "2 · Export" (render the resulting timeline to MP4/GIF) — no modal, matching
+// the other content tabs. The transport bar handles playback of what's built.
+struct MoviePane: View {
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 6) {
+                stepHeader("1 · Animate", "what moves")
+                MovieBuilderControls()
+
+                Divider().padding(.vertical, 14)
+
+                stepHeader("2 · Export", "save the file")
+                MovieExportControls()
+            }
+            .padding(16)
+            // Clear the floating tab-bar pill so the Export button stays reachable.
+            .padding(.bottom, 56)
+        }
+    }
+
+    @ViewBuilder
+    private func stepHeader(_ title: String, _ subtitle: String) -> some View {
+        HStack(spacing: 6) {
+            Text(title.uppercased())
+                .font(.system(size: 11, weight: .bold))
+                .foregroundStyle(TimelineTheme.accent)
+            Text(subtitle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.top, 2)
     }
 }

--- a/swiftui/PyMOLViewer/Panels/MovieExportSheet.swift
+++ b/swiftui/PyMOLViewer/Panels/MovieExportSheet.swift
@@ -263,20 +263,12 @@ final class MovieExporter: ObservableObject {
 
 // MARK: - Reusable controls
 
-// Which portion of the export form to render. The MovieExportSheet shows `.all`
-// (frames + format + render together); the Movie tab's top nav drives `.frames`
-// vs `.export` so the two read/write the SAME instance's state (kept mounted).
-enum MovieExportMode { case all, frames, export }
-
-// The export form, reused by both the MovieExportSheet and the Movie content
-// tab's MoviePane. Self-contained (owns its MovieExporter); each embedding gets
-// its own instance.
+// The export form (presented by MovieExportSheet from the top Export menu /
+// transport overflow). Self-contained (owns its MovieExporter). Renders the
+// full timeline — no frame-range picker.
 struct MovieExportControls: View {
     @EnvironmentObject var engine: PyMOLEngine
     @StateObject private var exporter = MovieExporter()
-
-    /// Which fields to show (Movie tab splits Frames / Export into nav steps).
-    var mode: MovieExportMode = .all
 
     private struct SizePreset: Identifiable { let id = UUID(); let name: String; let w: Int; let h: Int }
     private let presets = [SizePreset(name: "720p", w: 1280, h: 720),
@@ -285,79 +277,56 @@ struct MovieExportControls: View {
 
     @State private var format: MovieExporter.Format = .mp4
     @State private var presetIdx = 0
-    @State private var first = 1
-    @State private var last = 1
     @State private var rayMode = false
 
-    private var showFrames: Bool { mode != .export }
-    private var showExport: Bool { mode != .frames }
-    private var total: Int { max(last - first + 1, 1) }
+    private var frameCount: Int { max(engine.playback.frameCount, 1) }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
-            if showFrames {
-                labeled("Frame range") {
-                    HStack(spacing: 12) {
-                        Stepper("First: \(first)", value: $first, in: 1...max(engine.playback.frameCount, 1))
-                        Stepper("Last: \(last)", value: $last, in: 1...max(engine.playback.frameCount, 1))
-                    }.font(.system(size: 13))
-                }
-                Text(engine.playback.frameCount <= 1
-                     ? "Nothing to render yet — author an animation in Animate (a camera roll works from a single structure)."
-                     : "\(total) of \(engine.playback.frameCount) frames at \(Int(engine.playback.movieFPS.rounded())) fps.")
-                    .font(.caption).foregroundStyle(.secondary)
+            labeled("Format") {
+                Picker("", selection: $format) {
+                    ForEach(MovieExporter.Format.allCases) { Text($0.rawValue).tag($0) }
+                }.pickerStyle(.segmented)
             }
-
-            if showExport {
-                labeled("Format") {
-                    Picker("", selection: $format) {
-                        ForEach(MovieExporter.Format.allCases) { Text($0.rawValue).tag($0) }
-                    }.pickerStyle(.segmented)
-                }
-                labeled("Size") {
-                    Picker("", selection: $presetIdx) {
-                        ForEach(presets.indices, id: \.self) { i in
-                            Text("\(presets[i].name)  ·  \(presets[i].w)×\(presets[i].h)").tag(i)
-                        }
-                    }.pickerStyle(.segmented)
-                }
-                Toggle(isOn: $rayMode) {
-                    Label("Ray-traced frames (slow)", systemImage: "sparkles")
-                }.tint(TimelineTheme.accent)
-                if rayMode {
-                    Text("Ray-tracing every frame is much slower — use a short range first.")
-                        .font(.caption).foregroundStyle(.orange)
-                }
-
-                if exporter.isExporting {
-                    VStack(alignment: .leading, spacing: 6) {
-                        ProgressView(value: exporter.progress)
-                            .tint(TimelineTheme.accent)
-                        Text("Rendering frame \(Int(exporter.progress * Double(total)))/\(total)…")
-                            .font(.caption).foregroundStyle(.secondary)
+            labeled("Size") {
+                Picker("", selection: $presetIdx) {
+                    ForEach(presets.indices, id: \.self) { i in
+                        Text("\(presets[i].name)  ·  \(presets[i].w)×\(presets[i].h)").tag(i)
                     }
-                }
-                if let err = exporter.errorText {
-                    Text(err).font(.caption).foregroundStyle(.red)
-                }
-
-                Button(action: runExport) {
-                    Label(exporter.isExporting ? "Rendering…" : "Render & Export",
-                          systemImage: "film")
-                        .font(.system(size: 14, weight: .semibold))
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 10)
-                }
-                .buttonStyle(.borderedProminent)
-                .tint(TimelineTheme.accent)
-                .disabled(exporter.isExporting || engine.playback.frameCount <= 1)
+                }.pickerStyle(.segmented)
             }
-        }
-        .onAppear { last = max(engine.playback.frameCount, 1); first = 1 }
-        .onChange(of: engine.playback.frameCount) { n in
-            // Keep the range valid as the timeline appears/changes (e.g. after a
-            // camera roll is built from the Animate section just above).
-            last = max(n, 1); first = min(first, last)
+            Toggle(isOn: $rayMode) {
+                Label("Ray-traced frames (slow)", systemImage: "sparkles")
+            }.tint(TimelineTheme.accent)
+            if rayMode {
+                Text("Ray-tracing every frame is much slower.")
+                    .font(.caption).foregroundStyle(.orange)
+            }
+            Text("\(frameCount) frames at \(Int(engine.playback.movieFPS.rounded())) fps.")
+                .font(.caption).foregroundStyle(.secondary)
+
+            if exporter.isExporting {
+                VStack(alignment: .leading, spacing: 6) {
+                    ProgressView(value: exporter.progress)
+                        .tint(TimelineTheme.accent)
+                    Text("Rendering frame \(Int(exporter.progress * Double(frameCount)))/\(frameCount)…")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+            }
+            if let err = exporter.errorText {
+                Text(err).font(.caption).foregroundStyle(.red)
+            }
+
+            Button(action: runExport) {
+                Label(exporter.isExporting ? "Rendering…" : "Render & Export",
+                      systemImage: "film")
+                    .font(.system(size: 14, weight: .semibold))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(TimelineTheme.accent)
+            .disabled(exporter.isExporting || engine.playback.frameCount <= 1)
         }
         .onChange(of: exporter.finishedURL) { url in
             if let url = url { deliver(url) }
@@ -367,7 +336,7 @@ struct MovieExportControls: View {
     private func runExport() {
         let p = presets[presetIdx]
         exporter.start(engine: engine, format: format, width: p.w, height: p.h,
-                       first: first, last: last, fps: Int(engine.playback.movieFPS.rounded()),
+                       first: 1, last: frameCount, fps: Int(engine.playback.movieFPS.rounded()),
                        rayTraced: rayMode)
     }
 
@@ -435,42 +404,21 @@ struct MovieExportSheet: View {
 
 // MARK: - Movie content tab
 
-// The unified Movie flow as an in-panel content tab (iPhone bottom tab bar),
-// with a segmented top nav between the three steps — Animate (author a
-// camera/state/scene movie) · Frames (pick the range) · Export (render to
-// MP4/GIF). Frames + Export share one MovieExportControls instance (kept
-// mounted) so the chosen range carries into the render. The transport bar
-// handles playback of what's built.
+// The Movie content tab authors an animation (camera / state / scene movie)
+// that plays on the transport. Rendering to a file lives in the top Export
+// menu → "Export Movie" (enabled once there's something to play), so this pane
+// is purely the builder.
 struct MoviePane: View {
-    enum Step: String, CaseIterable, Identifiable {
-        case animate = "Animate", frames = "Frames", export = "Export"
-        var id: String { rawValue }
-    }
-    @State private var step: Step = .animate
-
     var body: some View {
-        VStack(spacing: 0) {
-            Picker("", selection: $step) {
-                ForEach(Step.allCases) { Text($0.rawValue).tag($0) }
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                MovieBuilderControls()
+                Text("Build & Play to preview on the transport. To save a file, use the Export menu (top-right) → Export Movie.")
+                    .font(.caption).foregroundStyle(.secondary)
             }
-            .pickerStyle(.segmented)
-            .padding(.horizontal, 16)
-            .padding(.top, 10)
-            .padding(.bottom, 4)
-
-            ScrollView {
-                VStack(alignment: .leading, spacing: 6) {
-                    if step == .animate {
-                        MovieBuilderControls()
-                    } else {
-                        // Same instance across Frames↔Export so the range persists.
-                        MovieExportControls(mode: step == .frames ? .frames : .export)
-                    }
-                }
-                .padding(16)
-                // Clear the floating tab-bar pill so the action button stays reachable.
-                .padding(.bottom, 56)
-            }
+            .padding(16)
+            // Clear the floating tab-bar pill so the controls stay reachable.
+            .padding(.bottom, 56)
         }
     }
 }

--- a/swiftui/PyMOLViewer/Panels/MovieExportSheet.swift
+++ b/swiftui/PyMOLViewer/Panels/MovieExportSheet.swift
@@ -413,8 +413,6 @@ struct MoviePane: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
                 MovieBuilderControls(initialTab: Self.initialTabFromEnv)
-                Text("Build & Play to preview on the transport. To save a file, use the Export menu (top-right) → Export Movie.")
-                    .font(.caption).foregroundStyle(.secondary)
             }
             .padding(16)
             // Clear the floating tab-bar pill so the controls stay reachable.

--- a/swiftui/PyMOLViewer/Panels/MovieExportSheet.swift
+++ b/swiftui/PyMOLViewer/Panels/MovieExportSheet.swift
@@ -412,13 +412,23 @@ struct MoviePane: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
-                MovieBuilderControls()
+                MovieBuilderControls(initialTab: Self.initialTabFromEnv)
                 Text("Build & Play to preview on the transport. To save a file, use the Export menu (top-right) → Export Movie.")
                     .font(.caption).foregroundStyle(.secondary)
             }
             .padding(16)
             // Clear the floating tab-bar pill so the controls stay reachable.
             .padding(.bottom, 56)
+        }
+    }
+
+    // Test affordance: preselect the builder tab for the screenshot harness
+    // (simctl can't tap). PYMOL_AUTOMOVIETAB=camera|states|scenes.
+    private static var initialTabFromEnv: MovieBuilderControls.Tab {
+        switch ProcessInfo.processInfo.environment["PYMOL_AUTOMOVIETAB"] {
+        case "states": return .states
+        case "scenes": return .scenes
+        default: return .camera
         }
     }
 }

--- a/swiftui/PyMOLViewer/Panels/MovieExportSheet.swift
+++ b/swiftui/PyMOLViewer/Panels/MovieExportSheet.swift
@@ -415,6 +415,7 @@ struct MoviePane: View {
                 MovieBuilderControls(initialTab: Self.initialTabFromEnv)
             }
             .padding(16)
+            .reportPaneHeight(2)    // natural height (before tab-bar clearance)
             // Clear the floating tab-bar pill so the controls stay reachable.
             .padding(.bottom, 56)
         }

--- a/swiftui/PyMOLViewer/Panels/MovieExportSheet.swift
+++ b/swiftui/PyMOLViewer/Panels/MovieExportSheet.swift
@@ -263,12 +263,20 @@ final class MovieExporter: ObservableObject {
 
 // MARK: - Reusable controls
 
+// Which portion of the export form to render. The MovieExportSheet shows `.all`
+// (frames + format + render together); the Movie tab's top nav drives `.frames`
+// vs `.export` so the two read/write the SAME instance's state (kept mounted).
+enum MovieExportMode { case all, frames, export }
+
 // The export form, reused by both the MovieExportSheet and the Movie content
 // tab's MoviePane. Self-contained (owns its MovieExporter); each embedding gets
 // its own instance.
 struct MovieExportControls: View {
     @EnvironmentObject var engine: PyMOLEngine
     @StateObject private var exporter = MovieExporter()
+
+    /// Which fields to show (Movie tab splits Frames / Export into nav steps).
+    var mode: MovieExportMode = .all
 
     private struct SizePreset: Identifiable { let id = UUID(); let name: String; let w: Int; let h: Int }
     private let presets = [SizePreset(name: "720p", w: 1280, h: 720),
@@ -281,60 +289,69 @@ struct MovieExportControls: View {
     @State private var last = 1
     @State private var rayMode = false
 
+    private var showFrames: Bool { mode != .export }
+    private var showExport: Bool { mode != .frames }
+    private var total: Int { max(last - first + 1, 1) }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
-            labeled("Format") {
-                Picker("", selection: $format) {
-                    ForEach(MovieExporter.Format.allCases) { Text($0.rawValue).tag($0) }
-                }.pickerStyle(.segmented)
-            }
-            labeled("Size") {
-                Picker("", selection: $presetIdx) {
-                    ForEach(presets.indices, id: \.self) { i in
-                        Text("\(presets[i].name)  ·  \(presets[i].w)×\(presets[i].h)").tag(i)
-                    }
-                }.pickerStyle(.segmented)
-            }
-            labeled("Frames") {
-                HStack(spacing: 12) {
-                    Stepper("First: \(first)", value: $first, in: 1...max(engine.playback.frameCount, 1))
-                    Stepper("Last: \(last)", value: $last, in: 1...max(engine.playback.frameCount, 1))
-                }.font(.system(size: 13))
-            }
-            Toggle(isOn: $rayMode) {
-                Label("Ray-traced frames (slow)", systemImage: "sparkles")
-            }.tint(TimelineTheme.accent)
-            if rayMode {
-                Text("Ray-tracing every frame is much slower — use a short range first.")
-                    .font(.caption).foregroundStyle(.orange)
-            }
-            if engine.playback.frameCount <= 1 {
-                Text("Nothing to export yet — author an animation above (a camera roll works from a single structure).")
+            if showFrames {
+                labeled("Frame range") {
+                    HStack(spacing: 12) {
+                        Stepper("First: \(first)", value: $first, in: 1...max(engine.playback.frameCount, 1))
+                        Stepper("Last: \(last)", value: $last, in: 1...max(engine.playback.frameCount, 1))
+                    }.font(.system(size: 13))
+                }
+                Text(engine.playback.frameCount <= 1
+                     ? "Nothing to render yet — author an animation in Animate (a camera roll works from a single structure)."
+                     : "\(total) of \(engine.playback.frameCount) frames at \(Int(engine.playback.movieFPS.rounded())) fps.")
                     .font(.caption).foregroundStyle(.secondary)
             }
 
-            if exporter.isExporting {
-                VStack(alignment: .leading, spacing: 6) {
-                    ProgressView(value: exporter.progress)
-                        .tint(TimelineTheme.accent)
-                    Text("Rendering frame \(Int(exporter.progress * Double(max(last - first + 1, 1))))/\(max(last - first + 1, 1))…")
-                        .font(.caption).foregroundStyle(.secondary)
+            if showExport {
+                labeled("Format") {
+                    Picker("", selection: $format) {
+                        ForEach(MovieExporter.Format.allCases) { Text($0.rawValue).tag($0) }
+                    }.pickerStyle(.segmented)
                 }
-            }
-            if let err = exporter.errorText {
-                Text(err).font(.caption).foregroundStyle(.red)
-            }
+                labeled("Size") {
+                    Picker("", selection: $presetIdx) {
+                        ForEach(presets.indices, id: \.self) { i in
+                            Text("\(presets[i].name)  ·  \(presets[i].w)×\(presets[i].h)").tag(i)
+                        }
+                    }.pickerStyle(.segmented)
+                }
+                Toggle(isOn: $rayMode) {
+                    Label("Ray-traced frames (slow)", systemImage: "sparkles")
+                }.tint(TimelineTheme.accent)
+                if rayMode {
+                    Text("Ray-tracing every frame is much slower — use a short range first.")
+                        .font(.caption).foregroundStyle(.orange)
+                }
 
-            Button(action: runExport) {
-                Label(exporter.isExporting ? "Rendering…" : "Render & Export",
-                      systemImage: "film")
-                    .font(.system(size: 14, weight: .semibold))
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 10)
+                if exporter.isExporting {
+                    VStack(alignment: .leading, spacing: 6) {
+                        ProgressView(value: exporter.progress)
+                            .tint(TimelineTheme.accent)
+                        Text("Rendering frame \(Int(exporter.progress * Double(total)))/\(total)…")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                if let err = exporter.errorText {
+                    Text(err).font(.caption).foregroundStyle(.red)
+                }
+
+                Button(action: runExport) {
+                    Label(exporter.isExporting ? "Rendering…" : "Render & Export",
+                          systemImage: "film")
+                        .font(.system(size: 14, weight: .semibold))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 10)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(TimelineTheme.accent)
+                .disabled(exporter.isExporting || engine.playback.frameCount <= 1)
             }
-            .buttonStyle(.borderedProminent)
-            .tint(TimelineTheme.accent)
-            .disabled(exporter.isExporting || engine.playback.frameCount <= 1)
         }
         .onAppear { last = max(engine.playback.frameCount, 1); first = 1 }
         .onChange(of: engine.playback.frameCount) { n in
@@ -418,38 +435,42 @@ struct MovieExportSheet: View {
 
 // MARK: - Movie content tab
 
-// The unified Movie flow as an in-panel content tab (iPhone bottom tab bar):
-// "1 · Animate" (author a camera/state/scene movie) flows straight into
-// "2 · Export" (render the resulting timeline to MP4/GIF) — no modal, matching
-// the other content tabs. The transport bar handles playback of what's built.
+// The unified Movie flow as an in-panel content tab (iPhone bottom tab bar),
+// with a segmented top nav between the three steps — Animate (author a
+// camera/state/scene movie) · Frames (pick the range) · Export (render to
+// MP4/GIF). Frames + Export share one MovieExportControls instance (kept
+// mounted) so the chosen range carries into the render. The transport bar
+// handles playback of what's built.
 struct MoviePane: View {
-    var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 6) {
-                stepHeader("1 · Animate", "what moves")
-                MovieBuilderControls()
-
-                Divider().padding(.vertical, 14)
-
-                stepHeader("2 · Export", "save the file")
-                MovieExportControls()
-            }
-            .padding(16)
-            // Clear the floating tab-bar pill so the Export button stays reachable.
-            .padding(.bottom, 56)
-        }
+    enum Step: String, CaseIterable, Identifiable {
+        case animate = "Animate", frames = "Frames", export = "Export"
+        var id: String { rawValue }
     }
+    @State private var step: Step = .animate
 
-    @ViewBuilder
-    private func stepHeader(_ title: String, _ subtitle: String) -> some View {
-        HStack(spacing: 6) {
-            Text(title.uppercased())
-                .font(.system(size: 11, weight: .bold))
-                .foregroundStyle(TimelineTheme.accent)
-            Text(subtitle)
-                .font(.caption)
-                .foregroundStyle(.secondary)
+    var body: some View {
+        VStack(spacing: 0) {
+            Picker("", selection: $step) {
+                ForEach(Step.allCases) { Text($0.rawValue).tag($0) }
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal, 16)
+            .padding(.top, 10)
+            .padding(.bottom, 4)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 6) {
+                    if step == .animate {
+                        MovieBuilderControls()
+                    } else {
+                        // Same instance across Frames↔Export so the range persists.
+                        MovieExportControls(mode: step == .frames ? .frames : .export)
+                    }
+                }
+                .padding(16)
+                // Clear the floating tab-bar pill so the action button stays reachable.
+                .padding(.bottom, 56)
+            }
         }
-        .padding(.top, 2)
     }
 }

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -2011,6 +2011,11 @@ struct ScenesPane: View {
 
     private let danger = Color(red: 0.75, green: 0.29, blue: 0.23)
 
+    // Local order mirror so chips can be reordered by hold+drag; persisted to
+    // PyMOL via `scene_order`. Synced from engine.sceneNames on add/remove.
+    @State private var sceneOrder: [String] = []
+    @State private var draggingScene: String?
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 10) {
@@ -2018,10 +2023,27 @@ struct ScenesPane: View {
                 // view as a new scene (in line with the existing scenes).
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: 8) {
-                        ForEach(engine.sceneNames, id: \.self) { name in sceneChip(name) }
+                        ForEach(sceneOrder, id: \.self) { name in
+                            sceneChip(name)
+                                .opacity(draggingScene == name ? 0.35 : 1)
+                                .onDrag {
+                                    draggingScene = name
+                                    return NSItemProvider(object: name as NSString)
+                                }
+                                .onDrop(of: ["public.text"],
+                                        delegate: SceneDropDelegate(item: name, order: $sceneOrder,
+                                                                    dragging: $draggingScene,
+                                                                    onReorder: applySceneOrder))
+                        }
                         addChip
                     }
                     .padding(.vertical, 4)
+                }
+                .onAppear { sceneOrder = engine.sceneNames }
+                .onChange(of: engine.sceneNames) { newNames in
+                    // Resync only when the SET changes (scene added/removed); a
+                    // pure reorder (same set) keeps the user's dragged order.
+                    if Set(newNames) != Set(sceneOrder) { sceneOrder = newNames }
                 }
 
                 if engine.sceneNames.isEmpty {
@@ -2091,6 +2113,12 @@ struct ScenesPane: View {
         .accessibilityLabel("New scene from current view")
     }
 
+    // Persist the dragged chip order to PyMOL.
+    private func applySceneOrder() {
+        guard !sceneOrder.isEmpty else { return }
+        engine.runCommand("scene_order " + sceneOrder.joined(separator: " "))
+    }
+
     // Compact icon+label button; several sit on one row (Update/Prev/Next/Delete).
     private func sceneActionButton(_ title: String, _ icon: String,
                                    danger: Bool = false, _ action: @escaping () -> Void) -> some View {
@@ -2122,6 +2150,30 @@ struct ScenesPane: View {
         }
         .buttonStyle(.plain)
         .overlay(alignment: .top) { Divider() }
+    }
+}
+
+// Reorders scene chips live as one is dragged over another (hold + move).
+private struct SceneDropDelegate: DropDelegate {
+    let item: String
+    @Binding var order: [String]
+    @Binding var dragging: String?
+    let onReorder: () -> Void
+
+    func dropEntered(info: DropInfo) {
+        guard let dragging = dragging, dragging != item,
+              let from = order.firstIndex(of: dragging),
+              let to = order.firstIndex(of: item) else { return }
+        withAnimation(.easeInOut(duration: 0.15)) {
+            order.move(fromOffsets: IndexSet(integer: from),
+                       toOffset: to > from ? to + 1 : to)
+        }
+    }
+    func dropUpdated(info: DropInfo) -> DropProposal? { DropProposal(operation: .move) }
+    func performDrop(info: DropInfo) -> Bool {
+        dragging = nil
+        onReorder()
+        return true
     }
 }
 

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -1842,8 +1842,8 @@ struct SceneCard: View {
     // in ObjectPanel (shared with Objects / Selections).
     var body: some View {
         VStack(spacing: 3) {
-            SceneStrip()
-            Divider().background(PanelTheme.disabledColor.opacity(0.3))
+            // Scene management (the strip) now lives in the dedicated Scenes tab;
+            // this card holds the global DISPLAY settings only.
             ForEach(SceneCatalog.groups, id: \.self) { group in
                 sceneGroup(group)
             }
@@ -1997,67 +1997,120 @@ struct SceneCard: View {
 
 // MARK: - Scenes strip (saved camera/representation snapshots)
 
-private struct SceneStrip: View {
+// The Scenes content tab — a full scene manager (PyMOL's Scene menu) in the
+// global/teal language. Scenes recall the whole visualization, so everything
+// here uses TimelineTheme.accent (teal), distinct from the per-object coral
+// A/S/H/L/C. Append wires to the movie; an opt-in toggle shows glanceable scene
+// buttons over the 3D viewport.
+struct ScenesPane: View {
     @EnvironmentObject var engine: PyMOLEngine
-    @State private var showBuilder = false
+    /// Drives the in-viewport scene-button overlay (owned by ContentView).
+    @Binding var showViewportButtons: Bool
+    /// Jump to the Movie tab (set by ContentView).
+    var onOpenMovie: (() -> Void)? = nil
+
+    private let danger = Color(red: 0.75, green: 0.29, blue: 0.23)
 
     var body: some View {
-        VStack(spacing: 4) {
-            HStack(spacing: 8) {
-                Text("Scenes")
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundColor(PanelTheme.textColor)
-                Spacer(minLength: 0)
-                actionIcon("plus") { engine.runCommand("scene new, store") }
-                    .accessibilityLabel("Store new scene")
-                actionIcon("arrow.clockwise") { engine.runCommand("scene auto, update") }
-                    .accessibilityLabel("Update current scene")
-                actionIcon("xmark") { engine.runCommand("scene auto, delete") }
-                    .accessibilityLabel("Delete current scene")
-                actionIcon("film") { showBuilder = true }
-                    .accessibilityLabel("Make scene-loop movie")
-            }
-            if engine.sceneNames.isEmpty {
-                Text("No scenes — tap + to store the current view.")
-                    .font(.system(size: 9))
-                    .foregroundColor(PanelTheme.disabledColor)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            } else {
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 4) {
-                        ForEach(engine.sceneNames, id: \.self) { name in
-                            let sel = name == engine.currentScene
-                            Button {
-                                engine.runCommand("scene \(name), recall, animate=1")
-                            } label: {
-                                Text(name)
-                                    .font(.system(size: 9, weight: sel ? .bold : .regular))
-                                    .padding(.horizontal, 7).padding(.vertical, 3)
-                                    .background(sel ? TimelineTheme.accent : PanelTheme.buttonBackground)
-                                    .foregroundColor(sel ? Color.black : PanelTheme.buttonText)
-                                    .clipShape(Capsule())
-                            }
-                            .buttonStyle(.plain)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                if engine.sceneNames.isEmpty {
+                    Text("No scenes yet. Append the current view to store your first scene.")
+                        .font(.system(size: 13))
+                        .foregroundColor(PanelTheme.disabledColor)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.vertical, 10)
+                } else {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 8) {
+                            ForEach(engine.sceneNames, id: \.self) { name in sceneChip(name) }
                         }
+                        .padding(.vertical, 6)
                     }
                 }
+
+                Button { engine.runCommand("scene new, store") } label: {
+                    HStack(spacing: 10) {
+                        Image(systemName: "plus").font(.system(size: 17, weight: .bold))
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text("Append current view").font(.system(size: 15, weight: .semibold))
+                            Text("Saves a new scene + a movie segment").font(.system(size: 11)).opacity(0.85)
+                        }
+                        Spacer()
+                    }
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 14).padding(.vertical, 12)
+                    .frame(maxWidth: .infinity)
+                    .background(TimelineTheme.accent)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
+                .buttonStyle(.plain)
+                .padding(.vertical, 6)
+
+                Toggle(isOn: $showViewportButtons) {
+                    Label("Show scene buttons in viewport", systemImage: "rectangle.grid.1x2")
+                        .font(.system(size: 14))
+                }
+                .tint(TimelineTheme.accent)
+                .padding(.vertical, 4)
+
+                groupHeader(engine.currentScene.isEmpty ? "Selected" : "Selected · \(engine.currentScene)")
+                actionRow("Update from current view", "arrow.clockwise") { engine.runCommand("scene auto, update") }
+                actionRow("Next scene", "chevron.right") { engine.runCommand("scene auto, next") }
+                actionRow("Previous scene", "chevron.left") { engine.runCommand("scene auto, previous") }
+                actionRow("Delete current scene", "trash", destructive: true) { engine.runCommand("scene auto, delete") }
+
+                groupHeader("All scenes")
+                actionRow("Build movie from scenes", "film") { onOpenMovie?() }
+                actionRow("Clear all scenes", "xmark", destructive: true) { engine.runCommand("scene *, clear") }
             }
-        }
-        .sheet(isPresented: $showBuilder) {
-            MovieBuilderSheet(initialTab: .scenes)
+            .padding(.horizontal, 10)
+            .padding(.bottom, 56)   // clear the floating tab-bar pill
         }
     }
 
-    private func actionIcon(_ systemName: String, _ action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            Image(systemName: systemName)
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundColor(PanelTheme.buttonText)
-                .frame(width: 24, height: 22)
-                .background(PanelTheme.buttonBackground)
-                .clipShape(RoundedRectangle(cornerRadius: 5))
+    private func sceneChip(_ name: String) -> some View {
+        let sel = name == engine.currentScene
+        return Button {
+            engine.runCommand("scene \(name), recall, animate=1")
+        } label: {
+            Text(name)
+                .font(.system(size: 14, weight: .bold, design: .monospaced))
+                .padding(.horizontal, 14).frame(height: 38)
+                .background(sel ? TimelineTheme.accent : Color.white)
+                .foregroundColor(sel ? .white : TimelineTheme.accent)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .strokeBorder(TimelineTheme.accent.opacity(sel ? 0 : 0.5), lineWidth: 1.5)
+                )
         }
         .buttonStyle(.plain)
+    }
+
+    private func groupHeader(_ title: String) -> some View {
+        Text(title.uppercased())
+            .font(.system(size: 10, weight: .bold, design: .monospaced))
+            .foregroundColor(PanelTheme.disabledColor)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.top, 14).padding(.bottom, 2)
+    }
+
+    private func actionRow(_ title: String, _ icon: String,
+                           destructive: Bool = false, _ action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                Image(systemName: icon).frame(width: 22)
+                    .foregroundColor(destructive ? danger : TimelineTheme.accent)
+                Text(title).font(.system(size: 15))
+                    .foregroundColor(destructive ? danger : PanelTheme.textColor)
+                Spacer()
+            }
+            .padding(.vertical, 12)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .overlay(alignment: .top) { Divider() }
     }
 }
 

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -658,13 +658,6 @@ struct ObjectPanel: View {
                     .foregroundColor(PanelTheme.headerColor)
                 Spacer()
                 selectionModeMenu
-                Button(action: { refreshObjects() }) {
-                    Image(systemName: "arrow.clockwise")
-                        .font(.system(size: 10))
-                        .foregroundColor(PanelTheme.headerColor)
-                }
-                .buttonStyle(.plain)
-                .help("Refresh")
             }
             .padding(.horizontal, 8)
             .padding(.vertical, 4)

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -708,6 +708,10 @@ struct ObjectPanel: View {
                     }
                 }
                 .padding(.vertical, 2)
+                // Report natural list height so the portrait panel can hug Objects
+                // (capped at 1/3). Harmless in landscape/iPad (no listener there).
+                .reportPaneHeight(1)
+                .padding(.bottom, 56)   // clearance when capped + scrolling (portrait)
             }
         }
         .background(PanelTheme.background)
@@ -2073,6 +2077,7 @@ struct ScenesPane: View {
             }
             .padding(.horizontal, 12)
             .padding(.top, 8)
+            .reportPaneHeight(5)    // natural height (before tab-bar clearance)
             .padding(.bottom, 56)   // clear the floating tab-bar pill
         }
     }

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -2013,58 +2013,44 @@ struct ScenesPane: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 0) {
-                if engine.sceneNames.isEmpty {
-                    Text("No scenes yet. Append the current view to store your first scene.")
-                        .font(.system(size: 13))
-                        .foregroundColor(PanelTheme.disabledColor)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.vertical, 10)
-                } else {
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: 8) {
-                            ForEach(engine.sceneNames, id: \.self) { name in sceneChip(name) }
-                        }
-                        .padding(.vertical, 6)
+            VStack(alignment: .leading, spacing: 10) {
+                // Scene chips with an inline "+" chip that stores the current
+                // view as a new scene (in line with the existing scenes).
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(engine.sceneNames, id: \.self) { name in sceneChip(name) }
+                        addChip
                     }
+                    .padding(.vertical, 4)
                 }
 
-                Button { engine.runCommand("scene new, store") } label: {
-                    HStack(spacing: 10) {
-                        Image(systemName: "plus").font(.system(size: 17, weight: .bold))
-                        VStack(alignment: .leading, spacing: 1) {
-                            Text("Append current view").font(.system(size: 15, weight: .semibold))
-                            Text("Saves a new scene + a movie segment").font(.system(size: 11)).opacity(0.85)
-                        }
-                        Spacer()
+                if engine.sceneNames.isEmpty {
+                    Text("Tap + to store the current view as your first scene.")
+                        .font(.system(size: 12))
+                        .foregroundColor(PanelTheme.disabledColor)
+                } else {
+                    // Per-scene actions, all on one row for vertical efficiency.
+                    HStack(spacing: 8) {
+                        sceneActionButton("Update", "arrow.clockwise") { engine.runCommand("scene auto, update") }
+                        sceneActionButton("Prev", "chevron.left") { engine.runCommand("scene auto, previous") }
+                        sceneActionButton("Next", "chevron.right") { engine.runCommand("scene auto, next") }
+                        sceneActionButton("Delete", "trash", danger: true) { engine.runCommand("scene auto, delete") }
                     }
-                    .foregroundColor(.white)
-                    .padding(.horizontal, 14).padding(.vertical, 12)
-                    .frame(maxWidth: .infinity)
-                    .background(TimelineTheme.accent)
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
                 }
-                .buttonStyle(.plain)
-                .padding(.vertical, 6)
 
                 Toggle(isOn: $showViewportButtons) {
                     Label("Show scene buttons in viewport", systemImage: "rectangle.grid.1x2")
                         .font(.system(size: 14))
                 }
                 .tint(TimelineTheme.accent)
-                .padding(.vertical, 4)
+                .padding(.top, 2)
 
-                groupHeader(engine.currentScene.isEmpty ? "Selected" : "Selected · \(engine.currentScene)")
-                actionRow("Update from current view", "arrow.clockwise") { engine.runCommand("scene auto, update") }
-                actionRow("Next scene", "chevron.right") { engine.runCommand("scene auto, next") }
-                actionRow("Previous scene", "chevron.left") { engine.runCommand("scene auto, previous") }
-                actionRow("Delete current scene", "trash", destructive: true) { engine.runCommand("scene auto, delete") }
-
-                groupHeader("All scenes")
+                Divider().padding(.vertical, 2)
                 actionRow("Build movie from scenes", "film") { onOpenMovie?() }
                 actionRow("Clear all scenes", "xmark", destructive: true) { engine.runCommand("scene *, clear") }
             }
-            .padding(.horizontal, 10)
+            .padding(.horizontal, 12)
+            .padding(.top, 8)
             .padding(.bottom, 56)   // clear the floating tab-bar pill
         }
     }
@@ -2088,12 +2074,37 @@ struct ScenesPane: View {
         .buttonStyle(.plain)
     }
 
-    private func groupHeader(_ title: String) -> some View {
-        Text(title.uppercased())
-            .font(.system(size: 10, weight: .bold, design: .monospaced))
-            .foregroundColor(PanelTheme.disabledColor)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.top, 14).padding(.bottom, 2)
+    // Trailing "+" chip in the scene row — stores the current view as a new scene.
+    private var addChip: some View {
+        Button { engine.runCommand("scene new, store") } label: {
+            Image(systemName: "plus")
+                .font(.system(size: 15, weight: .bold))
+                .frame(width: 44, height: 38)
+                .foregroundColor(TimelineTheme.accent)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .strokeBorder(TimelineTheme.accent.opacity(0.5),
+                                      style: StrokeStyle(lineWidth: 1.5, dash: [4, 3]))
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("New scene from current view")
+    }
+
+    // Compact icon+label button; several sit on one row (Update/Prev/Next/Delete).
+    private func sceneActionButton(_ title: String, _ icon: String,
+                                   danger: Bool = false, _ action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            VStack(spacing: 3) {
+                Image(systemName: icon).font(.system(size: 15, weight: .medium))
+                Text(title).font(.system(size: 10, weight: .medium))
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 9)
+            .foregroundColor(danger ? self.danger : TimelineTheme.accent)
+            .background(RoundedRectangle(cornerRadius: 9).fill(Color.gray.opacity(0.13)))
+        }
+        .buttonStyle(.plain)
     }
 
     private func actionRow(_ title: String, _ icon: String,

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -650,12 +650,11 @@ struct ObjectPanel: View {
 
     private var panelBody: some View {
         VStack(spacing: 0) {
-            // Panel-wide toolbar: the selection-pick mode and refresh act on the
-            // whole panel, so they live here rather than in any one section header.
+            // Panel-wide toolbar: the selection-pick mode acts on the whole panel,
+            // so it lives here rather than in any one section header. (The former
+            // "Inspector" label was dropped — the bottom tab already names the pane;
+            // SCENE moved fully into the Settings tab.)
             HStack(spacing: 8) {
-                Text("Inspector")
-                    .font(.system(size: 11, weight: .bold))
-                    .foregroundColor(PanelTheme.headerColor)
                 Spacer()
                 selectionModeMenu
             }
@@ -669,9 +668,8 @@ struct ObjectPanel: View {
                     let objects = engine.objects.filter { !$0.isSelection }
                     let selections = engine.objects.filter { $0.isSelection }
 
-                    // SCENE — global display settings.
-                    sectionHeader("SCENE", id: "scene", tag: "global") { EmptyView() }
-                    if openSections.contains("scene") { SceneCard() }
+                    // SCENE (global display settings) now lives in the Settings tab
+                    // → "Scene settings"; it was removed from the Inspector here.
 
                     // OBJECTS — the loaded molecules + the global "all" row.
                     sectionHeader("OBJECTS", id: "objects",
@@ -1833,7 +1831,9 @@ private struct HelpButton: View {
     }
 }
 
-private struct SceneCard: View {
+// Non-private: also hosted in the Settings tab (ContentView.settingsPane) now
+// that SCENE lives fully under Settings rather than the Inspector.
+struct SceneCard: View {
     @EnvironmentObject var engine: PyMOLEngine
     @State private var showSettings = false
     // Per-sub-group expand state; the heavier groups start collapsed.

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -787,10 +787,11 @@ struct ContentView: View {
     @ViewBuilder
     private func iPhoneLandscapeLayout(geo: GeometryProxy) -> some View {
         let total = geo.size.width
-        // Reuse panelFrac (shared with portrait) as a width share, clamped so the
-        // panel never eats more than ~45% of the landscape width.
-        let panelW = min(max(total * panelFrac, 300), total * 0.45)
-        HStack(spacing: 0) {
+        let panelW = min(max(total * 0.40, 320), 430)
+        ZStack(alignment: .topTrailing) {
+            // Full-bleed viewport (+ optional sequence strip): the 3D view spans
+            // the WHOLE width; the control panel floats over its right edge for
+            // better space utilization (full-screen hides it entirely).
             VStack(spacing: 0) {
                 if engine.sequenceVisible {
                     SequencePanel().frame(height: ipadSequenceHeight)
@@ -798,17 +799,25 @@ struct ContentView: View {
                 }
                 viewportView
             }
-            if iosFullScreen {
-                EmptyView()
-            } else if showThemeStudio {
-                resizeDivider(landscape: true, total: total)
-                ThemeStudioPanel(onClose: { withAnimation(.easeInOut(duration: 0.2)) { showThemeStudio = false } })
-                    .environmentObject(engine)
-                    .environmentObject(themeManager)
-                    .frame(width: panelW)
-            } else {
-                resizeDivider(landscape: true, total: total)
-                panelContent.frame(width: panelW)
+
+            if !iosFullScreen {
+                Group {
+                    if showThemeStudio {
+                        ThemeStudioPanel(onClose: { withAnimation(.easeInOut(duration: 0.2)) { showThemeStudio = false } })
+                            .environmentObject(engine)
+                            .environmentObject(themeManager)
+                    } else {
+                        panelContent
+                    }
+                }
+                .frame(width: panelW)
+                .frame(maxHeight: .infinity)
+                .clipShape(RoundedRectangle(cornerRadius: 18))
+                .overlay(RoundedRectangle(cornerRadius: 18).strokeBorder(Color.primary.opacity(0.08)))
+                .shadow(color: .black.opacity(0.22), radius: 14, x: -3, y: 3)
+                .padding(.top, 54)        // clear the floating toolbar pills
+                .padding(.trailing, 8)
+                .padding(.bottom, engine.hasTimeline ? 72 : 10)  // clear the transport
             }
         }
     }

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -786,12 +786,17 @@ struct ContentView: View {
     // right edge. Full-screen hides the panel; the divider resizes it.
     @ViewBuilder
     private func iPhoneLandscapeLayout(geo: GeometryProxy) -> some View {
-        let total = geo.size.width
-        let panelW = min(max(total * 0.40, 320), 430)
+        let panelW = min(max(geo.size.width * 0.38, 300), 420)
+        let topInset: CGFloat = 46                                  // clear the toolbar pills
+        let botInset: CGFloat = engine.hasTimeline ? 64 : 8         // clear the transport
+        // Explicit height (TabView won't reliably fill a maxHeight frame), so the
+        // panel spans full height between the insets and the tab bar sits at the
+        // bottom — not stranded mid-screen.
+        let panelH = max(geo.size.height - topInset - botInset, 120)
         ZStack(alignment: .topTrailing) {
             // Full-bleed viewport (+ optional sequence strip): the 3D view spans
-            // the WHOLE width; the control panel floats over its right edge for
-            // better space utilization (full-screen hides it entirely).
+            // the WHOLE width; the control panel is a frosted-glass overlay on the
+            // right so the structure shows through behind it.
             VStack(spacing: 0) {
                 if engine.sequenceVisible {
                     SequencePanel().frame(height: ipadSequenceHeight)
@@ -807,17 +812,17 @@ struct ContentView: View {
                             .environmentObject(engine)
                             .environmentObject(themeManager)
                     } else {
-                        panelContent
+                        panelTabs
                     }
                 }
-                .frame(width: panelW)
-                .frame(maxHeight: .infinity)
-                .clipShape(RoundedRectangle(cornerRadius: 18))
-                .overlay(RoundedRectangle(cornerRadius: 18).strokeBorder(Color.primary.opacity(0.08)))
-                .shadow(color: .black.opacity(0.22), radius: 14, x: -3, y: 3)
-                .padding(.top, 54)        // clear the floating toolbar pills
-                .padding(.trailing, 8)
-                .padding(.bottom, engine.hasTimeline ? 72 : 10)  // clear the transport
+                .frame(width: panelW, height: panelH, alignment: .top)
+                .background(.ultraThinMaterial)                     // frosted glass
+                .clipShape(UnevenRoundedRectangle(topLeadingRadius: 18, bottomLeadingRadius: 18))
+                .overlay(alignment: .leading) {
+                    Rectangle().fill(Color.primary.opacity(0.08)).frame(width: 0.5)
+                }
+                .shadow(color: .black.opacity(0.18), radius: 12, x: -2, y: 1)
+                .padding(.top, topInset)        // flush to the right edge (no trailing pad)
             }
         }
     }
@@ -1186,7 +1191,8 @@ struct ContentView: View {
 
     // Shared control content: Console / Objects / Sequence as exclusive tabs
     // (Sequence is its own tab now — not a strip and not a toolbar/Export item).
-    private var panelContent: some View {
+    // The 5-tab control panel (no background — callers pick the chrome).
+    private var panelTabs: some View {
         TabView(selection: $selectedTab) {
             CommandPanel(showInput: !RayMolBuild.iosRestricted)
                 .tabItem { Label("Console", systemImage: "terminal") }.tag(0)
@@ -1200,7 +1206,11 @@ struct ContentView: View {
             settingsPane
                 .tabItem { Label("Settings", systemImage: "gearshape") }.tag(4)
         }
-        .background(themeChromeBg)
+    }
+
+    // Portrait / opaque docked panel.
+    private var panelContent: some View {
+        panelTabs.background(themeChromeBg)
     }
 
     // Settings content tab (iPhone). Relocates the former top-bar Theme + Reset

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -697,19 +697,9 @@ struct ContentView: View {
             // Dynamic Island / nav bar) and insets the viewport while active —
             // NOT a full-bleed overlay, which would slide under the notch.
             .safeAreaInset(edge: .top, spacing: 0) {
-                VStack(spacing: 0) {
-                    if engine.measureMode != nil { measureOverlay }
-                    // Sequence viewer as a strip below the toolbar / above the
-                    // viewport (desktop-style), toggled from Settings → "Show
-                    // sequence". iPhone portrait only; iPad stacks it in-column.
-                    if hSize == .compact && vSize == .regular
-                        && engine.sequenceVisible && !iosFullScreen {
-                        SequencePanel()
-                            .frame(height: ipadSequenceHeight)
-                            .background(themeChromeBg)
-                        Divider()
-                    }
-                }
+                // Measurement bar docks in the top safe area while active. (The
+                // sequence strip moved BELOW the viewport — see iPhoneLayout.)
+                if engine.measureMode != nil { measureOverlay }
             }
             .navigationTitle(hSize == .compact ? "" : "RayMol")
             .navigationBarTitleDisplayMode(.inline)
@@ -949,10 +939,16 @@ struct ContentView: View {
         let total = geo.size.height
         let panelSize = portraitPanelHeight(total: total)
         VStack(spacing: 0) {
-            // The sequence strip (when enabled) docks in the top safe area via
-            // .safeAreaInset(edge: .top) at the layout root — NOT here — so it sits
-            // below the status bar / nav bar instead of bleeding under the notch.
             viewportView
+            // Sequence strip: docked BELOW the viewport and ABOVE the bottom panel
+            // (desktop-style), toggled from Settings → "Show sequence". (The
+            // measurement bar still docks in the top safe area.)
+            if engine.sequenceVisible && !iosFullScreen {
+                Divider()
+                SequencePanel()
+                    .frame(height: ipadSequenceHeight)
+                    .background(themeChromeBg)
+            }
             if iosFullScreen {
                 // Full-screen viewport: bottom panel + sequence hidden, 3D fills.
                 EmptyView()

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -1078,6 +1078,8 @@ struct ContentView: View {
                 .tabItem { Label("Console", systemImage: "terminal") }.tag(0)
             ObjectPanel()
                 .tabItem { Label("Objects", systemImage: "cube") }.tag(1)
+            MoviePane()
+                .tabItem { Label("Movie", systemImage: "film") }.tag(2)
             settingsPane
                 .tabItem { Label("Settings", systemImage: "gearshape") }.tag(4)
         }

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -73,6 +73,72 @@ private struct SafeAreaReader: UIViewRepresentable {
 }
 #endif
 
+// MARK: - iPhone-landscape custom panel bar
+//
+// In iPhone landscape we render the control panel WITHOUT a TabView, because a TabView is
+// the only thing that spawns the iOS-26 floating capsule tab bar, and that capsule anchors
+// to the WINDOW safe area — it cannot be inset by any SwiftUI frame/padding/safeAreaPadding
+// (verified on-device). A plain HStack of buttons is ordinary content: it obeys its parent
+// column's frame, so when the column is narrowed by the notch every tab (incl. Settings)
+// stays LEFT of the black notch-stripe. Portrait / iPad keep the real TabView (panelTabs).
+
+/// The 5 control tabs in display order, matching `panelTabs` EXACTLY (same tags / icons /
+/// labels). Tag 3 is intentionally absent (the "poison" tag handled by the panel-grow onChange).
+private struct PanelTabSpec: Identifiable {
+    let tag: Int
+    let title: String
+    let systemImage: String
+    var id: Int { tag }
+}
+
+private let landscapePanelTabSpecs: [PanelTabSpec] = [
+    .init(tag: 0, title: "Console",  systemImage: "terminal"),
+    .init(tag: 1, title: "Objects",  systemImage: "cube"),
+    .init(tag: 5, title: "Scenes",   systemImage: "rectangle.on.rectangle"),
+    .init(tag: 2, title: "Movie",    systemImage: "film"),
+    .init(tag: 4, title: "Settings", systemImage: "gearshape"),
+]
+
+/// Custom bottom tab bar for iPhone landscape. Writes the same `$selectedTab` the TabView
+/// would, so the tag-3 poison-grow onChange and every deep-link keep working; it never
+/// emits tag 3.
+private struct LandscapeTabBar: View {
+    @Binding var selection: Int
+    let tint: Color
+    let chrome: Color
+    let inactive: Color
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(landscapePanelTabSpecs) { spec in
+                let isSel = selection == spec.tag
+                Button {
+                    selection = spec.tag
+                } label: {
+                    VStack(spacing: 2) {
+                        Image(systemName: spec.systemImage)
+                            .font(.system(size: 17, weight: isSel ? .semibold : .regular))
+                        Text(spec.title)
+                            .font(.system(size: 10, weight: isSel ? .semibold : .regular))
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.8)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 6)
+                    .foregroundStyle(isSel ? tint : inactive.opacity(0.55))
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(spec.title)
+                .accessibilityAddTraits(isSel ? [.isSelected, .isButton] : [.isButton])
+            }
+        }
+        .padding(.horizontal, 4)
+        .padding(.vertical, 4)
+        .background(chrome.overlay(alignment: .top) { Divider().opacity(0.6) })
+    }
+}
+
 private extension View {
     /// Tighten inter-section spacing on grouped lists (iOS 17+); no-op elsewhere.
     @ViewBuilder func compactListSections() -> some View {
@@ -886,31 +952,27 @@ struct ContentView: View {
 
             if !iosFullScreen {
                 Divider()
+                // The panel column is narrowed by the notch on the island-on-RIGHT side so
+                // it ends at the black stripe's left edge; flush to the true window edge when
+                // the island is on the left. .clipped() guarantees nothing paints past it.
                 if showThemeStudio {
                     ThemeStudioPanel(onClose: { withAnimation(.easeInOut(duration: 0.2)) { showThemeStudio = false } })
                         .environmentObject(engine)
                         .environmentObject(themeManager)
-                        .frame(width: panelW)
-                } else {
-                    // The panel sits flush against whatever its right neighbour is:
-                    // the true screen edge when the island is on the LEFT, or the
-                    // black notch-stripe when the island is on the RIGHT. No inset —
-                    // the stripe (below) is what keeps the island off the panel.
-                    //
-                    // Only .top is ignored (the nav bar is hidden in landscape). We do
-                    // NOT ignore .horizontal: that let the TabView's bottom tab bar
-                    // bleed rightward into the trailing safe area, pushing the last tab
-                    // (Settings) under the black notch-stripe. The .background already
-                    // fills the frame to the screen edge, so the bleed bought nothing.
-                    panelTabs
-                        .ignoresSafeArea(.container, edges: .top)
-                        .frame(width: panelW, alignment: .leading)
+                        .frame(width: panelW - (islandOnRight ? notch : 0), alignment: .leading)
                         .background(themeChromeBg)
+                        .clipped()
+                } else {
+                    // Custom pane + custom bottom bar — NO TabView, so the iOS-26 floating
+                    // capsule cannot exist; plain content obeys the narrowed column frame.
+                    landscapePanelBody
+                        .frame(width: panelW - (islandOnRight ? notch : 0), alignment: .leading)
+                        .background(themeChromeBg)
+                        .clipped()
                 }
 
-                // Island on the RIGHT: letterbox it away with a solid black stripe at
-                // the far-right edge so the cutout never overlaps the panel. The panel
-                // butts flush against this stripe; the viewer fills everything left.
+                // Island on the RIGHT: solid black letterbox over the cutout, filling the
+                // reserved notch width to the window edge (full height via ignoresSafeArea).
                 if islandOnRight && notch > 0 {
                     Color.black
                         .frame(width: notch)
@@ -1345,6 +1407,34 @@ struct ContentView: View {
     // Portrait / opaque docked panel.
     private var panelContent: some View {
         panelTabs.background(themeChromeBg)
+    }
+
+    // iPhone-landscape ONLY panel body: the selected pane rendered WITHOUT a TabView (so the
+    // iOS-26 floating capsule can't exist), plus the custom LandscapeTabBar. Mirrors
+    // panelTabs' tag→view mapping 1:1. Being plain content, it obeys the narrowed column
+    // frame, keeping every tab — including Settings — left of the notch-stripe.
+    @ViewBuilder
+    private var landscapePanelBody: some View {
+        VStack(spacing: 0) {
+            Group {
+                switch selectedTab {
+                case 1:  ObjectPanel()
+                case 5:  ScenesPane(showViewportButtons: $showSceneButtons,
+                                    onOpenMovie: { selectedTab = 2 })
+                case 2:  MoviePane()
+                case 4:  settingsPane
+                default: CommandPanel(showInput: !RayMolBuild.iosRestricted)   // tag 0 (and any stray)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            LandscapeTabBar(
+                selection: $selectedTab,
+                tint: themeManager.active.tabTint.color,
+                chrome: themeManager.active.panelBackground.color,
+                inactive: themeManager.active.panelText.color
+            )
+        }
     }
 
     // Settings content tab (iPhone). Relocates the former top-bar Theme + Reset

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -524,10 +524,10 @@ struct ContentView: View {
     // safeAreaInsetsDidChange — reliable across a landscapeLeft<->Right flip,
     // unlike geo.safeAreaInsets (which reports the island inset regardless of side).
     @State private var windowTrailingInset: CGFloat = 0
-    @State private var windowLeadingInset: CGFloat = 0   // debug
     // In landscape the window reports the island inset SYMMETRICALLY on both sides,
     // so the insets can't tell us which side the island is physically on — the
-    // interface orientation does. landscapeLeft => island on the RIGHT.
+    // interface orientation does. Verified on-device (iPhone 15 Pro): when the
+    // island sits on the RIGHT the interface orientation is .landscapeRight.
     @State private var islandOnRight = false
 
     private func refreshIslandSide() {
@@ -535,7 +535,7 @@ struct ContentView: View {
         let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
         let scene = scenes.first { $0.activationState == .foregroundActive } ?? scenes.first
         if let io = scene?.interfaceOrientation {
-            islandOnRight = (io == .landscapeLeft)
+            islandOnRight = (io == .landscapeRight)
         }
         #endif
     }
@@ -593,7 +593,6 @@ struct ContentView: View {
             .background {
                 SafeAreaReader { insets in
                     if windowTrailingInset != insets.right { windowTrailingInset = insets.right }
-                    if windowLeadingInset != insets.left { windowLeadingInset = insets.left }
                 }
             }
             #endif
@@ -875,15 +874,6 @@ struct ContentView: View {
                 }
                 .padding(.top, 8)
                 .padding(.horizontal, 8)
-            }
-            // TEMP diagnostic — exact inset values so we can see why the panel insets.
-            .overlay(alignment: .bottomLeading) {
-                Text(verbatim: "islandR \(islandOnRight ? 1 : 0)  applied \(Int(islandOnRight ? windowTrailingInset : 0))  winL \(Int(windowLeadingInset))  winR \(Int(windowTrailingInset))")
-                    .font(.system(size: 12, weight: .bold, design: .monospaced))
-                    .padding(6)
-                    .background(.black.opacity(0.7))
-                    .foregroundStyle(.green)
-                    .padding(10)
             }
 
             if !iosFullScreen {

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -523,6 +523,10 @@ struct ContentView: View {
                 Group {
                     if phonePortrait {
                         iPhoneLayout(geo: geo)
+                    } else if isPhoneLandscape {
+                        // iPhone landscape mirrors the portrait UX with the same
+                        // 5-tab control panel, docked on the RIGHT instead of bottom.
+                        iPhoneLandscapeLayout(geo: geo)
                     } else {
                         iPadMacStyleLayout(geo: geo)
                     }
@@ -775,6 +779,40 @@ struct ContentView: View {
         }
     }
 
+    // MARK: iPhone landscape — portrait UX, panel docked on the RIGHT
+
+    // Same components as portrait (sequence strip + viewport + the 5-tab control
+    // panel), but laid out horizontally: viewport on the left, the panel on the
+    // right edge. Full-screen hides the panel; the divider resizes it.
+    @ViewBuilder
+    private func iPhoneLandscapeLayout(geo: GeometryProxy) -> some View {
+        let total = geo.size.width
+        // Reuse panelFrac (shared with portrait) as a width share, clamped so the
+        // panel never eats more than ~45% of the landscape width.
+        let panelW = min(max(total * panelFrac, 300), total * 0.45)
+        HStack(spacing: 0) {
+            VStack(spacing: 0) {
+                if engine.sequenceVisible {
+                    SequencePanel().frame(height: ipadSequenceHeight)
+                    Divider()
+                }
+                viewportView
+            }
+            if iosFullScreen {
+                EmptyView()
+            } else if showThemeStudio {
+                resizeDivider(landscape: true, total: total)
+                ThemeStudioPanel(onClose: { withAnimation(.easeInOut(duration: 0.2)) { showThemeStudio = false } })
+                    .environmentObject(engine)
+                    .environmentObject(themeManager)
+                    .frame(width: panelW)
+            } else {
+                resizeDivider(landscape: true, total: total)
+                panelContent.frame(width: panelW)
+            }
+        }
+    }
+
     // MARK: iPad (regular size class) layout — mac-style stack
 
     // Mirrors the desktop macOSLayout: a left column with the terminal
@@ -933,9 +971,9 @@ struct ContentView: View {
         // iPhone (compact) only: collapse/expand the single bottom control panel.
         // The iPad mac-style layout uses iosPadPanelMenu (per-pane toggles) instead.
         ToolbarItem(placement: .primaryAction) {
-            // iPhone PORTRAIT only (the compact bottom-panel layout). iPhone
-            // landscape + iPad use the mac-style layout with iosPadPanelMenu.
-            if hSize == .compact && vSize == .regular {
+            // iPhone (both orientations) — the tab-panel layout uses a full-screen
+            // toggle. iPad uses the mac-style layout with iosPadPanelMenu.
+            if hSize == .compact {
                 Button {
                     withAnimation(.easeInOut(duration: 0.2)) { iosFullScreen.toggle() }
                 } label: {
@@ -955,10 +993,9 @@ struct ContentView: View {
     // and show/hide the Objects + Raymond right column — the desktop arrangement.
     private var iosPadPanelMenu: some ToolbarContent {
         ToolbarItem(placement: .primaryAction) {
-            // Shown whenever the mac-style layout is active: iPad (both orientations)
-            // and iPhone LANDSCAPE. Hidden only in iPhone portrait (which uses the
-            // compact bottom-panel layout + iosPanelToggle).
-            if !(hSize == .compact && vSize == .regular) {
+            // iPad only (mac-style layout). iPhone — both orientations — uses the
+            // 5-tab control panel + the full-screen toggle (iosPanelToggle).
+            if hSize == .regular {
                 Button {
                     showPanePopover.toggle()
                 } label: {

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -565,6 +565,10 @@ struct ContentView: View {
             .navigationTitle(hSize == .compact ? "" : "RayMol")
             .navigationBarTitleDisplayMode(.inline)
             .toolbarBackground(.hidden, for: .navigationBar)
+            // iPhone landscape hides the nav bar entirely (its toolbar items are
+            // re-floated over the viewer) so the right panel content starts at the
+            // very top with no nav-bar gap.
+            .toolbar(isPhoneLandscape ? .hidden : .visible, for: .navigationBar)
             // Auto-grow the panel when a detail view opens so its options are
             // visible (the panel's ScrollView covers any remaining overflow);
             // restore the user's size when everything collapses.
@@ -786,12 +790,14 @@ struct ContentView: View {
     // right edge. Full-screen hides the panel; the divider resizes it.
     @ViewBuilder
     private func iPhoneLandscapeLayout(geo: GeometryProxy) -> some View {
-        // Viewer takes the left 2/3; the control panel is a solid column on the
-        // right 1/3 (full-screen hides it and the viewer takes the whole width).
-        let panelW = iosFullScreen ? 0 : geo.size.width / 3
+        // Viewer takes the left ~62%; the control panel is a solid column on the
+        // right (full-screen hides it and the viewer takes the whole width). The
+        // nav bar is hidden in landscape (see body), so all the chrome floats over
+        // the viewer and the panel content starts at the very top — no gap.
+        let panelW = iosFullScreen ? 0 : geo.size.width * 0.38
         HStack(spacing: 0) {
-            // Left 2/3: the molecular viewer (+ optional sequence strip). The
-            // expand/share buttons float in ITS top-right corner.
+            // Left: the molecular viewer (+ optional sequence strip), with the
+            // toolbar buttons floating over its top edge.
             VStack(spacing: 0) {
                 if engine.sequenceVisible {
                     SequencePanel().frame(height: ipadSequenceHeight)
@@ -799,10 +805,14 @@ struct ContentView: View {
                 }
                 viewportView
             }
-            .overlay(alignment: .topTrailing) {
-                landscapeViewerControls
-                    .padding(.top, 6)
-                    .padding(.trailing, 8)
+            .overlay(alignment: .top) {
+                HStack(alignment: .top, spacing: 0) {
+                    landscapeViewerControls(leading: true)   // Open · Measure
+                    Spacer(minLength: 0)
+                    landscapeViewerControls(leading: false)  // Full-screen · Export
+                }
+                .padding(.top, 8)
+                .padding(.horizontal, 8)
             }
 
             if !iosFullScreen {
@@ -821,23 +831,39 @@ struct ContentView: View {
         }
     }
 
-    // Expand (full-screen) + Export, floated in the viewer's top-right corner in
-    // landscape (so they sit over the viewer, not the right panel).
-    private var landscapeViewerControls: some View {
+    // Floating toolbar pills over the viewer in landscape (the nav bar is hidden
+    // there). leading = Open · Measure (top-left); trailing = Full-screen · Export
+    // (top-right, at the viewer/panel boundary).
+    @ViewBuilder
+    private func landscapeViewerControls(leading: Bool) -> some View {
         HStack(spacing: 2) {
-            Button {
-                withAnimation(.easeInOut(duration: 0.2)) { iosFullScreen.toggle() }
-            } label: {
-                Image(systemName: iosFullScreen
-                      ? "arrow.down.right.and.arrow.up.left"
-                      : "arrow.up.left.and.arrow.down.right")
-                    .frame(width: 42, height: 34)
+            if leading {
+                Button { showFileImporter = true } label: {
+                    Image(systemName: "folder").frame(width: 42, height: 34)
+                }
+                .accessibilityLabel("Open")
+                Button {
+                    engine.setMeasureMode(engine.measureMode == nil ? .distance : nil)
+                } label: {
+                    Image(systemName: engine.measureMode == nil ? "ruler" : "ruler.fill")
+                        .frame(width: 42, height: 34)
+                }
+                .accessibilityLabel("Measure")
+            } else {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) { iosFullScreen.toggle() }
+                } label: {
+                    Image(systemName: iosFullScreen
+                          ? "arrow.down.right.and.arrow.up.left"
+                          : "arrow.up.left.and.arrow.down.right")
+                        .frame(width: 42, height: 34)
+                }
+                .accessibilityLabel(iosFullScreen ? "Exit full screen" : "Full-screen viewport")
+                Menu { exportMenuContent } label: {
+                    Image(systemName: "square.and.arrow.up").frame(width: 42, height: 34)
+                }
+                .accessibilityLabel("Export")
             }
-            .accessibilityLabel(iosFullScreen ? "Exit full screen" : "Full-screen viewport")
-            Menu { exportMenuContent } label: {
-                Image(systemName: "square.and.arrow.up").frame(width: 42, height: 34)
-            }
-            .accessibilityLabel("Export")
         }
         .tint(TimelineTheme.accent)
         .padding(.horizontal, 4)

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -896,8 +896,14 @@ struct ContentView: View {
                     // the true screen edge when the island is on the LEFT, or the
                     // black notch-stripe when the island is on the RIGHT. No inset —
                     // the stripe (below) is what keeps the island off the panel.
+                    //
+                    // Only .top is ignored (the nav bar is hidden in landscape). We do
+                    // NOT ignore .horizontal: that let the TabView's bottom tab bar
+                    // bleed rightward into the trailing safe area, pushing the last tab
+                    // (Settings) under the black notch-stripe. The .background already
+                    // fills the frame to the screen edge, so the bleed bought nothing.
                     panelTabs
-                        .ignoresSafeArea(.container, edges: [.top, .horizontal])
+                        .ignoresSafeArea(.container, edges: .top)
                         .frame(width: panelW, alignment: .leading)
                         .background(themeChromeBg)
                 }

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -50,6 +50,29 @@ extension Notification.Name {
     static let mcpOpenConnectSheet = Notification.Name("raymol.mcp.openConnectSheet")
 }
 
+#if os(iOS)
+// Reports the key window's safe-area insets via UIKit's safeAreaInsetsDidChange,
+// which fires at the correct time on rotation (including a landscapeLeft<->Right
+// flip, where the size doesn't change but the Dynamic Island moves sides).
+private struct SafeAreaReader: UIViewRepresentable {
+    var onChange: (UIEdgeInsets) -> Void
+    func makeUIView(context: Context) -> Reader { Reader(onChange) }
+    func updateUIView(_ uiView: Reader, context: Context) { uiView.onChange = onChange; uiView.report() }
+    final class Reader: UIView {
+        var onChange: (UIEdgeInsets) -> Void
+        init(_ onChange: @escaping (UIEdgeInsets) -> Void) {
+            self.onChange = onChange
+            super.init(frame: .zero)
+            isUserInteractionEnabled = false
+        }
+        required init?(coder: NSCoder) { fatalError() }
+        override func safeAreaInsetsDidChange() { super.safeAreaInsetsDidChange(); report() }
+        override func didMoveToWindow() { super.didMoveToWindow(); report() }
+        func report() { onChange(window?.safeAreaInsets ?? .zero) }
+    }
+}
+#endif
+
 private extension View {
     /// Tighten inter-section spacing on grouped lists (iOS 17+); no-op elsewhere.
     @ViewBuilder func compactListSections() -> some View {
@@ -496,6 +519,11 @@ struct ContentView: View {
     // rotations (so a pane the user turned on stays on). iPad keeps the show* bools.
     @State private var landConsole = false
     @State private var landObjects = false
+    // The actual right-edge window safe-area inset (the Dynamic Island only when
+    // it's on the trailing side). Fed by SafeAreaReader via UIKit's
+    // safeAreaInsetsDidChange — reliable across a landscapeLeft<->Right flip,
+    // unlike geo.safeAreaInsets (which reports the island inset regardless of side).
+    @State private var windowTrailingInset: CGFloat = 0
 
     // iPhone landscape == compact width + compact height (iPad is regular height in
     // both orientations; iPhone portrait is compact width + regular height).
@@ -544,6 +572,15 @@ struct ContentView: View {
             // — NOT the keyboard — so keyboard avoidance still pushes the console +
             // command field up above the on-screen keyboard.
             .ignoresSafeArea(.container, edges: (hSize == .regular && vSize == .regular) ? [] : .all)
+            #if os(iOS)
+            // Track the real per-side window safe-area inset (correct across a
+            // landscapeLeft<->Right flip) for the landscape panel's trailing inset.
+            .background {
+                SafeAreaReader { insets in
+                    if windowTrailingInset != insets.right { windowTrailingInset = insets.right }
+                }
+            }
+            #endif
             // Measurement bar docks in the top safe area (below the status bar /
             // Dynamic Island / nav bar) and insets the viewport while active —
             // NOT a full-bleed overlay, which would slide under the notch.
@@ -830,7 +867,7 @@ struct ContentView: View {
                     // (trailing ≈ 0) → flush; on the RIGHT → clears the island.
                     panelTabs
                         .ignoresSafeArea(.container, edges: [.top, .horizontal])
-                        .padding(.trailing, geo.safeAreaInsets.trailing)
+                        .padding(.trailing, windowTrailingInset)
                         .frame(width: panelW, alignment: .leading)
                         .background(themeChromeBg)
                 }

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -466,8 +466,8 @@ struct ContentView: View {
     // keeps the compact bottom-panel layout; everything else (iPad both
     // orientations, iPhone landscape) uses the mac-style layout.
     @Environment(\.verticalSizeClass) private var vSize
-    @State private var panelFrac: CGFloat = 0.28
-    @State private var committedFrac: CGFloat = 0.28
+    @State private var panelFrac: CGFloat = 0.53
+    @State private var committedFrac: CGFloat = 0.53
     @State private var panelCollapsed = false
     // iPhone: full-screen viewport mode (hides the bottom panel + sequence strip).
     // Replaces the old drag-to-collapse; driven by iosPanelToggle.
@@ -483,7 +483,7 @@ struct ContentView: View {
     // Panel share to return to when no detail view is open. While a detail view
     // (SCENE or an object card) is expanded the panel auto-grows to its max so
     // the options are visible; collapsing restores this remembered size.
-    @State private var collapsedFrac: CGFloat = 0.28
+    @State private var collapsedFrac: CGFloat = 0.53
     @State private var didConfigForCompact = false
     @AppStorage("ipadGestureCoachSeen") private var gestureCoachSeen = false
     @State private var showGestureLegend = false

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -50,6 +50,18 @@ extension Notification.Name {
     static let mcpOpenConnectSheet = Notification.Name("raymol.mcp.openConnectSheet")
 }
 
+private extension View {
+    /// Tighten inter-section spacing on grouped lists (iOS 17+); no-op elsewhere.
+    @ViewBuilder func compactListSections() -> some View {
+        #if os(iOS)
+        if #available(iOS 17.0, *) { self.listSectionSpacing(.compact) }
+        else { self }
+        #else
+        self
+        #endif
+    }
+}
+
 struct ContentView: View {
     @EnvironmentObject var engine: PyMOLEngine
     @EnvironmentObject private var themeManager: ThemeManager
@@ -1198,6 +1210,8 @@ struct ContentView: View {
             }
             .listStyle(.insetGrouped)
             .scrollContentBackground(.hidden)
+            .compactListSections()
+            .environment(\.defaultMinListRowHeight, 38)
             // Clear the floating tab-bar pill so the Reset section stays reachable.
             .safeAreaInset(edge: .bottom) { Color.clear.frame(height: 56) }
         }
@@ -1449,6 +1463,14 @@ struct ContentView: View {
                 } label: {
                     Label("Copy Image", systemImage: "doc.on.clipboard")
                 }
+                // Export the authored movie (Movie tab). Disabled until there's
+                // a timeline to render.
+                Button {
+                    showExportSheet = true
+                } label: {
+                    Label("Export Movie…", systemImage: "film")
+                }
+                .disabled(engine.playback.frameCount <= 1)
                 // Render options in a submenu whose toggles DON'T dismiss the
                 // menu (flip both before exporting). dismiss-disabled is iOS-only.
                 #if os(iOS)

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -1089,7 +1089,8 @@ struct ContentView: View {
                 if showSceneButtons && !engine.sceneNames.isEmpty {
                     sceneButtonsOverlay
                         .padding(.leading, 12)
-                        .padding(.bottom, engine.hasTimeline ? 56 : 12)
+                        // Sit clear ABOVE the transport bar (don't overlap it).
+                        .padding(.bottom, engine.hasTimeline ? 96 : 12)
                 }
             }
             .overlay(alignment: .bottomTrailing) {

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -1185,19 +1185,16 @@ struct ContentView: View {
             }
         } else {
             List {
-                Section("Display") {
+                // Single ungrouped section — no per-item headers for one-row items.
+                Section {
                     Toggle(isOn: $engine.sequenceVisible) {
                         Label("Show sequence", systemImage: "textformat.abc")
                     }
-                }
-                Section("Scene & rendering") {
                     Button {
                         withAnimation(.easeInOut(duration: 0.2)) { settingsSceneOpen = true }
                     } label: {
                         settingsRow("Display settings", "slider.horizontal.3")
                     }
-                }
-                Section("Appearance") {
                     Button {
                         if !showThemeStudio { panelCollapsed = false }
                         withAnimation(.easeInOut(duration: 0.2)) { showThemeStudio = true }
@@ -1205,23 +1202,27 @@ struct ContentView: View {
                         settingsRow("Themes", "paintpalette")
                     }
                 }
-                Section("Reset") {
-                    Button { engine.runCommand("reset") } label: {
-                        Label("Reset view", systemImage: "arrow.counterclockwise")
+                // Reset actions — all on one row.
+                Section {
+                    HStack(spacing: 8) {
+                        settingsResetButton("Reset view", "arrow.counterclockwise") {
+                            engine.runCommand("reset")
+                        }
+                        settingsResetButton("Effects", "circle.lefthalf.filled") {
+                            engine.resetEffects()
+                        }
+                        settingsResetButton("Clear", "trash", danger: true) {
+                            showClearSessionConfirm = true
+                        }
                     }
-                    Button { engine.resetEffects() } label: {
-                        Label("Reset effects", systemImage: "circle.lefthalf.filled")
-                    }
-                    Button(role: .destructive) { showClearSessionConfirm = true } label: {
-                        Label("Clear session…", systemImage: "trash")
-                    }
+                    .listRowInsets(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
                 }
             }
             .listStyle(.insetGrouped)
             .scrollContentBackground(.hidden)
             .compactListSections()
             .environment(\.defaultMinListRowHeight, 38)
-            // Clear the floating tab-bar pill so the Reset section stays reachable.
+            // Clear the floating tab-bar pill so the Reset row stays reachable.
             .safeAreaInset(edge: .bottom) { Color.clear.frame(height: 56) }
         }
     }
@@ -1235,6 +1236,22 @@ struct ContentView: View {
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.tertiary)
         }
+    }
+
+    // Compact icon+label button; three sit on one row in the Reset section.
+    private func settingsResetButton(_ title: String, _ icon: String,
+                                     danger: Bool = false, _ action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            VStack(spacing: 3) {
+                Image(systemName: icon).font(.system(size: 15))
+                Text(title).font(.system(size: 11)).lineLimit(1)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+            .foregroundStyle(danger ? Color.red : TimelineTheme.accent)
+            .background(RoundedRectangle(cornerRadius: 9).fill(Color.gray.opacity(0.13)))
+        }
+        .buttonStyle(.plain)
     }
 
     // Draggable splitter between viewport and panel. Drag toward the viewport

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -525,6 +525,20 @@ struct ContentView: View {
     // unlike geo.safeAreaInsets (which reports the island inset regardless of side).
     @State private var windowTrailingInset: CGFloat = 0
     @State private var windowLeadingInset: CGFloat = 0   // debug
+    // In landscape the window reports the island inset SYMMETRICALLY on both sides,
+    // so the insets can't tell us which side the island is physically on — the
+    // interface orientation does. landscapeLeft => island on the RIGHT.
+    @State private var islandOnRight = false
+
+    private func refreshIslandSide() {
+        #if os(iOS)
+        let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+        let scene = scenes.first { $0.activationState == .foregroundActive } ?? scenes.first
+        if let io = scene?.interfaceOrientation {
+            islandOnRight = (io == .landscapeLeft)
+        }
+        #endif
+    }
 
     // iPhone landscape == compact width + compact height (iPad is regular height in
     // both orientations; iPhone portrait is compact width + regular height).
@@ -716,7 +730,16 @@ struct ContentView: View {
                 }
             }
         }
+        #if os(iOS)
+        .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
+            refreshIslandSide()   // interface orientation is valid immediately (no settle delay)
+        }
+        #endif
         .onAppear {
+            #if os(iOS)
+            UIDevice.current.beginGeneratingDeviceOrientationNotifications()
+            refreshIslandSide()
+            #endif
             initializeEngine()
             maybePresentFirstBootTheme()
             // iPhone (compact): start full-screen with the panel collapsed and
@@ -855,7 +878,7 @@ struct ContentView: View {
             }
             // TEMP diagnostic — exact inset values so we can see why the panel insets.
             .overlay(alignment: .bottomLeading) {
-                Text(verbatim: "geoL \(Int(geo.safeAreaInsets.leading))  geoT \(Int(geo.safeAreaInsets.trailing))  winL \(Int(windowLeadingInset))  winR \(Int(windowTrailingInset))  panelW \(Int(panelW))")
+                Text(verbatim: "islandR \(islandOnRight ? 1 : 0)  applied \(Int(islandOnRight ? windowTrailingInset : 0))  winL \(Int(windowLeadingInset))  winR \(Int(windowTrailingInset))")
                     .font(.system(size: 12, weight: .bold, design: .monospaced))
                     .padding(6)
                     .background(.black.opacity(0.7))
@@ -878,7 +901,7 @@ struct ContentView: View {
                     // (trailing ≈ 0) → flush; on the RIGHT → clears the island.
                     panelTabs
                         .ignoresSafeArea(.container, edges: [.top, .horizontal])
-                        .padding(.trailing, windowTrailingInset)
+                        .padding(.trailing, islandOnRight ? windowTrailingInset : 0)
                         .frame(width: panelW, alignment: .leading)
                         .background(themeChromeBg)
                 }

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -442,6 +442,8 @@ struct ContentView: View {
     // sheet so the screenshot harness can capture it (simctl can't tap).
     @State private var showBuilderSheet = false
     @State private var showExportSheet = false
+    // Explainer when "Export Movie" is tapped with no animation built yet.
+    @State private var showNoMovieAlert = false
     @State private var showSettingsSheet = false
     // The panel + viewport FRAME resize live while dragging the divider, but the
     // Metal DRAWABLE is frozen during the drag (engine.suppressDrawableResize) so
@@ -1053,6 +1055,13 @@ struct ContentView: View {
     private var viewportView: some View {
         MetalViewport()
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            // Attached here (not the giant body chain) to keep that expression
+            // under the Swift type-checker's complexity limit.
+            .alert("No movie to export", isPresented: $showNoMovieAlert) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text("There’s no animation yet. Open the Movie tab, pick a motion (e.g. Camera → Roll) and tap Build & Play — then Export Movie will render it.")
+            }
             .overlay { if engine.objects.isEmpty && !showThemeStudio && !hasRestoreSnapshot { emptyStateView } }
             // Cold-launch restore: cover the viewport with the last-scene snapshot
             // until the reloaded session has rendered (see restoreAutosaveIfAvailable).
@@ -1463,14 +1472,15 @@ struct ContentView: View {
                 } label: {
                     Label("Copy Image", systemImage: "doc.on.clipboard")
                 }
-                // Export the authored movie (Movie tab). Disabled until there's
-                // a timeline to render.
+                // Export the authored movie (Movie tab). Stays tappable even with
+                // no movie so it can explain what's missing rather than silently
+                // doing nothing.
                 Button {
-                    showExportSheet = true
+                    if engine.playback.frameCount <= 1 { showNoMovieAlert = true }
+                    else { showExportSheet = true }
                 } label: {
                     Label("Export Movie…", systemImage: "film")
                 }
-                .disabled(engine.playback.frameCount <= 1)
                 // Render options in a submenu whose toggles DON'T dismiss the
                 // menu (flip both before exporting). dismiss-disabled is iOS-only.
                 #if os(iOS)

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -496,21 +496,6 @@ struct ContentView: View {
     // rotations (so a pane the user turned on stays on). iPad keeps the show* bools.
     @State private var landConsole = false
     @State private var landObjects = false
-    // Trailing safe-area inset (the Dynamic Island side in landscape). Read from
-    // the key window + refreshed on rotation, because a landscapeLeft<->Right flip
-    // keeps the same size (no SwiftUI relayout) but moves the island side. Used so
-    // the right panel only reserves island space when the island is on the right.
-    @State private var trailingSafeInset: CGFloat = 0
-
-    private func refreshTrailingSafeInset() {
-        #if os(iOS)
-        let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
-        let scene = scenes.first { $0.activationState == .foregroundActive } ?? scenes.first
-        let window = scene?.windows.first { $0.isKeyWindow } ?? scene?.windows.first
-        let inset = window?.safeAreaInsets.right ?? 0
-        if trailingSafeInset != inset { trailingSafeInset = inset }
-        #endif
-    }
 
     // iPhone landscape == compact width + compact height (iPad is regular height in
     // both orientations; iPhone portrait is compact width + regular height).
@@ -692,17 +677,7 @@ struct ContentView: View {
                 }
             }
         }
-        #if os(iOS)
-        .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
-            // landscapeLeft<->Right keeps the same size; refresh the island inset.
-            DispatchQueue.main.async { refreshTrailingSafeInset() }
-        }
-        #endif
         .onAppear {
-            #if os(iOS)
-            UIDevice.current.beginGeneratingDeviceOrientationNotifications()
-            refreshTrailingSafeInset()
-            #endif
             initializeEngine()
             maybePresentFirstBootTheme()
             // iPhone (compact): start full-screen with the panel collapsed and
@@ -850,12 +825,12 @@ struct ContentView: View {
                 } else {
                     // Panel background is flush to the screen's right edge; the tab
                     // CONTENT is inset from the right only by the actual trailing
-                    // safe-area (the Dynamic Island). So when the island is on the
-                    // LEFT (trailingSafeInset ≈ 0) the panel is flush; on the RIGHT
-                    // it reserves just enough space to clear the island.
+                    // safe-area (the Dynamic Island), read reactively from geo so it
+                    // updates on a landscapeLeft<->Right flip. Island on the LEFT
+                    // (trailing ≈ 0) → flush; on the RIGHT → clears the island.
                     panelTabs
                         .ignoresSafeArea(.container, edges: [.top, .horizontal])
-                        .padding(.trailing, trailingSafeInset)
+                        .padding(.trailing, geo.safeAreaInsets.trailing)
                         .frame(width: panelW, alignment: .leading)
                         .background(themeChromeBg)
                 }

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -139,6 +139,29 @@ private struct LandscapeTabBar: View {
     }
 }
 
+// MARK: - Per-tab natural-height measurement (portrait "hug content" sizing)
+//
+// Each portrait pane reports the NATURAL height of its content (measured from
+// INSIDE its own scroll/stack, so it's the true content height — not the
+// constrained panel frame) keyed by its tab tag. The portrait layout reads the
+// active tab's reported height and sizes the bottom panel to hug it (capped).
+struct PaneHeightKey: PreferenceKey {
+    static let defaultValue: [Int: CGFloat] = [:]
+    static func reduce(value: inout [Int: CGFloat], nextValue: () -> [Int: CGFloat]) {
+        value.merge(nextValue()) { max($0, $1) }
+    }
+}
+
+extension View {
+    /// Report this view's measured height for `tag` up the preference chain
+    /// (used by the portrait panel to hug each tab's natural content height).
+    func reportPaneHeight(_ tag: Int) -> some View {
+        background(GeometryReader { g in
+            Color.clear.preference(key: PaneHeightKey.self, value: [tag: g.size.height])
+        })
+    }
+}
+
 private extension View {
     /// Tighten inter-section spacing on grouped lists (iOS 17+); no-op elsewhere.
     @ViewBuilder func compactListSections() -> some View {
@@ -573,6 +596,10 @@ struct ContentView: View {
     // (SCENE or an object card) is expanded the panel auto-grows to its max so
     // the options are visible; collapsing restores this remembered size.
     @State private var collapsedFrac: CGFloat = 0.53
+    // Portrait per-tab "hug content" sizing: natural content height per tab tag,
+    // reported via PaneHeightKey. The portrait panel sizes to the active tab's
+    // content (capped). (panelFrac/committedFrac above are now iPad-only.)
+    @State private var paneHeights: [Int: CGFloat] = [:]
     @State private var didConfigForCompact = false
     @AppStorage("ipadGestureCoachSeen") private var gestureCoachSeen = false
     @State private var showGestureLegend = false
@@ -888,10 +915,39 @@ struct ContentView: View {
     // single resizable/collapsible control panel (TabView of Console / Objects /
     // Sequence / Raymond) docks at the bottom. Selecting a tab and dragging the
     // divider behave exactly as before.
+    // Bottom-panel chrome that must fit ABOVE the reported pure content height:
+    // the floating tab bar's footprint + a little breathing room. Tuned on-device.
+    private let portraitPanelChrome: CGFloat = 84
+
+    /// Portrait bottom-panel height, per active tab (no drag — heights are policy
+    /// driven). Console is a fixed tall pane; Objects/Scenes/Movie HUG their content
+    /// up to a per-tab cap (then scroll); Settings is compact at its root and grows
+    /// to 3/4 when a detail editor (Display settings / Themes) is open.
+    private func portraitPanelHeight(total: CGFloat) -> CGFloat {
+        let floor: CGFloat = 150
+        // A detail editor open in Settings → 3/4 of the screen.
+        if showThemeStudio || (selectedTab == 4 && settingsSceneOpen) {
+            return total * 0.75
+        }
+        // Measured content + chrome, for the hug tabs.
+        func hug(_ tag: Int, cap: CGFloat, extra: CGFloat = 0) -> CGFloat {
+            let content = paneHeights[tag].map { $0 + extra + portraitPanelChrome }
+            return min(max(content ?? cap, floor), cap)
+        }
+        switch selectedTab {
+        case 0:  return total * 0.5                              // Console — fixed tall
+        case 1:  return hug(1, cap: total / 3, extra: 44)        // Objects — +toolbar; cap 1/3
+        case 5:  return hug(5, cap: total * 0.5)                 // Scenes
+        case 2:  return hug(2, cap: total * 0.5)                 // Movie
+        case 4:  return total * 0.42                             // Settings root — compact
+        default: return total * 0.45
+        }
+    }
+
     @ViewBuilder
     private func iPhoneLayout(geo: GeometryProxy) -> some View {
         let total = geo.size.height
-        let panelSize = min(max(total * panelFrac, 200), total * 0.92)
+        let panelSize = portraitPanelHeight(total: total)
         VStack(spacing: 0) {
             // The sequence strip (when enabled) docks in the top safe area via
             // .safeAreaInset(edge: .top) at the layout root — NOT here — so it sits
@@ -902,16 +958,20 @@ struct ContentView: View {
                 EmptyView()
             } else if showThemeStudio {
                 // Theme studio takes over the bottom region; viewport stays live above.
-                resizeDivider(landscape: false, total: geo.size.height)
                 ThemeStudioPanel(onClose: { withAnimation(.easeInOut(duration: 0.2)) { showThemeStudio = false } })
                     .environmentObject(engine)
                     .environmentObject(themeManager)
                     .frame(height: panelSize)
             } else {
-                resizeDivider(landscape: false, total: geo.size.height)
-                panelContent.frame(height: panelSize)
+                // Per-tab policy height (drag handle removed). The panes report their
+                // natural content height via PaneHeightKey; the height animates on tab
+                // switch / content change / Settings drill-in.
+                panelContent
+                    .frame(height: panelSize)
+                    .onPreferenceChange(PaneHeightKey.self) { paneHeights = $0 }
             }
         }
+        .animation(.easeInOut(duration: 0.25), value: panelSize)
     }
 
     // MARK: iPhone landscape — portrait UX, panel docked on the RIGHT

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -458,8 +458,10 @@ struct ContentView: View {
     // iPhone: full-screen viewport mode (hides the bottom panel + sequence strip).
     // Replaces the old drag-to-collapse; driven by iosPanelToggle.
     @State private var iosFullScreen = false
-    // Settings tab: in-panel drill into the SCENE card (moved here from Inspector).
+    // Settings tab: in-panel drill into the display-settings card.
     @State private var settingsSceneOpen = false
+    // Scenes tab: opt-in glanceable scene buttons overlaid on the viewport.
+    @State private var showSceneButtons = false
     // Panel fraction to restore after the Theme Studio closes (it temporarily
     // opens to ~60% of the screen so the viewport/studio split matches the spec).
     @State private var fracBeforeThemeStudio: CGFloat? = nil
@@ -684,8 +686,13 @@ struct ContentView: View {
                     case "objects":  selectedTab = 1
                     case "movie":    selectedTab = 2
                     case "settings": selectedTab = 4
+                    case "scenes":   selectedTab = 5
                     default: break
                     }
+                }
+                // Test affordance: force the in-viewport scene buttons on.
+                if ProcessInfo.processInfo.environment["PYMOL_AUTOSCENEBTN"] != nil {
+                    showSceneButtons = true
                 }
             }
             if let s = ProcessInfo.processInfo.environment["PYMOL_AUTOSHEET"] {
@@ -903,6 +910,7 @@ struct ContentView: View {
             } label: {
                 Image(systemName: engine.measureMode == nil ? "ruler" : "ruler.fill")
             }
+            .tint(TimelineTheme.accent)
             .accessibilityLabel("Measure")
         }
     }
@@ -921,6 +929,7 @@ struct ContentView: View {
                           ? "arrow.down.right.and.arrow.up.left"
                           : "arrow.up.left.and.arrow.down.right")
                 }
+                .tint(TimelineTheme.accent)
                 .accessibilityLabel(iosFullScreen ? "Exit full screen" : "Full-screen viewport")
             }
         }
@@ -1003,6 +1012,32 @@ struct ContentView: View {
         #endif
     }
 
+    // Floating scene chips over the viewport (teal/global), shown only when the
+    // Scenes tab's "Show scene buttons in viewport" toggle is on. Tap = recall.
+    private var sceneButtonsOverlay: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                ForEach(engine.sceneNames, id: \.self) { name in
+                    let sel = name == engine.currentScene
+                    Button {
+                        engine.runCommand("scene \(name), recall, animate=1")
+                    } label: {
+                        Text(name)
+                            .font(.system(size: 12, weight: .bold, design: .monospaced))
+                            .padding(.horizontal, 9).frame(height: 28)
+                            .background(sel ? TimelineTheme.accent : Color.white.opacity(0.92))
+                            .foregroundColor(sel ? .white : TimelineTheme.accent)
+                            .clipShape(RoundedRectangle(cornerRadius: 7))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(6)
+        }
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 11))
+        .frame(maxWidth: 230)
+    }
+
     private var viewportView: some View {
         MetalViewport()
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -1026,6 +1061,15 @@ struct ContentView: View {
             // full-width bar on iPad.
             .overlay(alignment: .bottom) {
                 if engine.hasTimeline { transportOverlay }
+            }
+            // Opt-in glanceable scene buttons (Scenes tab → "Show scene buttons
+            // in viewport"). Sits above the transport when a timeline is present.
+            .overlay(alignment: .bottomLeading) {
+                if showSceneButtons && !engine.sceneNames.isEmpty {
+                    sceneButtonsOverlay
+                        .padding(.leading, 12)
+                        .padding(.bottom, engine.hasTimeline ? 56 : 12)
+                }
             }
             .overlay(alignment: .bottomTrailing) {
                 Button { showGestureLegend = true } label: {
@@ -1080,6 +1124,9 @@ struct ContentView: View {
                 .tabItem { Label("Console", systemImage: "terminal") }.tag(0)
             ObjectPanel()
                 .tabItem { Label("Objects", systemImage: "cube") }.tag(1)
+            ScenesPane(showViewportButtons: $showSceneButtons,
+                       onOpenMovie: { selectedTab = 2 })
+                .tabItem { Label("Scenes", systemImage: "rectangle.on.rectangle") }.tag(5)
             MoviePane()
                 .tabItem { Label("Movie", systemImage: "film") }.tag(2)
             settingsPane
@@ -1106,7 +1153,7 @@ struct ContentView: View {
                             .font(.system(size: 15, weight: .medium))
                     }
                     Spacer()
-                    Text("Scene settings").font(.system(size: 13, weight: .semibold))
+                    Text("Display settings").font(.system(size: 13, weight: .semibold))
                         .foregroundStyle(.secondary)
                 }
                 .padding(.horizontal, 14).padding(.vertical, 8)
@@ -1126,7 +1173,7 @@ struct ContentView: View {
                     Button {
                         withAnimation(.easeInOut(duration: 0.2)) { settingsSceneOpen = true }
                     } label: {
-                        settingsRow("Scene settings", "slider.horizontal.3")
+                        settingsRow("Display settings", "slider.horizontal.3")
                     }
                 }
                 Section("Appearance") {
@@ -1292,6 +1339,7 @@ struct ContentView: View {
             } label: {
                 Label("Open", systemImage: "folder")
             }
+            .tint(TimelineTheme.accent)   // global controls read teal
         }
     }
 
@@ -1443,6 +1491,7 @@ struct ContentView: View {
             } label: {
                 Label("Export", systemImage: "square.and.arrow.up")
             }
+            .tint(TimelineTheme.accent)
         }
     }
 

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -786,17 +786,12 @@ struct ContentView: View {
     // right edge. Full-screen hides the panel; the divider resizes it.
     @ViewBuilder
     private func iPhoneLandscapeLayout(geo: GeometryProxy) -> some View {
-        let panelW = min(max(geo.size.width * 0.38, 300), 420)
-        let topInset: CGFloat = 46                                  // clear the toolbar pills
-        let botInset: CGFloat = engine.hasTimeline ? 64 : 8         // clear the transport
-        // Explicit height (TabView won't reliably fill a maxHeight frame), so the
-        // panel spans full height between the insets and the tab bar sits at the
-        // bottom — not stranded mid-screen.
-        let panelH = max(geo.size.height - topInset - botInset, 120)
-        ZStack(alignment: .topTrailing) {
-            // Full-bleed viewport (+ optional sequence strip): the 3D view spans
-            // the WHOLE width; the control panel is a frosted-glass overlay on the
-            // right so the structure shows through behind it.
+        // Viewer takes the left 2/3; the control panel is a solid column on the
+        // right 1/3 (full-screen hides it and the viewer takes the whole width).
+        let panelW = iosFullScreen ? 0 : geo.size.width / 3
+        HStack(spacing: 0) {
+            // Left 2/3: the molecular viewer (+ optional sequence strip). The
+            // expand/share buttons float in ITS top-right corner.
             VStack(spacing: 0) {
                 if engine.sequenceVisible {
                     SequencePanel().frame(height: ipadSequenceHeight)
@@ -804,27 +799,50 @@ struct ContentView: View {
                 }
                 viewportView
             }
+            .overlay(alignment: .topTrailing) {
+                landscapeViewerControls
+                    .padding(.top, 6)
+                    .padding(.trailing, 8)
+            }
 
             if !iosFullScreen {
+                Divider()
                 Group {
                     if showThemeStudio {
                         ThemeStudioPanel(onClose: { withAnimation(.easeInOut(duration: 0.2)) { showThemeStudio = false } })
                             .environmentObject(engine)
                             .environmentObject(themeManager)
                     } else {
-                        panelTabs
+                        panelContent
                     }
                 }
-                .frame(width: panelW, height: panelH, alignment: .top)
-                .background(.ultraThinMaterial)                     // frosted glass
-                .clipShape(UnevenRoundedRectangle(topLeadingRadius: 18, bottomLeadingRadius: 18))
-                .overlay(alignment: .leading) {
-                    Rectangle().fill(Color.primary.opacity(0.08)).frame(width: 0.5)
-                }
-                .shadow(color: .black.opacity(0.18), radius: 12, x: -2, y: 1)
-                .padding(.top, topInset)        // flush to the right edge (no trailing pad)
+                .frame(width: panelW)
             }
         }
+    }
+
+    // Expand (full-screen) + Export, floated in the viewer's top-right corner in
+    // landscape (so they sit over the viewer, not the right panel).
+    private var landscapeViewerControls: some View {
+        HStack(spacing: 2) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) { iosFullScreen.toggle() }
+            } label: {
+                Image(systemName: iosFullScreen
+                      ? "arrow.down.right.and.arrow.up.left"
+                      : "arrow.up.left.and.arrow.down.right")
+                    .frame(width: 42, height: 34)
+            }
+            .accessibilityLabel(iosFullScreen ? "Exit full screen" : "Full-screen viewport")
+            Menu { exportMenuContent } label: {
+                Image(systemName: "square.and.arrow.up").frame(width: 42, height: 34)
+            }
+            .accessibilityLabel("Export")
+        }
+        .tint(TimelineTheme.accent)
+        .padding(.horizontal, 4)
+        .background(.regularMaterial, in: Capsule())
+        .overlay(Capsule().strokeBorder(Color.primary.opacity(0.08)))
     }
 
     // MARK: iPad (regular size class) layout — mac-style stack
@@ -985,9 +1003,10 @@ struct ContentView: View {
         // iPhone (compact) only: collapse/expand the single bottom control panel.
         // The iPad mac-style layout uses iosPadPanelMenu (per-pane toggles) instead.
         ToolbarItem(placement: .primaryAction) {
-            // iPhone (both orientations) — the tab-panel layout uses a full-screen
-            // toggle. iPad uses the mac-style layout with iosPadPanelMenu.
-            if hSize == .compact {
+            // iPhone PORTRAIT uses the nav-bar full-screen toggle. iPhone landscape
+            // shows it (with Export) in the viewer's top-right overlay; iPad uses
+            // iosPadPanelMenu.
+            if hSize == .compact && vSize == .regular {
                 Button {
                     withAnimation(.easeInOut(duration: 0.2)) { iosFullScreen.toggle() }
                 } label: {
@@ -1528,76 +1547,71 @@ struct ContentView: View {
     // hands off to the system share sheet (Save to Files / Mail / AirDrop / …).
     private var iosExportToolbar: some ToolbarContent {
         ToolbarItem(placement: .primaryAction) {
-            Menu {
-                Menu {
-                    Button("Current View Size") { iosShareImage(scale: 1) }
-                    Button("2× View") { iosShareImage(scale: 2) }
-                    // 4K is memory-heavy (esp. ray-traced); skip it on iPhone
-                    // where the smaller RAM budget makes the export likely to
-                    // be jettisoned. iPad keeps the full-resolution option.
-                    if hSize != .compact {
-                        Button("4K · 3840 × 2160") { iosShareImage(size: CGSize(width: 3840, height: 2160)) }
-                    }
-                } label: {
-                    Label("Share Image", systemImage: "photo")
+            // iPhone landscape shows Export in the viewer's top-right overlay
+            // (landscapeViewerControls) instead of the nav bar.
+            if !isPhoneLandscape {
+                Menu { exportMenuContent } label: {
+                    Label("Export", systemImage: "square.and.arrow.up")
                 }
-                Button {
-                    iosCopyImage()
-                } label: {
-                    Label("Copy Image", systemImage: "doc.on.clipboard")
-                }
-                // Export the authored movie (Movie tab). Stays tappable even with
-                // no movie so it can explain what's missing rather than silently
-                // doing nothing.
-                Button {
-                    if engine.playback.frameCount <= 1 { showNoMovieAlert = true }
-                    else { showExportSheet = true }
-                } label: {
-                    Label("Export Movie…", systemImage: "film")
-                }
-                // Render options in a submenu whose toggles DON'T dismiss the
-                // menu (flip both before exporting). dismiss-disabled is iOS-only.
-                #if os(iOS)
-                if #available(iOS 16.4, *) {
-                    Menu {
-                        renderOptionToggles
-                    } label: {
-                        Label("Render Options", systemImage: "slider.horizontal.3")
-                    }
-                    .menuActionDismissBehavior(.disabled)
-                } else {
-                    renderOptionToggles
-                }
-                #else
-                renderOptionToggles
-                #endif
-                Divider()
-                // Same format set as the macOS export menu (parity).
-                Menu {
-                    Button("PDB (.pdb)") { iosShareStructure(ext: "pdb") }
-                    Button("mmCIF (.cif)") { iosShareStructure(ext: "cif") }
-                    Button("SDF (.sdf)") { iosShareStructure(ext: "sdf") }
-                    Button("MOL (.mol)") { iosShareStructure(ext: "mol") }
-                    Button("MOL2 (.mol2)") { iosShareStructure(ext: "mol2") }
-                    Button("XYZ (.xyz)") { iosShareStructure(ext: "xyz") }
-                    Button("PQR (.pqr)") { iosShareStructure(ext: "pqr") }
-                    Divider()
-                    // 3D models that work on this NO_OPENGL / libxml-off build
-                    // (CPU-ray export path). glTF/COLLADA/STL are unavailable.
-                    Button("VRML (.wrl)") { iosShareStructure(ext: "wrl") }
-                    Button("POV-Ray (.pov)") { iosShareStructure(ext: "pov") }
-                } label: {
-                    Label("Share Structure", systemImage: "atom")
-                }
-                Button {
-                    iosShareSession()
-                } label: {
-                    Label("Share Session (.pse)", systemImage: "doc.text")
-                }
-            } label: {
-                Label("Export", systemImage: "square.and.arrow.up")
+                .tint(TimelineTheme.accent)
             }
-            .tint(TimelineTheme.accent)
+        }
+    }
+
+    // The Export menu's items — reused by the nav-bar toolbar (portrait / iPad)
+    // and the iPhone-landscape viewer overlay.
+    @ViewBuilder private var exportMenuContent: some View {
+        Menu {
+            Button("Current View Size") { iosShareImage(scale: 1) }
+            Button("2× View") { iosShareImage(scale: 2) }
+            // 4K is memory-heavy (esp. ray-traced); skip it on iPhone where the
+            // smaller RAM budget makes the export likely to be jettisoned.
+            if hSize != .compact {
+                Button("4K · 3840 × 2160") { iosShareImage(size: CGSize(width: 3840, height: 2160)) }
+            }
+        } label: {
+            Label("Share Image", systemImage: "photo")
+        }
+        Button { iosCopyImage() } label: {
+            Label("Copy Image", systemImage: "doc.on.clipboard")
+        }
+        // Export the authored movie; stays tappable even with no movie so it can
+        // explain what's missing rather than silently doing nothing.
+        Button {
+            if engine.playback.frameCount <= 1 { showNoMovieAlert = true }
+            else { showExportSheet = true }
+        } label: {
+            Label("Export Movie…", systemImage: "film")
+        }
+        #if os(iOS)
+        if #available(iOS 16.4, *) {
+            Menu { renderOptionToggles } label: {
+                Label("Render Options", systemImage: "slider.horizontal.3")
+            }
+            .menuActionDismissBehavior(.disabled)
+        } else {
+            renderOptionToggles
+        }
+        #else
+        renderOptionToggles
+        #endif
+        Divider()
+        Menu {
+            Button("PDB (.pdb)") { iosShareStructure(ext: "pdb") }
+            Button("mmCIF (.cif)") { iosShareStructure(ext: "cif") }
+            Button("SDF (.sdf)") { iosShareStructure(ext: "sdf") }
+            Button("MOL (.mol)") { iosShareStructure(ext: "mol") }
+            Button("MOL2 (.mol2)") { iosShareStructure(ext: "mol2") }
+            Button("XYZ (.xyz)") { iosShareStructure(ext: "xyz") }
+            Button("PQR (.pqr)") { iosShareStructure(ext: "pqr") }
+            Divider()
+            Button("VRML (.wrl)") { iosShareStructure(ext: "wrl") }
+            Button("POV-Ray (.pov)") { iosShareStructure(ext: "pov") }
+        } label: {
+            Label("Share Structure", systemImage: "atom")
+        }
+        Button { iosShareSession() } label: {
+            Label("Share Session (.pse)", systemImage: "doc.text")
         }
     }
 

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -455,6 +455,9 @@ struct ContentView: View {
     @State private var panelFrac: CGFloat = 0.28
     @State private var committedFrac: CGFloat = 0.28
     @State private var panelCollapsed = false
+    // iPhone: full-screen viewport mode (hides the bottom panel + sequence strip).
+    // Replaces the old drag-to-collapse; driven by iosPanelToggle.
+    @State private var iosFullScreen = false
     // Panel fraction to restore after the Theme Studio closes (it temporarily
     // opens to ~60% of the screen so the viewport/studio split matches the spec).
     @State private var fracBeforeThemeStudio: CGFloat? = nil
@@ -523,7 +526,19 @@ struct ContentView: View {
             // Dynamic Island / nav bar) and insets the viewport while active —
             // NOT a full-bleed overlay, which would slide under the notch.
             .safeAreaInset(edge: .top, spacing: 0) {
-                if engine.measureMode != nil { measureOverlay }
+                VStack(spacing: 0) {
+                    if engine.measureMode != nil { measureOverlay }
+                    // Sequence viewer as a strip below the toolbar / above the
+                    // viewport (desktop-style), toggled from Settings → "Show
+                    // sequence". iPhone portrait only; iPad stacks it in-column.
+                    if hSize == .compact && vSize == .regular
+                        && engine.sequenceVisible && !iosFullScreen {
+                        SequencePanel()
+                            .frame(height: ipadSequenceHeight)
+                            .background(themeChromeBg)
+                        Divider()
+                    }
+                }
             }
             .navigationTitle(hSize == .compact ? "" : "RayMol")
             .navigationBarTitleDisplayMode(.inline)
@@ -564,7 +579,7 @@ struct ContentView: View {
                     }
                 }
             }
-            .toolbar { iosOpenToolbar; iosMeasureToolbar; iosThemeToolbar; iosResetMenu; iosPanelToggle; iosPadPanelMenu; iosExportToolbar }
+            .toolbar { iosOpenToolbar; iosMeasureToolbar; iosPanelToggle; iosPadPanelMenu; iosExportToolbar }
             .fileImporter(isPresented: $showFileImporter,
                           allowedContentTypes: iosImportTypes,
                           allowsMultipleSelection: false) { result in
@@ -659,6 +674,17 @@ struct ContentView: View {
                     panelCollapsed = (p != "open")
                     engine.sequenceVisible = (p == "open")
                 }
+                // Test affordance: preselect a bottom-panel tab for the screenshot
+                // harness (simctl can't tap). PYMOL_AUTOTAB=console|objects|movie|settings.
+                if let t = ProcessInfo.processInfo.environment["PYMOL_AUTOTAB"] {
+                    switch t {
+                    case "console":  selectedTab = 0
+                    case "objects":  selectedTab = 1
+                    case "movie":    selectedTab = 2
+                    case "settings": selectedTab = 4
+                    default: break
+                    }
+                }
             }
             if let s = ProcessInfo.processInfo.environment["PYMOL_AUTOSHEET"] {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 3.5) {
@@ -705,16 +731,21 @@ struct ContentView: View {
         let total = geo.size.height
         let panelSize = min(max(total * panelFrac, 200), total * 0.92)
         VStack(spacing: 0) {
+            // The sequence strip (when enabled) docks in the top safe area via
+            // .safeAreaInset(edge: .top) at the layout root — NOT here — so it sits
+            // below the status bar / nav bar instead of bleeding under the notch.
             viewportView
-            if showThemeStudio {
-                // Theme studio takes over the bottom region (force-shown even if
-                // the panel was collapsed); viewport stays live above.
+            if iosFullScreen {
+                // Full-screen viewport: bottom panel + sequence hidden, 3D fills.
+                EmptyView()
+            } else if showThemeStudio {
+                // Theme studio takes over the bottom region; viewport stays live above.
                 resizeDivider(landscape: false, total: geo.size.height)
                 ThemeStudioPanel(onClose: { withAnimation(.easeInOut(duration: 0.2)) { showThemeStudio = false } })
                     .environmentObject(engine)
                     .environmentObject(themeManager)
                     .frame(height: panelSize)
-            } else if !panelCollapsed {
+            } else {
                 resizeDivider(landscape: false, total: geo.size.height)
                 panelContent.frame(height: panelSize)
             }
@@ -882,11 +913,13 @@ struct ContentView: View {
             // landscape + iPad use the mac-style layout with iosPadPanelMenu.
             if hSize == .compact && vSize == .regular {
                 Button {
-                    withAnimation(.easeInOut(duration: 0.2)) { panelCollapsed.toggle() }
+                    withAnimation(.easeInOut(duration: 0.2)) { iosFullScreen.toggle() }
                 } label: {
-                    Image(systemName: panelCollapsed ? "square.split.1x2" : "square.split.1x2.fill")
+                    Image(systemName: iosFullScreen
+                          ? "arrow.down.right.and.arrow.up.left"
+                          : "arrow.up.left.and.arrow.down.right")
                 }
-                .accessibilityLabel(panelCollapsed ? "Show controls" : "Hide controls")
+                .accessibilityLabel(iosFullScreen ? "Exit full screen" : "Full-screen viewport")
             }
         }
     }
@@ -1045,10 +1078,63 @@ struct ContentView: View {
                 .tabItem { Label("Console", systemImage: "terminal") }.tag(0)
             ObjectPanel()
                 .tabItem { Label("Objects", systemImage: "cube") }.tag(1)
-            SequencePanel()
-                .tabItem { Label("Sequence", systemImage: "textformat.abc") }.tag(2)
+            settingsPane
+                .tabItem { Label("Settings", systemImage: "gearshape") }.tag(4)
         }
         .background(themeChromeBg)
+    }
+
+    // Settings content tab (iPhone). Relocates the former top-bar Theme + Reset
+    // controls here, adds the Show-sequence toggle (drives the strip above the
+    // viewport), and links to scene/render settings — all in-panel, consistent
+    // with the other tabs (no top-level modal).
+    private var settingsPane: some View {
+        List {
+            Section("Display") {
+                Toggle(isOn: $engine.sequenceVisible) {
+                    Label("Show sequence", systemImage: "textformat.abc")
+                }
+            }
+            Section("Appearance") {
+                Button {
+                    if !showThemeStudio { panelCollapsed = false }
+                    withAnimation(.easeInOut(duration: 0.2)) { showThemeStudio = true }
+                } label: {
+                    settingsRow("Themes", "paintpalette")
+                }
+            }
+            Section("Scene & rendering") {
+                Button { showSettingsSheet = true } label: {
+                    settingsRow("Scene settings", "slider.horizontal.3")
+                }
+            }
+            Section("Reset") {
+                Button { engine.runCommand("reset") } label: {
+                    Label("Reset view", systemImage: "arrow.counterclockwise")
+                }
+                Button { engine.resetEffects() } label: {
+                    Label("Reset effects", systemImage: "circle.lefthalf.filled")
+                }
+                Button(role: .destructive) { showClearSessionConfirm = true } label: {
+                    Label("Clear session…", systemImage: "trash")
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
+        // Clear the floating tab-bar pill so the Reset section stays reachable.
+        .safeAreaInset(edge: .bottom) { Color.clear.frame(height: 56) }
+    }
+
+    @ViewBuilder
+    private func settingsRow(_ title: String, _ icon: String) -> some View {
+        HStack {
+            Label(title, systemImage: icon)
+            Spacer()
+            Image(systemName: "chevron.right")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.tertiary)
+        }
     }
 
     // Draggable splitter between viewport and panel. Drag toward the viewport

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -496,6 +496,21 @@ struct ContentView: View {
     // rotations (so a pane the user turned on stays on). iPad keeps the show* bools.
     @State private var landConsole = false
     @State private var landObjects = false
+    // Trailing safe-area inset (the Dynamic Island side in landscape). Read from
+    // the key window + refreshed on rotation, because a landscapeLeft<->Right flip
+    // keeps the same size (no SwiftUI relayout) but moves the island side. Used so
+    // the right panel only reserves island space when the island is on the right.
+    @State private var trailingSafeInset: CGFloat = 0
+
+    private func refreshTrailingSafeInset() {
+        #if os(iOS)
+        let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+        let scene = scenes.first { $0.activationState == .foregroundActive } ?? scenes.first
+        let window = scene?.windows.first { $0.isKeyWindow } ?? scene?.windows.first
+        let inset = window?.safeAreaInsets.right ?? 0
+        if trailingSafeInset != inset { trailingSafeInset = inset }
+        #endif
+    }
 
     // iPhone landscape == compact width + compact height (iPad is regular height in
     // both orientations; iPhone portrait is compact width + regular height).
@@ -677,7 +692,17 @@ struct ContentView: View {
                 }
             }
         }
+        #if os(iOS)
+        .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
+            // landscapeLeft<->Right keeps the same size; refresh the island inset.
+            DispatchQueue.main.async { refreshTrailingSafeInset() }
+        }
+        #endif
         .onAppear {
+            #if os(iOS)
+            UIDevice.current.beginGeneratingDeviceOrientationNotifications()
+            refreshTrailingSafeInset()
+            #endif
             initializeEngine()
             maybePresentFirstBootTheme()
             // iPhone (compact): start full-screen with the panel collapsed and
@@ -817,16 +842,23 @@ struct ContentView: View {
 
             if !iosFullScreen {
                 Divider()
-                Group {
-                    if showThemeStudio {
-                        ThemeStudioPanel(onClose: { withAnimation(.easeInOut(duration: 0.2)) { showThemeStudio = false } })
-                            .environmentObject(engine)
-                            .environmentObject(themeManager)
-                    } else {
-                        panelContent
-                    }
+                if showThemeStudio {
+                    ThemeStudioPanel(onClose: { withAnimation(.easeInOut(duration: 0.2)) { showThemeStudio = false } })
+                        .environmentObject(engine)
+                        .environmentObject(themeManager)
+                        .frame(width: panelW)
+                } else {
+                    // Panel background is flush to the screen's right edge; the tab
+                    // CONTENT is inset from the right only by the actual trailing
+                    // safe-area (the Dynamic Island). So when the island is on the
+                    // LEFT (trailingSafeInset ≈ 0) the panel is flush; on the RIGHT
+                    // it reserves just enough space to clear the island.
+                    panelTabs
+                        .ignoresSafeArea(.container, edges: [.top, .horizontal])
+                        .padding(.trailing, trailingSafeInset)
+                        .frame(width: panelW, alignment: .leading)
+                        .background(themeChromeBg)
                 }
-                .frame(width: panelW)
             }
         }
     }

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -524,6 +524,7 @@ struct ContentView: View {
     // safeAreaInsetsDidChange — reliable across a landscapeLeft<->Right flip,
     // unlike geo.safeAreaInsets (which reports the island inset regardless of side).
     @State private var windowTrailingInset: CGFloat = 0
+    @State private var windowLeadingInset: CGFloat = 0   // debug
 
     // iPhone landscape == compact width + compact height (iPad is regular height in
     // both orientations; iPhone portrait is compact width + regular height).
@@ -578,6 +579,7 @@ struct ContentView: View {
             .background {
                 SafeAreaReader { insets in
                     if windowTrailingInset != insets.right { windowTrailingInset = insets.right }
+                    if windowLeadingInset != insets.left { windowLeadingInset = insets.left }
                 }
             }
             #endif
@@ -850,6 +852,15 @@ struct ContentView: View {
                 }
                 .padding(.top, 8)
                 .padding(.horizontal, 8)
+            }
+            // TEMP diagnostic — exact inset values so we can see why the panel insets.
+            .overlay(alignment: .bottomLeading) {
+                Text(verbatim: "geoL \(Int(geo.safeAreaInsets.leading))  geoT \(Int(geo.safeAreaInsets.trailing))  winL \(Int(windowLeadingInset))  winR \(Int(windowTrailingInset))  panelW \(Int(panelW))")
+                    .font(.system(size: 12, weight: .bold, design: .monospaced))
+                    .padding(6)
+                    .background(.black.opacity(0.7))
+                    .foregroundStyle(.green)
+                    .padding(10)
             }
 
             if !iosFullScreen {

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -458,6 +458,8 @@ struct ContentView: View {
     // iPhone: full-screen viewport mode (hides the bottom panel + sequence strip).
     // Replaces the old drag-to-collapse; driven by iosPanelToggle.
     @State private var iosFullScreen = false
+    // Settings tab: in-panel drill into the SCENE card (moved here from Inspector).
+    @State private var settingsSceneOpen = false
     // Panel fraction to restore after the Theme Studio closes (it temporarily
     // opens to ~60% of the screen so the viewport/studio split matches the spec).
     @State private var fracBeforeThemeStudio: CGFloat? = nil
@@ -1090,42 +1092,68 @@ struct ContentView: View {
     // controls here, adds the Show-sequence toggle (drives the strip above the
     // viewport), and links to scene/render settings — all in-panel, consistent
     // with the other tabs (no top-level modal).
+    @ViewBuilder
     private var settingsPane: some View {
-        List {
-            Section("Display") {
-                Toggle(isOn: $engine.sequenceVisible) {
-                    Label("Show sequence", systemImage: "textformat.abc")
+        if settingsSceneOpen {
+            // In-panel drill into the SCENE card (moved here fully from the
+            // Inspector). A back row returns to the Settings root — no modal.
+            VStack(spacing: 0) {
+                HStack(spacing: 6) {
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.2)) { settingsSceneOpen = false }
+                    } label: {
+                        Label("Settings", systemImage: "chevron.left")
+                            .font(.system(size: 15, weight: .medium))
+                    }
+                    Spacer()
+                    Text("Scene settings").font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 14).padding(.vertical, 8)
+                Divider()
+                ScrollView {
+                    SceneCard().padding(.bottom, 56)
                 }
             }
-            Section("Appearance") {
-                Button {
-                    if !showThemeStudio { panelCollapsed = false }
-                    withAnimation(.easeInOut(duration: 0.2)) { showThemeStudio = true }
-                } label: {
-                    settingsRow("Themes", "paintpalette")
+        } else {
+            List {
+                Section("Display") {
+                    Toggle(isOn: $engine.sequenceVisible) {
+                        Label("Show sequence", systemImage: "textformat.abc")
+                    }
+                }
+                Section("Scene & rendering") {
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.2)) { settingsSceneOpen = true }
+                    } label: {
+                        settingsRow("Scene settings", "slider.horizontal.3")
+                    }
+                }
+                Section("Appearance") {
+                    Button {
+                        if !showThemeStudio { panelCollapsed = false }
+                        withAnimation(.easeInOut(duration: 0.2)) { showThemeStudio = true }
+                    } label: {
+                        settingsRow("Themes", "paintpalette")
+                    }
+                }
+                Section("Reset") {
+                    Button { engine.runCommand("reset") } label: {
+                        Label("Reset view", systemImage: "arrow.counterclockwise")
+                    }
+                    Button { engine.resetEffects() } label: {
+                        Label("Reset effects", systemImage: "circle.lefthalf.filled")
+                    }
+                    Button(role: .destructive) { showClearSessionConfirm = true } label: {
+                        Label("Clear session…", systemImage: "trash")
+                    }
                 }
             }
-            Section("Scene & rendering") {
-                Button { showSettingsSheet = true } label: {
-                    settingsRow("Scene settings", "slider.horizontal.3")
-                }
-            }
-            Section("Reset") {
-                Button { engine.runCommand("reset") } label: {
-                    Label("Reset view", systemImage: "arrow.counterclockwise")
-                }
-                Button { engine.resetEffects() } label: {
-                    Label("Reset effects", systemImage: "circle.lefthalf.filled")
-                }
-                Button(role: .destructive) { showClearSessionConfirm = true } label: {
-                    Label("Clear session…", systemImage: "trash")
-                }
-            }
+            .listStyle(.insetGrouped)
+            .scrollContentBackground(.hidden)
+            // Clear the floating tab-bar pill so the Reset section stays reachable.
+            .safeAreaInset(edge: .bottom) { Color.clear.frame(height: 56) }
         }
-        .listStyle(.insetGrouped)
-        .scrollContentBackground(.hidden)
-        // Clear the floating tab-bar pill so the Reset section stays reachable.
-        .safeAreaInset(edge: .bottom) { Color.clear.frame(height: 56) }
     }
 
     @ViewBuilder

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -856,9 +856,16 @@ struct ContentView: View {
         // control content lays out identically in both orientations. (Full-screen
         // hides it; the nav bar is hidden in landscape so the panel starts at top.)
         let panelW = iosFullScreen ? 0 : geo.size.height
+        // The Dynamic-Island inset (≈59pt in landscape; 0 on notch-less devices).
+        // The window reports it symmetrically, so which physical side it's on comes
+        // from islandOnRight (interface orientation).
+        let notch = windowTrailingInset
         HStack(spacing: 0) {
             // Left: the molecular viewer (+ optional sequence strip), with the
-            // toolbar buttons floating over its top edge.
+            // toolbar buttons floating over its top edge. The 3D viewport bleeds
+            // full to the left screen edge — including UNDER the island when it's on
+            // the left — but the floating control pill is nudged inward by the island
+            // width so it isn't hidden behind the cutout.
             VStack(spacing: 0) {
                 if engine.sequenceVisible {
                     SequencePanel().frame(height: ipadSequenceHeight)
@@ -873,7 +880,8 @@ struct ContentView: View {
                     landscapeViewerControls(leading: false)  // Full-screen · Export
                 }
                 .padding(.top, 8)
-                .padding(.horizontal, 8)
+                .padding(.leading, 8 + (islandOnRight ? 0 : notch))
+                .padding(.trailing, 8)
             }
 
             if !iosFullScreen {
@@ -884,16 +892,23 @@ struct ContentView: View {
                         .environmentObject(themeManager)
                         .frame(width: panelW)
                 } else {
-                    // Panel background is flush to the screen's right edge; the tab
-                    // CONTENT is inset from the right only by the actual trailing
-                    // safe-area (the Dynamic Island), read reactively from geo so it
-                    // updates on a landscapeLeft<->Right flip. Island on the LEFT
-                    // (trailing ≈ 0) → flush; on the RIGHT → clears the island.
+                    // The panel sits flush against whatever its right neighbour is:
+                    // the true screen edge when the island is on the LEFT, or the
+                    // black notch-stripe when the island is on the RIGHT. No inset —
+                    // the stripe (below) is what keeps the island off the panel.
                     panelTabs
                         .ignoresSafeArea(.container, edges: [.top, .horizontal])
-                        .padding(.trailing, islandOnRight ? windowTrailingInset : 0)
                         .frame(width: panelW, alignment: .leading)
                         .background(themeChromeBg)
+                }
+
+                // Island on the RIGHT: letterbox it away with a solid black stripe at
+                // the far-right edge so the cutout never overlaps the panel. The panel
+                // butts flush against this stripe; the viewer fills everything left.
+                if islandOnRight && notch > 0 {
+                    Color.black
+                        .frame(width: notch)
+                        .ignoresSafeArea(.container, edges: .all)
                 }
             }
         }

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -601,7 +601,11 @@ struct ContentView: View {
         let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
         let scene = scenes.first { $0.activationState == .foregroundActive } ?? scenes.first
         if let io = scene?.interfaceOrientation {
-            islandOnRight = (io == .landscapeRight)
+            // Verified on-device (iPhone 15 Pro, yellow bg) AND on-sim (cutout visible
+            // inside a debug-colored stripe): the Dynamic Island sits on the physical
+            // RIGHT when interfaceOrientation == .landscapeLeft. (The naming is
+            // counter-intuitive; trust the empirical mapping, not the enum label.)
+            islandOnRight = (io == .landscapeLeft)
         }
         #endif
     }

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -790,11 +790,11 @@ struct ContentView: View {
     // right edge. Full-screen hides the panel; the divider resizes it.
     @ViewBuilder
     private func iPhoneLandscapeLayout(geo: GeometryProxy) -> some View {
-        // Viewer takes the left ~62%; the control panel is a solid column on the
-        // right (full-screen hides it and the viewer takes the whole width). The
-        // nav bar is hidden in landscape (see body), so all the chrome floats over
-        // the viewer and the panel content starts at the very top — no gap.
-        let panelW = iosFullScreen ? 0 : geo.size.width * 0.38
+        // Right panel uses the SAME width as the portrait panel — i.e. the
+        // device's short edge, which in landscape is geo.size.height — so the
+        // control content lays out identically in both orientations. (Full-screen
+        // hides it; the nav bar is hidden in landscape so the panel starts at top.)
+        let panelW = iosFullScreen ? 0 : geo.size.height
         HStack(spacing: 0) {
             // Left: the molecular viewer (+ optional sequence strip), with the
             // toolbar buttons floating over its top edge.

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -1090,9 +1090,9 @@ final class PyMOLEngine: ObservableObject {
     // Author a movie via the high-level builders (appkit_movie.make_movie).
     // kind: roll | rock | nutate | state_loop | state_sweep | scenes.
     func buildMovie(kind: String, duration: Double = 12, angle: Double = 30,
-                    loop: Bool = true, factor: Int = 1, pause: Double = 2,
+                    axis: String = "y", loop: Bool = true, factor: Int = 1, pause: Double = 2,
                     scenes: [String]? = nil) {
-        var args = "kind='\(kind)', duration=\(duration), angle=\(angle), "
+        var args = "kind='\(kind)', duration=\(duration), angle=\(angle), axis='\(axis)', "
             + "loop=\(loop ? 1 : 0), factor=\(factor), pause=\(pause)"
         if let s = scenes {
             let list = s.map { "'\($0.replacingOccurrences(of: "'", with: ""))'" }


### PR DESCRIPTION
## Summary

A comprehensive, conservative refinement of the **RayMol iPhone UX** (32 incremental, on-device-verified batches) that stays faithful to desktop PyMOL's mental model while improving touch ergonomics. Covers **portrait, landscape, and the bottom-panel sizing model**. iPad's mac-style layout is intentionally left unchanged.

Verified throughout on an **iPhone 15 Pro** (physical device) and an **iPhone 17 Pro simulator** (iOS 26.2) in portrait and **both** landscape orientations.

---

## Bottom tab bar & top toolbar

- **5-tab bottom bar:** Console · Objects · Scenes · Movie · Settings.
- New **⚙ Settings** tab, which let the **Theme + Reset** buttons be removed from the top toolbar — the top-right pill is now just **Full-screen + Export**.
- **Global vs. per-object visual language:** global controls (top toolbar, scenes, transport) read **teal**; per-object **A/S/H/L/C** stay **coral**.

## Settings tab (new)

- **Show sequence** toggle, **Display settings** (the SCENE render card — bg/lighting/effects/ray — moved here *fully* out of the Objects inspector), **Themes**, and a **Reset** row (Reset view / Effects / Clear session).
- Inspector cleanup: removed the non-functional **↻ refresh**, the **"Inspector"** label, and the SCENE section (the **✋ Residues** selection-mode control stays).

## Scenes tab (new)

- Scene **chips** recall on tap; inline dashed **+** chip stores the current view; **hold-and-drag to reorder** (persisted via `scene_order`); compact **Update / Prev / Next / Delete** row; **Build movie from scenes**; **Clear all**.
- Opt-in **"Show scene buttons in viewport"** → floating chip overlay that clears the transport bar.

## Movie tab

- The tab is now the **builder only** (Camera / States / Scenes), with compact single-row dropdowns and **Build & Play** pinned to a consistent position across all three sub-tabs.
- Camera **rotation Axis (X/Y/Z)** selector (threads through `buildMovie(axis:)` -> `appkit_movie.make_movie`); full PyMOL **state speeds** (1x ... 1/16x); **seamless loop**.
- **Export Movie** relocated to the top **Export** menu (tappable even when empty -> shows an explainer).

## Full-screen

- Replaced the bottom-panel drag-to-collapse with a dedicated **full-screen viewport toggle**.

## Landscape layout

- Viewer on the **left (~2/3)**, control panel docked on the **right (~1/3)**, panel width matched to the portrait panel.
- Toolbar pills **float over the viewer** (Open/Measure top-left, Expand/Share top-right); nav bar hidden in landscape.
- **Dynamic Island handling:** a solid black **letterbox stripe** covers the cutout on the island side; the panel is flush on the other side; the 3D viewer bleeds full-bleed under the cutout. The island side is derived from `interfaceOrientation` (empirically verified — the enum naming is counter-intuitive).
- **Custom landscape tab bar (no TabView)** so the iOS 26 floating-capsule tab bar can't anchor to the window edge and clip the last tab (**Settings**) under the notch stripe.

## Portrait bottom-panel sizing — now content-aware (drag handle removed)

Replaced the single drag-resizable fraction with a **per-tab height policy**, all transitions animated:

| Tab | Height |
|---|---|
| Console | fixed 1/2 (terminal needs standing room) |
| Objects / Scenes / Movie | **hug** natural content, capped (Objects 1/3; Scenes & Movie 1/2), then scroll |
| Settings - root | compact |
| Settings - Display settings / Themes | **3/4** |

Mechanism: each pane reports its **natural** content height (measured from inside its own scroll/stack, so it's true content height — not the constrained frame) via a `PaneHeightKey` preference, keyed by tab tag.

## Sequence strip

- Relocated **below the viewport, above the bottom panel** (desktop-style). The measurement bar still docks in the top safe area.

---

## Files changed

- `swiftui/PyMOLViewer/Shared/ContentView.swift` — tab bar, Settings/Scenes panes, landscape layout, custom landscape tab bar, content-aware portrait sizing, sequence-strip placement.
- `swiftui/PyMOLViewer/Panels/ObjectPanel.swift` — Scenes pane, inspector cleanup, per-tab height reporting.
- `swiftui/PyMOLViewer/Panels/MovieBuilderSheet.swift`, `MovieExportSheet.swift` — builder controls, axis selector, export relocation.
- `swiftui/PyMOLViewer/Shared/PyMOLEngine.swift` — `buildMovie(axis:)`.
- `README.md`, `.gitignore` — minor (Slack badge, build-artifact ignores).

## Testing

Each batch was built and run on the iPhone 17 Pro simulator and deployed to the iPhone 15 Pro. Landscape notch behavior was confirmed by temporarily coloring the letterbox stripe so the Dynamic-Island cutout is visible inside it, proving the stripe lands on the correct (island) side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
