### PR TITLE
fix(surface): reset transparency flag on recolor so surfaces return to opaque (#80)

### DIFF
--- a/layer2/RepSurface.cpp
+++ b/layer2/RepSurface.cpp
@@ -1858,6 +1858,16 @@ Rep* RepSurface::recolor()
   auto const I = this;
   assert(cs == this->cs);
 
+  // Reset the transparency flag before recomputing per-vertex alpha below. A
+  // `transparency` setting change invalidates at cRepInvColor, which re-runs
+  // recolor() in place on this same Rep (see Rep::update); the per-vertex loop
+  // only ever calls setHasTransparency() (=true) when at_transp > 0 and never
+  // clears it. Without this reset the flag stays stuck true after transparency
+  // returns to 0, so the now-opaque surface keeps being routed into the
+  // transparent pass and renders semi-transparent. Mirrors RepCartoon, which
+  // passes the computed boolean to setHasTransparency().
+  I->setHasTransparency(false);
+
   MapType *map = nullptr, *ambient_occlusion_map = nullptr;
   int a, i0, i, j, c1;
   float *v0, *vc, *va;


### PR DESCRIPTION
## Summary

Fixes #80 — a molecular surface stays **semi-transparent** after its `transparency` setting is raised and then lowered back to `0`. Once a surface has ever been transparent in a session, `set transparency, 0` no longer restores full opacity (the cartoon/interior bleeds through).

## Root cause

A `transparency` change invalidates the surface at `cRepInvColor`, which `Rep::update()` routes to `RepSurface::recolor()` **in place** on the same `Rep`. In `recolor()` the per-vertex loop only ever calls `setHasTransparency()` (defaults to `true`) when `at_transp > 0`, and `RepSurfaceCGOGenerate()` likewise only sets it when `alpha < 1`. Nothing ever resets `Rep::m_has_transparency` back to `false` for a surface (it's initialized `false` only at construction).

So after `1.0 → 0.0`, `recolor()` runs with `at_transp == 0`, skips the flag-setting branch, and leaves the flag stuck `true`. `CoordSet.cpp` then keeps routing the now-opaque surface into `RenderPass::Transparent`, so it renders through the alpha-blended/OIT path (depth-write disabled) and looks see-through.

`RepCartoon` already does this correctly — it computes a boolean and calls `setHasTransparency(hasAlpha)`, which resets the flag when there's no alpha. This PR brings `RepSurface` in line.

## Fix

Reset `m_has_transparency` to `false` at the top of `RepSurface::recolor()`, before the per-vertex loop recomputes alpha. The loop then re-arms it only when it actually observes `at_transp > 0` (including the per-atom `variable_alpha` case). One line + explanatory comment; no behavior change for genuinely transparent surfaces.

## Testing (iPad Pro 13" M5 simulator, headless A/B render)

Load 1ubq, `show surface` + `show cartoon` (surface cyan, cartoon red), same camera; render offscreen (`PYMOL_AUTOEXPORT` rt=0 = Metal raster). Metric = mean abs pixel difference vs. the opaque control.

| Scenario | MAD vs opaque control | Result |
| --- | --- | --- |
| `transparency 1.0 → render → 0.0` **before fix** | **8.99** | ❌ semi-transparent (10.7% of px differ) |
| `transparency 1.0 → render → 0.0` **after fix** | **0.00** | ✅ pixel-identical to opaque |
| `transparency 0.5` held (regression) | 14.65 | ✅ still transparent — fix doesn't disable transparency |

Confirmed visually: the round-trip surface is now solid cyan with no bleed-through.

## Notes

- The fix is in shared core (`layer2/RepSurface.cpp`), so it applies to both the Metal and GL renderers.
- #80 also identifies a secondary, allocation-dependent Metal issue (`RendererMetal::_vboCache` is never purged via `invalidateVBOCache()`). It is **not** addressed here — this deterministic root cause fully resolves the reported symptom in testing. Left as a follow-up robustness item on the issue.
