### PR TITLE
RayMol 1.5.0 — surface contour/clipping, macOS inspector, + two RC bug fixes

### DIFF
--- a/docs/release-notes/v1.5.0.md
+++ b/docs/release-notes/v1.5.0.md
@@ -1,0 +1,24 @@
+## RayMol 1.5.0
+
+A feature release: richer surface rendering, a reorganized inspector, and a batch of Metal fidelity fixes that bring cartoons, surfaces, and shadows closer to desktop PyMOL.
+
+### Surfaces
+- **Outer-contour outline.** Draw a crisp silhouette around surfaces — and it holds up on transparent and clipped surfaces, not just opaque ones — *Scene / Surface card*.
+- **Contour color control.** Pick the outline color directly on the Surface card.
+- **Per-representation clipping.** Clip a surface independently of the global slab, with the solid-interior cap following the per-rep clip.
+
+### Inspector
+- **Segmented section switcher on macOS & iPad**, mirroring the iPhone tabs — a faster way to move between Scene, Objects, and Selections.
+- **Per-object "Flat sheets" toggle** on the Cartoon card.
+- **Camera rotation-axis (X/Y/Z) selector.**
+
+### Rendering fidelity (Metal)
+- **Flat β-sheets now render flat**, matching desktop PyMOL's cartoon sheets.
+- **Per-representation line width** is honored by the Metal renderer.
+- **Ambient occlusion no longer draws contour lines on cartoons**, and **shadows no longer draw a serrated lighter border** along helix and stick silhouettes.
+- **Surfaces return to opaque when recolored** (the transparency flag is reset), and a surface's per-rep clip no longer leaks onto the cartoon.
+
+### Command line
+- **Clicking the viewport no longer steals focus** from the command line, and **up/down history** works again — type, manipulate, keep typing.
+
+Built on the open-source PyMOL engine. Updates install automatically via the in-app updater (**Check for Updates…** in the app menu).

--- a/layerGraphics/metal/RendererMetal.mm
+++ b/layerGraphics/metal/RendererMetal.mm
@@ -2387,8 +2387,16 @@ void RendererMetal::runPostChain()
       std::memcpy(cu.projection, cd.projection, 64);
       cu.pointSize = 1.0f; cu.pad[0] = cu.pad[1] = cu.pad[2] = 0.0f;
       [ce setVertexBytes:&cu length:sizeof(cu) atIndex:1];
-      { struct { float front, back, enabled, pad; } _cl = { cd.clipFront, cd.clipBack,
-          cd.clipFront >= 0.0f ? 1.0f : 0.0f, 0.0f };
+      // Coverage mask is intentionally CLIP-AGNOSTIC for the per-rep clip: the
+      // outer contour must trace the surface's true outer silhouette, not the
+      // per-rep "peek inside" clip cross-section. Feeding cd.clipFront/Back here
+      // discards the clipped fragments, so the clip cut edge would enter the
+      // mask boundary and get outlined (the reported bug). Bind a disabled clip
+      // (enabled=0) so the mask is the full surface footprint. The GLOBAL slab
+      // still applies (it rides in cd.projection, shared with the live draw), and
+      // the visible clipped surface + its interior cap are drawn by separate
+      // passes that keep the per-rep clip — only the contour changes.
+      { struct { float front, back, enabled, pad; } _cl = { -1.0f, 1e6f, 0.0f, 0.0f };
         [ce setFragmentBytes:&_cl length:sizeof(_cl) atIndex:1]; }
       if (cd.ibo) {
         [ce drawIndexedPrimitives:MTLPrimitiveTypeTriangle

--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -113,7 +113,7 @@
 		F2078076B68D28457409F7A5 /* RayMol.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RayMol.entitlements; sourceTree = "<group>"; };
 		F607D204A410CA38B84223BE /* RayMolUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RayMolUpdater.swift; sourceTree = "<group>"; };
 		FB1304C662D9011F7C4505FC /* MCPStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPStatusView.swift; sourceTree = "<group>"; };
-		"TEMP_5EBB7E6B-A0AE-4165-81DA-0850DBB9ED0C" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
+		"TEMP_1D57EF62-1208-465D-B283-30D1E9C88DB0" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -165,6 +165,13 @@
 			path = PyMOLViewerUITests;
 			sourceTree = "<group>";
 		};
+		2546ADB0463B97DEFECC69B7 /* agent-memory */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = "agent-memory";
+			sourceTree = "<group>";
+		};
 		3EBD6226DB025AF86B7A30A2 = {
 			isa = PBXGroup;
 			children = (
@@ -202,8 +209,17 @@
 				F607D204A410CA38B84223BE /* RayMolUpdater.swift */,
 				7D3E805AC2D63B01AB7EE29C /* Theme.swift */,
 				EDC5E722722DEF7FBB1D649F /* ThemeManager.swift */,
+				8A6984461B8872674752E6C0 /* .claude */,
 			);
 			path = Shared;
+			sourceTree = "<group>";
+		};
+		8A6984461B8872674752E6C0 /* .claude */ = {
+			isa = PBXGroup;
+			children = (
+				2546ADB0463B97DEFECC69B7 /* agent-memory */,
+			);
+			path = .claude;
 			sourceTree = "<group>";
 		};
 		9CB24941D41B87B6FB69845B /* Products */ = {
@@ -225,10 +241,10 @@
 			path = Bridge;
 			sourceTree = "<group>";
 		};
-		"TEMP_3D944F36-002C-4481-8434-A30C1D2E15C5" /* swiftui */ = {
+		"TEMP_9F36A463-CC38-4F20-BEED-3893FD6257E0" /* swiftui */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_5EBB7E6B-A0AE-4165-81DA-0850DBB9ED0C" /* PyMOLBridge.xcconfig */,
+				"TEMP_1D57EF62-1208-465D-B283-30D1E9C88DB0" /* PyMOLBridge.xcconfig */,
 			);
 			path = swiftui;
 			sourceTree = "<group>";
@@ -852,7 +868,7 @@
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -866,7 +882,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.5.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -882,7 +898,7 @@
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -896,7 +912,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.5.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -913,7 +929,7 @@
 				CODE_SIGN_ENTITLEMENTS = PyMOLViewer/RayMol.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = VT99UQUQ89;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -929,7 +945,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.5.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -966,7 +982,7 @@
 				CODE_SIGN_ENTITLEMENTS = PyMOLViewer/RayMol.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = VT99UQUQ89;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -982,7 +998,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.5.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -994,7 +1010,7 @@
 		};
 		76B7E9DB75E073D1E60928FA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_5EBB7E6B-A0AE-4165-81DA-0850DBB9ED0C" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_1D57EF62-1208-465D-B283-30D1E9C88DB0" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1079,7 +1095,7 @@
 		};
 		D8F44FDFF036013D2F03BA83 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_5EBB7E6B-A0AE-4165-81DA-0850DBB9ED0C" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_1D57EF62-1208-465D-B283-30D1E9C88DB0" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -377,6 +377,19 @@ struct ContentView: View {
                         // right column is collapsed (where MousePanel used to live).
                         // Minimizable to a small mouse button to free up the view.
                         .overlay(alignment: .bottomTrailing) { mouseLegendCard }
+                        // Opt-in glanceable scene buttons (Scenes inspector →
+                        // "Show scene buttons in viewport"). The iOS path wires
+                        // this in viewportView; macOS needs it here too. Flat 12pt
+                        // bottom padding: the TransportBar docks BELOW the viewport
+                        // frame (sibling in the VStack), so no transport clearance
+                        // is needed as on iOS.
+                        .overlay(alignment: .bottomLeading) {
+                            if showSceneButtons && !engine.sceneNames.isEmpty {
+                                sceneButtonsOverlay
+                                    .padding(.leading, 12)
+                                    .padding(.bottom, 12)
+                            }
+                        }
                     if engine.hasTimeline {
                         Divider()
                         TransportBar()
@@ -554,6 +567,34 @@ struct ContentView: View {
     // Scenes tab: opt-in glanceable scene buttons overlaid on the viewport.
     // Also outside #if os(iOS) since inspectorSwitcher (shared) binds to it.
     @State private var showSceneButtons = false
+
+    // Floating scene chips over the viewport (teal/global), shown only when the
+    // Scenes tab's "Show scene buttons in viewport" toggle is on. Tap = recall.
+    // Declared outside #if os(iOS) so BOTH the iOS viewportView overlay and the
+    // macOS macOSLayout viewport overlay can consume it (single source of truth).
+    private var sceneButtonsOverlay: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                ForEach(engine.sceneNames, id: \.self) { name in
+                    let sel = name == engine.currentScene
+                    Button {
+                        engine.runCommand("scene \(name), recall, animate=1")
+                    } label: {
+                        Text(name)
+                            .font(.system(size: 12, weight: .bold, design: .monospaced))
+                            .padding(.horizontal, 9).frame(height: 28)
+                            .background(sel ? TimelineTheme.accent : Color.white.opacity(0.92))
+                            .foregroundColor(sel ? .white : TimelineTheme.accent)
+                            .clipShape(RoundedRectangle(cornerRadius: 7))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(6)
+        }
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 11))
+        .frame(maxWidth: 230)
+    }
 
     #if os(iOS)
     // Default to the Objects tab: a touch user tunes representations far more
@@ -1347,31 +1388,7 @@ struct ContentView: View {
         #endif
     }
 
-    // Floating scene chips over the viewport (teal/global), shown only when the
-    // Scenes tab's "Show scene buttons in viewport" toggle is on. Tap = recall.
-    private var sceneButtonsOverlay: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 6) {
-                ForEach(engine.sceneNames, id: \.self) { name in
-                    let sel = name == engine.currentScene
-                    Button {
-                        engine.runCommand("scene \(name), recall, animate=1")
-                    } label: {
-                        Text(name)
-                            .font(.system(size: 12, weight: .bold, design: .monospaced))
-                            .padding(.horizontal, 9).frame(height: 28)
-                            .background(sel ? TimelineTheme.accent : Color.white.opacity(0.92))
-                            .foregroundColor(sel ? .white : TimelineTheme.accent)
-                            .clipShape(RoundedRectangle(cornerRadius: 7))
-                    }
-                    .buttonStyle(.plain)
-                }
-            }
-            .padding(6)
-        }
-        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 11))
-        .frame(maxWidth: 230)
-    }
+    // (sceneButtonsOverlay moved above, outside #if os(iOS), so macOS can use it.)
 
     private var viewportView: some View {
         MetalViewport()

--- a/swiftui/make_dmg.sh
+++ b/swiftui/make_dmg.sh
@@ -32,7 +32,12 @@ set -euo pipefail
 
 PYMOL_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SWIFTUI="$PYMOL_ROOT/swiftui"
-DERIVED="$HOME/Library/Developer/Xcode/DerivedData/PyMOLViewer-aqnajyficesyypbspyruqcvqhkhp/Build/Products/Release"
+# DerivedData path is keyed off the .xcodeproj's absolute path, so building from
+# a git worktree lands in a different dir than a hardcoded main-repo hash. Pin it
+# explicitly (below, via -derivedDataPath) so the build location is deterministic
+# from any checkout — main repo or worktree. Artifact contents are unaffected.
+RELEASE_DD="$PYMOL_ROOT/build_mac_release_dd"
+DERIVED="$RELEASE_DD/Build/Products/Release"
 ENTITLEMENTS="$SWIFTUI/RayMol_DeveloperID.entitlements"
 WORK="$PYMOL_ROOT/build_dmg"
 APPNAME="RayMol"
@@ -74,6 +79,7 @@ else
 fi
 xcodebuild -project "$SWIFTUI/PyMOLViewer.xcodeproj" -scheme PyMOLViewer_macOS \
   -configuration Release -destination 'platform=macOS,arch=arm64' \
+  -derivedDataPath "$RELEASE_DD" \
   CODE_SIGNING_ALLOWED=NO build >/dev/null
 SRC_APP="$DERIVED/$APPNAME.app"
 [ -d "$SRC_APP" ] || { echo "ERROR: built app not found at $SRC_APP"; exit 1; }
@@ -175,7 +181,13 @@ cp -R "$APP" "$DMGROOT/"
 ln -s /Applications "$DMGROOT/Applications"
 DMG="$PYMOL_ROOT/$APPNAME-$VERSION.dmg"
 rm -f "$DMG"
-hdiutil create -volname "$APPNAME" -srcfolder "$DMGROOT" -fs HFS+ -format UDZO -ov "$DMG"
+# Mount-free packaging: `hdiutil create -srcfolder` mounts a temp volume at
+# /Volumes/RayMol, which sandbox/TCC blocks in automated runs. makehybrid +
+# convert produces an identical UDZO DMG without ever mounting a volume.
+RAW="$WORK/raw.dmg"; rm -f "$RAW"
+hdiutil makehybrid -hfs -hfs-volume-name "$APPNAME" -o "$RAW" "$DMGROOT"
+hdiutil convert "$RAW" -format UDZO -o "$DMG"
+rm -f "$RAW"
 
 echo "== 7/8  Sign + notarize + staple the DMG =="
 codesign --force --timestamp --sign "$DEVID" "$DMG"

--- a/swiftui/project.yml
+++ b/swiftui/project.yml
@@ -56,8 +56,8 @@ targets:
         PRODUCT_NAME: RayMol
         PRODUCT_BUNDLE_IDENTIFIER: io.raymol.RayMol
         INFOPLIST_GENERATION_MODE: GeneratedFile
-        MARKETING_VERSION: "1.4.1"
-        CURRENT_PROJECT_VERSION: 13
+        MARKETING_VERSION: "1.5.0"
+        CURRENT_PROJECT_VERSION: 14
         GENERATE_INFOPLIST_FILE: YES
         # Generate a launch screen so iOS renders at the device's NATIVE
         # resolution. Without it the app is letterboxed at a legacy size on


### PR DESCRIPTION
## Summary
Cuts **RayMol 1.5.0 (build 14)** and fixes the two bugs found in RC testing.

### RC bug fixes (this PR)
- **Surface outer-contour no longer traces the per-rep clip cut.** The contour's coverage-mask pass was applying the per-representation "peek inside" clip, so the clip cross-section entered the outlined boundary. It now builds the mask from the full surface footprint, so the contour hugs only the true outer silhouette. Global slab clipping still applies; the visible clipped surface, its interior cap, and the AO-exempt path are unaffected. (`layerGraphics/metal/RendererMetal.mm`)
- **"Show scene buttons in viewport" now works on macOS.** The toggle already drove `showSceneButtons`, but the overlay consuming it was compiled `#if os(iOS)` only, so `macOSLayout` never rendered it. `sceneButtonsOverlay` is moved out of the iOS block and attached to the macOS viewport. (`swiftui/PyMOLViewer/Shared/ContentView.swift`)

Both root causes were adversarially verified against the code and both fixes confirmed live in the RC.

### Release prep
- Bump to `1.5.0` / build `14` (`project.yml` + regenerated `project.pbxproj`).
- Release notes: `docs/release-notes/v1.5.0.md`.
- `build(release)`: `make_dmg.sh` now builds from any checkout (pinned `-derivedDataPath`) and packages the DMG mount-free (`makehybrid`), so releases can be cut from a worktree / automated run.

### 1.5.0 headline content (already on master)
Surface outer-contour outline (+ contour color, works on transparent/clipped), per-representation surface clipping, macOS/iPad inspector segmented switcher, per-object Flat-sheets toggle, camera rotation-axis selector, and Metal fidelity fixes (flat β-sheets, per-rep line width, SSAO/shadow silhouettes, surface transparency reset). Closes the earlier-reported #72 and #73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)