### PR TITLE
fix: Metal/command-line bugs from evaluator feedback + flat-sheets toggle (#71, #72, #73)

### DIFF
--- a/layer1/CGOGL.cpp
+++ b/layer1/CGOGL.cpp
@@ -1574,7 +1574,14 @@ static void CGO_gl_special(CCGORenderer* I, CGO_op_data pc)
   }
   switch (mode) {
   case LINEWIDTH_DYNAMIC_WITH_SCALE_RIBBON: {
-    float line_width = SettingGet_f(I->G, nullptr, nullptr, cSetting_ribbon_width);
+    // Per-rep ribbon_width (was global) + feed the raw width to the Metal
+    // renderer (issue #71; see LINEWIDTH_FOR_LINES).
+    float raw_width =
+        SettingGet_f(I->G, csSetting, objSetting, cSetting_ribbon_width);
+    if (I->G->Renderer) {
+      I->G->Renderer->lineWidth(raw_width);
+    }
+    float line_width = raw_width;
     if (!openVR)
       line_width = SceneGetDynamicLineWidth(I->info, line_width);
     if (I->info && I->info->width_scale_flag) {
@@ -1614,6 +1621,11 @@ static void CGO_gl_special(CCGORenderer* I, CGO_op_data pc)
           I->rep->obj->Setting.get(), cSetting_mesh_width);
     } else {
       line_width = SettingGet_f(I->G, nullptr, nullptr, cSetting_mesh_width);
+    }
+    // Feed the raw width to the Metal renderer (issue #71; glLineWidth is a
+    // no-op stub under Metal). Pre-dynamic-scale value matches _lineWidth units.
+    if (I->G->Renderer) {
+      I->G->Renderer->lineWidth(line_width);
     }
     if (!openVR)
       line_width = SceneGetDynamicLineWidth(I->info, line_width);
@@ -1843,8 +1855,18 @@ static void CGO_gl_special(CCGORenderer* I, CGO_op_data pc)
     glLineWidthAndUniform(lineradius * 2.f / vScale, shaderPrg);
   } break;
   case LINEWIDTH_FOR_LINES: {
-    float line_width = SceneGetDynamicLineWidth(
-        I->info, SettingGet_f(I->G, nullptr, nullptr, cSetting_line_width));
+    // Per-rep/object width. Previously read the GLOBAL setting (nullptr,nullptr),
+    // so the per-object line_width slider (issue #71) had no visible effect.
+    // Resolve from the rep/object settings, and feed the RAW width to the active
+    // renderer: glLineWidth() is a no-op stub under Metal, and drawLinesAA reads
+    // _lineWidth in these raw units (matching the global set in SceneRender).
+    // Harmless for GL (glLineWidth below still applies the DPI-scaled width).
+    float raw_width =
+        SettingGet_f(I->G, csSetting, objSetting, cSetting_line_width);
+    if (I->G->Renderer) {
+      I->G->Renderer->lineWidth(raw_width);
+    }
+    float line_width = SceneGetDynamicLineWidth(I->info, raw_width);
     if (I->info && I->info->width_scale_flag) {
       line_width *= I->info->width_scale;
     }

--- a/layer1/SceneRender.cpp
+++ b/layer1/SceneRender.cpp
@@ -2062,13 +2062,24 @@ void SceneRenderMetal(PyMOLGlobals* G)
         outlineWidth, dofEnabled, dofFocus, dofRange, temporalAO,
         upscaleEnabled, dofAperture);
     // Lighting model — the Metal lit shaders read these instead of hard-coded
-    // constants, so the Scene-panel lighting sliders take effect.
+    // constants, so the Scene-panel lighting sliders take effect. Specular and
+    // shininess must go through PyMOL's light-count adjustment (the same path
+    // GL uses in CShaderPrg::Set_Specular_Values), NOT the raw settings: the
+    // default specular=1.0 is meant to resolve to specular_intensity (0.5), and
+    // spec_reflect/spec_count/light_count further scale it. Feeding the raw 1.0
+    // made the reflect highlight ~2x too strong, so flat cartoon β-sheets read
+    // as rounded/lumpy (issue #72). The Metal lit shader applies specular only
+    // from the reflect light (direct spec is 0, matching GL's default), so we
+    // pass the adjusted reflect specular/shininess into the spec/shininess slots.
+    float specReflect, specPower, specDirect, specDirectPower;
+    SceneGetAdjustedLightValues(
+        G, &specReflect, &specPower, &specDirect, &specDirectPower);
     G->Renderer->setLightingParams(
         SettingGetGlobal_f(G, cSetting_ambient),
         SettingGetGlobal_f(G, cSetting_direct),
         SettingGetGlobal_f(G, cSetting_reflect),
-        SettingGetGlobal_f(G, cSetting_specular),
-        SettingGetGlobal_f(G, cSetting_shininess),
+        specReflect,
+        specPower,
         SettingGetGlobal_f(G, cSetting_metal_sss_wrap));
     // MSAA: 4x when metal_msaa is on, otherwise single-sample. The renderer
     // stashes this and applies it at the next setDrawable (no encoder open),

--- a/modules/pymol/appkit_inspector.py
+++ b/modules/pymol/appkit_inspector.py
@@ -19,7 +19,8 @@ REPS = ['lines', 'sticks', 'ribbon', 'cartoon', 'dots', 'spheres',
 # Numeric/bool settings exposed per rep (besides color, handled separately).
 REP_SETTINGS = {
     'cartoon':    ['cartoon_transparency', 'cartoon_loop_radius',
-                   'cartoon_tube_radius', 'cartoon_fancy_helices'],
+                   'cartoon_tube_radius', 'cartoon_fancy_helices',
+                   'cartoon_flat_sheets'],
     'surface':    ['transparency', 'surface_quality', 'solvent_radius',
                    'surface_clip_front', 'surface_clip_back', 'metal_interior_cap',
                    'surface_contour', 'surface_contour_width',

--- a/swiftui/PyMOLViewer/Panels/CommandPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/CommandPanel.swift
@@ -161,7 +161,11 @@ struct CommandTextField: NSViewRepresentable {
     var onComplete: (String) -> String?
 
     func makeNSView(context: Context) -> NSTextField {
-        let field = CommandNSTextField()
+        // Arrow-key history is handled in the delegate's doCommandBy (moveUp:/
+        // moveDown:), not via an NSTextField.keyDown override — a focused field's
+        // key events are swallowed by the window's field editor, so keyDown never
+        // sees the arrows. A plain NSTextField is therefore sufficient.
+        let field = NSTextField()
         field.delegate = context.coordinator
         field.font = .monospacedSystemFont(ofSize: fontSize, weight: .regular)
         field.textColor = NSColor(textColor)
@@ -170,8 +174,6 @@ struct CommandTextField: NSViewRepresentable {
         field.focusRingType = .none
         field.placeholderString = "Enter command..."
         field.cell?.sendsActionOnEndEditing = false
-        field.onUpArrow = onUpArrow
-        field.onDownArrow = onDownArrow
         return field
     }
 
@@ -187,10 +189,6 @@ struct CommandTextField: NSViewRepresentable {
         context.coordinator.onUpArrow = onUpArrow
         context.coordinator.onDownArrow = onDownArrow
         context.coordinator.parent = self
-        if let cmdField = nsView as? CommandNSTextField {
-            cmdField.onUpArrow = onUpArrow
-            cmdField.onDownArrow = onDownArrow
-        }
     }
 
     func makeCoordinator() -> Coordinator {
@@ -234,32 +232,30 @@ struct CommandTextField: NSViewRepresentable {
                 }
                 return true
             }
+            // Up/Down arrows → command history. While the field is focused its key
+            // events go to the window's shared field editor (an NSTextView), so a
+            // focused NSTextField never sees keyDown for the arrows — they arrive
+            // here as moveUp:/moveDown: instead (the same delegate path that makes
+            // Return and Tab work). Recall via the history closures, then push the
+            // recalled text straight into the field editor (setting the field's
+            // stringValue while it is being edited is unreliable — mirror the Tab
+            // handling above) and put the caret at the end.
+            if selector == #selector(NSResponder.moveUp(_:)) {
+                onUpArrow()
+                let s = parent.text
+                textView.string = s
+                textView.setSelectedRange(NSRange(location: (s as NSString).length, length: 0))
+                return true
+            }
+            if selector == #selector(NSResponder.moveDown(_:)) {
+                onDownArrow()
+                let s = parent.text
+                textView.string = s
+                textView.setSelectedRange(NSRange(location: (s as NSString).length, length: 0))
+                return true
+            }
             return false
         }
-    }
-}
-
-/// NSTextField subclass that intercepts up/down arrow key events.
-private class CommandNSTextField: NSTextField {
-    var onUpArrow: (() -> Void)?
-    var onDownArrow: (() -> Void)?
-
-    override func keyUp(with event: NSEvent) {
-        super.keyUp(with: event)
-    }
-
-    override func keyDown(with event: NSEvent) {
-        switch event.keyCode {
-        case 126: // Up arrow
-            onUpArrow?()
-            return
-        case 125: // Down arrow
-            onDownArrow?()
-            return
-        default:
-            break
-        }
-        super.keyDown(with: event)
     }
 }
 

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -95,6 +95,7 @@ enum RepCatalog {
                 RepProperty(setting: "cartoon_loop_radius",   label: "Loop radius",  kind: .slider),
                 RepProperty(setting: "cartoon_tube_radius",   label: "Tube radius",  kind: .slider),
                 RepProperty(setting: "cartoon_fancy_helices", label: "Fancy helices", kind: .toggle),
+                RepProperty(setting: "cartoon_flat_sheets",   label: "Flat sheets",   kind: .toggle),
             ]),
         "surface": RepSpec(rep: "surface", display: "Surface",
             colorSetting: "surface_color", defaultColor: -1, properties: [

--- a/swiftui/PyMOLViewer/Shared/MetalViewport.swift
+++ b/swiftui/PyMOLViewer/Shared/MetalViewport.swift
@@ -87,7 +87,15 @@ struct MetalViewport: NSViewRepresentable {
 class PyMOLMTKView: MTKView {
     weak var coordinator: MetalViewport.Coordinator?
 
-    override var acceptsFirstResponder: Bool { true }
+    // Decline keyboard first-responder so a click in the viewport does NOT steal
+    // focus from the command-line input (issue #73): the command line stays "hot"
+    // for typing while the user rotates/picks, matching desktop PyMOL. Mouse events
+    // are still delivered to this view via the mouse overrides below + acceptsFirstMouse
+    // (they don't require first-responder status). Trade-off: single-key PyMOL
+    // shortcuts routed through keyDown -> handleKeyDown no longer fire while the
+    // command line holds focus; RayMol is command-line/UI-driven, so keeping the
+    // prompt focused is the intended behavior.
+    override var acceptsFirstResponder: Bool { false }
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 
     override func mouseDown(with event: NSEvent) {


### PR DESCRIPTION
## Summary

Four bugs surfaced by the RosettaCommons evaluator feedback and follow-up testing — three in the Metal renderer / desktop parity, one in the command-line UX. Each was root-caused (systematic debugging: hypotheses tested empirically **before** any code change) and functionally verified on the rebuilt macOS app.

Closes #71, #72, #73.

## Fixes

### fix(metal): honor per-rep line_width — #71
The width CGO ops read the width from the **global** setting, so a per-object `line_width` slider had no effect; and Metal has no `glLineWidth` (no-op stub), so the value never reached the Metal line path (`drawLinesAA`, which reads `_lineWidth` in raw px). Now resolve width from the rep/object settings and push the raw width to the active renderer. Harmless for GL.
- **Verified:** `line_width 1` vs `line_width 8` now visibly different.

### fix(metal): adjust specular so flat sheets render flat — #72
Flat cartoon β-sheets rendered as rounded/lumpy ribbons instead of flat arrow strands (evaluator side-by-side vs desktop PyMOL). Geometry and CGO normals are **correct and identical** for GL and Metal (flat faces carry constant per-face normals). Root cause: the Metal lit shader was fed the **raw** `specular` (1.0); the GL path runs it through `SceneGetAdjustedLightValues`, which resolves the default `1.0 → specular_intensity (0.5)`. The un-halved reflect specular saturated the flat top face while the side faces stayed dark → a flat plank read as a rounded cylinder. Now route the Metal path through the same adjustment (GL/ray/Metal parity for all reps).
- **Ruled out first:** SSAO/shadows (toggling both off changed nothing); `cartoon_flat_sheets` being ignored (toggling it clearly changes geometry — flattening works).
- **Verified:** flat sheets now match the desktop-PyMOL reference render; spheres/sticks keep correct highlights (no regression).

### fix(ui): keep command focus on viewport click + restore arrow history — #73
Two command-line regressions on macOS:
1. Clicking the viewport stole keyboard focus from the command input (`PyMOLMTKView` accepted first-responder). Now declines first-responder so the prompt stays hot while rotating/picking, matching desktop PyMOL; mouse events still arrive via the mouse overrides + `acceptsFirstMouse`.
2. Up/down arrows didn't recall history — a focused `NSTextField`'s arrows go to the field editor, so the old `keyDown` subclass never saw them. Now handled in the delegate's `doCommandBy` as `moveUp:`/`moveDown:` (the path Return/Tab already use); dead subclass removed.
- **Verified:** typing lands in the prompt after a viewport click; Up recalls prior commands in sequence.

### feat(ui): per-object "Flat sheets" toggle in the Cartoon inspector — #72 (companion)
Follow-up to the flat-sheet rendering fix: `cartoon_flat_sheets` is now a per-object toggle in the representation inspector, right below "Fancy helices". Reuses the existing `RepProperty` `.toggle` path (object-scoped `set cartoon_flat_sheets, 0/1, <object>`, cartoon auto-rebuilds) and is added to `appkit_inspector.REP_SETTINGS` so the toggle reflects the object's current value (on by default). Swift + bundled-Python only, no C++.
- **Verified:** toggle flips β-sheets flat↔twisted per object (confirmed on the running build).

## Build / test
Two-stage macOS build (`build_macos.sh` core rebuild for the C++ changes, then `xcodebuild`). All four fixes verified functionally on the running Debug build via automated screen capture; the flat-sheets toggle verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XiQXSyVqEuMAZLY3pNDxwr
