### PR TITLE
fix(metal): scale-aware normal-offset shadows — no cartoon triangles, keep inter-element shadows (#87)

### DIFF
--- a/layer1/SceneRender.cpp
+++ b/layer1/SceneRender.cpp
@@ -1844,7 +1844,7 @@ static void SceneRenderPostProcessStack(PyMOLGlobals* G, const GLFramebufferConf
 // scene radius. Loaded as the renderer's PROJECTION while MODELVIEW stays the
 // camera modelview, so vbo_vertex's projection*(modelview*model) yields light
 // clip for model-space vertices.
-static glm::mat4 SceneBuildLightViewProjEye(PyMOLGlobals* G)
+static glm::mat4 SceneBuildLightViewProjEye(PyMOLGlobals* G, float* outRadius = nullptr)
 {
   float mn[3], mx[3];
   glm::vec3 centerEye(0.0f);
@@ -1872,6 +1872,9 @@ static glm::mat4 SceneBuildLightViewProjEye(PyMOLGlobals* G)
   glm::mat4 lightView = glm::lookAt(lightPos, centerEye, up);
   glm::mat4 lightProj =
       glm::ortho(-radius, radius, -radius, radius, 0.05f, radius * 4.0f);
+  if (outRadius)
+    *outRadius = radius; // world half-extent of the ortho box; the renderer
+                         // turns this into a scale-aware shadow bias (Angstroms)
   return lightProj * lightView;
 }
 
@@ -2127,9 +2130,11 @@ void SceneRenderMetal(PyMOLGlobals* G)
   // (an object visible only in cell B darkening an object in cell A). Grid mode
   // therefore renders unshadowed (geometry-only parity for now).
   if (!I->grid.active && SettingGetGlobal_b(G, cSetting_metal_shadows)) {
-    glm::mat4 lightVP_eye = SceneBuildLightViewProjEye(G);
+    float shadowRadius = 1.0f;
+    glm::mat4 lightVP_eye = SceneBuildLightViewProjEye(G, &shadowRadius);
     const float* mvp = SceneGetModelViewMatrixPtr(G);
     G->Renderer->setLightViewProjEye(glm::value_ptr(lightVP_eye));
+    G->Renderer->setShadowFrustum(shadowRadius);
     G->Renderer->matrixMode(0x1701); // PROJECTION = light VP (eye space)
     G->Renderer->loadMatrixf(glm::value_ptr(lightVP_eye));
     G->Renderer->matrixMode(0x1700); // MODELVIEW = camera modelview

--- a/layerGraphics/Renderer.h
+++ b/layerGraphics/Renderer.h
@@ -352,6 +352,10 @@ public:
   virtual void beginShadowPass() {}
   virtual void endShadowPass() {}
   virtual void setLightViewProjEye(const float* m) {}
+  // World half-extent of the shadow ortho box, so the receiver can express its
+  // self-shadow bias in Angstroms (scale-invariant) rather than a frustum
+  // fraction. Default: no-op (GL unaffected).
+  virtual void setShadowFrustum(float radius) {}
 
   // GPU-tessellated Bezier tubes ("tube cartoon"). controlPoints is a tightly
   // packed array of cubic Bezier patches: 4 Float3 control points each

--- a/layerGraphics/metal/RendererMetal.h
+++ b/layerGraphics/metal/RendererMetal.h
@@ -201,6 +201,7 @@ public:
   void beginShadowPass() override;
   void endShadowPass() override;
   void setLightViewProjEye(const float* m) override;
+  void setShadowFrustum(float radius) override;
 
 private:
   void buildImpostorPipelines();
@@ -455,6 +456,9 @@ private:
   NSUInteger _cylinderShadowStride = 0;
   bool _shadowMode = false;       // true between begin/endShadowPass
   float _lightViewProjEye[16];    // eye-space light VP, column-major (PostU)
+  float _shadowRadius = 1.0f;     // world half-extent of the shadow ortho box
+                                  // (from SceneBuildLightViewProjEye); lets the
+                                  // receiver bias be expressed in Angstroms.
   void buildShadowPipelines();
   // Depth-only shadow pipeline for an arbitrary lit vertex layout (e.g. the
   // surface's stride-44), mirroring oitPipelineForVD.

--- a/layerGraphics/metal/RendererMetal.mm
+++ b/layerGraphics/metal/RendererMetal.mm
@@ -1090,6 +1090,22 @@ fragment float4 post_ssao_fog(PostVOut in [[stage_in]],
         float2 dd = float2(dfdx(fragDepth), dfdy(fragDepth));
         float sep = 0.022 + 2.5 * (abs(dd.x) + abs(dd.y));
         sep = min(sep, 0.05);
+        // Cartoon/ribbon receivers (aoExempt, the #79 mask) self-shadow on their
+        // OWN coarse triangle mesh: the shadow map is rasterized from the same
+        // low-poly cartoon tube, so the receiver's light-space depth crosses the
+        // stored (faceted) caster depth per-triangle and the small default `sep`
+        // lets that leak through as blocky, per-triangle self-shadow acne — the
+        // "triangles under shadows". Cartoon self-shadow is unwanted anyway (see
+        // the self-shadow suppression note in this pass), so on cartoon pixels
+        // raise the separation to a fixed fraction of the (scale-invariant)
+        // light-space depth range. This suppresses self + adjacent occlusion so
+        // the ribbon is cleanly lit, while genuinely separated casters (gap >
+        // kCartoonSelfShadowSep) still shadow it. Surface pixels are NOT masked,
+        // so surface pockets keep the fine default sep and their AO/shadow detail.
+        if (aoExempt) {
+          const float kCartoonSelfShadowSep = 0.12;
+          sep = max(sep, kCartoonSelfShadowSep);
+        }
         float2 texel =
             1.0 / float2(shadowTex.get_width(), shadowTex.get_height());
         // 4x4 taps of hardware-bilinear depth comparison (sample_compare with a

--- a/layerGraphics/metal/RendererMetal.mm
+++ b/layerGraphics/metal/RendererMetal.mm
@@ -944,6 +944,7 @@ struct PostU {
   float shadowIntensity;
   float aoExemptEnabled; // >0.5: aoMaskTex marks pixels that skip the SSAO term (#79)
   float4x4 lightViewProj; // eye-space light view*proj for shadow-map sampling
+  float shadowRadius;    // world half-extent of the shadow ortho box (Angstroms)
 };
 
 // Linear eye distance (positive, toward the scene) from window depth [0,1].
@@ -990,6 +991,35 @@ static float3 post_eye_normal(depth2d<float> depthTex, sampler s, float2 uv,
   float3 n = normalize(cross(gx, gy));
   if (n.z < 0.0) n = -n; // face toward camera
   return n;
+}
+
+// Bilaterally-smoothed eye-space normal. A plain depth reconstruction of the
+// coarse cartoon mesh gives a FACETED (flat per-triangle) normal, which made
+// both the light-facing faceGate and the shadow-map self-comparison vary per
+// triangle — the "triangles under shadows". Averaging post_eye_normal over a
+// small neighbourhood, weighted by eye-Z similarity, smooths across the facets
+// (a near-continuous surface normal) but rejects samples across a real
+// silhouette (large depth jump -> ~0 weight), so the #83 edge behaviour is kept.
+static float3 post_eye_normal_smooth(depth2d<float> depthTex, sampler s, float2 uv,
+                                     float2 invres, float cd, float3 cp, float projA,
+                                     float projB, float projX, float projY) {
+  float3 nSum = post_eye_normal(depthTex, s, uv, invres, cd, cp,
+                                projA, projB, projX, projY);
+  float wSum = 1.0;
+  float ztol = max(0.02 * abs(cp.z), 0.05);
+  for (int j = -1; j <= 1; j++)
+    for (int i = -1; i <= 1; i++) {
+      if (i == 0 && j == 0) continue;
+      float2 o = float2(float(i), float(j)) * 2.0 * invres;
+      float dn = depthTex.sample(s, uv + o);
+      if (dn >= 0.99999) continue;
+      float3 pn = post_eye_pos(uv + o, dn, projA, projB, projX, projY);
+      float w = exp(-abs(pn.z - cp.z) / ztol);
+      nSum += post_eye_normal(depthTex, s, uv + o, invres, dn, pn,
+                              projA, projB, projX, projY) * w;
+      wSum += w;
+    }
+  return normalize(nSum);
 }
 
 fragment float4 post_ssao_fog(PostVOut in [[stage_in]],
@@ -1067,45 +1097,42 @@ fragment float4 post_ssao_fog(PostVOut in [[stage_in]],
   //       light than the receiver (a real gap), not the same/adjacent surface.
   if (u.shadowEnabled > 0.5 && d < 0.99999 && !flatCap) {
     float3 p = post_eye_pos(in.uv, d, u.projA, u.projB, u.projX, u.projY);
-    // Eye-space surface normal, reconstructed robustly from the depth buffer so the
-    // stencil never crosses a silhouette (see post_eye_normal). The old
-    // cross(dfdx(p),dfdy(p)) produced garbage normals in a 1-2px band at every
-    // silhouette, giving a noisy faceGate that read as a serrated lighter border.
     float2 invres = 1.0 / float2(colorTex.get_width(), colorTex.get_height());
-    float3 nrm = post_eye_normal(depthTex, s, in.uv, invres, d, p,
-                                 u.projA, u.projB, u.projX, u.projY);
+    // SMOOTH eye-space normal (see post_eye_normal_smooth). The coarse cartoon
+    // mesh yields a faceted per-triangle normal from a plain reconstruction,
+    // which made faceGate + the self-shadow compare step per triangle -> the
+    // "triangles under shadows". The bilateral average removes that.
+    float3 nrm = post_eye_normal_smooth(depthTex, s, in.uv, invres, d, p,
+                                        u.projA, u.projB, u.projX, u.projY);
     float3 Ldir = normalize(float3(0.4, 0.4, 1.0));      // key light (eye space)
     float faceGate = smoothstep(0.0, 0.35, dot(nrm, Ldir));
-    float4 lc = u.lightViewProj * float4(p, 1.0);        // eye -> light clip
+    // Scale-aware, in ANGSTROMS: the light ortho box spans (radius*4 - 0.05) in
+    // world Z, so an Angstrom bias maps to light-space fragDepth as sepA/S. This
+    // is structure-size-invariant (fixes "shadows on some structures, not
+    // others"); the removed sep=0.12 was a frustum FRACTION (~19A dead-zone at
+    // radius 40) that erased genuine inter-element cast shadows.
+    float S = max(u.shadowRadius * 4.0 - 0.05, 1.0);
+    float worldTexel = 2.0 * u.shadowRadius / 4096.0;    // one shadow-map texel
+    float c = clamp(dot(nrm, Ldir), 0.0, 1.0);
+    // Normal-offset shadow mapping: push the receiver OUT along its smooth normal
+    // (more at grazing angles) so the light-space compare leaves the receiver's
+    // OWN stored facet -> self-shadow acne is pushed under map precision, while a
+    // genuinely separated occluder (orders of magnitude farther) still casts.
+    float3 pOff = p + nrm * (1.5 * worldTexel / max(c, 0.25));
+    float4 lc = u.lightViewProj * float4(pOff, 1.0);     // eye -> light clip
     if (faceGate > 0.0 && lc.w > 0.0) {
       float3 ndc = lc.xyz / lc.w;                        // light NDC, GL [-1,1]
       float2 suv = float2(0.5 * ndc.x + 0.5, 0.5 - 0.5 * ndc.y);
       float fragDepth = 0.5 + 0.5 * ndc.z;               // same 0.5+0.5 remap
       if (suv.x > 0.0 && suv.x < 1.0 && suv.y > 0.0 && suv.y < 1.0 &&
           fragDepth > 0.0 && fragDepth < 1.0) {
-        // Separation threshold (light-space depth). Large enough that a thin
-        // cartoon slab or an adjacent coil does NOT cast onto itself, small
-        // enough that a distinctly-separated caster and deep surface pockets
-        // still do. Slope term adds margin on faces grazing to the light.
-        float2 dd = float2(dfdx(fragDepth), dfdy(fragDepth));
-        float sep = 0.022 + 2.5 * (abs(dd.x) + abs(dd.y));
-        sep = min(sep, 0.05);
-        // Cartoon/ribbon receivers (aoExempt, the #79 mask) self-shadow on their
-        // OWN coarse triangle mesh: the shadow map is rasterized from the same
-        // low-poly cartoon tube, so the receiver's light-space depth crosses the
-        // stored (faceted) caster depth per-triangle and the small default `sep`
-        // lets that leak through as blocky, per-triangle self-shadow acne — the
-        // "triangles under shadows". Cartoon self-shadow is unwanted anyway (see
-        // the self-shadow suppression note in this pass), so on cartoon pixels
-        // raise the separation to a fixed fraction of the (scale-invariant)
-        // light-space depth range. This suppresses self + adjacent occlusion so
-        // the ribbon is cleanly lit, while genuinely separated casters (gap >
-        // kCartoonSelfShadowSep) still shadow it. Surface pixels are NOT masked,
-        // so surface pockets keep the fine default sep and their AO/shadow detail.
-        if (aoExempt) {
-          const float kCartoonSelfShadowSep = 0.12;
-          sep = max(sep, kCartoonSelfShadowSep);
-        }
+        // Slope-scaled bias in ANGSTROMS -> fragDepth (sepA/S), plus a one-texel
+        // floor for depth quantisation on large assemblies. Small enough that
+        // real inter-element gaps (~2A+) still cast; the slope term covers steep
+        // facets where the normal-offset alone leaves residual self-crossing.
+        float slopeTan = sqrt(max(0.0, 1.0 - c * c)) / max(c, 0.15);
+        float sepA = clamp(0.35 + 1.2 * slopeTan, 0.35, 6.0);
+        float sep = sepA / S + 1.0 / 4096.0;
         float2 texel =
             1.0 / float2(shadowTex.get_width(), shadowTex.get_height());
         // 4x4 taps of hardware-bilinear depth comparison (sample_compare with a
@@ -1608,6 +1635,7 @@ struct RTU {
   float fogStart, fogEnd, aoRadius, aoIntensity;
   float shadowIntensity, nSamples, frame, rtShadow; // rtShadow>0.5: trace shadows
   float4x4 lightViewProj;  // eye-space light view*proj for shadow-map sampling
+  float shadowRadius;      // world half-extent of the shadow ortho box (Angstroms)
 };
 
 static float rt_hash(float2 p) {
@@ -1722,13 +1750,13 @@ fragment float4 rt_composite(PostVOut in [[stage_in]],
   if (d >= 0.99999) return float4(col, 1.0);  // background: leave as-is
   if (d <= 0.0015) return float4(col, 1.0);   // interior-cap cross-section: flat
 
-  // Eye-space position + robust normal (matches post_ssao_fog reconstruction).
-  // post_eye_normal avoids the cross-silhouette derivative blow-up that plain
-  // cross(dfdx,dfdy) produces (serrated lighter shadow border on edges).
+  // Eye-space position + SMOOTH normal (matches post_ssao_fog). The bilateral
+  // smoothing removes the coarse-mesh facet normal that made faceGate + the
+  // shadow-map self-compare step per triangle.
   float3 pEye = post_eye_pos(in.uv, d, u.projA, u.projB, u.projX, u.projY);
   float2 invres = 1.0 / float2(colorTex.get_width(), colorTex.get_height());
-  float3 nEye = post_eye_normal(depthTex, s, in.uv, invres, d, pEye,
-                                u.projA, u.projB, u.projX, u.projY);
+  float3 nEye = post_eye_normal_smooth(depthTex, s, in.uv, invres, d, pEye,
+                                       u.projA, u.projB, u.projX, u.projY);
 
   // Depth-aware 5x5 blur of the AO term: weight neighbours by eye-space depth
   // closeness so AO doesn't bleed across object silhouettes.
@@ -1764,17 +1792,25 @@ fragment float4 rt_composite(PostVOut in [[stage_in]],
     float shadow = (1.0 - vis) * faceGate;
     col *= (1.0 - shadow * u.shadowIntensity);
   } else if (u.shadowIntensity > 0.0) {
+    // Default RT path shadow-map fallback: same scale-aware, normal-offset,
+    // Angstrom-bias treatment as post_ssao_fog, so cartoons get proper
+    // inter-element shadows without per-triangle self-shadow acne here too.
     float3 Ldir = normalize(float3(0.4, 0.4, 1.0));      // key light (eye space)
     float faceGate = smoothstep(0.0, 0.35, dot(nEye, Ldir));
-    float4 lc = u.lightViewProj * float4(pEye, 1.0);     // eye -> light clip
+    float S = max(u.shadowRadius * 4.0 - 0.05, 1.0);
+    float worldTexel = 2.0 * u.shadowRadius / 4096.0;
+    float c = clamp(dot(nEye, Ldir), 0.0, 1.0);
+    float3 pOff = pEye + nEye * (1.5 * worldTexel / max(c, 0.25));
+    float4 lc = u.lightViewProj * float4(pOff, 1.0);     // eye -> light clip
     if (faceGate > 0.0 && lc.w > 0.0) {
       float3 ndc = lc.xyz / lc.w;
       float2 suv = float2(0.5 * ndc.x + 0.5, 0.5 - 0.5 * ndc.y);
       float fragDepth = 0.5 + 0.5 * ndc.z;
       if (suv.x > 0.0 && suv.x < 1.0 && suv.y > 0.0 && suv.y < 1.0 &&
           fragDepth > 0.0 && fragDepth < 1.0) {
-        float2 dd = float2(dfdx(fragDepth), dfdy(fragDepth));
-        float sep = min(0.022 + 2.5 * (abs(dd.x) + abs(dd.y)), 0.05);
+        float slopeTan = sqrt(max(0.0, 1.0 - c * c)) / max(c, 0.15);
+        float sepA = clamp(0.35 + 1.2 * slopeTan, 0.35, 6.0);
+        float sep = sepA / S + 1.0 / 4096.0;
         float2 stex = 1.0 / float2(shadowTex.get_width(), shadowTex.get_height());
         float lit = 0.0;
         for (int j = -2; j <= 1; j++)
@@ -2113,6 +2149,7 @@ void RendererMetal::runPostChain()
       float fogStart, fogEnd, aoRadius, aoIntensity;
       float shadowIntensity, nSamples, frame, rtShadow;
       float lightViewProj[16];   // eye-space light VP for shadow-map sampling
+      float shadowRadius;        // matches MSL RTU: shadow ortho half-extent
     } u;
     std::memcpy(u.invModelview, _modelviewInv.data(), 16 * sizeof(float));
     simd_float4x4 inv;
@@ -2143,6 +2180,7 @@ void RendererMetal::runPostChain()
     // composite still gates on shadowIntensity). Default off -> shadow-map path.
     u.rtShadow = _rtShadowEnabled ? 1.0f : 0.0f;
     std::memcpy(u.lightViewProj, _lightViewProjEye, 16 * sizeof(float));
+    u.shadowRadius = _shadowRadius;
 
     // Pass A: trace AO -> _rtAO (R16Float).
     // MRC: all per-frame render-pass descriptors in runPostChain use the
@@ -2238,6 +2276,7 @@ void RendererMetal::runPostChain()
       float aoEnabled, aoIntensity, aoRadiusPx, projX;
       float projY, shadowEnabled, shadowIntensity, aoExemptEnabled;
       float lightViewProj[16]; // eye-space light VP (matches MSL PostU)
+      float shadowRadius;      // matches MSL PostU: shadow ortho half-extent
     } u;
     u.projA = _projA; u.projB = _projB;
     u.fogStart = _fogStart; u.fogEnd = _fogEnd;
@@ -2251,6 +2290,7 @@ void RendererMetal::runPostChain()
     u.shadowIntensity = 0.45f;
     u.aoExemptEnabled = aoMaskReady ? 1.0f : 0.0f;
     std::memcpy(u.lightViewProj, _lightViewProjEye, 16 * sizeof(float));
+    u.shadowRadius = _shadowRadius;
 
     MTLRenderPassDescriptor* pd = [MTLRenderPassDescriptor renderPassDescriptor];
     pd.colorAttachments[0].texture = _postColor;
@@ -2672,6 +2712,11 @@ void RendererMetal::endTransparentOIT()
 void RendererMetal::setLightViewProjEye(const float* m)
 {
   if (m) std::memcpy(_lightViewProjEye, m, 16 * sizeof(float));
+}
+
+void RendererMetal::setShadowFrustum(float radius)
+{
+  _shadowRadius = (radius > 1.0f) ? radius : 1.0f;
 }
 
 void RendererMetal::beginShadowPass()


### PR DESCRIPTION
Fixes #87.

## Problem

Two requirements, in tension:
1. **Remove** the triangular faceting ("triangles under shadows") on cartoon helices when `metal_shadows` is on.
2. **Keep** genuine **inter-element** cast shadows — chain→chain, helix→helix, ligand/sticks→cartoon — which users rely on for depth.

The faceting is **self-shadow acne on the coarse cartoon triangle mesh**: the shadow map is rasterized from the same low-poly tube the receiver later samples, so a ribbon shadows itself per-triangle. Confirmed by instrumentation (dumping each shadow sub-term): the dominant term was blocky per-triangle PCF self-occlusion; the depth-reconstructed normal was faceted, making `faceGate` step per triangle too.

## Why a blunt bias doesn't work

The trap: the self-shadow separation was expressed as a **fraction of the light frustum depth**. A first attempt (`sep = 0.12`) removed the acne but that's ~**19 Å** of required gap at radius 40 — so it also erased real inter-element shadows across typical gaps (helix–helix ~8–12 Å, ligand ~3.5 Å). That's the "shadows not cast / used to work better" regression. The distinguishing principle: **self-shadow acne is facet/precision-scale (sub-Å–~1 Å); genuine inter-element shadows are real spatial gaps (Å–tens of Å).** The cure must be calibrated to the facet scale, not the frustum.

## Fix

Applied to both the screen-space receiver (`post_ssao_fog`) and the default-RT shadow-map fallback (`rt_composite`):

- **Bilaterally-smoothed reconstructed normal** (`post_eye_normal_smooth`, depth-weighted average that crosses facets but not silhouettes) → `faceGate` + the offset direction no longer step per triangle. No G-buffer needed.
- **Normal-offset shadow mapping**: push the receiver point out along the smooth normal by ~1.5 shadow-map texels (more at grazing angles) so the light-space compare leaves the receiver's own stored facet → acne pushed under map precision.
- **Bias in absolute Ångströms** (const 0.35 + slope up to 6, + a one-texel floor), mapped to light-space depth via the frustum span `S = radius*4 − 0.05`. Structure-size-invariant → consistent across small and large structures; a real inter-element gap (≳2 Å) is far larger than the bias, so it still casts.
- **Plumb the ortho half-extent `radius` explicitly** from `SceneBuildLightViewProjEye` → `setShadowFrustum` → `PostU/RTU.shadowRadius` (deriving it in-shader is wrong by ~7.7%). Appended after `lightViewProj` to keep the mat4 alignment intact.
- The #79 `aoExempt` mask now touches **only** the SSAO term again (its original job).

**Rejected:** a smooth-normal **G-buffer** (2nd MRT attachment) — it would force every opaque scene pipeline to declare `color(1)` or Metal fails pipeline creation and floods errors; large, crash-prone. The contained shader-only approach above achieves the same cure.

_Design was produced and adversarially verified via a multi-agent workflow (map pipeline → 3 candidate designs → skeptic per design → synthesis), which caught the G-buffer regression surface and the in-shader radius math error before any code was written._

## Verification (host offscreen A/B, multiple angles + zoom levels; interactive confirmation)

_(The isolated mac-vm-test VM harness was used to A/B the earlier iteration; this Metal-shader change renders identically host/VM.)_

Before (acne) vs after (fix), across angles and zoom levels:
- **256b helix bundle** (4 views): triangles gone at every angle/zoom; inter-helix cast shadows present.
- **Ubiquitin β-sheet** (4 views): flat strand planks smooth; strand→strand + helix→sheet shadows present.
- **Hemoglobin**: inter-chain shadows at the α/β interface.
- Diff heatmaps confirm only the acne/shadow regions changed (background + lit areas untouched); result matches the PyMOL **CPU ray-tracer** reference look.

## Files
- `layer1/SceneRender.cpp` — expose `radius`, call `setShadowFrustum`
- `layerGraphics/Renderer.h`, `layerGraphics/metal/RendererMetal.h` — `setShadowFrustum` + `_shadowRadius`
- `layerGraphics/metal/RendererMetal.mm` — `post_eye_normal_smooth`, rewrite the shadow blocks in `post_ssao_fog` + `rt_composite`, `shadowRadius` in PostU/RTU (MSL + CPU)

macOS SwiftUI + Metal. Core lib + Xcode app both rebuilt.
