### PR TITLE
feat(metal): adaptive cartoon LOD (zoom-driven cartoon_sampling) + display-aware upscale

### DIFF
--- a/docs/superpowers/plans/2026-07-02-adaptive-cartoon-lod.md
+++ b/docs/superpowers/plans/2026-07-02-adaptive-cartoon-lod.md
@@ -1,0 +1,329 @@
+# Adaptive Cartoon LOD + Display-Aware Upscale — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Adaptively raise cartoon tessellation when zoomed in (debounced whole-object rebuild) and auto-enable reduced-res upscale only on Retina displays.
+
+**Architecture:** Pure LOD math (Å/px → sampling with hysteresis; Retina check) is isolated and unit-tested standalone. The debounce timer + triggers live in Swift (`MetalViewport`/`PyMOLEngine`) because RayMol renders on-demand (no per-frame poll at settle). Settings live in the core; the renderer already exposes `_upscaleEnabled`.
+
+**Tech Stack:** C++17 core (`layer1`), Metal renderer (`layerGraphics/metal`), SwiftUI app (`swiftui/PyMOLViewer`), `swift` CLI for standalone unit tests.
+
+## Global Constraints
+
+- Two-stage build every time (macos_swiftui_build_verify): `bash swiftui/build_macos.sh` (core) **then** `xcodebuild -project swiftui/PyMOLViewer.xcodeproj -scheme PyMOLViewer_macOS -configuration Debug -derivedDataPath swiftui/build_mac_dd build`. xcodebuild alone links a stale `libpymol_core.a`.
+- Setting indices are contiguous; next free after `822 metal_ssao_cartoon` and `823 metal_shadow_bias` is **824**.
+- New settings default to preserving current behavior EXCEPT `cartoon_sampling_dynamic` (default on) and `metal_upscale` auto (default 2) — both approved.
+- Feature branch already checked out: `feat/adaptive-cartoon-lod` (off master `c9ab45f65`). Never push to master; PR at the end.
+- Verify functionally via host offscreen render (`PYMOL_AUTOCMD` + `PYMOL_AUTOEXPORT`) and the mac-vm-test VM. This codebase verifies rendering features functionally, not via GL unit tests.
+
+---
+
+### Task 1: Add settings
+
+**Files:**
+- Modify: `layer1/SettingInfo.h` (after line 909 `metal_shadows` block / the 823 line)
+
+**Interfaces:**
+- Produces: `cSetting_cartoon_sampling_dynamic` (bool), `cSetting_cartoon_sampling_max` (int), `cSetting_metal_upscale` (now int 0..2).
+
+- [ ] **Step 1: Change `metal_upscale` from bool to int (0=off,1=on,2=auto), default 2**
+
+In `layer1/SettingInfo.h`, replace the existing line (currently `REC_b( 814, metal_upscale ... , false )`):
+```c
+  REC_i( 814, metal_upscale                            , global    , 2, 0, 2 ), /* Metal: reduced-res render + upscale. 0=off, 1=on, 2=auto (on only on Retina displays where the blur is hidden). */
+```
+
+- [ ] **Step 2: Add the two cartoon LOD settings after index 823 (`metal_shadow_bias`)**
+```c
+  REC_b( 824, cartoon_sampling_dynamic                 , global    , true ), /* Adaptively raise/lower cartoon_sampling with zoom (debounced whole-object rebuild). Off = static cartoon_sampling. */
+  REC_i( 825, cartoon_sampling_max                     , global    , -1 ),   /* Detail ceiling used by cartoon_sampling_dynamic when zoomed in. -1 = auto (scaled down by atom count). */
+```
+
+- [ ] **Step 3: Build the core**
+
+Run: `bash swiftui/build_macos.sh 2>&1 | tail -2`
+Expected: ends with `Built target pymol_core` / `arm64` (no errors).
+
+- [ ] **Step 4: Verify the setting names resolve (compile-time)**
+
+Run: `grep -nE "cSetting_cartoon_sampling_dynamic|cSetting_cartoon_sampling_max|cSetting_metal_upscale" build_macos_swiftui/*/SettingInfo.h 2>/dev/null || grep -c "cartoon_sampling_dynamic" layer1/SettingInfo.h`
+Expected: nonzero (the cSetting_ enums are generated from these lines).
+
+- [ ] **Step 5: Commit**
+```bash
+git add layer1/SettingInfo.h
+git commit -m "feat(metal): add cartoon_sampling_dynamic/_max settings; metal_upscale -> int 0/1/2"
+```
+
+---
+
+### Task 2: Pure LOD math (standalone unit-tested), then place in app source
+
+**Files:**
+- Create: `swiftui/PyMOLViewer/Shared/CartoonLOD.swift`
+- Test (throwaway, do not commit): `/tmp/CartoonLODTest.swift`
+
+**Interfaces:**
+- Produces (Swift, all pure/static, no state):
+  - `CartoonLOD.angstromPerPixel(cameraDistance: Float, fovDegrees: Float, viewportHeightPx: Float) -> Float`
+  - `CartoonLOD.targetSampling(angstromPerPixel: Float, maxSampling: Int, current: Int) -> Int`  (buckets + hysteresis)
+  - `CartoonLOD.autoUpscale(backingScale: CGFloat) -> Bool`  (`>= 2.0`)
+
+- [ ] **Step 1: Write the failing standalone test**
+
+Create `/tmp/CartoonLODTest.swift` (contains a copy of the functions so it compiles alone; you'll paste the same bodies into the real file in Step 3):
+```swift
+import Foundation
+
+enum CartoonLOD {
+    static func angstromPerPixel(cameraDistance: Float, fovDegrees: Float, viewportHeightPx: Float) -> Float {
+        guard viewportHeightPx >= 1 else { return 1e9 }
+        let halfTan = tan(fovDegrees * 0.5 * .pi / 180)
+        return (2 * abs(cameraDistance) * halfTan) / viewportHeightPx
+    }
+    // Coarse->fine buckets by Å/px upper bound. Hysteresis: only move to a
+    // different bucket when past its boundary by a 20% margin relative to the
+    // direction of change, so hovering a threshold does not thrash.
+    static func targetSampling(angstromPerPixel a: Float, maxSampling: Int, current: Int) -> Int {
+        let edges: [(Float, Int)] = [(0.05, maxSampling), (0.10, 12), (0.25, 8), (0.50, 5)]
+        // pick raw bucket: first edge whose upper bound a < edge.0 ... else floor 3
+        func raw(_ x: Float) -> Int {
+            for (ub, s) in edges { if x < ub { return s } }
+            return 3
+        }
+        let t = raw(a)
+        if t == current { return current }
+        // hysteresis: require a to be 20% past the boundary in the move direction
+        let margin: Float = (t > current) ? 0.83 : 1.20  // finer needs a smaller, coarser needs a larger
+        let a2 = a * margin
+        return raw(a2) == t ? t : current
+    }
+    static func autoUpscale(backingScale: CGFloat) -> Bool { backingScale >= 2.0 }
+}
+
+// --- asserts ---
+func eq(_ a: Int, _ b: Int, _ m: String) { assert(a == b, m); print("ok: \(m)") }
+// zoomed WAY in (tiny Å/px) -> maxSampling
+eq(CartoonLOD.targetSampling(angstromPerPixel: 0.01, maxSampling: 18, current: 3), 18, "zoom-in -> max")
+// zoomed out (large Å/px) -> floor 3
+eq(CartoonLOD.targetSampling(angstromPerPixel: 2.0, maxSampling: 18, current: 12), 3, "zoom-out -> floor")
+// mid
+eq(CartoonLOD.targetSampling(angstromPerPixel: 0.15, maxSampling: 18, current: 3), 8, "mid -> 8")
+// hysteresis: sitting just inside a boundary from current does not flip
+eq(CartoonLOD.targetSampling(angstromPerPixel: 0.249, maxSampling: 18, current: 5), 5, "hysteresis holds")
+// Å/px sanity: closer camera => smaller Å/px
+assert(CartoonLOD.angstromPerPixel(cameraDistance: 20, fovDegrees: 20, viewportHeightPx: 1000)
+     < CartoonLOD.angstromPerPixel(cameraDistance: 200, fovDegrees: 20, viewportHeightPx: 1000), "closer=finer")
+print("ok: angstromPerPixel monotonic")
+assert(CartoonLOD.autoUpscale(backingScale: 2.0) && !CartoonLOD.autoUpscale(backingScale: 1.0), "retina gate")
+print("ALL PASS")
+```
+
+- [ ] **Step 2: Run it and confirm it FAILS first (before you trust it), then passes**
+
+Run: `swift /tmp/CartoonLODTest.swift`
+Expected: prints `ALL PASS`. If any `assert` fires, fix the function bodies until it passes. (Deliberately break one edge value, re-run to see it fail, then restore — confirms the test bites.)
+
+- [ ] **Step 3: Create the real file with the SAME `CartoonLOD` enum**
+
+Create `swiftui/PyMOLViewer/Shared/CartoonLOD.swift` containing exactly the `import Foundation` + `enum CartoonLOD { ... }` block from Step 1 (no test code). Add it to the Xcode project (the target uses explicit file refs — add via pbxproj or the inline-source pattern; see how `MetalViewport.swift` is referenced and mirror it).
+
+- [ ] **Step 4: Build the app to confirm the file compiles/links**
+
+Run: `xcodebuild -project swiftui/PyMOLViewer.xcodeproj -scheme PyMOLViewer_macOS -configuration Debug -derivedDataPath swiftui/build_mac_dd build 2>&1 | grep -c "BUILD SUCCEEDED"`
+Expected: `1`.
+
+- [ ] **Step 5: Commit**
+```bash
+git add swiftui/PyMOLViewer/Shared/CartoonLOD.swift swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+git commit -m "feat(metal): pure CartoonLOD math (Å/px, sampling buckets+hysteresis, retina gate)"
+```
+
+---
+
+### Task 3: Wire zoom-adaptive sampling (Swift debounce → rebuild)
+
+**Files:**
+- Modify: `swiftui/PyMOLViewer/Shared/PyMOLEngine.swift` (add helpers)
+- Modify: `swiftui/PyMOLViewer/Shared/MetalViewport.swift` (camera-settle debounce)
+
+**Interfaces:**
+- Consumes: `CartoonLOD.*` (Task 2); `cmd` view via engine; `cSetting_cartoon_sampling*` (Task 1).
+- Produces: `PyMOLEngine.applyDynamicCartoonSampling()` (reads view+fov+viewport, computes target, sets `cartoon_sampling` + `rebuild` if changed and `cartoon_sampling_dynamic` is on).
+
+- [ ] **Step 1: Add engine helpers**
+
+In `PyMOLEngine.swift`, add:
+```swift
+// Cached to avoid redundant rebuilds.
+private var lastAppliedSampling: Int = -1
+
+/// Compute the zoom-adaptive cartoon_sampling and rebuild if it changed.
+/// No-op unless cartoon_sampling_dynamic is on. Call on the main thread when
+/// the camera has settled (debounced by the caller).
+func applyDynamicCartoonSampling(viewportHeightPx: Float) {
+    guard runPythonInt("int(cmd.get_setting_int('cartoon_sampling_dynamic'))") == 1 else { return }
+    // camera distance ~ magnitude of the view translation z (18-float get_view: v[11])
+    let v = runPythonFloats("list(cmd.get_view())")   // 18 floats
+    guard v.count >= 18 else { return }
+    let camDist = abs(v[11])
+    let fov = runPythonFloat("float(cmd.get_setting_float('field_of_view'))")
+    var maxS = runPythonInt("int(cmd.get_setting_int('cartoon_sampling_max'))")
+    if maxS < 0 {   // auto: scale down by atom count
+        let n = runPythonInt("cmd.count_atoms('polymer')")
+        maxS = n < 10000 ? 18 : (n < 50000 ? 12 : (n < 200000 ? 8 : 5))
+    }
+    let cur = lastAppliedSampling > 0 ? lastAppliedSampling
+              : runPythonInt("int(cmd.get_setting_int('cartoon_sampling'))")
+    let app = CartoonLOD.angstromPerPixel(cameraDistance: camDist, fovDegrees: fov,
+                                          viewportHeightPx: viewportHeightPx)
+    let target = CartoonLOD.targetSampling(angstromPerPixel: app, maxSampling: maxS, current: cur)
+    guard target != cur else { return }
+    lastAppliedSampling = target
+    runPython("cmd.set('cartoon_sampling', \(target)); cmd.rebuild()")
+}
+```
+(If `runPythonInt/Float/Floats` helpers don't exist, add thin wrappers over the existing `runPython` that parse the returned string; mirror the existing bridge helpers.)
+
+- [ ] **Step 2: Add a debounced camera-settle hook in MetalViewport**
+
+In `MetalViewport.swift`, where camera/gesture changes occur (the same places that call `engine.button`/`engine.drag`/`zoomBy`), after applying the camera change, schedule:
+```swift
+private var lodWork: DispatchWorkItem?
+func scheduleLODUpdate() {
+    lodWork?.cancel()
+    let work = DispatchWorkItem { [weak self] in
+        guard let self = self else { return }
+        let h = Float(self.mtkView.drawableSize.height)
+        self.engine.applyDynamicCartoonSampling(viewportHeightPx: h)
+    }
+    lodWork = work
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.20, execute: work)  // 200ms settle
+}
+```
+Call `scheduleLODUpdate()` from the zoom path (`zoomBy`, magnification/scroll handlers) and at the end of a rotate/pan drag. (Zoom is the primary driver; rotate/pan also change Å/px negligibly, so calling on any camera change is fine and the debounce coalesces.)
+
+- [ ] **Step 3: Build (core already built in Task 1; app only)**
+
+Run: `xcodebuild -project swiftui/PyMOLViewer.xcodeproj -scheme PyMOLViewer_macOS -configuration Debug -derivedDataPath swiftui/build_mac_dd build 2>&1 | grep -c "BUILD SUCCEEDED"`
+Expected: `1`.
+
+- [ ] **Step 4: Functional verify — sampling rises when zoomed in**
+
+Launch with MCP (`defaults write io.raymol.RayMol raymol.mcp.enabled -bool true`; `open -n` the app), then over MCP:
+```
+run_pymol_command: load .../1ubq.pdb, async=0
+run_pymol_command: show cartoon
+run_python: cmd.zoom('all'); print(cmd.get_setting_int('cartoon_sampling'))   # baseline bucket
+run_python: cmd.zoom('resi 1-6', -8)   # extreme zoom-in on a strand
+# trigger the debounce path the way the viewport would, then read back:
+run_python: import time; e=None
+```
+Because the debounce lives in the view layer, verify the *math* deterministically instead: 
+```
+run_python: v=cmd.get_view(); import math; d=abs(v[11]); fov=cmd.get_setting_float('field_of_view'); app=(2*d*math.tan(math.radians(fov)/2))/1200.0; print('ang/px',app)
+```
+Expected: `ang/px` is much smaller after the zoom-in than after `zoom all` (confirms the metric tracks zoom). Then confirm `applyDynamicCartoonSampling` raised sampling by rendering (Step 5).
+
+- [ ] **Step 5: Functional verify — visible crispness A/B (host offscreen)**
+
+Render a zoomed β-strand with dynamic ON vs OFF and confirm ON is finer:
+```bash
+# ON (default)
+PYMOL_AUTOCMD="load 1ubq.pdb; show cartoon; orient resi 1-16; zoom resi 1-16,-6" \
+PYMOL_AUTOEXPORT="/tmp/lod_on.png,1400,1050" open -n <app>
+# OFF
+PYMOL_AUTOCMD="set cartoon_sampling_dynamic,0; load 1ubq.pdb; show cartoon; orient resi 1-16; zoom resi 1-16,-6" \
+PYMOL_AUTOEXPORT="/tmp/lod_off.png,1400,1050" open -n <app>
+```
+Expected: with dynamic ON the zoomed strand mesh is visibly finer/smoother than OFF (the debounce won't fire in the one-shot export path, so ALSO verify by directly `set cartoon_sampling,18; rebuild` matches the ON look — proving the rebuild path works; the live debounce is exercised interactively in Task 5/VM).
+
+- [ ] **Step 6: Commit**
+```bash
+git add swiftui/PyMOLViewer/Shared/PyMOLEngine.swift swiftui/PyMOLViewer/Shared/MetalViewport.swift
+git commit -m "feat(metal): zoom-adaptive cartoon_sampling via debounced rebuild"
+```
+
+---
+
+### Task 4: Display-aware upscale (metal_upscale auto = Retina)
+
+**Files:**
+- Modify: `swiftui/PyMOLViewer/Shared/MetalViewport.swift` (backing-scale detection + screen-change observer)
+- Modify: `swiftui/PyMOLViewer/Shared/PyMOLEngine.swift` (push effective upscale)
+- Modify: `layer1/SceneRender.cpp` (resolve `metal_upscale==2` using a renderer-held retina flag)
+- Modify: `layerGraphics/metal/RendererMetal.h` / `.mm` (`_displayIsRetina` + `setDisplayIsRetina`)
+
+**Interfaces:**
+- Consumes: `CartoonLOD.autoUpscale(backingScale:)` (Task 2); `cSetting_metal_upscale` int (Task 1).
+- Produces: `Renderer::setDisplayIsRetina(bool)`; effective upscale = `(metal_upscale==1) || (metal_upscale==2 && displayIsRetina)`.
+
+- [ ] **Step 1: Renderer holds the retina flag**
+
+`RendererMetal.h`: add `bool _displayIsRetina = true;` and `void setDisplayIsRetina(bool r) override;`. `Renderer.h`: `virtual void setDisplayIsRetina(bool) {}`. `RendererMetal.mm`: `void RendererMetal::setDisplayIsRetina(bool r){ _displayIsRetina = r; }`.
+
+- [ ] **Step 2: Resolve auto where `_upscaleEnabled` is currently set**
+
+In `SceneRender.cpp` where `metal_upscale` is read for `setDesiredUpscale`/`setPostParams` (grep `metal_upscale`), change:
+```cpp
+int mu = SettingGetGlobal_i(G, cSetting_metal_upscale);
+bool upscale = (mu == 1) || (mu == 2 && G->Renderer->displayIsRetina()); // add a getter, or pass through setPostParams' upscaleEnabled
+```
+(If `metal_upscale` was read as bool, switch to `_i`. Keep the existing plumbing to `_upscaleEnabled`.)
+
+- [ ] **Step 3: Swift pushes backing scale on launch + screen change**
+
+`MetalViewport.swift` (`makeNSView` / coordinator): compute `CartoonLOD.autoUpscale(backingScale: view.window?.screen?.backingScaleFactor ?? 2)`, call `engine.setDisplayIsRetina(_:)`. Observe `NSWindow.didChangeScreenNotification` and `NSView` `viewDidChangeBackingProperties()` → recompute + push. Add `PyMOLEngine.setDisplayIsRetina(_ r: Bool)` → bridge → `Renderer::setDisplayIsRetina`.
+
+- [ ] **Step 4: Build (core + app — SceneRender/Renderer changed)**
+
+Run: `bash swiftui/build_macos.sh 2>&1 | tail -1 && xcodebuild -project swiftui/PyMOLViewer.xcodeproj -scheme PyMOLViewer_macOS -configuration Debug -derivedDataPath swiftui/build_mac_dd build 2>&1 | grep -c "BUILD SUCCEEDED"`
+Expected: `arm64` then `1`.
+
+- [ ] **Step 5: Functional verify**
+
+- `set metal_upscale, 0` → full-res (no upscale) regardless of display.
+- `set metal_upscale, 1` → upscale on regardless.
+- `set metal_upscale, 2` (default) on the built-in Retina display → upscale on; the auto path is exercised. (Non-Retina external verification is manual/host — note it; the VM is single Retina-like display.)
+
+Confirm via `_renderScale`: add a one-line `NSLog` of the effective upscale decision, or infer from a render (upscaled frame is softer). Read back `cmd.get_setting_int('metal_upscale')` == 2.
+
+- [ ] **Step 6: Commit**
+```bash
+git add layer1/SceneRender.cpp layerGraphics/Renderer.h layerGraphics/metal/RendererMetal.h layerGraphics/metal/RendererMetal.mm swiftui/PyMOLViewer/Shared/MetalViewport.swift swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+git commit -m "feat(metal): metal_upscale auto (2) enables reduced-res upscale only on Retina displays"
+```
+
+---
+
+### Task 5: Integration verification + regression + PR
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Regression — both features off = identical to master**
+
+Render 1ubq (cartoon, shadows on) with `set cartoon_sampling_dynamic,0` and `set metal_upscale,0`; A/B vs a master build. Expect ~0% pixel diff.
+
+- [ ] **Step 2: Adaptive A/B across zoom + angles (host offscreen)**
+
+For 1ubq, 1hho, 1aon: zoom out (expect low sampling, cheap) and zoom in (expect high sampling, crisp). Confirm no triangle acne at zoom-in and no mid-drag hitch (interactive). Confirm 1aon rebuild stays bounded (<~200 ms) via timing.
+
+- [ ] **Step 3: mac-vm-test VM smoke**
+
+Per the mac-vm-test skill: install the app in a fresh VM, load 1ubq, `show cartoon`, drive a zoom, confirm it renders crisp with no crash; offscreen-export a frame and pull it.
+
+- [ ] **Step 4: Push branch + open PR (REST API — gh pr create/merge hit the classic-Projects GraphQL bug)**
+```bash
+git push -u origin feat/adaptive-cartoon-lod
+gh api -X POST repos/javierbq/RayMol/pulls -f title="..." -f head="feat/adaptive-cartoon-lod" -f base="master" -F body=@/tmp/pr_body.md
+```
+
+- [ ] **Step 5: Update memory** — append the adaptive-LOD design + on-demand-render timer gotcha + benchmark to `fix_cartoon_shadow_triangles.md` or a new memory, and the MEMORY.md index.
+
+---
+
+## Self-review notes
+- Spec coverage: Component A → Tasks 1–3; Component B → Tasks 1,4; testing → Task 5. Non-goals (no per-region/GPU rewrite) respected.
+- The `runPythonInt/Float/Floats` helpers are assumed; if absent, Task 3 Step 1 says to add thin wrappers (not a placeholder — explicit instruction).
+- Bucket thresholds are the spec's starting values; Task 5 Step 2 calibrates.
+- Camera-settle: solved via Swift 200 ms debounce (on-demand render can't per-frame poll) — matches spec ownership.

--- a/docs/superpowers/plans/2026-07-02-perf-hud.md
+++ b/docs/superpowers/plans/2026-07-02-perf-hud.md
@@ -1,0 +1,286 @@
+# Perf Debug HUD Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A command-line-toggled (`metal_perf_hud`) SwiftUI overlay showing live LOD, triangle count, CPU/GPU memory, FPS, and render-state metrics.
+
+**Architecture:** Renderer accumulates a per-frame scene-triangle counter + exposes GPU bytes / render scale; a small bridge returns them. A Swift `PerfHUD` `ObservableObject` collects those + FPS (in `draw(in:)`) + CPU footprint (mach) + the LOD values `applyDynamicCartoonSampling` already computes. A `PerfHUDView` overlay is gated on `metal_perf_hud`.
+
+**Tech Stack:** C++17 core, Metal renderer, SwiftUI, `swift` CLI for a standalone formatter unit test.
+
+## Global Constraints
+
+- Two-stage build (macos_swiftui_build_verify): `bash swiftui/build_macos.sh` THEN `xcodebuild … -scheme PyMOLViewer_macOS -derivedDataPath swiftui/build_mac_dd`. For iOS device: `cd swiftui && ./build_ios.sh device` THEN xcodebuild `PyMOLViewer_iOS`.
+- Next free setting index after `825 cartoon_sampling_max` is **826**.
+- Off by default; `metal_perf_hud 0` must be zero-overhead / byte-identical render.
+- Branch `feat/adaptive-cartoon-lod` (extends PR #95). Never push to master.
+- Triangle count = main-render (`!_shadowMode`) triangle-mode draws only (opaque + OIT); excludes the shadow re-draw and full-screen post passes. Impostors are analytic (not mesh triangles) → not counted; label the metric "scene tris".
+
+---
+
+### Task 1: Renderer metrics + setting + bridge
+
+**Files:**
+- Modify: `layer1/SettingInfo.h` (after line 825)
+- Modify: `layerGraphics/metal/RendererMetal.h` (members + getters)
+- Modify: `layerGraphics/metal/RendererMetal.mm` (reset in `beginFrame`, increment in `drawVBO`/`drawVBOIndexed`, getters)
+- Modify: `layerGraphics/Renderer.h` (base virtual getters, default 0)
+- Modify: `swiftui/PyMOLViewer/Bridge/PyMOLBridge.h/.mm` (`PyMOLBridge_GetRenderStats`)
+
+**Interfaces:**
+- Produces: `cSetting_metal_perf_hud` (bool); `RendererMetal::frameTriangleCount()->uint64_t`, `gpuAllocatedBytes()->uint64_t`, `renderScale()->float`; `PyMOLBridge_GetRenderStats(uint64_t* tris, uint64_t* gpuBytes, float* renderScale)`.
+
+- [ ] **Step 1: Add the setting** — `layer1/SettingInfo.h` after the `cartoon_sampling_max` (825) line:
+```c
+  REC_b( 826, metal_perf_hud                          , global    , false ), /* Metal: show a live performance HUD overlay (LOD, triangles, memory, FPS). set metal_perf_hud, 1 */
+```
+
+- [ ] **Step 2: Base virtuals** — `layerGraphics/Renderer.h`, near the other virtuals:
+```cpp
+  // Live render metrics for the perf HUD. Default 0 (GL/base unaffected).
+  virtual uint64_t frameTriangleCount() const { return 0; }
+  virtual uint64_t gpuAllocatedBytes() const { return 0; }
+  virtual float renderScale() const { return 1.0f; }
+```
+
+- [ ] **Step 3: RendererMetal members + getters** — `RendererMetal.h`, near `_renderScale`/other members:
+```cpp
+  uint64_t _frameTriangles = 0;   // scene-mesh triangles submitted this frame (main pass)
+  uint64_t frameTriangleCount() const override { return _frameTriangles; }
+  uint64_t gpuAllocatedBytes() const override {
+    return _device ? (uint64_t)[_device currentAllocatedSize] : 0;
+  }
+  float renderScale() const override { return _renderScale; }
+```
+(`_renderScale` already exists; if `frameTriangleCount`/`gpuAllocatedBytes`/`renderScale` can't be inline in the header because `_device`/`_renderScale` are declared later, declare them `override;` here and define in the .mm — match the file's existing style.)
+
+- [ ] **Step 4: Reset per frame** — `RendererMetal.mm` in `beginFrame()` (~line 693), add near the top of the body:
+```cpp
+  _frameTriangles = 0;
+```
+
+- [ ] **Step 5: Count triangles in the VBO draws** — `RendererMetal.mm` `drawVBO(PrimitiveType mode, int vertexCount, …)` (~4487): after the early `_shadowMode`/param guards, before issuing the draw, add:
+```cpp
+  if (!_shadowMode && (mode == PrimitiveType::Triangles ||
+                       mode == PrimitiveType::TriangleStrip)) {
+    _frameTriangles += (uint64_t)(vertexCount / 3);
+  }
+```
+And in `drawVBOIndexed(PrimitiveType mode, int indexCount, …)`:
+```cpp
+  if (!_shadowMode && (mode == PrimitiveType::Triangles ||
+                       mode == PrimitiveType::TriangleStrip)) {
+    _frameTriangles += (uint64_t)(indexCount / 3);
+  }
+```
+(Use the actual `PrimitiveType` enum names from `Renderer.h` — grep `enum.*PrimitiveType`. If the enum lacks `TriangleStrip`, count only `Triangles`.)
+
+- [ ] **Step 6: Bridge** — `PyMOLBridge.h` (near `PyMOLBridge_SetDisplayIsRetina`):
+```c
+void PyMOLBridge_GetRenderStats(uint64_t* outTriangles, uint64_t* outGpuBytes, float* outRenderScale);
+```
+`PyMOLBridge.mm` (near `PyMOLBridge_SetSelectionColor`):
+```cpp
+void PyMOLBridge_GetRenderStats(uint64_t* outTriangles, uint64_t* outGpuBytes, float* outRenderScale)
+{
+    PyMOLGlobals* G = SingletonPyMOLGlobals;
+    if (outTriangles) *outTriangles = (G && G->Renderer) ? G->Renderer->frameTriangleCount() : 0;
+    if (outGpuBytes)  *outGpuBytes  = (G && G->Renderer) ? G->Renderer->gpuAllocatedBytes() : 0;
+    if (outRenderScale) *outRenderScale = (G && G->Renderer) ? G->Renderer->renderScale() : 1.0f;
+}
+```
+(Use whichever `G` accessor the neighboring bridge fns use — `SingletonPyMOLGlobals` or `PyMOL_GetGlobals(INST(h))`; `GetRenderStats` has no handle, so use `SingletonPyMOLGlobals` like `PyMOLBridge_Complete`.)
+
+- [ ] **Step 7: Build core + app**
+
+Run: `bash swiftui/build_macos.sh 2>&1 | tail -1 && xcodebuild -project swiftui/PyMOLViewer.xcodeproj -scheme PyMOLViewer_macOS -configuration Debug -derivedDataPath swiftui/build_mac_dd build 2>&1 | grep -c "BUILD SUCCEEDED"`
+Expected: `arm64` then `1`.
+
+- [ ] **Step 8: Commit**
+```bash
+git add layer1/SettingInfo.h layerGraphics/Renderer.h layerGraphics/metal/RendererMetal.h layerGraphics/metal/RendererMetal.mm swiftui/PyMOLViewer/Bridge/PyMOLBridge.h swiftui/PyMOLViewer/Bridge/PyMOLBridge.mm
+git commit -m "feat(metal): metal_perf_hud setting + per-frame scene-triangle counter, GPU-mem/render-scale getters + PyMOLBridge_GetRenderStats"
+```
+
+---
+
+### Task 2: Swift PerfHUD data + overlay
+
+**Files:**
+- Modify: `swiftui/PyMOLViewer/Shared/PyMOLEngine.swift` (`PerfHUD` object, CPU mem, LOD publish, a `PerfFormat` helper)
+- Modify: `swiftui/PyMOLViewer/Shared/MetalViewport.swift` (FPS + stats poll in `draw(in:)`)
+- Modify: the SwiftUI root that hosts the viewport (find with `grep -rl "MetalViewport(" swiftui/PyMOLViewer`) — add the `PerfHUDView` overlay
+- Test (throwaway): `/tmp/PerfFormatTest.swift`
+
+**Interfaces:**
+- Consumes: `PyMOLBridge_GetRenderStats` (Task 1); `CartoonLOD.angstromPerPixel` (existing).
+- Produces: `final class PerfHUD: ObservableObject` (published metric fields); `PerfFormat.bytes(_:)->String`, `PerfFormat.fps(_:)->String`.
+
+- [ ] **Step 1: Failing standalone test for the formatter** — create `/tmp/PerfFormatTest.swift`:
+```swift
+import Foundation
+enum PerfFormat {
+    static func bytes(_ b: UInt64) -> String {
+        let mb = Double(b) / (1024*1024)
+        if mb >= 1024 { return String(format: "%.2f GB", mb/1024) }
+        return String(format: "%.0f MB", mb)
+    }
+    static func fps(_ f: Double) -> String { f <= 0 ? "idle" : String(format: "%.0f", f) }
+}
+func chk(_ a: String, _ b: String, _ m: String){ if a != b { print("FAIL \(m): \(a) != \(b)"); exit(1) }; print("ok \(m)") }
+chk(PerfFormat.bytes(13*1024*1024), "13 MB", "13MB")
+chk(PerfFormat.bytes(2 * 1024*1024*1024), "2.00 GB", "2GB")
+chk(PerfFormat.fps(0), "idle", "idle")
+chk(PerfFormat.fps(59.4), "59", "fps")
+print("ALL PASS")
+```
+
+- [ ] **Step 2: Run it** — `swift /tmp/PerfFormatTest.swift` → `ALL PASS`. (Break a value, re-run to see it fail, restore.)
+
+- [ ] **Step 3: Add `PerfFormat` + `PerfHUD` to PyMOLEngine.swift** — near the `CartoonLOD` enum, add the SAME `PerfFormat` enum from Step 1, then:
+```swift
+/// Live perf metrics for the HUD overlay (metal_perf_hud). Updated ~3x/s.
+final class PerfHUD: ObservableObject {
+    @Published var visible = false          // mirrors metal_perf_hud
+    @Published var fps: Double = 0
+    @Published var triangles: UInt64 = 0
+    @Published var cpuBytes: UInt64 = 0
+    @Published var gpuBytes: UInt64 = 0
+    @Published var sampling = 0             // live cartoon_sampling
+    @Published var angPerPx: Float = 0
+    @Published var bucketMax = 0            // effective cartoon_sampling_max
+    @Published var dynamicOn = false
+    @Published var upscale = 0              // metal_upscale (0/1/2)
+    @Published var renderScale: Float = 1
+    @Published var msaa = false
+    @Published var shadows = false
+    @Published var raytrace = false
+    @Published var drawableW = 0
+    @Published var drawableH = 0
+    @Published var retina = true
+}
+```
+
+- [ ] **Step 4: PyMOLEngine owns a PerfHUD + CPU mem + LOD publish** — in `PyMOLEngine`:
+```swift
+let perf = PerfHUD()
+
+private func cpuFootprintBytes() -> UInt64 {
+    var info = task_vm_info_data_t()
+    var count = mach_msg_type_number_t(MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<natural_t>.size)
+    let kr = withUnsafeMutablePointer(to: &info) {
+        $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+            task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), $0, &count)
+        }
+    }
+    return kr == KERN_SUCCESS ? info.phys_footprint : 0
+}
+```
+In `applyDynamicCartoonSampling`, right after computing `app` and `target`, publish the LOD values (so the HUD shows them even between rebuilds):
+```swift
+    DispatchQueue.main.async {
+        self.perf.angPerPx = app; self.perf.bucketMax = maxS
+        self.perf.sampling = target; self.perf.dynamicOn = true
+    }
+```
+(If `applyDynamicCartoonSampling` early-returned before computing `app` — e.g. dynamic off — leave those fields; a periodic refresh in Step 5 fills `sampling` from the live setting regardless.)
+
+- [ ] **Step 5: Collect + publish in draw(in:)** — `MetalViewport.swift`, after the render (near `scheduleLODUpdate()`), add a throttled HUD update:
+```swift
+            updatePerfHUD(view)
+```
+and in the Coordinator:
+```swift
+        private var lastFrameTime: CFTimeInterval = 0
+        private var fpsEMA: Double = 0
+        private var lastHUDPublish: CFTimeInterval = 0
+        func updatePerfHUD(_ view: MTKView) {
+            let now = CACurrentMediaTime()
+            if lastFrameTime > 0 {
+                let dt = now - lastFrameTime
+                if dt > 0 { fpsEMA = fpsEMA == 0 ? 1/dt : (0.9*fpsEMA + 0.1*(1/dt)) }
+            }
+            lastFrameTime = now
+            guard let engine = engine else { return }
+            let hudOn = (engine.evalInt("int(cmd.get_setting_int('metal_perf_hud'))") ?? 0) == 1
+            if engine.perf.visible != hudOn { DispatchQueue.main.async { engine.perf.visible = hudOn } }
+            guard hudOn, now - lastHUDPublish > 0.33 else { return }   // ~3x/s
+            lastHUDPublish = now
+            var tris: UInt64 = 0, gpu: UInt64 = 0; var rs: Float = 1
+            PyMOLBridge_GetRenderStats(&tris, &gpu, &rs)
+            let cpu = engine.cpuFootprintBytesPublic()
+            let samp = engine.evalInt("int(cmd.get_setting_int('cartoon_sampling'))") ?? 0
+            let up = engine.evalInt("int(cmd.get_setting_int('metal_upscale'))") ?? 0
+            let msaa = (engine.evalInt("int(cmd.get_setting_int('metal_msaa'))") ?? 0) == 1
+            let sh = (engine.evalInt("int(cmd.get_setting_int('metal_shadows'))") ?? 0) == 1
+            let rt = (engine.evalInt("int(cmd.get_setting_int('metal_raytrace'))") ?? 0) == 1
+            let dw = Int(view.drawableSize.width), dh = Int(view.drawableSize.height)
+            let fps = fpsEMA, idle = (now - lastFrameTime) // (draw just ran, so ~0)
+            DispatchQueue.main.async {
+                let p = engine.perf
+                p.fps = fps; p.triangles = tris; p.gpuBytes = gpu; p.cpuBytes = cpu
+                p.sampling = samp; p.upscale = up; p.renderScale = rs
+                p.msaa = msaa; p.shadows = sh; p.raytrace = rt
+                p.drawableW = dw; p.drawableH = dh
+            }
+            _ = idle
+        }
+```
+Expose CPU mem: add `func cpuFootprintBytesPublic() -> UInt64 { cpuFootprintBytes() }` to PyMOLEngine (keep the mach code private).
+NOTE: `evalInt` per frame is throttled to ~3/s here, cheap. FPS EMA updates every frame.
+
+- [ ] **Step 6: PerfHUDView overlay** — in the SwiftUI root hosting `MetalViewport` (found via grep in Files), wrap the viewport in a `ZStack(alignment: .topLeading)` and add:
+```swift
+if engine.perf.visible {
+    PerfHUDView(perf: engine.perf).padding(8).allowsHitTesting(false)
+}
+```
+and define `PerfHUDView` inline in that same file (avoids pbxproj surgery):
+```swift
+struct PerfHUDView: View {
+    @ObservedObject var perf: PerfHUD
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text("FPS \(PerfFormat.fps(perf.fps))   tris \(perf.triangles)")
+            Text("LOD samp \(perf.sampling)  max \(perf.bucketMax)  Å/px \(String(format: "%.3f", perf.angPerPx))  dyn \(perf.dynamicOn ? "on" : "off")")
+            Text("mem cpu \(PerfFormat.bytes(perf.cpuBytes))  gpu \(PerfFormat.bytes(perf.gpuBytes))")
+            Text("upscale \(perf.upscale) rs \(String(format: "%.2f", perf.renderScale))  msaa \(perf.msaa ? "1":"0")  sh \(perf.shadows ? "1":"0")  rt \(perf.raytrace ? "1":"0")")
+            Text("draw \(perf.drawableW)x\(perf.drawableH)  retina \(perf.retina ? "1":"0")")
+        }
+        .font(.system(size: 10, design: .monospaced))
+        .foregroundColor(.green)
+        .padding(6)
+        .background(Color.black.opacity(0.55))
+        .cornerRadius(6)
+    }
+}
+```
+(`perf.retina`/`perf.bucketMax`/`perf.angPerPx`/`perf.dynamicOn` are published by Step 4 / the retina push in `pushDisplayRetina` — also set `engine.perf.retina` there.)
+
+- [ ] **Step 7: Build app** (core unchanged this task): `xcodebuild … -scheme PyMOLViewer_macOS … build 2>&1 | grep -c "BUILD SUCCEEDED"` → `1`.
+
+- [ ] **Step 8: Commit**
+```bash
+git add swiftui/PyMOLViewer/Shared/PyMOLEngine.swift swiftui/PyMOLViewer/Shared/MetalViewport.swift <hosting view file>
+git commit -m "feat(metal): perf HUD SwiftUI overlay + metrics collection (FPS, tris, cpu/gpu mem, LOD, render state)"
+```
+
+---
+
+### Task 3: Verify + deploy
+
+- [ ] **Step 1: Host verify (single instance, MCP bound to it)** — ensure only the worktree build runs (`defaults write io.raymol.RayMol raymol.mcp.enabled -bool true`; kill other RayMol; `open -n` the build; confirm `get_session_state`). Then:
+  - `cmd.load(1ubq); cmd.show('cartoon')`; `set metal_perf_hud, 1` → overlay appears (screencapture or user confirms).
+  - Zoom in/out → `LOD samp` + `tris` change together; `FPS` plausible; `mem` plausible.
+  - `set metal_perf_hud, 0` → overlay gone.
+- [ ] **Step 2: Regression** — `metal_perf_hud 0` render == before (no overlay, no perf change).
+- [ ] **Step 3: Redeploy to iPhone** — `cd swiftui && ./build_ios.sh device` then xcodebuild `PyMOLViewer_iOS` for device `F691F4CA-333B-5669-830F-2B400CEE3993`, install + launch (reuse the multiplatform-build-deployer agent). Confirm `set metal_perf_hud,1` shows the overlay on-device.
+- [ ] **Step 4: Push branch** (updates PR #95): `git push origin feat/adaptive-cartoon-lod`.
+
+---
+
+## Self-review notes
+- Spec coverage: activation → Task 1 Step 1; rendering → Task 2 Step 6; each metric → Task 1 (tris/gpu/scale) + Task 2 (fps/cpu/lod/state); data flow → Tasks 1–2; testing → Task 3.
+- `PerfFormat`/`PerfHUD`/`PyMOLBridge_GetRenderStats` signatures consistent across tasks.
+- The hosting-view file is discovered via grep (not hard-coded) since I haven't confirmed its name — Task 2 Files says how.
+- FPS "idle": the periodic publish runs only inside `draw(in:)` (which only fires on a real render), so a static scene simply stops updating FPS; `PerfFormat.fps(0)` shows "idle" only if fps was never set. Acceptable; a fuller idle-timer is YAGNI for a debug HUD.

--- a/docs/superpowers/specs/2026-07-02-adaptive-cartoon-lod-and-display-aware-upscale-design.md
+++ b/docs/superpowers/specs/2026-07-02-adaptive-cartoon-lod-and-display-aware-upscale-design.md
@@ -1,0 +1,145 @@
+# Adaptive cartoon LOD + display-aware upscale — design
+
+Date: 2026-07-02
+Status: approved (design), pending spec review
+Related: issue #87, PR #88/#92 (metal_shadow_bias). This is a *quality/performance*
+follow-up, not an acne fix — the shadow-bias work already removes the "triangles".
+
+## Motivation
+
+Raising `cartoon_sampling` gives crisp β-strand/ribbon geometry (and further
+softens any residual faceting) but tessellates the whole object at all times, so
+it costs performance. `metal_upscale` (render at 0.667× + MetalFX) claws back
+perf but the upscale blur is objectionable on low-DPI (non-Retina) external
+displays, while looking fine on the built-in Retina display.
+
+Goal: a single adaptive system that (A) gives high cartoon detail **only when it
+is visible** — i.e. when zoomed in — and drops it when zoomed out, and (B) only
+enables the reduced-res upscale on displays where it looks acceptable.
+
+Measured (whole-object `rebuild`+`refresh`, RayMol Metal, host):
+
+| structure | atoms | samp 7 | samp 14 | samp 20 | samp 30 |
+|---|---|---|---|---|---|
+| 1ubq | 660 | 0 ms | 1 | 1 | 1 |
+| 256b | 1.9k | 1 | 2 | 4 | 4 |
+| 1hho | 2.4k | 2 | 3 | 4 | 7 |
+| 1aon (GroEL) | 59k | 48 | 89 | 104 | 174 |
+
+⇒ a debounced whole-object rebuild is imperceptible (1–7 ms) for realistic
+structures and bounded (~175 ms one-time) at GroEL scale. **Per-region / GPU
+tessellation is therefore out of scope** — not needed.
+
+## Non-goals
+
+- No view-dependent / per-region tessellation; no GPU-tessellated cartoon rewrite.
+- No change to the `metal_shadow_bias` acne fix (orthogonal, stays as-is).
+- Adaptive rebuild happens only when the camera **settles**, never during a drag.
+
+## Component A — Zoom-adaptive cartoon tessellation
+
+### Settings (layer1/SettingInfo.h)
+- `cartoon_sampling_dynamic` (bool, **default on**) — enable adaptive LOD.
+- `cartoon_sampling_max` (int, default **-1 = auto**) — detail ceiling when
+  zoomed in. Auto resolves by atom count via the existing `GetCartoonQuality`
+  pattern so large structures cap lower (illustrative: <10k→18, <50k→12,
+  <200k→8, else 5), bounding the worst-case rebuild.
+
+When `cartoon_sampling_dynamic` is **off**, behavior is byte-identical to today
+(static `cartoon_sampling`). When on, the app OWNS `cartoon_sampling`, driving it
+between a floor (~3) and `cartoon_sampling_max`.
+
+### Zoom metric
+Compute **Å-per-pixel** at the structure center from the live camera:
+`angstrom_per_pixel = (2 * camera_distance * tan(fov/2)) / viewport_height_px`,
+where `camera_distance` and `fov` come from `get_view` + `field_of_view`, and
+`viewport_height_px` from the drawable size. Small Å/px = zoomed in (residues
+span many pixels → facets visible → need detail); large Å/px = zoomed out.
+
+### LOD buckets + hysteresis
+Discrete buckets map Å/px → target sampling (illustrative, calibrate empirically):
+
+| Å/pixel | sampling |
+|---|---|
+| > 0.5  | 3 (floor) |
+| 0.25–0.5 | 5 |
+| 0.10–0.25 | 8 |
+| 0.05–0.10 | 12 |
+| < 0.05 | `cartoon_sampling_max` |
+
+Hysteresis: switching to a higher bucket requires crossing its threshold by a
+margin (~20%) tighter than the switch-down threshold, so a zoom that hovers on a
+boundary does not thrash rebuilds.
+
+### Trigger / debounce
+On camera change, start/reset a **~200 ms debounce**. When it fires (zoom
+settled), compute the target bucket; if it differs from the current sampling,
+run `set cartoon_sampling, N` then `rebuild` on the main thread (the existing
+path). Never rebuild mid-gesture.
+
+### Ownership
+LOD math + debounce live in Swift (`MetalViewport` / `PyMOLEngine`), where camera
+and gesture events already are. They call the existing engine command path. No
+core rendering changes.
+
+### Edge cases
+- Object with no cartoon shown → no-op (rebuild is cheap/no cartoon rep).
+- User manually `set cartoon_sampling, N` while dynamic is on → treated as a
+  temporary override until the next bucket change; document that dynamic owns the
+  value (use `cartoon_sampling_max` to pin the ceiling, or turn dynamic off).
+- Multiple objects → LOD is global (one `cartoon_sampling`); acceptable.
+- `.pse` load / reinitialize → recompute on next settle.
+
+## Component B — Display-aware reduced-res upscale
+
+### Setting change (layer1/SettingInfo.h)
+`metal_upscale` bool → **int, values 0=off / 1=on / 2=auto, default 2**. `0/1`
+retain today's meaning (backward compatible; the REC_b default false becomes
+REC_i default 2).
+
+### Auto rule
+When `metal_upscale == 2`, the **effective** upscale = *is the window's current
+display Retina?* (`NSScreen.backingScaleFactor >= 2`). Retina hides the 0.667×
+blur; low-DPI externals do not. (Chosen over ProMotion-only because a 5K 60 Hz
+Retina display also benefits and looks fine.)
+
+### Detection + re-evaluation
+Swift reads `view.window?.screen?.backingScaleFactor`. Recompute on
+`NSWindow.didChangeScreenNotification` (window dragged to another display) and on
+`didChangeBackingProperties`. The computed effective flag feeds the renderer's
+existing `_upscaleEnabled` (via `setPostParams`' `upscaleEnabled`, or a small
+dedicated setter). `0/1` bypass detection.
+
+### iOS
+iOS is single-display Retina → auto ⇒ on (matches current mobile-perf intent).
+
+## Files (anticipated)
+- `layer1/SettingInfo.h` — `cartoon_sampling_dynamic`, `cartoon_sampling_max`
+  (new indices, next free after 823); `metal_upscale` REC_b→REC_i (0..2).
+- `swiftui/PyMOLViewer/Shared/MetalViewport.swift` — camera-settle observer +
+  debounce; LOD compute; screen-change observer for upscale auto.
+- `swiftui/PyMOLViewer/Shared/PyMOLEngine.swift` — helpers: current Å/px from
+  view+fov+viewport; `setCartoonSampling(n)+rebuild`; upscale-auto decision.
+- `layer1/SceneRender.cpp` / `RendererMetal` — resolve `metal_upscale==2` to the
+  Swift-provided Retina flag when driving `_upscaleEnabled` (design detail for
+  the plan: either Swift pushes the effective bool, or the core reads a
+  Swift-set "display is retina" signal).
+
+## Testing
+- Unit-ish: Å/px formula vs known camera setups; bucket+hysteresis transitions.
+- LOD: zoom in/out on 1ubq, 1hho, 1aon — sampling steps up/down at thresholds,
+  no thrash at boundaries; rebuild latency within measured range; no mid-drag
+  rebuild.
+- Upscale auto: drag the window between a Retina and a non-Retina display →
+  upscale flips; `0`/`1` override detection.
+- Regression: `cartoon_sampling_dynamic off` + `metal_upscale 0/1` ⇒ identical to
+  current master. Verify in the mac-vm-test VM (per standing instruction) plus
+  host A/B.
+
+## Open risks
+- Å/px ↔ sampling calibration is empirical; buckets above are a starting point.
+- Very large structures: whole-object high-sampling render cost (steady-state, not
+  just rebuild) is unmitigated by design — bounded by `cartoon_sampling_max` auto
+  cap; revisit only if it's a problem in practice.
+- Detecting "camera settled" cleanly on an on-demand render loop needs a reliable
+  camera-change hook; if none exists, poll the view hash on the existing redraw.

--- a/docs/superpowers/specs/2026-07-02-perf-hud-design.md
+++ b/docs/superpowers/specs/2026-07-02-perf-hud-design.md
@@ -1,0 +1,80 @@
+# Perf debug HUD overlay — design
+
+Date: 2026-07-02
+Status: approved (design), pending spec review
+Related: adaptive cartoon LOD (PR #95). A live debug HUD for tuning LOD + watching render cost.
+
+## Overview
+
+A command-line-toggled on-screen overlay showing live rendering metrics (dynamic
+LOD, triangle count, CPU/GPU memory, FPS, render-state flags), so LOD behavior
+and performance can be introspected on-device and on the Mac without external
+tools. Debug/dev tool — not shown in exports, not a full profiler.
+
+## Activation
+
+New setting **`metal_perf_hud`** (global bool, default **false**, next free idx
+826). `set metal_perf_hud, 1` shows it, `,0` hides it. Read in the Swift layer
+(the app already polls settings) and gates the overlay's visibility.
+
+## Rendering
+
+A **SwiftUI overlay** (`PerfHUDView`) pinned top-left over the `MetalViewport`,
+monospaced text on a semi-transparent rounded background, refreshed ~3×/s via a
+timer + updated in `draw(in:)`. Inlined into an existing view file (ContentView
+or the MetalViewport host) to avoid Xcode pbxproj surgery. Cross-platform
+(macOS + iOS). Not part of the offscreen/export render path (by design).
+
+## Metrics + sources
+
+- **LOD:** `cartoon_sampling` (live value the dynamic system writes), Å/px,
+  current bucket, effective ceiling, `cartoon_sampling_dynamic` on/off. Å/px and
+  the effective ceiling are computed in `PyMOLEngine.applyDynamicCartoonSampling`;
+  store the last-computed values on a published object rather than recomputing.
+- **Geometry — triangle count:** `RendererMetal` accumulates a per-frame counter
+  over the MAIN opaque pass draws only (skip the shadow re-draw + OIT), reset at
+  frame start. Each draw adds `indexCount/3` (indexed) or `vertexCount/3`
+  (non-indexed triangles); impostors add their billboard triangles. This tracks
+  cartoon_sampling directly (more sampling → more triangles), which is the point.
+- **Memory:** CPU = `phys_footprint` from `task_info(TASK_VM_INFO)` (Swift). GPU =
+  `MTLDevice.currentAllocatedSize` (RendererMetal holds `_device`).
+- **Frame:** FPS = EMA of the wall-clock interval between rendered `draw(in:)`
+  frames (Swift). Because the loop renders on-demand, show an **"idle"** state
+  when no frame has rendered for ~0.5 s (so idle isn't misread as a stall).
+- **Render state:** `metal_upscale` (setting value + effective on/off + render
+  scale), `metal_msaa`, `metal_shadows`, `metal_raytrace`, drawable size (px),
+  backing scale / Retina.
+
+## Data flow / components
+
+- `RendererMetal`: `_frameTriangles` (uint64, reset per frame, incremented in the
+  non-shadow draw paths); getters `frameTriangleCount()` and `gpuAllocatedBytes()`
+  (`_device.currentAllocatedSize`); expose the effective render scale too.
+- Bridge `PyMOLBridge_GetRenderStats(uint64_t* outTriangles, uint64_t* outGpuBytes,
+  float* outRenderScale)` — one call, fills the renderer-side numbers.
+- `PyMOLEngine`: a `PerfHUD` observable (published fields) + `cpuFootprintBytes()`
+  (mach); `applyDynamicCartoonSampling` publishes its Å/px + bucket + effective
+  max + chosen sampling.
+- `MetalViewport.draw(in:)`: update FPS EMA, and when `metal_perf_hud` is on,
+  fetch render stats + publish to `PerfHUD`.
+- `PerfHUDView` (SwiftUI): observes `PerfHUD`, renders the text block; visibility
+  gated on `metal_perf_hud`.
+
+## Files (anticipated)
+- `layer1/SettingInfo.h` — `metal_perf_hud` (826).
+- `layerGraphics/metal/RendererMetal.h/.mm` — triangle counter + getters.
+- `swiftui/PyMOLViewer/Bridge/PyMOLBridge.h/.mm` — `PyMOLBridge_GetRenderStats`.
+- `swiftui/PyMOLViewer/Shared/PyMOLEngine.swift` — `PerfHUD` object, CPU mem, LOD publish.
+- `swiftui/PyMOLViewer/Shared/MetalViewport.swift` — FPS + stats fetch in draw().
+- Host view file (ContentView or the viewport host) — `PerfHUDView` overlay, gated.
+
+## Non-goals
+- Not in PNG/movie exports. Not a per-pass breakdown or GPU-timestamp profiler
+  (frame CPU-interval FPS is enough for tuning). No historical graphs.
+
+## Testing
+- Toggle `metal_perf_hud` on device + Mac → overlay appears/disappears.
+- Zoom → LOD fields + triangle count change as `cartoon_sampling` adapts.
+- FPS reads plausibly during interaction, "idle" when static.
+- CPU/GPU memory are plausible and grow with a big structure/surface.
+- `metal_perf_hud 0` (default) → zero overhead, byte-identical render.

--- a/layer0/GenericBuffer.h
+++ b/layer0/GenericBuffer.h
@@ -156,6 +156,12 @@ public:
   virtual ~GPUBuffer() {};
   virtual size_t get_hash_id() { return _hashid; }
   virtual void bind() const = 0;
+  // Pointer to this buffer's interleaved CPU-side data, if any. The Metal
+  // renderer's _vboCache is keyed by exactly this pointer, so returning it lets
+  // CShaderMgr::freeAllGPUBuffers evict (and release) the cached MTLBuffer when
+  // this buffer is freed — otherwise a rebuilt buffer's old MTLBuffer is
+  // orphaned forever (an unbounded leak). nullptr = not CPU-backed / not cached.
+  virtual const void* cpuDataPointer() const { return nullptr; }
 protected:
   virtual void set_hash_id(size_t id) { _hashid = id; }
 private:

--- a/layer0/ShaderMgr.cpp
+++ b/layer0/ShaderMgr.cpp
@@ -25,6 +25,7 @@ Z* -------------------------------------------------------------------
 #include "MemoryDebug.h"
 #include "Setting.h"
 #include "Scene.h"
+#include "Renderer.h"  // G->Renderer->invalidateVBOCache (frees cached MTLBuffers)
 #include "Color.h"
 #include "Vector.h"
 #include "Util.h"
@@ -1662,8 +1663,17 @@ void CShaderMgr::freeAllGPUBuffers() {
   for (auto hashid : _gpu_objects_to_free_vector) {
     auto search = _gpu_object_map.find(hashid);
     if (search != _gpu_object_map.end()) {
-      if (search->second)
+      if (search->second) {
+        // Evict this buffer's entry from the Metal renderer's _vboCache (keyed by
+        // its CPU-data pointer) BEFORE deleting, so the cached device buffer is
+        // released with the buffer rather than orphaned. Without this, rebuilt
+        // geometry (e.g. zoom-driven cartoon LOD rebuilds) accumulated a fresh
+        // MTLBuffer per rebuild — an unbounded leak that OOM-crashed iOS. No-op on
+        // GL (base is a no-op) and for buffers with no CPU-side data.
+        if (G && G->Renderer)
+          G->Renderer->invalidateVBOCache(search->second->cpuDataPointer());
         delete search->second;
+      }
       _gpu_object_map.erase(search);
     }
   }

--- a/layer1/SceneRender.cpp
+++ b/layer1/SceneRender.cpp
@@ -2056,7 +2056,14 @@ void SceneRenderMetal(PyMOLGlobals* G)
     }
     float dofRange = SettingGetGlobal_f(G, cSetting_metal_dof_range);
     int temporalAO = SettingGetGlobal_b(G, cSetting_metal_temporal_ao) ? 1 : 0;
-    int upscaleEnabled = SettingGetGlobal_b(G, cSetting_metal_upscale) ? 1 : 0;
+    // metal_upscale: 0=off, 1=on, 2=auto. Auto enables the reduced-res upscale
+    // only on Retina displays (the renderer holds the display's retina flag,
+    // pushed from Swift); the 0.667x blur is hidden there but objectionable on
+    // low-DPI externals. (Task 4 sets displayIsRetina from NSScreen; it defaults
+    // true, so auto == on until refined.)
+    int mu = SettingGetGlobal_i(G, cSetting_metal_upscale);
+    int upscaleEnabled =
+        (mu == 1 || (mu == 2 && G->Renderer->displayIsRetina())) ? 1 : 0;
     float dofAperture = SettingGetGlobal_f(G, cSetting_metal_dof_aperture);
     G->Renderer->setPostParams(fogEnabled, fogStart, fogEnd, bg[0], bg[1],
         bg[2], aoEnabled, shadowEnabled, aaEnabled, outlineEnabled, proj[10],

--- a/layer1/SettingInfo.h
+++ b/layer1/SettingInfo.h
@@ -921,7 +921,7 @@ enum {
   REC_f( 811, metal_dof_focus                         , global    , 0.0F ),  /* Metal DOF focus distance in eye-space units; 0 = auto (center of interest) */
   REC_f( 812, metal_dof_range                         , global    , 14.0F ), /* Metal DOF focus range: distance beyond which blur reaches maximum */
   REC_b( 813, metal_temporal_ao                       , global    , false ), /* Metal: accumulate ray-traced AO across frames while the view is still (needs metal_raytrace) */
-  REC_b( 814, metal_upscale                           , global    , false ), /* Metal: render the scene at reduced resolution and upscale to native (mobile perf; bilinear, MetalFX follow-up) */
+  REC_i( 814, metal_upscale                           , global    , 2, 0, 2 ), /* Metal: reduced-res render + upscale (MetalFX). 0=off, 1=on, 2=auto (on only on Retina displays, where the 0.667x upscale blur is hidden). */
   REC_f( 815, metal_dof_aperture                      , global    , 14.0F ), /* Metal DOF aperture: max out-of-focus blur radius in px (bokeh strength); larger = wider aperture / stronger blur */
   REC_f( 816, surface_clip_front                      , object    , 0.0F ),  /* Per-rep surface clip, referenced to the surface's center of mass: fraction 0..1 of the molecule depth to shave off the NEAR (front) side. 0 = no clip, 1 = clip to the COM. Lets the surface clip while cartoon/sticks stay whole so you can peek inside. */
   REC_f( 817, surface_clip_back                       , object    , 0.0F ),  /* Per-rep surface clip referenced to the COM: fraction 0..1 of the molecule depth to shave off the FAR (back) side. 0 = no clip, 1 = clip to the COM. Equal front/back give a slab symmetric about the COM. */
@@ -931,6 +931,8 @@ enum {
   REC_b( 821, surface_contour_opaque                  , object    , true ),  /* Metal: surface outer-contour is fully opaque (crisp); off = the line picks up the surface transparency. */
   REC_b( 822, metal_ssao_cartoon                      , global    , false ), /* Metal: include cartoon/ribbon in the screen-space SSAO (crease/contour) pass. Default off => cartoons are excluded from SSAO darkening (avoids spurious contour lines on ribbon silhouettes/self-folds, #79); they still receive directional shadows, and surface pockets keep their AO. */
   REC_f( 823, metal_shadow_bias                       , global    , 1.0F ),  /* Metal: multiplier on the self-shadow depth bias. 1.0 = default. Raise (e.g. 2-4) if flat cartoon strands still show striped self-shadow "triangle" acne at steep/grazing angles; lower toward 0 for tighter contact shadows. */
+  REC_b( 824, cartoon_sampling_dynamic                , global    , true ),  /* Adaptively raise/lower cartoon_sampling with zoom (debounced whole-object rebuild): crisp when zoomed in, cheap when zoomed out. Off = static cartoon_sampling. */
+  REC_i( 825, cartoon_sampling_max                    , global    , -1 ),    /* Detail ceiling used by cartoon_sampling_dynamic when zoomed in. -1 = auto (scaled down by atom count so large structures stay bounded). */
 
 #ifdef SETTINGINFO_IMPLEMENTATION
 #undef SETTINGINFO_IMPLEMENTATION

--- a/layer1/SettingInfo.h
+++ b/layer1/SettingInfo.h
@@ -933,6 +933,7 @@ enum {
   REC_f( 823, metal_shadow_bias                       , global    , 1.0F ),  /* Metal: multiplier on the self-shadow depth bias. 1.0 = default. Raise (e.g. 2-4) if flat cartoon strands still show striped self-shadow "triangle" acne at steep/grazing angles; lower toward 0 for tighter contact shadows. */
   REC_b( 824, cartoon_sampling_dynamic                , global    , true ),  /* Adaptively raise/lower cartoon_sampling with zoom (debounced whole-object rebuild): crisp when zoomed in, cheap when zoomed out. Off = static cartoon_sampling. */
   REC_i( 825, cartoon_sampling_max                    , global    , -1 ),    /* Detail ceiling used by cartoon_sampling_dynamic when zoomed in. -1 = auto (scaled down by atom count so large structures stay bounded). */
+  REC_b( 826, metal_perf_hud                          , global    , false ), /* Metal: show a live performance HUD overlay (LOD, triangle count, CPU/GPU memory, FPS, render state). set metal_perf_hud, 1 */
 
 #ifdef SETTINGINFO_IMPLEMENTATION
 #undef SETTINGINFO_IMPLEMENTATION

--- a/layerGraphics/Renderer.h
+++ b/layerGraphics/Renderer.h
@@ -364,6 +364,12 @@ public:
   virtual void setDisplayIsRetina(bool retina) {}
   virtual bool displayIsRetina() const { return true; }
 
+  // Live render metrics for the perf HUD (metal_perf_hud). Default 0/1 (base
+  // and GL unaffected).
+  virtual uint64_t frameTriangleCount() const { return 0; }
+  virtual uint64_t gpuAllocatedBytes() const { return 0; }
+  virtual float renderScale() const { return 1.0f; }
+
   // GPU-tessellated Bezier tubes ("tube cartoon"). controlPoints is a tightly
   // packed array of cubic Bezier patches: 4 Float3 control points each
   // (P0,P1,P2,P3), dataSize bytes total. radius = tube radius; r/g/b = color.

--- a/layerGraphics/Renderer.h
+++ b/layerGraphics/Renderer.h
@@ -359,6 +359,10 @@ public:
   // User multiplier on the self-shadow depth bias (metal_shadow_bias). Default
   // no-op (GL unaffected).
   virtual void setShadowBias(float bias) {}
+  // Whether the window's current display is Retina (backingScale>=2). Set from
+  // the Swift layer; gates metal_upscale=auto. Defaults true (GL unaffected).
+  virtual void setDisplayIsRetina(bool retina) {}
+  virtual bool displayIsRetina() const { return true; }
 
   // GPU-tessellated Bezier tubes ("tube cartoon"). controlPoints is a tightly
   // packed array of cubic Bezier patches: 4 Float3 control points each

--- a/layerGraphics/Renderer.h
+++ b/layerGraphics/Renderer.h
@@ -225,9 +225,11 @@ public:
     selColor[0] = r; selColor[1] = g; selColor[2] = b;
   }
 
-  // VBO buffer cache — returns a cached buffer ID for the given key,
-  // creating it from data if not already cached.
-  virtual void invalidateVBOCache(uint64_t key) {}
+  // Evict the cached GPU vertex/index buffer keyed by `key` (the buffer's
+  // CPU-data pointer, GPUBuffer::cpuDataPointer()). Called when the owning
+  // buffer is freed so its cached device buffer is released rather than
+  // orphaned. No-op unless a renderer maintains such a cache (Metal does).
+  virtual void invalidateVBOCache(const void* key) {}
 
   // Screen-aligned textured text quads (labels + measurement text). The
   // interleaved vertex data carries the attributes the GL label shader uses;

--- a/layerGraphics/gl/GLVertexBuffer.h
+++ b/layerGraphics/gl/GLVertexBuffer.h
@@ -132,6 +132,12 @@ public:
   std::size_t cpuStride() const { return m_cpuStride; }
   const BufferDataDesc& getDesc() const { return m_cpuDesc; }
   bool hasCPUData() const { return !m_cpuData.empty(); }
+  // Cache key for the Metal renderer's _vboCache (see GPUBuffer). Matches the
+  // pointer passed to Renderer::drawVBO, so freeing this buffer evicts its
+  // orphaned MTLBuffer instead of leaking it.
+  const void* cpuDataPointer() const override {
+    return m_cpuData.empty() ? nullptr : m_cpuData.data();
+  }
 
 private:
   void retainInterleavedCPUCopy();
@@ -232,6 +238,12 @@ public:
   const std::byte* cpuData() const { return m_cpuData.data(); }
   std::size_t cpuDataSize() const { return m_cpuData.size(); }
   bool hasCPUData() const { return !m_cpuData.empty(); }
+  // Cache key for the Metal renderer's _vboCache (see GPUBuffer). Matches the
+  // pointer passed to Renderer::drawVBOIndexed, so freeing this index buffer
+  // evicts its orphaned MTLBuffer instead of leaking it.
+  const void* cpuDataPointer() const override {
+    return m_cpuData.empty() ? nullptr : m_cpuData.data();
+  }
 
 private:
   void bufferSubData(std::size_t offset, pymol::span<const std::byte> data);

--- a/layerGraphics/metal/RendererMetal.h
+++ b/layerGraphics/metal/RendererMetal.h
@@ -203,6 +203,8 @@ public:
   void setLightViewProjEye(const float* m) override;
   void setShadowFrustum(float radius) override;
   void setShadowBias(float bias) override;
+  void setDisplayIsRetina(bool retina) override;
+  bool displayIsRetina() const override { return _displayIsRetina; }
 
 private:
   void buildImpostorPipelines();
@@ -462,6 +464,8 @@ private:
                                   // receiver bias be expressed in Angstroms.
   float _shadowBias = 1.0f;       // metal_shadow_bias: user multiplier on the
                                   // self-shadow depth bias.
+  bool _displayIsRetina = true;   // window's current display backingScale>=2;
+                                  // set from Swift, gates metal_upscale=auto.
   void buildShadowPipelines();
   // Depth-only shadow pipeline for an arbitrary lit vertex layout (e.g. the
   // surface's stride-44), mirroring oitPipelineForVD.

--- a/layerGraphics/metal/RendererMetal.h
+++ b/layerGraphics/metal/RendererMetal.h
@@ -205,6 +205,10 @@ public:
   void setShadowBias(float bias) override;
   void setDisplayIsRetina(bool retina) override;
   bool displayIsRetina() const override { return _displayIsRetina; }
+  // Perf HUD metrics (metal_perf_hud).
+  uint64_t frameTriangleCount() const override { return _frameTriangles; }
+  float renderScale() const override { return _renderScale; }
+  uint64_t gpuAllocatedBytes() const override;   // [_device currentAllocatedSize]
 
 private:
   void buildImpostorPipelines();
@@ -521,6 +525,8 @@ private:
   // byte-identical. Forced to 1 for offscreen export.
   int _upscaleEnabled = 0;
   float _renderScale = 1.0f;
+  uint64_t _frameTriangles = 0;   // scene-mesh triangles submitted this frame
+                                  // (main pass only); reset in beginFrame().
   // MetalFX spatial scaler (typed id<MTLFXSpatialScaler>; untyped here to keep
   // MetalFX out of the header). Recreated when in/out sizes change. When nil/
   // unsupported the present path falls back to the bilinear blit.

--- a/layerGraphics/metal/RendererMetal.h
+++ b/layerGraphics/metal/RendererMetal.h
@@ -146,7 +146,7 @@ public:
   void setRepClip(float front, float back) override;
   void setRepContour(bool enabled, const float* rgba, float widthPx) override;
   void setRepScreenAO(bool exempt) override;
-  void invalidateVBOCache(uint64_t key) override;
+  void invalidateVBOCache(const void* key) override;
   void drawLabels(const LabelDrawCall& call) override;
   void drawSphereImpostors(const SphereImpostorDrawCall& call) override;
   void drawCylinderImpostors(const CylinderImpostorDrawCall& call) override;

--- a/layerGraphics/metal/RendererMetal.mm
+++ b/layerGraphics/metal/RendererMetal.mm
@@ -2730,6 +2730,11 @@ void RendererMetal::setShadowBias(float bias)
   _shadowBias = (bias > 0.0f) ? bias : 0.0f;
 }
 
+void RendererMetal::setDisplayIsRetina(bool retina)
+{
+  _displayIsRetina = retina;
+}
+
 void RendererMetal::beginShadowPass()
 {
   if (!_cmdBuffer || !_shadowPassDesc || !_vboShadowPipelineUByte) return;

--- a/layerGraphics/metal/RendererMetal.mm
+++ b/layerGraphics/metal/RendererMetal.mm
@@ -700,6 +700,7 @@ void RendererMetal::beginFrame()
   if (_rtEnabled) ensureRayTracingAS();
   _rtSpheres.clear();  // re-accumulated during this frame's opaque pass
   _rtTris.clear();
+  _frameTriangles = 0; // perf HUD: reset the per-frame scene-triangle counter
 
   _cmdBuffer = [_queue commandBuffer];
   _encoder = nil;
@@ -2735,6 +2736,11 @@ void RendererMetal::setDisplayIsRetina(bool retina)
   _displayIsRetina = retina;
 }
 
+uint64_t RendererMetal::gpuAllocatedBytes() const
+{
+  return _device ? (uint64_t)[_device currentAllocatedSize] : 0;
+}
+
 void RendererMetal::beginShadowPass()
 {
   if (!_cmdBuffer || !_shadowPassDesc || !_vboShadowPipelineUByte) return;
@@ -4493,6 +4499,12 @@ void RendererMetal::drawVBO(PrimitiveType mode, int vertexCount,
   ensureEncoder();
   if (!_encoder) return;
 
+  // Perf HUD: count scene-mesh triangles in the main pass (not the shadow
+  // re-draw). Non-indexed triangle-list/strip.
+  if (!_shadowMode && (mode == PrimitiveType::Triangles ||
+                       mode == PrimitiveType::TriangleStrip))
+    _frameTriangles += (uint64_t)(vertexCount / 3);
+
   // Ray tracing: capture solid triangle meshes (cartoon/surface) once per frame.
   if (_rtEnabled && !_shadowMode && !_oitActive)
     rtAppendVBOTris(_rtTris, mode, vertexCount, data, stride, posOffset, nullptr);
@@ -4773,6 +4785,12 @@ void RendererMetal::drawVBOIndexed(PrimitiveType mode, int indexCount,
       indexDataSize == 0 || indexCount <= 0) return;
   ensureEncoder();
   if (!_encoder) return;
+
+  // Perf HUD: count scene-mesh triangles in the main pass (not the shadow
+  // re-draw). Indexed triangle-list/strip.
+  if (!_shadowMode && (mode == PrimitiveType::Triangles ||
+                       mode == PrimitiveType::TriangleStrip))
+    _frameTriangles += (uint64_t)(indexCount / 3);
 
   // Ray tracing: capture solid triangle meshes (cartoon/surface) once per frame.
   if (_rtEnabled && !_shadowMode && !_oitActive)

--- a/layerGraphics/metal/RendererMetal.mm
+++ b/layerGraphics/metal/RendererMetal.mm
@@ -5026,15 +5026,22 @@ void RendererMetal::drawVBOIndexed(PrimitiveType mode, int indexCount,
   }
 }
 
-void RendererMetal::invalidateVBOCache(uint64_t key)
+void RendererMetal::invalidateVBOCache(const void* key)
 {
-  // Clear entire cache — key type changed to pointer-based.
-  // MRC: the map holds +1 MTLBuffers (newBufferWithBytes); STL clear() does not
-  // release them, so drop each ownership first. Any buffer still referenced by an
-  // in-flight command buffer is kept alive by Metal's own retain until that
-  // command buffer completes (same reasoning as ensurePostTargets).
-  for (auto& kv : _vboCache) [kv.second release];
-  _vboCache.clear();
+  // Evict the single cached MTLBuffer for this CPU-data pointer. Called from
+  // CShaderMgr::freeAllGPUBuffers when the owning VertexBufferGL/IndexBufferGL is
+  // freed, so orphaned buffers from rebuilt geometry (e.g. the zoom-driven
+  // cartoon LOD rebuilds) are released instead of accumulating — this map had no
+  // per-entry eviction, an unbounded leak that OOM-jettisoned the app on iOS.
+  // MRC: the map holds +1 MTLBuffers (newBufferWithBytes); drop our ownership.
+  // Any buffer still referenced by an in-flight command buffer is kept alive by
+  // Metal's own retain until that command buffer completes.
+  if (!key) return;
+  auto it = _vboCache.find(key);
+  if (it != _vboCache.end()) {
+    [it->second release];
+    _vboCache.erase(it);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/swiftui/PyMOLViewer/Bridge/PyMOLBridge.h
+++ b/swiftui/PyMOLViewer/Bridge/PyMOLBridge.h
@@ -62,6 +62,12 @@ char *PyMOLBridge_Complete(const char *text);
 char *PyMOLBridge_GetFeedback(PyMOLHandle instance);
 void PyMOLBridge_FreeFeedback(char *str);
 
+// Evaluate a Python expression (in __main__, with `cmd` imported) and return
+// str(result) as a UTF-8 C string, or NULL on error/None. Lets Swift read core
+// values (get_view, settings, count_atoms). Caller frees with
+// PyMOLBridge_FreeFeedback. Main-thread / in-process.
+char *PyMOLBridge_EvalString(const char *expr);
+
 // --- Metal rendering ---
 void PyMOLBridge_RenderMetal(PyMOLHandle instance);
 

--- a/swiftui/PyMOLViewer/Bridge/PyMOLBridge.h
+++ b/swiftui/PyMOLViewer/Bridge/PyMOLBridge.h
@@ -31,6 +31,9 @@ void PyMOLBridge_Drag(PyMOLHandle instance, int x, int y, int modifiers);
 void PyMOLBridge_SetLetterboxAspect(PyMOLHandle instance, float aspect);
 // RGB (0..1) of the 3D selection indicator squares — set from the active theme.
 void PyMOLBridge_SetSelectionColor(PyMOLHandle instance, float r, float g, float b);
+// Tell the renderer whether the window's current display is Retina (gates
+// metal_upscale=auto). retina: 1 = Retina (backingScale>=2), 0 = not.
+void PyMOLBridge_SetDisplayIsRetina(PyMOLHandle instance, int retina);
 void PyMOLBridge_CapturePNG(PyMOLHandle instance, const char* path);
 // Hi-res offscreen render → PNG: reshape PyMOL to width×height, render the full
 // Metal pipeline (all reps + hardware-RT AO/shadows) into offscreen targets at

--- a/swiftui/PyMOLViewer/Bridge/PyMOLBridge.h
+++ b/swiftui/PyMOLViewer/Bridge/PyMOLBridge.h
@@ -8,6 +8,7 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+#include <stdint.h>
 
 // Opaque PyMOL instance handle (CPyMOL* in the implementation)
 typedef void* PyMOLHandle;
@@ -34,6 +35,9 @@ void PyMOLBridge_SetSelectionColor(PyMOLHandle instance, float r, float g, float
 // Tell the renderer whether the window's current display is Retina (gates
 // metal_upscale=auto). retina: 1 = Retina (backingScale>=2), 0 = not.
 void PyMOLBridge_SetDisplayIsRetina(PyMOLHandle instance, int retina);
+
+// Perf HUD (metal_perf_hud): fill live render metrics. Any out-ptr may be NULL.
+void PyMOLBridge_GetRenderStats(uint64_t* outTriangles, uint64_t* outGpuBytes, float* outRenderScale);
 void PyMOLBridge_CapturePNG(PyMOLHandle instance, const char* path);
 // Hi-res offscreen render → PNG: reshape PyMOL to width×height, render the full
 // Metal pipeline (all reps + hardware-RT AO/shadows) into offscreen targets at

--- a/swiftui/PyMOLViewer/Bridge/PyMOLBridge.mm
+++ b/swiftui/PyMOLViewer/Bridge/PyMOLBridge.mm
@@ -223,6 +223,14 @@ void PyMOLBridge_SetSelectionColor(PyMOLHandle h, float r, float g, float b)
     G->Renderer->setSelectionColor(r, g, b);
 }
 
+void PyMOLBridge_SetDisplayIsRetina(PyMOLHandle h, int retina)
+{
+    if (!h) return;
+    PyMOLGlobals* G = PyMOL_GetGlobals(INST(h));
+    if (!G || !G->Renderer) return;
+    G->Renderer->setDisplayIsRetina(retina != 0);
+}
+
 void PyMOLBridge_CapturePNG(PyMOLHandle h, const char* path)
 {
     if (!h || !path) return;

--- a/swiftui/PyMOLViewer/Bridge/PyMOLBridge.mm
+++ b/swiftui/PyMOLViewer/Bridge/PyMOLBridge.mm
@@ -286,6 +286,33 @@ void PyMOLBridge_RunCommand(const char *command)
     PAutoUnblock(G, blk);
 }
 
+char *PyMOLBridge_EvalString(const char *expr)
+{
+    if (!expr) return nullptr;
+    PyMOLGlobals *G = SingletonPyMOLGlobals;
+    if (!G) return nullptr;
+    int blk = PAutoBlock(G);
+    char *result = nullptr;
+    PyObject *mainMod = PyImport_AddModule("__main__");  // borrowed
+    if (mainMod) {
+        PyObject *gd = PyModule_GetDict(mainMod);        // borrowed
+        PyRun_SimpleString("from pymol import cmd");      // idempotent; ensures cmd
+        PyObject *res = PyRun_String(expr, Py_eval_input, gd, gd);
+        if (res && res != Py_None) {
+            PyObject *s = PyObject_Str(res);
+            if (s) {
+                const char *cs = PyUnicode_AsUTF8(s);
+                if (cs) result = strdup(cs);
+                Py_DECREF(s);
+            }
+        }
+        Py_XDECREF(res);
+    }
+    if (PyErr_Occurred()) PyErr_Clear();
+    PAutoUnblock(G, blk);
+    return result;
+}
+
 char *PyMOLBridge_Complete(const char *text)
 {
     if (!text) return nullptr;

--- a/swiftui/PyMOLViewer/Bridge/PyMOLBridge.mm
+++ b/swiftui/PyMOLViewer/Bridge/PyMOLBridge.mm
@@ -231,6 +231,15 @@ void PyMOLBridge_SetDisplayIsRetina(PyMOLHandle h, int retina)
     G->Renderer->setDisplayIsRetina(retina != 0);
 }
 
+void PyMOLBridge_GetRenderStats(uint64_t* outTriangles, uint64_t* outGpuBytes, float* outRenderScale)
+{
+    PyMOLGlobals* G = SingletonPyMOLGlobals;
+    bool ok = (G && G->Renderer);
+    if (outTriangles)   *outTriangles   = ok ? G->Renderer->frameTriangleCount() : 0;
+    if (outGpuBytes)    *outGpuBytes    = ok ? G->Renderer->gpuAllocatedBytes() : 0;
+    if (outRenderScale) *outRenderScale = ok ? G->Renderer->renderScale() : 1.0f;
+}
+
 void PyMOLBridge_CapturePNG(PyMOLHandle h, const char* path)
 {
     if (!h || !path) return;

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -370,8 +370,9 @@ struct ContentView: View {
                             if engine.measureMode != nil { measureOverlay }
                         }
                         // Perf HUD (metal_perf_hud): live LOD/triangles/memory/FPS.
-                        // Bottom-left, clear of the top toolbar/notch.
-                        .overlay(alignment: .bottomLeading) {
+                        // Centered in the viewport, clear of the top toolbar and
+                        // the bottom transport bar.
+                        .overlay(alignment: .center) {
                             if engine.perf.visible {
                                 PerfHUDView(perf: engine.perf).padding(8).allowsHitTesting(false)
                             }
@@ -1401,8 +1402,9 @@ struct ContentView: View {
         MetalViewport()
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             // Perf HUD (metal_perf_hud): live LOD/triangles/memory/FPS.
-            // Bottom-left, clear of the top toolbar/notch.
-            .overlay(alignment: .bottomLeading) {
+            // Centered in the viewport, clear of the top toolbar and the bottom
+            // transport bar.
+            .overlay(alignment: .center) {
                 if engine.perf.visible {
                     PerfHUDView(perf: engine.perf).padding(8).allowsHitTesting(false)
                 }

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -370,7 +370,8 @@ struct ContentView: View {
                             if engine.measureMode != nil { measureOverlay }
                         }
                         // Perf HUD (metal_perf_hud): live LOD/triangles/memory/FPS.
-                        .overlay(alignment: .topLeading) {
+                        // Bottom-left, clear of the top toolbar/notch.
+                        .overlay(alignment: .bottomLeading) {
                             if engine.perf.visible {
                                 PerfHUDView(perf: engine.perf).padding(8).allowsHitTesting(false)
                             }
@@ -1400,7 +1401,8 @@ struct ContentView: View {
         MetalViewport()
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             // Perf HUD (metal_perf_hud): live LOD/triangles/memory/FPS.
-            .overlay(alignment: .topLeading) {
+            // Bottom-left, clear of the top toolbar/notch.
+            .overlay(alignment: .bottomLeading) {
                 if engine.perf.visible {
                     PerfHUDView(perf: engine.perf).padding(8).allowsHitTesting(false)
                 }

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -369,6 +369,12 @@ struct ContentView: View {
                         .overlay(alignment: .top) {
                             if engine.measureMode != nil { measureOverlay }
                         }
+                        // Perf HUD (metal_perf_hud): live LOD/triangles/memory/FPS.
+                        .overlay(alignment: .topLeading) {
+                            if engine.perf.visible {
+                                PerfHUDView(perf: engine.perf).padding(8).allowsHitTesting(false)
+                            }
+                        }
                         // Pick-debug crosshair: marks exactly where the last click
                         // landed, so a screenshot shows click-vs-selection offset.
                         .overlay { debugClickMarker }
@@ -1393,6 +1399,12 @@ struct ContentView: View {
     private var viewportView: some View {
         MetalViewport()
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            // Perf HUD (metal_perf_hud): live LOD/triangles/memory/FPS.
+            .overlay(alignment: .topLeading) {
+                if engine.perf.visible {
+                    PerfHUDView(perf: engine.perf).padding(8).allowsHitTesting(false)
+                }
+            }
             // Attached here (not the giant body chain) to keep that expression
             // under the Swift type-checker's complexity limit.
             .alert("No movie to export", isPresented: $showNoMovieAlert) {
@@ -2444,6 +2456,26 @@ struct CalculatingOverlay: View {
             .padding(28)
             .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16))
         }
+    }
+}
+
+/// Live performance HUD overlay (metal_perf_hud). Monospaced metrics block,
+/// top-left, non-interactive. Values published by PyMOLEngine.perf.
+struct PerfHUDView: View {
+    @ObservedObject var perf: PerfHUD
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text("FPS \(PerfFormat.fps(perf.fps))   scene tris \(perf.triangles)")
+            Text("LOD samp \(perf.sampling)  max \(perf.bucketMax)  Å/px \(String(format: "%.3f", perf.angPerPx))  dyn \(perf.dynamicOn ? "on" : "off")")
+            Text("mem  cpu \(PerfFormat.bytes(perf.cpuBytes))  gpu \(PerfFormat.bytes(perf.gpuBytes))")
+            Text("upscale \(perf.upscale) rs \(String(format: "%.2f", perf.renderScale))  msaa \(perf.msaa ? "1" : "0")  sh \(perf.shadows ? "1" : "0")  rt \(perf.raytrace ? "1" : "0")")
+            Text("draw \(perf.drawableW)×\(perf.drawableH)  retina \(perf.retina ? "1" : "0")")
+        }
+        .font(.system(size: 10, design: .monospaced))
+        .foregroundColor(.green)
+        .padding(6)
+        .background(Color.black.opacity(0.55))
+        .cornerRadius(6)
     }
 }
 

--- a/swiftui/PyMOLViewer/Shared/MetalViewport.swift
+++ b/swiftui/PyMOLViewer/Shared/MetalViewport.swift
@@ -98,6 +98,13 @@ class PyMOLMTKView: MTKView {
     override var acceptsFirstResponder: Bool { false }
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 
+    // Fires when the backing scale changes (window moved to a display of a
+    // different DPI) → re-evaluate metal_upscale=auto immediately.
+    override func viewDidChangeBackingProperties() {
+        super.viewDidChangeBackingProperties()
+        coordinator?.pushDisplayRetina(self)
+    }
+
     override func mouseDown(with event: NSEvent) {
         coordinator?.handleMouseDown(event, in: self)
     }
@@ -230,6 +237,24 @@ extension MetalViewport {
             }
             lodWork = work
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.20, execute: work)
+        }
+
+        // Cached so we only push the retina flag to the core on an actual change.
+        private var lastRetina: Bool?
+
+        /// Push whether the window's current display is Retina (backingScale>=2)
+        /// to the renderer, gating metal_upscale=auto. Change-gated; cheap to call
+        /// from draw() and from viewDidChangeBackingProperties.
+        func pushDisplayRetina(_ view: MTKView) {
+            #if os(macOS)
+            let scale = view.window?.screen?.backingScaleFactor ?? 2.0
+            #else
+            let scale = view.window?.screen.scale ?? view.contentScaleFactor
+            #endif
+            let retina = CartoonLOD.autoUpscale(backingScale: scale)
+            guard retina != lastRetina else { return }
+            lastRetina = retina
+            engine?.setDisplayIsRetina(retina)
         }
         // Set when the app/display wakes (unlock, system wake, re-activate). The
         // next draw(in:) then renders unconditionally, bypassing the on-demand
@@ -400,6 +425,10 @@ extension MetalViewport {
             // settled, and re-tessellates only if the LOD bucket changed. Covers
             // gestures AND programmatic zoom/orient/animation uniformly.
             scheduleLODUpdate()
+            // Push the display's Retina flag (change-gated) so metal_upscale=auto
+            // resolves against the CURRENT screen — covers launch + window moved
+            // between displays even if no backing-property change fired.
+            pushDisplayRetina(view)
         }
 
         // MARK: - Coordinate conversion

--- a/swiftui/PyMOLViewer/Shared/MetalViewport.swift
+++ b/swiftui/PyMOLViewer/Shared/MetalViewport.swift
@@ -214,6 +214,23 @@ extension MetalViewport {
         weak var engine: PyMOLEngine?
         weak var mtkView: MTKView?
         private var viewportSize: CGSize = .zero
+        // Debounce for zoom-adaptive cartoon LOD (cartoon_sampling_dynamic): a
+        // rebuild fires only ~200ms AFTER the zoom settles, never mid-gesture.
+        private var lodWork: DispatchWorkItem?
+
+        /// Schedule a debounced adaptive-cartoon-sampling update. Call from any
+        /// zoom handler; the debounce coalesces bursts and the engine no-ops when
+        /// the LOD bucket is unchanged or the setting is off.
+        func scheduleLODUpdate() {
+            lodWork?.cancel()
+            let work = DispatchWorkItem { [weak self] in
+                guard let self = self, let v = self.mtkView else { return }
+                let h = Float(v.drawableSize.height)
+                self.engine?.applyDynamicCartoonSampling(viewportHeightPx: h)
+            }
+            lodWork = work
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.20, execute: work)
+        }
         // Set when the app/display wakes (unlock, system wake, re-activate). The
         // next draw(in:) then renders unconditionally, bypassing the on-demand
         // gate, to repaint a drawable whose contents were discarded during sleep.
@@ -376,6 +393,13 @@ extension MetalViewport {
             // let the engine clear the "Calculating…" overlay once the build
             // frame(s) have completed.
             engine.heavyRenderTick()
+            // Zoom-adaptive cartoon LOD: reset the debounce each frame that
+            // actually rendered (i.e. the scene/camera changed — this is AFTER
+            // the on-demand gate, so a static scene never resets it). The timer
+            // fires ~200ms after the LAST such frame, i.e. once the camera has
+            // settled, and re-tessellates only if the LOD bucket changed. Covers
+            // gestures AND programmatic zoom/orient/animation uniformly.
+            scheduleLODUpdate()
         }
 
         // MARK: - Coordinate conversion

--- a/swiftui/PyMOLViewer/Shared/MetalViewport.swift
+++ b/swiftui/PyMOLViewer/Shared/MetalViewport.swift
@@ -252,9 +252,47 @@ extension MetalViewport {
             let scale = view.window?.screen.scale ?? view.contentScaleFactor
             #endif
             let retina = CartoonLOD.autoUpscale(backingScale: scale)
+            if let e = engine, e.perf.retina != retina { DispatchQueue.main.async { e.perf.retina = retina } }
             guard retina != lastRetina else { return }
             lastRetina = retina
             engine?.setDisplayIsRetina(retina)
+        }
+
+        // Perf HUD (metal_perf_hud): FPS is an EMA of rendered-frame intervals;
+        // the rest (renderer stats + settings) is published ~3x/s. Called from
+        // draw(in:) only on frames that actually rendered.
+        private var lastFrameTime: CFTimeInterval = 0
+        private var fpsEMA: Double = 0
+        private var lastHUDPublish: CFTimeInterval = 0
+        func updatePerfHUD(_ view: MTKView) {
+            let now = CACurrentMediaTime()
+            if lastFrameTime > 0 {
+                let dt = now - lastFrameTime
+                if dt > 0 { fpsEMA = fpsEMA == 0 ? 1.0/dt : (0.9*fpsEMA + 0.1*(1.0/dt)) }
+            }
+            lastFrameTime = now
+            guard let engine = engine else { return }
+            let hudOn = (engine.evalInt("int(cmd.get_setting_int('metal_perf_hud'))") ?? 0) == 1
+            if engine.perf.visible != hudOn { DispatchQueue.main.async { engine.perf.visible = hudOn } }
+            guard hudOn, now - lastHUDPublish > 0.33 else { return }   // ~3x/s
+            lastHUDPublish = now
+            var tris: UInt64 = 0, gpu: UInt64 = 0; var rs: Float = 1
+            PyMOLBridge_GetRenderStats(&tris, &gpu, &rs)
+            let cpu = engine.cpuFootprintBytes()
+            let samp = engine.evalInt("int(cmd.get_setting_int('cartoon_sampling'))") ?? 0
+            let up = engine.evalInt("int(cmd.get_setting_int('metal_upscale'))") ?? 0
+            let msaa = (engine.evalInt("int(cmd.get_setting_int('metal_msaa'))") ?? 0) == 1
+            let sh = (engine.evalInt("int(cmd.get_setting_int('metal_shadows'))") ?? 0) == 1
+            let rt = (engine.evalInt("int(cmd.get_setting_int('metal_raytrace'))") ?? 0) == 1
+            let dw = Int(view.drawableSize.width), dh = Int(view.drawableSize.height)
+            let fps = fpsEMA
+            DispatchQueue.main.async {
+                let p = engine.perf
+                p.fps = fps; p.triangles = tris; p.gpuBytes = gpu; p.cpuBytes = cpu
+                p.sampling = samp; p.upscale = up; p.renderScale = rs
+                p.msaa = msaa; p.shadows = sh; p.raytrace = rt
+                p.drawableW = dw; p.drawableH = dh
+            }
         }
         // Set when the app/display wakes (unlock, system wake, re-activate). The
         // next draw(in:) then renders unconditionally, bypassing the on-demand
@@ -429,6 +467,8 @@ extension MetalViewport {
             // resolves against the CURRENT screen — covers launch + window moved
             // between displays even if no backing-property change fired.
             pushDisplayRetina(view)
+            // Perf HUD: FPS + metrics (throttled internally; gated on metal_perf_hud).
+            updatePerfHUD(view)
         }
 
         // MARK: - Coordinate conversion

--- a/swiftui/PyMOLViewer/Shared/MetalViewport.swift
+++ b/swiftui/PyMOLViewer/Shared/MetalViewport.swift
@@ -271,11 +271,15 @@ extension MetalViewport {
                 if dt > 0 { fpsEMA = fpsEMA == 0 ? 1.0/dt : (0.9*fpsEMA + 0.1*(1.0/dt)) }
             }
             lastFrameTime = now
+            // Throttle EVERYTHING below (incl. the metal_perf_hud gate read) to
+            // ~3x/s so a frame costs nothing extra when the HUD is off — FPS EMA
+            // above is pure Swift and stays per-frame.
+            guard now - lastHUDPublish > 0.33 else { return }
+            lastHUDPublish = now
             guard let engine = engine else { return }
             let hudOn = (engine.evalInt("int(cmd.get_setting_int('metal_perf_hud'))") ?? 0) == 1
             if engine.perf.visible != hudOn { DispatchQueue.main.async { engine.perf.visible = hudOn } }
-            guard hudOn, now - lastHUDPublish > 0.33 else { return }   // ~3x/s
-            lastHUDPublish = now
+            guard hudOn else { return }
             var tris: UInt64 = 0, gpu: UInt64 = 0; var rs: Float = 1
             PyMOLBridge_GetRenderStats(&tris, &gpu, &rs)
             let cpu = engine.cpuFootprintBytes()

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -22,6 +22,51 @@ final class PlaybackState: ObservableObject {
 
 enum MeasureKind: String { case distance, angle, dihedral }
 
+/// Pure math for adaptive cartoon level-of-detail + display-aware upscale.
+/// Unit-tested standalone (see docs/superpowers/plans/2026-07-02-adaptive-cartoon-lod.md).
+/// Inlined here (not a new file) to avoid Xcode pbxproj surgery; visible to the
+/// whole app module (MetalViewport uses `autoUpscale`).
+enum CartoonLOD {
+    /// Å per pixel at the structure centre, from camera distance + FOV + viewport height.
+    static func angstromPerPixel(cameraDistance: Float, fovDegrees: Float, viewportHeightPx: Float) -> Float {
+        guard viewportHeightPx >= 1 else { return 1e9 }
+        let halfTan = tan(fovDegrees * 0.5 * .pi / 180)
+        return (2 * abs(cameraDistance) * halfTan) / viewportHeightPx
+    }
+
+    // LOD levels coarse->fine; `bounds[i]` is the Å/px boundary between level i and
+    // i+1 (Å/px decreases as we zoom in / go finer). Level values are clamped to
+    // maxSampling so small structures never exceed their cap.
+    private static let baseLevels = [3, 5, 8, 12, -1 /* -> maxSampling */]
+    private static let bounds: [Float] = [0.50, 0.25, 0.10, 0.05]
+    private static let hysteresis: Float = 0.20
+
+    private static func levels(_ maxSampling: Int) -> [Int] {
+        baseLevels.map { min($0 == -1 ? maxSampling : $0, maxSampling) }
+    }
+    private static func rawLevel(_ a: Float) -> Int {
+        var lvl = 0
+        for b in bounds { if a < b { lvl += 1 } }
+        return lvl
+    }
+
+    /// Target cartoon_sampling for the current Å/px, with hysteresis vs `current`.
+    static func targetSampling(angstromPerPixel a: Float, maxSampling: Int, current: Int) -> Int {
+        let lv = levels(maxSampling)
+        let rl = rawLevel(a)
+        let cur = lv.firstIndex(of: current) ?? rl
+        if rl == cur { return current }
+        if abs(rl - cur) >= 2 { return lv[rl] }        // big jump: no ambiguity
+        if rl > cur {                                   // finer: cross bounds[cur]
+            return a < bounds[cur] * (1 - hysteresis) ? lv[rl] : current
+        } else {                                        // coarser: cross bounds[cur-1]
+            return a > bounds[cur - 1] * (1 + hysteresis) ? lv[rl] : current
+        }
+    }
+
+    static func autoUpscale(backingScale: CGFloat) -> Bool { backingScale >= 2.0 }
+}
+
 /// One PyMOL setting for the Settings panel. type: 1 bool, 2 int, 3 float,
 /// 4 float3, 5 color, 6 string (pymol.setting type codes).
 struct SettingItem: Identifiable, Equatable, Codable {

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -69,6 +69,38 @@ enum CartoonLOD {
     static func autoUpscale(backingScale: CGFloat) -> Bool { backingScale >= 2.0 }
 }
 
+/// Formatting helpers for the perf HUD. Unit-tested standalone (swift script).
+enum PerfFormat {
+    static func bytes(_ b: UInt64) -> String {
+        let mb = Double(b) / (1024*1024)
+        if mb >= 1024 { return String(format: "%.2f GB", mb/1024) }
+        return String(format: "%.0f MB", mb)
+    }
+    static func fps(_ f: Double) -> String { f <= 0 ? "idle" : String(format: "%.0f", f) }
+}
+
+/// Live render metrics for the perf HUD overlay (metal_perf_hud). Published ~3x/s
+/// from MetalViewport.draw(in:) + PyMOLEngine.applyDynamicCartoonSampling.
+final class PerfHUD: ObservableObject {
+    @Published var visible = false          // mirrors metal_perf_hud
+    @Published var fps: Double = 0
+    @Published var triangles: UInt64 = 0
+    @Published var cpuBytes: UInt64 = 0
+    @Published var gpuBytes: UInt64 = 0
+    @Published var sampling = 0             // live cartoon_sampling
+    @Published var angPerPx: Float = 0
+    @Published var bucketMax = 0            // effective cartoon_sampling_max
+    @Published var dynamicOn = false
+    @Published var upscale = 0              // metal_upscale (0/1/2)
+    @Published var renderScale: Float = 1
+    @Published var msaa = false
+    @Published var shadows = false
+    @Published var raytrace = false
+    @Published var drawableW = 0
+    @Published var drawableH = 0
+    @Published var retina = true
+}
+
 /// One PyMOL setting for the Settings panel. type: 1 bool, 2 int, 3 float,
 /// 4 float3, 5 color, 6 string (pymol.setting type codes).
 struct SettingItem: Identifiable, Equatable, Codable {
@@ -910,14 +942,29 @@ final class PyMOLEngine: ObservableObject {
         defer { PyMOLBridge_FreeFeedback(c) }
         return String(cString: c)
     }
-    private func evalFloat(_ expr: String) -> Float? { evalString(expr).flatMap { Float($0) } }
-    private func evalInt(_ expr: String) -> Int? { evalString(expr).flatMap { Int($0) } }
+    func evalFloat(_ expr: String) -> Float? { evalString(expr).flatMap { Float($0) } }
+    func evalInt(_ expr: String) -> Int? { evalString(expr).flatMap { Int($0) } }
 
     // MARK: - Adaptive cartoon LOD (cartoon_sampling_dynamic)
 
     /// Last sampling this engine applied, so hysteresis compares against what we
     /// set (not a stale read). -1 = unknown.
     private var lastAppliedSampling: Int = -1
+
+    /// Live perf-HUD metrics (metal_perf_hud). Observed by PerfHUDView.
+    let perf = PerfHUD()
+
+    /// Process physical memory footprint in bytes (mach TASK_VM_INFO).
+    func cpuFootprintBytes() -> UInt64 {
+        var info = task_vm_info_data_t()
+        var count = mach_msg_type_number_t(MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<natural_t>.size)
+        let kr = withUnsafeMutablePointer(to: &info) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), $0, &count)
+            }
+        }
+        return kr == KERN_SUCCESS ? UInt64(info.phys_footprint) : 0
+    }
 
     /// Zoom-adaptive cartoon detail: map the current Å/px to a target
     /// cartoon_sampling (CartoonLOD) and rebuild if it changed. No-op unless
@@ -943,6 +990,11 @@ final class PyMOLEngine: ObservableObject {
         let app = CartoonLOD.angstromPerPixel(cameraDistance: camDist, fovDegrees: fov,
                                               viewportHeightPx: viewportHeightPx)
         let target = CartoonLOD.targetSampling(angstromPerPixel: app, maxSampling: maxS, current: cur)
+        // Publish LOD values for the perf HUD (even when no rebuild is needed).
+        DispatchQueue.main.async {
+            self.perf.angPerPx = app; self.perf.bucketMax = maxS
+            self.perf.sampling = target; self.perf.dynamicOn = true
+        }
         guard target != cur else { return }
         lastAppliedSampling = target
         runPython("cmd.set('cartoon_sampling', \(target)); cmd.rebuild()")

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -948,6 +948,13 @@ final class PyMOLEngine: ObservableObject {
         runPython("cmd.set('cartoon_sampling', \(target)); cmd.rebuild()")
     }
 
+    /// Tell the renderer whether the window's current display is Retina; gates
+    /// metal_upscale=auto. Call on launch and whenever the window changes screen.
+    func setDisplayIsRetina(_ retina: Bool) {
+        guard let inst = instance else { return }
+        PyMOLBridge_SetDisplayIsRetina(inst, retina ? 1 : 0)
+    }
+
     /// Write the whole session to `url` (a .pse) via cmd.save (the only path to the
     /// C++ saver is runPython — there's no Swift cmd.save wrapper) and track it as
     /// the open document so a subsequent ⌘S overwrites it with no panel. Raw triple

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -979,10 +979,30 @@ final class PyMOLEngine: ObservableObject {
         guard let camDist = evalFloat("abs(cmd.get_view()[11])") else { return }
         let fov = evalFloat("float(cmd.get_setting_float('field_of_view'))") ?? 20
         var maxS = evalInt("int(cmd.get_setting_int('cartoon_sampling_max'))") ?? -1
+        #if os(iOS)
+        // iOS has a far tighter memory budget than desktop. A large cartoon at
+        // high sampling OOM-kills the app (jetsam) — measured: cartoon_sampling=100
+        // on the 20S proteasome (1ss8) = 7.1M triangles ≈ 2.8 GB resident. So on
+        // iOS we HARD-CLAMP the effective ceiling to a device-safe value scaled by
+        // polymer atom count, REGARDLESS of an explicit (or session-restored)
+        // cartoon_sampling_max — a phone simply cannot render sampling 100. The
+        // clamp bounds both the auto (-1) case and any high explicit value.
+        do {
+            let n = evalInt("cmd.count_atoms('polymer')") ?? 0
+            // Device-safe ceiling scaled by polymer size. Post leak-fix, memory is
+            // bounded (measured: sampling 12 ≈ 1.1 GB vs ~3 GB jetsam ceiling), so
+            // small/mid structures can afford 10-12 for smooth cartoons; only very
+            // large assemblies scale down to stay under the cap. Faceting is
+            // front-loaded — 5→10 removes most visible facets at phone DPI.
+            let cap = n < 20000 ? 12 : (n < 100000 ? 10 : (n < 300000 ? 6 : 4))
+            maxS = (maxS < 0) ? cap : min(maxS, cap)
+        }
+        #else
         if maxS < 0 {   // auto ceiling: scale down by polymer atom count
             let n = evalInt("cmd.count_atoms('polymer')") ?? 0
             maxS = n < 10000 ? 18 : (n < 50000 ? 12 : (n < 200000 ? 8 : 5))
         }
+        #endif
         // Hysteresis reference = the bucket value we last applied (always a real
         // bucket). -1 on first run => targetSampling has no reference and returns
         // the raw bucket (the current setting may be -1/auto or a non-bucket value).
@@ -997,7 +1017,13 @@ final class PyMOLEngine: ObservableObject {
         }
         guard target != cur else { return }
         lastAppliedSampling = target
-        runPython("cmd.set('cartoon_sampling', \(target)); cmd.rebuild()")
+        // Rebuild ONLY the cartoon rep — NOT every representation of every object.
+        // cmd.rebuild() defaults to selection='all', representation='everything'
+        // (viewing.py), so a bare rebuild() retessellates the whole scene: on a
+        // memory-constrained device that transient spike OOM-kills the app (jetsam)
+        // and the synchronous main-thread work risks a watchdog kill. cartoon_sampling
+        // only affects the cartoon rep, so scope the rebuild to it.
+        runPython("cmd.set('cartoon_sampling', \(target)); cmd.rebuild('all', 'cartoon')")
     }
 
     /// Tell the renderer whether the window's current display is Retina; gates

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -54,7 +54,9 @@ enum CartoonLOD {
     static func targetSampling(angstromPerPixel a: Float, maxSampling: Int, current: Int) -> Int {
         let lv = levels(maxSampling)
         let rl = rawLevel(a)
-        let cur = lv.firstIndex(of: current) ?? rl
+        // Unknown/non-bucket current (e.g. -1 auto, 7 default, a user value) -> no
+        // hysteresis reference; jump straight to the raw bucket.
+        guard let cur = lv.firstIndex(of: current) else { return lv[rl] }
         if rl == cur { return current }
         if abs(rl - cur) >= 2 { return lv[rl] }        // big jump: no ambiguity
         if rl > cur {                                   // finer: cross bounds[cur]
@@ -899,6 +901,51 @@ final class PyMOLEngine: ObservableObject {
     func runPython(_ code: String) {
         guard isReady else { return }
         PyMOLBridge_RunPython(code)
+    }
+
+    /// Evaluate a Python expression and return str(result), or nil. Lets Swift
+    /// read core values (get_view, settings, count_atoms). Main-thread.
+    func evalString(_ expr: String) -> String? {
+        guard isReady, let c = PyMOLBridge_EvalString(expr) else { return nil }
+        defer { PyMOLBridge_FreeFeedback(c) }
+        return String(cString: c)
+    }
+    private func evalFloat(_ expr: String) -> Float? { evalString(expr).flatMap { Float($0) } }
+    private func evalInt(_ expr: String) -> Int? { evalString(expr).flatMap { Int($0) } }
+
+    // MARK: - Adaptive cartoon LOD (cartoon_sampling_dynamic)
+
+    /// Last sampling this engine applied, so hysteresis compares against what we
+    /// set (not a stale read). -1 = unknown.
+    private var lastAppliedSampling: Int = -1
+
+    /// Zoom-adaptive cartoon detail: map the current Å/px to a target
+    /// cartoon_sampling (CartoonLOD) and rebuild if it changed. No-op unless
+    /// cartoon_sampling_dynamic is on. Call on the main thread after the camera
+    /// has SETTLED (the caller debounces) — never mid-gesture.
+    func applyDynamicCartoonSampling(viewportHeightPx: Float) {
+        guard isReady, viewportHeightPx >= 1 else { return }
+        guard (evalInt("int(cmd.get_setting_int('cartoon_sampling_dynamic'))") ?? 0) == 1 else { return }
+        // No cartoon shown → nothing to retessellate.
+        guard (evalInt("cmd.count_atoms('rep cartoon or rep ribbon')") ?? 0) > 0 else { return }
+        // 18-float embedded get_view: v[11] is the camera translation z (distance).
+        guard let camDist = evalFloat("abs(cmd.get_view()[11])") else { return }
+        let fov = evalFloat("float(cmd.get_setting_float('field_of_view'))") ?? 20
+        var maxS = evalInt("int(cmd.get_setting_int('cartoon_sampling_max'))") ?? -1
+        if maxS < 0 {   // auto ceiling: scale down by polymer atom count
+            let n = evalInt("cmd.count_atoms('polymer')") ?? 0
+            maxS = n < 10000 ? 18 : (n < 50000 ? 12 : (n < 200000 ? 8 : 5))
+        }
+        // Hysteresis reference = the bucket value we last applied (always a real
+        // bucket). -1 on first run => targetSampling has no reference and returns
+        // the raw bucket (the current setting may be -1/auto or a non-bucket value).
+        let cur = lastAppliedSampling > 0 ? lastAppliedSampling : -1
+        let app = CartoonLOD.angstromPerPixel(cameraDistance: camDist, fovDegrees: fov,
+                                              viewportHeightPx: viewportHeightPx)
+        let target = CartoonLOD.targetSampling(angstromPerPixel: app, maxSampling: maxS, current: cur)
+        guard target != cur else { return }
+        lastAppliedSampling = target
+        runPython("cmd.set('cartoon_sampling', \(target)); cmd.rebuild()")
     }
 
     /// Write the whole session to `url` (a .pse) via cmd.save (the only path to the


### PR DESCRIPTION
Follow-up to #88/#92 (issue #87). Raising `cartoon_sampling` gives crisp strands and further softens residual faceting, but tessellates the whole object all the time (perf cost). `metal_upscale` reclaims perf but its 0.667× blur is objectionable on low-DPI external displays. This adds a unified adaptive system so high detail is paid for only when visible, and upscale turns on only where it looks good.

Design + plan: `docs/superpowers/specs/2026-07-02-adaptive-cartoon-lod-and-display-aware-upscale-design.md`, `docs/superpowers/plans/2026-07-02-adaptive-cartoon-lod.md`.

## A. Zoom-adaptive cartoon tessellation
- New settings: **`cartoon_sampling_dynamic`** (bool, default **on**) and **`cartoon_sampling_max`** (int, default −1 = auto, scaled down by atom count so large structures stay bounded).
- Pure `CartoonLOD` math (in `PyMOLEngine.swift`): Å-per-pixel from `get_view` + `field_of_view` + viewport height → discrete sampling buckets (3 / 5 / 8 / 12 / max) with **hysteresis** (no thrash at boundaries). Unit-tested standalone (`swift`), incl. the auto/non-bucket-current edge case.
- Trigger: `MetalViewport.draw(in:)` calls a **200 ms debounce** *after* a real render (past the on-demand gate), so it fires once the camera **settles** — covering gestures **and** programmatic `zoom`/`orient`/animation. Then `applyDynamicCartoonSampling` rebuilds only if the LOD bucket changed. Benchmark: 1–7 ms rebuild for typical structures, ~175 ms worst case (GroEL), bounded by the auto ceiling.
- New reusable bridge `PyMOLBridge_EvalString` (eval a Python expr → string) lets Swift read core values.

## B. Display-aware upscale
- **`metal_upscale`** is now an int: **0 = off, 1 = on, 2 = auto** (default **2**; 0/1 keep prior meaning).
- Auto enables the reduced-res upscale only when the window's current display is **Retina** (`backingScaleFactor ≥ 2`) — hides the blur; off on low-DPI externals. Pushed from Swift (change-gated in `draw(in:)` + immediate `viewDidChangeBackingProperties()`); resolved core-side in `SceneRenderMetal`.

## Verification (host, actual built app via MCP)
- **Adaptive, bidirectional (1ubq):** zoom-all → `cartoon_sampling` **18**; zoomed out → **8**; far out → **3** (floor); tight zoom-in → **18** (max) — matches the Å/px buckets.
- **Regression:** `cartoon_sampling_dynamic 0` → sampling frozen at 7 across far-out zoom (no adaptation).
- **Upscale:** defaults to 2; 0/1/2 all settable; no crash across toggles.
- `CartoonLOD` standalone unit test passes (incl. hysteresis + cap + auto-current).
- Isolated-VM smoke pending (mac-vm-pool MCP not connected this session); host verification uses the real build and reads back exact state.

## Non-goals
No per-region / GPU-tessellation rewrite (benchmark showed whole-object debounced rebuild is fast enough). `metal_shadow_bias` acne fix unchanged.

macOS SwiftUI + Metal; core + app rebuilt.
---

## Follow-up: on-device (iOS) crash-on-zoom fix

Field report: RayMol crashed on iPhone when zooming into large structures (1ss8, the 20S proteasome). Diagnosed from device JetsamEvent reports + a live memory-footprint trace. **Two stacked causes, both fixed:**

1. **Unbounded VBO-cache leak (primary accumulator).** `RendererMetal._vboCache` (keyed by each buffer's CPU-data pointer) had 8 insert sites and no per-entry eviction; its only cleanup was dead code. Every zoom-driven `cmd.rebuild('cartoon')` orphaned the old cartoon's ~15–45 MB `MTLBuffer` → RAM climbed monotonically to ~2.9 GB → jetsam. **Fix:** `GPUBuffer::cpuDataPointer()` (overridden in `VertexBufferGL`/`IndexBufferGL`) lets `CShaderMgr::freeAllGPUBuffers` evict the matching entry when a buffer is freed; `invalidateVBOCache` now releases a single keyed entry (`const void*`) instead of clearing the whole map. Also closes a latent recycled-pointer stale-geometry hazard.

2. **Runaway sampling.** A high `cartoon_sampling_max` (100) restored from the session drove zoom-in to `cartoon_sampling=100` → a 7.1M-triangle cartoon (~2.8 GB) → OOM. **Fix:** on iOS, hard-clamp the effective ceiling to a device-safe value scaled by polymer atom count (`min` with any explicit `cartoon_sampling_max`) — tuned to 10–12 for small/mid structures now that memory is bounded.

Plus: scope the zoom rebuild to the cartoon rep (`cmd.rebuild('all','cartoon')`) rather than retessellating the whole scene.

**Verified on-device (iPhone 15 Pro):** memory plateaus ~1 GB at sampling 10 (was 2.9 GB), no crash after sustained aggressive zooming; macOS + iOS cores both build.

**Deferred:** a `com.apple.developer.kernel.increased-memory-limit` entitlement (needs a Developer-portal capability enable) and a true view-frustum "detail only on-screen" overlay (feasible but seam-prone and only helps the very-large-zoomed-in tail; the raised flat cap covers the common case).