### PR TITLE
feat(metal): metal_shadow_bias setting + stronger grazing default for steep-angle strand acne

### DIFF
--- a/layer1/SceneRender.cpp
+++ b/layer1/SceneRender.cpp
@@ -2135,6 +2135,7 @@ void SceneRenderMetal(PyMOLGlobals* G)
     const float* mvp = SceneGetModelViewMatrixPtr(G);
     G->Renderer->setLightViewProjEye(glm::value_ptr(lightVP_eye));
     G->Renderer->setShadowFrustum(shadowRadius);
+    G->Renderer->setShadowBias(SettingGetGlobal_f(G, cSetting_metal_shadow_bias));
     G->Renderer->matrixMode(0x1701); // PROJECTION = light VP (eye space)
     G->Renderer->loadMatrixf(glm::value_ptr(lightVP_eye));
     G->Renderer->matrixMode(0x1700); // MODELVIEW = camera modelview

--- a/layer1/SettingInfo.h
+++ b/layer1/SettingInfo.h
@@ -930,6 +930,7 @@ enum {
   REC_c( 820, surface_contour_color                   , object    , "-1" ),  /* Metal: surface outer-contour color; -1 = inherit the surface/object color, else a named/hex color. */
   REC_b( 821, surface_contour_opaque                  , object    , true ),  /* Metal: surface outer-contour is fully opaque (crisp); off = the line picks up the surface transparency. */
   REC_b( 822, metal_ssao_cartoon                      , global    , false ), /* Metal: include cartoon/ribbon in the screen-space SSAO (crease/contour) pass. Default off => cartoons are excluded from SSAO darkening (avoids spurious contour lines on ribbon silhouettes/self-folds, #79); they still receive directional shadows, and surface pockets keep their AO. */
+  REC_f( 823, metal_shadow_bias                       , global    , 1.0F ),  /* Metal: multiplier on the self-shadow depth bias. 1.0 = default. Raise (e.g. 2-4) if flat cartoon strands still show striped self-shadow "triangle" acne at steep/grazing angles; lower toward 0 for tighter contact shadows. */
 
 #ifdef SETTINGINFO_IMPLEMENTATION
 #undef SETTINGINFO_IMPLEMENTATION

--- a/layerGraphics/Renderer.h
+++ b/layerGraphics/Renderer.h
@@ -356,6 +356,9 @@ public:
   // self-shadow bias in Angstroms (scale-invariant) rather than a frustum
   // fraction. Default: no-op (GL unaffected).
   virtual void setShadowFrustum(float radius) {}
+  // User multiplier on the self-shadow depth bias (metal_shadow_bias). Default
+  // no-op (GL unaffected).
+  virtual void setShadowBias(float bias) {}
 
   // GPU-tessellated Bezier tubes ("tube cartoon"). controlPoints is a tightly
   // packed array of cubic Bezier patches: 4 Float3 control points each

--- a/layerGraphics/metal/RendererMetal.h
+++ b/layerGraphics/metal/RendererMetal.h
@@ -202,6 +202,7 @@ public:
   void endShadowPass() override;
   void setLightViewProjEye(const float* m) override;
   void setShadowFrustum(float radius) override;
+  void setShadowBias(float bias) override;
 
 private:
   void buildImpostorPipelines();
@@ -459,6 +460,8 @@ private:
   float _shadowRadius = 1.0f;     // world half-extent of the shadow ortho box
                                   // (from SceneBuildLightViewProjEye); lets the
                                   // receiver bias be expressed in Angstroms.
+  float _shadowBias = 1.0f;       // metal_shadow_bias: user multiplier on the
+                                  // self-shadow depth bias.
   void buildShadowPipelines();
   // Depth-only shadow pipeline for an arbitrary lit vertex layout (e.g. the
   // surface's stride-44), mirroring oitPipelineForVD.

--- a/layerGraphics/metal/RendererMetal.mm
+++ b/layerGraphics/metal/RendererMetal.mm
@@ -945,6 +945,7 @@ struct PostU {
   float aoExemptEnabled; // >0.5: aoMaskTex marks pixels that skip the SSAO term (#79)
   float4x4 lightViewProj; // eye-space light view*proj for shadow-map sampling
   float shadowRadius;    // world half-extent of the shadow ortho box (Angstroms)
+  float shadowBias;      // metal_shadow_bias: user multiplier on the self-shadow bias
 };
 
 // Linear eye distance (positive, toward the scene) from window depth [0,1].
@@ -1131,7 +1132,7 @@ fragment float4 post_ssao_fog(PostVOut in [[stage_in]],
         // real inter-element gaps (~2A+) still cast; the slope term covers steep
         // facets where the normal-offset alone leaves residual self-crossing.
         float slopeTan = sqrt(max(0.0, 1.0 - c * c)) / max(c, 0.15);
-        float sepA = clamp(0.35 + 1.2 * slopeTan, 0.35, 6.0);
+        float sepA = min(0.35 + 1.2 * slopeTan, 12.0) * u.shadowBias;
         float sep = sepA / S + 1.0 / 4096.0;
         float2 texel =
             1.0 / float2(shadowTex.get_width(), shadowTex.get_height());
@@ -1636,6 +1637,7 @@ struct RTU {
   float shadowIntensity, nSamples, frame, rtShadow; // rtShadow>0.5: trace shadows
   float4x4 lightViewProj;  // eye-space light view*proj for shadow-map sampling
   float shadowRadius;      // world half-extent of the shadow ortho box (Angstroms)
+  float shadowBias;        // metal_shadow_bias: user multiplier on the self-shadow bias
 };
 
 static float rt_hash(float2 p) {
@@ -1809,7 +1811,7 @@ fragment float4 rt_composite(PostVOut in [[stage_in]],
       if (suv.x > 0.0 && suv.x < 1.0 && suv.y > 0.0 && suv.y < 1.0 &&
           fragDepth > 0.0 && fragDepth < 1.0) {
         float slopeTan = sqrt(max(0.0, 1.0 - c * c)) / max(c, 0.15);
-        float sepA = clamp(0.35 + 1.2 * slopeTan, 0.35, 6.0);
+        float sepA = min(0.35 + 1.2 * slopeTan, 12.0) * u.shadowBias;
         float sep = sepA / S + 1.0 / 4096.0;
         float2 stex = 1.0 / float2(shadowTex.get_width(), shadowTex.get_height());
         float lit = 0.0;
@@ -2150,6 +2152,7 @@ void RendererMetal::runPostChain()
       float shadowIntensity, nSamples, frame, rtShadow;
       float lightViewProj[16];   // eye-space light VP for shadow-map sampling
       float shadowRadius;        // matches MSL RTU: shadow ortho half-extent
+      float shadowBias;          // matches MSL RTU: metal_shadow_bias multiplier
     } u;
     std::memcpy(u.invModelview, _modelviewInv.data(), 16 * sizeof(float));
     simd_float4x4 inv;
@@ -2181,6 +2184,7 @@ void RendererMetal::runPostChain()
     u.rtShadow = _rtShadowEnabled ? 1.0f : 0.0f;
     std::memcpy(u.lightViewProj, _lightViewProjEye, 16 * sizeof(float));
     u.shadowRadius = _shadowRadius;
+    u.shadowBias = _shadowBias;
 
     // Pass A: trace AO -> _rtAO (R16Float).
     // MRC: all per-frame render-pass descriptors in runPostChain use the
@@ -2277,6 +2281,7 @@ void RendererMetal::runPostChain()
       float projY, shadowEnabled, shadowIntensity, aoExemptEnabled;
       float lightViewProj[16]; // eye-space light VP (matches MSL PostU)
       float shadowRadius;      // matches MSL PostU: shadow ortho half-extent
+      float shadowBias;        // matches MSL PostU: metal_shadow_bias multiplier
     } u;
     u.projA = _projA; u.projB = _projB;
     u.fogStart = _fogStart; u.fogEnd = _fogEnd;
@@ -2291,6 +2296,7 @@ void RendererMetal::runPostChain()
     u.aoExemptEnabled = aoMaskReady ? 1.0f : 0.0f;
     std::memcpy(u.lightViewProj, _lightViewProjEye, 16 * sizeof(float));
     u.shadowRadius = _shadowRadius;
+    u.shadowBias = _shadowBias;
 
     MTLRenderPassDescriptor* pd = [MTLRenderPassDescriptor renderPassDescriptor];
     pd.colorAttachments[0].texture = _postColor;
@@ -2717,6 +2723,11 @@ void RendererMetal::setLightViewProjEye(const float* m)
 void RendererMetal::setShadowFrustum(float radius)
 {
   _shadowRadius = (radius > 1.0f) ? radius : 1.0f;
+}
+
+void RendererMetal::setShadowBias(float bias)
+{
+  _shadowBias = (bias > 0.0f) ? bias : 0.0f;
 }
 
 void RendererMetal::beginShadowPass()


### PR DESCRIPTION
Follow-up to #88 (issue #87). On flat cartoon **β-strands at steep/grazing angles**, residual striped self-shadow acne remained — the strand normal is ~perpendicular to the light so the normal-offset barely moves the light-space sample and the slope-scaled bias hit its cap.

## Changes
- **Raise the grazing self-shadow bias cap 6 → 12 Å.** Only affects the steepest facets (where the cap was biting); non-grazing bias stays ~0.35 Å, so inter-element and contact shadows are unchanged.
- **Add `metal_shadow_bias`** (global float, default 1.0) — a runtime multiplier on the self-shadow bias, plumbed via a small `setShadowBias()` setter into `PostU/RTU.shadowBias` (both the screen-space `post_ssao_fog` and the RT-composite shadow paths). `set metal_shadow_bias, 2..4` clears steep-angle strand acne on structures where it persists; lower toward 0 for tighter contact shadows.

## Verified
- The knob monotonically modulates self-shadow (helix mean luminance 147.9 / 150.7 / 154.2 at bias 0.2 / 1 / 3).
- Default (bias 1, cap 12) preserves inter-element cast shadows; β-strand + helix views clean at grazing angles.

macOS SwiftUI + Metal; core + app rebuilt.