### PR TITLE
macOS/iPad parity: right-inspector segmented switcher (Objects/Scenes/Movie/Display) + P0 regression fix

### DIFF
--- a/swiftui/PyMOLViewer/Panels/MovieBuilderSheet.swift
+++ b/swiftui/PyMOLViewer/Panels/MovieBuilderSheet.swift
@@ -206,6 +206,11 @@ struct MovieBuilderControls: View {
                 .background(RoundedRectangle(cornerRadius: 8).fill(Color.gray.opacity(0.13)))
                 .contentShape(Rectangle())
             }
+            // macOS adds its own disclosure chevron to a Menu, which squished the
+            // custom label down to "…". Hide it so the value text + custom chevron
+            // get the full width. (No-op on iOS, where there's no default indicator.)
+            .menuIndicator(.hidden)
+            .buttonStyle(.plain)
         }
         .frame(maxWidth: .infinity)
     }

--- a/swiftui/PyMOLViewer/Panels/TransportBar.swift
+++ b/swiftui/PyMOLViewer/Panels/TransportBar.swift
@@ -14,9 +14,12 @@
 import SwiftUI
 
 enum TimelineTheme {
-    // Distinct accent for transport controls (emerald-teal) — keeps the app
-    // visually "plainly distinguished" while reading as a media transport.
-    static let accent = Color(.sRGB, red: 0.20, green: 0.80, blue: 0.66, opacity: 1)
+    // Accent for transport / movie / scene controls — follows the ACTIVE THEME's
+    // accent (so Build & Play, scene icons, chips, etc. match the rest of the app)
+    // rather than a fixed teal. Mirrors SequencePanel's `ThemeManager.shared.active`
+    // read. Views that should recolor live on a theme switch already observe
+    // ThemeManager; others pick it up on their next render.
+    static var accent: Color { ThemeManager.shared.active.accent.color }
     static let bar = Color(.sRGB, red: 0.10, green: 0.11, blue: 0.12, opacity: 0.96)
     static let text = Color(white: 0.88)
     static let dim = Color(white: 0.55)

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -91,6 +91,22 @@ private struct PanelTabSpec: Identifiable {
     var id: Int { tag }
 }
 
+/// Segments of the iPad/macOS right-inspector switcher (mirrors the iPhone tabs:
+/// Console = left terminal; Settings = the Display render card).
+private enum InspectorTab: String, CaseIterable, Identifiable {
+    case objects = "Objects", scenes = "Scenes", movie = "Movie", display = "Display"
+    var id: String { rawValue }
+    /// Matches the iPhone tab-bar symbols (Settings → Display uses the slider icon).
+    var systemImage: String {
+        switch self {
+        case .objects: return "cube"
+        case .scenes:  return "rectangle.on.rectangle"
+        case .movie:   return "film"
+        case .display: return "slider.horizontal.3"
+        }
+    }
+}
+
 private let landscapePanelTabSpecs: [PanelTabSpec] = [
     .init(tag: 0, title: "Console",  systemImage: "terminal"),
     .init(tag: 1, title: "Objects",  systemImage: "cube"),
@@ -395,13 +411,8 @@ struct ContentView: View {
                     .environmentObject(themeManager)
                     .frame(width: 340)
             } else if showObjectPanel {
-                VStack(spacing: 0) {
-                    if showObjectPanel {
-                        ObjectPanel()
-                            .frame(minHeight: 150)
-                    }
-                }
-                .frame(width: 300)
+                inspectorSwitcher
+                    .frame(width: 360)
             }
         }
         } // end VStack
@@ -414,11 +425,13 @@ struct ContentView: View {
             Text("Download a structure from the RCSB PDB.")
         }
         .toolbar {
+            // Leading — tools (mirrors the iOS top-left): Open · Measure.
             macOpenToolbar
-            macThemeToolbar
-            exportMenu
             macMeasureToolbar
+            // Trailing — view toggles, then actions, then status. (Theme moved into
+            // the Display segment, mirroring iOS Settings → Themes.)
             panelToggles
+            exportMenu
             #if !RAYMOL_MAS_RESTRICTED
             ToolbarItem(placement: .automatic) {
                 MCPStatusView()
@@ -535,6 +548,13 @@ struct ContentView: View {
 
     // MARK: - iPadOS: TabView with panels
 
+    // iPad/macOS right-inspector active segment (Objects/Scenes/Movie/Display).
+    // Declared outside #if os(iOS) so macOSLayout can also reference inspectorSwitcher.
+    @State private var inspectorTab: InspectorTab = .objects
+    // Scenes tab: opt-in glanceable scene buttons overlaid on the viewport.
+    // Also outside #if os(iOS) since inspectorSwitcher (shared) binds to it.
+    @State private var showSceneButtons = false
+
     #if os(iOS)
     // Default to the Objects tab: a touch user tunes representations far more
     // than they type commands, and it avoids greeting them with console log text.
@@ -586,8 +606,6 @@ struct ContentView: View {
     @State private var iosFullScreen = false
     // Settings tab: in-panel drill into the display-settings card.
     @State private var settingsSceneOpen = false
-    // Scenes tab: opt-in glanceable scene buttons overlaid on the viewport.
-    @State private var showSceneButtons = false
     // Panel fraction to restore after the Theme Studio closes (it temporarily
     // opens to ~60% of the screen so the viewport/studio split matches the spec).
     @State private var fracBeforeThemeStudio: CGFloat? = nil
@@ -1095,7 +1113,7 @@ struct ContentView: View {
     @ViewBuilder
     private func iPadMacStyleLayout(geo: GeometryProxy) -> some View {
         let landscape = geo.size.width > geo.size.height
-        let rightW: CGFloat = 340                          // landscape side column
+        let rightW: CGFloat = 360                          // landscape side column
         let maxTerm = max(140, geo.size.height * 0.33)
         let clampedTermH = min(max(termH, 60), maxTerm)
         // Effective pane visibility: iPhone landscape uses its minimal-default
@@ -1140,14 +1158,12 @@ struct ContentView: View {
                         .background(themeChromeBg)
                 } else if showRight {
                     Divider()
-                    VStack(spacing: 0) {
-                        if cObj { ObjectPanel().frame(maxHeight: .infinity) }
-                    }
                     // Reserve top space so the floating toolbar doesn't hide the
-                    // Objects panel header / first object on iPhone (full-bleed).
-                    .padding(.top, panelTopInset)
-                    .frame(width: rightW)
-                    .background(themeChromeBg)
+                    // inspector header / first row on iPhone (full-bleed).
+                    inspectorSwitcher
+                        .padding(.top, panelTopInset)
+                        .frame(width: rightW)
+                        .background(themeChromeBg)
                 }
             }
         } else {
@@ -1173,11 +1189,9 @@ struct ContentView: View {
                         .background(themeChromeBg)
                 } else if showRight {
                     resizeDivider(landscape: false, total: geo.size.height)
-                    HStack(spacing: 0) {
-                        if cObj { ObjectPanel().frame(maxWidth: .infinity) }
-                    }
-                    .frame(height: bottomH)
-                    .background(themeChromeBg)
+                    inspectorSwitcher
+                        .frame(height: bottomH)
+                        .background(themeChromeBg)
                 }
             }
         }
@@ -1967,6 +1981,58 @@ struct ContentView: View {
     }
     #endif
 
+    // MARK: Regular-layout inspector switcher (iPad + macOS)
+    //
+    // The desktop/iPad right inspector mirrors the iPhone bottom tabs as a
+    // segmented switcher: Objects · Scenes · Movie · Display. (Console is the
+    // left terminal; Settings → the Display render card.) Each segment swaps in
+    // an existing shared view — nothing is rebuilt. Works by touch (iPad) and
+    // pointer (macOS); macOS menubar items are additive accelerators.
+    @ViewBuilder
+    private var inspectorSwitcher: some View {
+        VStack(spacing: 0) {
+            Picker("", selection: $inspectorTab) {
+                ForEach(InspectorTab.allCases) { tab in
+                    Label(tab.rawValue, systemImage: tab.systemImage).tag(tab)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .padding(.horizontal, 10)
+            .padding(.top, 8)
+            .padding(.bottom, 7)
+            Divider()
+            switch inspectorTab {
+            case .objects:
+                ObjectPanel()
+            case .scenes:
+                ScenesPane(showViewportButtons: $showSceneButtons,
+                           onOpenMovie: { inspectorTab = .movie })
+            case .movie:
+                MoviePane()
+            case .display:
+                // The SCENE render card (bg/lighting/effects/ray); its
+                // "All settings…" opens the shared searchable SettingsSheet. Theme
+                // Studio lives here too (moved off the toolbar → matches iOS, where
+                // Themes is under Settings).
+                ScrollView {
+                    VStack(spacing: 14) {
+                        Button {
+                            withAnimation(.easeInOut(duration: 0.2)) { showThemeStudio = true }
+                        } label: {
+                            Label("Theme Studio…", systemImage: "paintpalette")
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.large)
+                        SceneCard()
+                    }
+                    .padding(12)
+                }
+            }
+        }
+    }
+
     // MARK: - Toolbar
 
     // Always-available Open/Fetch (the empty-state CTA disappears once a
@@ -2004,7 +2070,8 @@ struct ContentView: View {
     }
 
     private var macMeasureToolbar: some ToolbarContent {
-        ToolbarItem {
+        // Leading, beside Open — mirrors the iOS top-left pair (Open · Measure).
+        ToolbarItem(placement: .navigation) {
             Button {
                 engine.setMeasureMode(engine.measureMode == nil ? .distance : nil)
             } label: {
@@ -2014,16 +2081,19 @@ struct ContentView: View {
         }
     }
 
+    // The three desktop panes as one consistent toggle group. NOTE the right panel
+    // toggle is "Inspector" (sidebar icon), NOT "Objects" — Objects is now a SEGMENT
+    // inside the inspector switcher, so the toolbar must not duplicate it.
     private var panelToggles: some ToolbarContent {
         ToolbarItemGroup {
+            Toggle(isOn: $showCommandPanel) {
+                Label("Console", systemImage: "terminal")
+            }
             Toggle(isOn: $engine.sequenceVisible) {
                 Label("Sequence", systemImage: "textformat.abc")
             }
             Toggle(isOn: $showObjectPanel) {
-                Label("Objects", systemImage: "cube")
-            }
-            Toggle(isOn: $showCommandPanel) {
-                Label("Console", systemImage: "terminal")
+                Label("Inspector", systemImage: "sidebar.right")
             }
         }
     }


### PR DESCRIPTION
## Summary

Brings the relevant parts of the iPhone UX refinement (#74) to the **desktop / iPad** — the shared regular-size-class layout (`macOSLayout` + `iPadMacStyleLayout`) — and **fixes a regression that #74 introduced on the desktop**. Everything reuses existing shared views; nothing is rebuilt.

Verified on the running macOS app across all four segments; iPad uses the identical shared `inspectorSwitcher`.

## Right-inspector segmented switcher

The right inspector (previously Objects-only) gains a segmented switcher that mirrors the iPhone tab bar — **Objects · Scenes · Movie · Display** — each segment swapping in an existing shared view:

| Segment | View | Notes |
|---|---|---|
| Objects | `ObjectPanel` | unchanged |
| Scenes | `ScenesPane` | store / recall / drag-reorder / build-movie / clear |
| Movie | `MovieBuilderControls` | Camera/States/Scenes, axis X/Y/Z, state speeds, seamless loop, Build & Play |
| Display | `SceneCard` | render controls + **All settings…** (→ `SettingsSheet`) |

(Console stays the left terminal; Settings → the Display render card, matching iOS.) Wired into all three inspector spots: macOS right column, iPad-landscape right column, iPad-portrait bottom panel. Works by touch (iPad) and pointer (macOS).

## P0 regression fix

#74 moved the SCENE render card and the searchable settings browser out of `ObjectPanel` into iOS-only tab content. Because macOS/iPad share `ObjectPanel` but not those tabs, **bg color / lighting / effects / AO / ray and the ~825-setting browser became reachable on the desktop only via raw console commands.** The **Display** segment restores `SceneCard` (and its "All settings…" reopens the shared `SettingsSheet`), closing the gap. Movie *authoring* (the builder) is likewise now reachable on the desktop.

## Toolbar cleanup + theme consistency

- **Removed the cube "Objects" toolbar toggle** — it duplicated the new Objects *segment*. The right-panel toggle is now **"Inspector"** (sidebar icon).
- **Regrouped the toolbar** (mirrors iOS: tools left, actions right): `Open · Measure` leading; `Console · Sequence · Inspector` toggles, then `Export`, then MCP status trailing.
- **Theme moved off the toolbar into the Display segment** (a "Theme Studio…" button at the top), mirroring iOS Settings → Themes.
- **`TimelineTheme.accent` now follows the active theme's accent** (Build & Play, scene icons, transport, chips) instead of a fixed teal — so the controls match the rest of the app's palette.
- **Wider right inspector** (300→360 macOS, 340→360 iPad) and hide macOS's default `Menu` disclosure indicator so the Movie builder dropdowns show their values instead of "…".

## Files

- `swiftui/PyMOLViewer/Shared/ContentView.swift` — `InspectorTab` + `inspectorSwitcher`; wired into the macOS/iPad right columns; toolbar regroup; Inspector toggle; Theme-in-Display; panel widths.
- `swiftui/PyMOLViewer/Panels/TransportBar.swift` — `TimelineTheme.accent` → `ThemeManager.shared.active.accent.color`.
- `swiftui/PyMOLViewer/Panels/MovieBuilderSheet.swift` — `.menuIndicator(.hidden)` on the builder dropdowns.

## Not included (follow-ups)

macOS menubar *accelerators* (Display Settings… / Scenes / Make Movie / Reset) and adding **Export Movie…** to the File ▸ Export menu — additive, deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
