### PR TITLE
Drive RayMol over MCP from host into a mac-vm-test VM (dev flags + skill)

### DIFF
--- a/.claude/skills/raymol-mac-vm/SKILL.md
+++ b/.claude/skills/raymol-mac-vm/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: raymol-mac-vm
+description: Develop and functionally test the native macOS RayMol app inside an isolated, disposable macOS VM AND drive it over its built-in MCP server from the host. Use when working on the macOS SwiftUI/Metal RayMol app and you want to build it, run it in a throwaway VM (not the host UI), and load/color/render/measure structures in it via MCP from this session. Builds on the mac-vm-test skill + mac-vm-pool MCP; adds the RayMol-specific dev flags and a direct-HTTP MCP driver so host↔VM control works.
+---
+
+# raymol-mac-vm
+
+Host-compile RayMol (macOS SwiftUI/Metal), run it in a **fresh disposable macOS
+VM**, and **drive it over MCP from the host** — so macOS RayMol development can
+lean on the isolated VM instead of the host's own UI.
+
+This is the RayMol-specific companion to the generic **`mac-vm-test`** skill. It
+reuses that skill's VM lifecycle (the `mac-vm-pool` MCP server) and SSH/tart
+plumbing, and adds the two pieces RayMol needs:
+
+1. **Dev flags** so the in-VM RayMol MCP server is reachable from the host and
+   runs headlessly (no UI click). All three are read only from the process
+   environment and are absent from any Finder/`open` launch, so they never
+   affect shipped or App Store builds:
+   - `RAYMOL_MCP_BIND=0.0.0.0` — bind a reachable interface instead of VM
+     loopback (`modules/raymol_mcp/server.py`; default `127.0.0.1`).
+   - `RAYMOL_MCP_ENABLE=1` — force the server to auto-start on a fresh clone
+     even though the UI toggle is off (`swiftui/.../MCPServerManager.swift`).
+   - `RAYMOL_MCP_AUTOTRUST=1` — skip the interactive "Allow" approval (existing
+     flag; there's no one to click in a headless VM).
+2. **`raymol-vm-mcp.py`** — a host-side driver that talks JSON-RPC straight to
+   the VM's MCP endpoint (bearer-token authed). No `claude mcp add` needed, so
+   it works in the *current* session (a freshly-registered MCP server otherwise
+   won't attach until `/mcp`/restart).
+
+`$SK` below is this skill's dir (`.claude/skills/raymol-mac-vm`). The driver is
+`$SK/raymol-vm-mcp.py`.
+
+## Prerequisites
+Same as `mac-vm-test`: the `mac-vm-pool` MCP server running (so the
+`mcp__mac-vm-pool__*` tools exist), a baked `mac-test-golden` image, the entitled
+`tart` CLI in `$MVP_TART_BIN`, and the baked SSH key `~/.mac-vm-pool/id_ed25519`.
+If `mac-vm-test` isn't set up, do that first.
+
+## The loop — do these in order
+
+### 1. Acquire a VM
+Call `mcp__mac-vm-pool__acquire_vm` with a `client_id`. It returns
+`{ lease_id, vm_name, ip, ... }`. Save `IP=<ip>`, `VM=<vm_name>`,
+`LEASE=<lease_id>`. If it returns `{"queued": true}`, the 2-VM cap is full —
+release something or stop.
+
+### 2. Build RayMol ON THE HOST
+Two-stage build (the C++ core is a static lib the app only *links*; `xcodebuild`
+alone silently relinks a **stale** `libpymol_core.a`):
+```bash
+# Stage 1 — ONLY if you changed C++ core (layer*/appkit/layerGraphics).
+# Swift/ObjC or Python (modules/) changes DO NOT need this.
+bash swiftui/build_macos.sh
+
+# Stage 2 — always. Bundles modules/ (incl. the edited raymol_mcp) + links the app.
+xcodebuild -project swiftui/PyMOLViewer.xcodeproj -scheme PyMOLViewer_macOS \
+  -configuration Debug -derivedDataPath swiftui/build_mac_dd build
+APP="swiftui/build_mac_dd/Build/Products/Debug/RayMol.app"
+```
+(From a worktree without its own core: symlink `deps_macos` and
+`build_macos_swiftui` from the main repo, or run stage 1 in the worktree — see
+the `macos_swiftui_build_verify` memory.)
+
+### 3. Install the .app into the VM
+```bash
+KEY=~/.mac-vm-pool/id_ed25519
+SSHOPTS=(-i "$KEY" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null)
+ssh "${SSHOPTS[@]}" admin@"$IP" 'rm -rf ~/Apps/RayMol.app && mkdir -p ~/Apps'
+scp "${SSHOPTS[@]}" -r "$APP" admin@"$IP":~/Apps/
+```
+
+### 4. Launch it in the VM **with the dev env**
+The three `RAYMOL_MCP_*` vars must reach the GUI app's process. A plain
+`launchctl setenv` over SSH does NOT reach the console Aqua session (an
+`open`-launched app never sees it), so set them in the CONSOLE user's launchd
+domain (needs root; passwordless sudo works on the golden image), then `open`.
+**This is the verified path** (2026-07-04, golden image macOS 15.7.7):
+```bash
+ssh "${SSHOPTS[@]}" admin@"$IP" '
+  set -e
+  CUID=$(id -u)
+  sudo launchctl asuser $CUID launchctl setenv RAYMOL_MCP_BIND 0.0.0.0
+  sudo launchctl asuser $CUID launchctl setenv RAYMOL_MCP_AUTOTRUST 1
+  sudo launchctl asuser $CUID launchctl setenv RAYMOL_MCP_ENABLE 1
+  open ~/Apps/RayMol.app
+'
+sleep 15   # engine inits async; auto-start retries ~10s, then binds + writes handoff
+```
+Confirm it took: `ssh "${SSHOPTS[@]}" admin@"$IP" 'ps eww -p $(pgrep -f "RayMol.app/Contents/MacOS/RayMol") | tr " " "\n" | grep RAYMOL_MCP'`
+should list all three, and the server should listen on `*:PORT` (see step 5).
+
+### 5. Discover the endpoint + token, then sanity-check
+The app writes `~/Library/Application Support/RayMol/mcp.json` (`{port, token}`)
+when the server starts. The driver reads it over SSH:
+```bash
+python3 "$SK/raymol-vm-mcp.py" --vm-ip "$IP" discover   # prints endpoint + token
+python3 "$SK/raymol-vm-mcp.py" --vm-ip "$IP" ping        # initialize round-trip
+```
+`ping` printing `serverInfo` proves host↔VM MCP works. (You can export
+`RAYMOL_VM_ENDPOINT`/`RAYMOL_VM_TOKEN` from `discover` to skip re-discovery on
+every call, or just pass `--vm-ip "$IP"` each time.)
+
+### 6. Drive RayMol
+```bash
+D=(python3 "$SK/raymol-vm-mcp.py" --vm-ip "$IP")
+"${D[@]}" cmd "fetch 1ubq, async=0"
+"${D[@]}" cmd "hide everything; show cartoon; spectrum count, rainbow; bg_color white"
+"${D[@]}" state                       # loaded objects, selections, camera (JSON)
+"${D[@]}" capture /tmp/ubq.png        # ray-traced PNG -> host file; then Read it
+"${D[@]}" py "print(cmd.get_chains('1ubq'))"
+"${D[@]}" search "hiv protease" --limit 5
+```
+`capture` writes the PNG on the host; open/Read it to verify the render. The 5
+tools are `run_pymol_command` (`cmd`), `run_python` (`py`), `get_session_state`
+(`state`), `capture_viewport` (`capture`), `search_pdb` (`search`).
+
+### 7. ALWAYS release — even on failure
+```bash
+# On failure, first grab diagnostics:
+"$MVP_TART_BIN" accessibility find "$VM" --app io.raymol.RayMol --max-results 100 \
+  > /tmp/ax.txt 2>&1 || true
+ssh "${SSHOPTS[@]}" admin@"$IP" 'screencapture -x /tmp/fail.png' || true
+```
+Then call `mcp__mac-vm-pool__release_vm` with `LEASE`. This destroys the VM, so
+no MCP state, token, or app copy lingers.
+
+## Native tools instead of the direct driver (optional)
+If you'd rather use native `mcp__raymol-vm__*` tools, register the VM endpoint:
+```bash
+python3 "$SK/raymol-vm-mcp.py" --vm-ip "$IP" register --run   # claude mcp add raymol-vm
+```
+Then run `/mcp` (or start a fresh Claude Code session) to attach — a newly-added
+MCP server does NOT connect to the session that added it. Remove it on release:
+`claude mcp remove raymol-vm --scope user`. For an in-session agentic loop the
+direct driver (steps 5–6) is simpler and leaves no config behind.
+
+## Troubleshooting
+- **`discover` fails / handoff missing** → the server didn't start. Confirm the
+  process actually has the env (the `ps eww … grep RAYMOL_MCP` check in step 4 —
+  if empty, the `launchctl asuser` setenv didn't land before `open`), the app is
+  running, and give it a few more seconds (engine init + ~10s of auto-start retries).
+- **`ping` → connection refused** → server not bound wide. Confirm the process
+  env includes `RAYMOL_MCP_BIND=0.0.0.0` and the port listens on `*:` (not
+  `127.0.0.1:`): `ssh "${SSHOPTS[@]}" admin@"$IP" 'lsof -nP -iTCP -sTCP:LISTEN | grep -i raymol'`.
+- **`ping` → 401** → stale token. Re-run `discover` (token is per app launch).
+- **`ping` → timeout (not refused)** → guest firewall may block the port. SSH
+  (:22) works, so inbound is generally open; if a high port is filtered, allow it
+  on the golden image (`socketfilterfw`) — a mac-vm-pool/golden-image change.
+- **tool calls → "waiting for the user to approve"** → the process env is missing
+  `RAYMOL_MCP_AUTOTRUST=1`.
+
+## Security
+`RAYMOL_MCP_BIND=0.0.0.0` is opt-in and dev-only; production stays loopback. In a
+disposable NAT'd VM the listener is reachable only from the host (and at most one
+sibling VM), never the LAN/internet, and **every request still requires the
+bearer token**. The direct driver persists nothing to `~/.claude.json`. All three
+flags are stripped from Mac App Store builds by `RAYMOL_MAS_RESTRICTED`.

--- a/.claude/skills/raymol-mac-vm/raymol-vm-mcp.py
+++ b/.claude/skills/raymol-mac-vm/raymol-vm-mcp.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Drive RayMol's built-in MCP server over HTTP from the host.
+
+RayMol's MCP server is MCP "Streamable HTTP": JSON-RPC 2.0 over HTTP POST to
+`/mcp`, bearer-token authed. This CLI talks to it directly (no MCP client
+registration), which is what lets the host drive a RayMol running INSIDE a
+mac-vm-test VM: the VM app must be launched with RAYMOL_MCP_BIND=0.0.0.0 (so the
+server binds a reachable interface) and RAYMOL_MCP_AUTOTRUST=1 (so tool calls
+don't wait for an interactive Allow click). See SKILL.md.
+
+Endpoint + token resolution (first that applies wins):
+  1. --endpoint / --token flags
+  2. $RAYMOL_VM_ENDPOINT / $RAYMOL_VM_TOKEN
+  3. --vm-ip IP  -> SSH into the VM, read the handoff file
+     ~/Library/Application Support/RayMol/mcp.json ({port, token}), and build
+     http://IP:port/mcp
+
+Stdlib only (urllib/json/base64/subprocess/argparse) so it runs under any
+python3 with no install step.
+
+Examples:
+  raymol-vm-mcp.py --vm-ip 192.168.64.33 discover        # print endpoint+token
+  raymol-vm-mcp.py --vm-ip 192.168.64.33 ping            # health check
+  raymol-vm-mcp.py --vm-ip 192.168.64.33 cmd "fetch 1ubq, async=0"
+  raymol-vm-mcp.py --vm-ip 192.168.64.33 cmd "hide everything; show cartoon; util.cbc"
+  raymol-vm-mcp.py --vm-ip 192.168.64.33 capture /tmp/shot.png
+  raymol-vm-mcp.py --vm-ip 192.168.64.33 state
+  raymol-vm-mcp.py --vm-ip 192.168.64.33 py "print(cmd.get_names('objects'))"
+  raymol-vm-mcp.py --vm-ip 192.168.64.33 search "hiv protease" --limit 5
+  raymol-vm-mcp.py --vm-ip 192.168.64.33 register --run   # add native raymol-vm MCP server
+"""
+
+import argparse
+import base64
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+PROTOCOL_VERSION = "2025-06-18"
+DEFAULT_SSH_USER = "admin"
+DEFAULT_SSH_KEY = os.path.expanduser("~/.mac-vm-pool/id_ed25519")
+HANDOFF_PATH = "$HOME/Library/Application Support/RayMol/mcp.json"
+# capture_viewport CPU ray-traces, so give tool calls a generous read timeout.
+INIT_TIMEOUT = 10
+CALL_TIMEOUT = 180
+
+
+def _eprint(*a):
+    print(*a, file=sys.stderr)
+
+
+# --- VM handoff discovery over SSH ---------------------------------------
+
+def ssh_discover(vm_ip, key=DEFAULT_SSH_KEY, user=DEFAULT_SSH_USER):
+    """Read {port, token} from the VM's RayMol handoff file over SSH."""
+    cmd = [
+        "ssh", "-i", key,
+        "-o", "StrictHostKeyChecking=no",
+        "-o", "UserKnownHostsFile=/dev/null",
+        "-o", "ConnectTimeout=10",
+        "%s@%s" % (user, vm_ip),
+        'cat "%s"' % HANDOFF_PATH,
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise SystemExit(
+            "discovery failed: could not read %s on %s@%s\n%s\n"
+            "Is RayMol running in the VM with the server enabled "
+            "(RAYMOL_MCP_ENABLE=1)? Has the handoff file been written yet?"
+            % (HANDOFF_PATH, user, vm_ip, proc.stderr.strip())
+        )
+    try:
+        obj = json.loads(proc.stdout)
+        port, token = int(obj["port"]), str(obj["token"])
+    except Exception as e:
+        raise SystemExit("discovery: bad handoff JSON on %s: %r (%s)"
+                         % (vm_ip, proc.stdout, e))
+    return "http://%s:%d/mcp" % (vm_ip, port), token
+
+
+def resolve_endpoint(args):
+    """Resolve (endpoint, token) from flags, env, or SSH discovery."""
+    endpoint = args.endpoint or os.environ.get("RAYMOL_VM_ENDPOINT")
+    token = args.token or os.environ.get("RAYMOL_VM_TOKEN")
+    if endpoint and token:
+        return endpoint, token
+    if args.vm_ip:
+        return ssh_discover(args.vm_ip, args.key, args.ssh_user)
+    raise SystemExit(
+        "no endpoint: pass --endpoint URL --token TOK, set "
+        "$RAYMOL_VM_ENDPOINT/$RAYMOL_VM_TOKEN, or pass --vm-ip IP to discover."
+    )
+
+
+# --- Minimal MCP-over-HTTP client ----------------------------------------
+
+class Client:
+    def __init__(self, endpoint, token):
+        self.endpoint = endpoint
+        self.token = token
+        self.session_id = None
+
+    def _post(self, message, timeout):
+        body = json.dumps(message).encode("utf-8")
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": "Bearer %s" % self.token,
+        }
+        if self.session_id:
+            headers["Mcp-Session-Id"] = self.session_id
+        req = urllib.request.Request(self.endpoint, data=body,
+                                     method="POST", headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as r:
+                sid = r.headers.get("Mcp-Session-Id")
+                if sid:
+                    self.session_id = sid
+                raw = r.read()
+                return json.loads(raw) if raw else None
+        except urllib.error.HTTPError as e:
+            if e.code == 401:
+                raise SystemExit(
+                    "401 unauthorized: bearer token mismatch or stale. "
+                    "Re-run `discover` (the token is per-app-launch)."
+                )
+            raise SystemExit("HTTP %d from %s: %s"
+                             % (e.code, self.endpoint, e.read().decode("utf-8", "replace")))
+        except urllib.error.URLError as e:
+            raise SystemExit(
+                "cannot reach %s: %s\nChecklist: RayMol running in the VM? "
+                "launched with RAYMOL_MCP_BIND=0.0.0.0? VM IP correct? "
+                "guest firewall open on the port?" % (self.endpoint, e.reason)
+            )
+
+    def initialize(self):
+        resp = self._post({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "raymol-vm-mcp", "version": "1.0.0"},
+            },
+        }, INIT_TIMEOUT)
+        if not resp or "result" not in resp:
+            raise SystemExit("initialize failed: %r" % resp)
+        # Be a well-behaved client: announce initialized (server 202s / ignores).
+        self._post({"jsonrpc": "2.0", "method": "notifications/initialized"},
+                   INIT_TIMEOUT)
+        return resp["result"]
+
+    def call_tool(self, name, arguments, timeout=CALL_TIMEOUT):
+        resp = self._post({
+            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+            "params": {"name": name, "arguments": arguments or {}},
+        }, timeout)
+        if not resp:
+            raise SystemExit("empty response to tools/call %s" % name)
+        if "error" in resp:
+            raise SystemExit("JSON-RPC error: %s" % resp["error"])
+        return resp.get("result", {})
+
+    def close(self):
+        if not self.session_id:
+            return
+        headers = {"Authorization": "Bearer %s" % self.token,
+                   "Mcp-Session-Id": self.session_id}
+        req = urllib.request.Request(self.endpoint, method="DELETE",
+                                     headers=headers)
+        try:
+            urllib.request.urlopen(req, timeout=INIT_TIMEOUT).read()
+        except Exception:
+            pass  # best-effort session cleanup
+
+
+# --- result rendering -----------------------------------------------------
+
+def _first_text(result):
+    for item in result.get("content", []):
+        if item.get("type") == "text":
+            return item.get("text", "")
+    return ""
+
+
+def _first_image_b64(result):
+    for item in result.get("content", []):
+        if item.get("type") == "image":
+            return item.get("data")
+    return None
+
+
+def emit_tool_result(result, exit_on_error=True):
+    """Print a text result; return isError. Exits nonzero on tool error."""
+    is_error = bool(result.get("isError"))
+    text = _first_text(result)
+    if is_error:
+        _eprint(text or "(tool error, no text)")
+        if exit_on_error:
+            raise SystemExit(2)
+    else:
+        if text:
+            print(text)
+    return is_error
+
+
+# --- subcommands ----------------------------------------------------------
+
+def cmd_discover(args):
+    endpoint, token = resolve_endpoint(args)
+    print(json.dumps({"endpoint": endpoint, "token": token}, indent=2))
+    _eprint("\n# shell exports:")
+    _eprint("export RAYMOL_VM_ENDPOINT=%s" % endpoint)
+    _eprint("export RAYMOL_VM_TOKEN=%s" % token)
+
+
+def cmd_ping(args):
+    endpoint, token = resolve_endpoint(args)
+    c = Client(endpoint, token)
+    try:
+        info = c.initialize()
+        print(json.dumps({"ok": True, "endpoint": endpoint,
+                          "serverInfo": info.get("serverInfo")}, indent=2))
+    finally:
+        c.close()
+
+
+def _with_client(args, fn):
+    endpoint, token = resolve_endpoint(args)
+    c = Client(endpoint, token)
+    try:
+        c.initialize()
+        return fn(c)
+    finally:
+        c.close()
+
+
+def cmd_run(args):
+    _with_client(args, lambda c: emit_tool_result(
+        c.call_tool("run_pymol_command", {"command": args.command})))
+
+
+def cmd_py(args):
+    code = args.code
+    if args.file:
+        with open(args.file) as f:
+            code = f.read()
+    if not code:
+        raise SystemExit("py: provide code inline or with --file")
+    _with_client(args, lambda c: emit_tool_result(
+        c.call_tool("run_python", {"code": code})))
+
+
+def cmd_state(args):
+    _with_client(args, lambda c: emit_tool_result(
+        c.call_tool("get_session_state", {})))
+
+
+def cmd_capture(args):
+    def _do(c):
+        result = c.call_tool("capture_viewport",
+                             {"width": args.width, "height": args.height})
+        if result.get("isError"):
+            emit_tool_result(result)  # prints error + exits
+            return
+        b64 = _first_image_b64(result)
+        if not b64:
+            raise SystemExit("capture: no image in response: %r" % result)
+        with open(args.out, "wb") as f:
+            f.write(base64.b64decode(b64))
+        print("wrote %s (%d bytes)" % (args.out, os.path.getsize(args.out)))
+    _with_client(args, _do)
+
+
+def cmd_search(args):
+    _with_client(args, lambda c: emit_tool_result(
+        c.call_tool("search_pdb", {"query": args.query, "limit": args.limit})))
+
+
+def cmd_call(args):
+    try:
+        arguments = json.loads(args.json_args) if args.json_args else {}
+    except Exception as e:
+        raise SystemExit("call: --args must be JSON: %s" % e)
+    _with_client(args, lambda c: print(json.dumps(
+        c.call_tool(args.tool, arguments), indent=2)))
+
+
+def cmd_register(args):
+    endpoint, token = resolve_endpoint(args)
+    add = ["claude", "mcp", "add", "--transport", "http", args.name, endpoint,
+           "--header", "Authorization: Bearer %s" % token, "--scope", "user"]
+    printable = " ".join(
+        (a if " " not in a else '"%s"' % a) for a in add)
+    if args.run:
+        subprocess.run(["claude", "mcp", "remove", args.name, "--scope", "user"],
+                       capture_output=True, text=True)  # idempotent
+        proc = subprocess.run(add, capture_output=True, text=True)
+        sys.stdout.write(proc.stdout)
+        sys.stderr.write(proc.stderr)
+        if proc.returncode == 0:
+            _eprint("\nRegistered '%s'. In Claude Code run /mcp (or restart) "
+                    "to attach. Remove later: claude mcp remove %s --scope user"
+                    % (args.name, args.name))
+        raise SystemExit(proc.returncode)
+    print(printable)
+    _eprint("\n# not run (pass --run to execute). Remove later:")
+    _eprint("claude mcp remove %s --scope user" % args.name)
+
+
+def build_parser():
+    p = argparse.ArgumentParser(
+        prog="raymol-vm-mcp.py",
+        description="Drive RayMol's MCP server over HTTP (host -> VM).")
+    p.add_argument("--endpoint", help="MCP URL, e.g. http://IP:PORT/mcp")
+    p.add_argument("--token", help="bearer token")
+    p.add_argument("--vm-ip", help="VM IP; discover endpoint+token over SSH")
+    p.add_argument("--key", default=DEFAULT_SSH_KEY, help="SSH key for discovery")
+    p.add_argument("--ssh-user", default=DEFAULT_SSH_USER, help="SSH user (default admin)")
+    sub = p.add_subparsers(dest="sub", required=True)
+
+    sub.add_parser("discover", help="print endpoint+token").set_defaults(func=cmd_discover)
+    sub.add_parser("ping", help="initialize (health check)").set_defaults(func=cmd_ping)
+    sub.add_parser("state", help="get_session_state").set_defaults(func=cmd_state)
+
+    sp = sub.add_parser("cmd", help="run_pymol_command")
+    sp.add_argument("command")
+    sp.set_defaults(func=cmd_run)
+
+    sp = sub.add_parser("py", help="run_python")
+    sp.add_argument("code", nargs="?", default="")
+    sp.add_argument("--file", help="read code from a file instead")
+    sp.set_defaults(func=cmd_py)
+
+    sp = sub.add_parser("capture", help="capture_viewport -> PNG file")
+    sp.add_argument("out")
+    sp.add_argument("--width", type=int, default=640)
+    sp.add_argument("--height", type=int, default=480)
+    sp.set_defaults(func=cmd_capture)
+
+    sp = sub.add_parser("search", help="search_pdb")
+    sp.add_argument("query")
+    sp.add_argument("--limit", type=int, default=10)
+    sp.set_defaults(func=cmd_search)
+
+    sp = sub.add_parser("call", help="generic tools/call")
+    sp.add_argument("tool")
+    sp.add_argument("json_args", nargs="?", default="", metavar="JSON")
+    sp.set_defaults(func=cmd_call)
+
+    sp = sub.add_parser("register", help="add native raymol-vm MCP server (fresh session)")
+    sp.add_argument("--name", default="raymol-vm")
+    sp.add_argument("--run", action="store_true", help="execute claude mcp add")
+    sp.set_defaults(func=cmd_register)
+
+    return p
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/superpowers/specs/2026-07-03-raymol-mcp-vm-access-design.md
+++ b/docs/superpowers/specs/2026-07-03-raymol-mcp-vm-access-design.md
@@ -1,0 +1,124 @@
+# RayMol MCP: host → VM access for mac-vm-test-driven macOS development
+
+**Date:** 2026-07-03
+**Status:** approved, implementing
+**Goal:** Make the mac-vm-test skill the primary loop for macOS RayMol development,
+which requires the host Claude Code session to drive RayMol *while it runs inside a
+disposable macOS VM* via RayMol's built-in MCP server.
+
+## Problem / current state
+
+RayMol's built-in MCP server ([`modules/raymol_mcp/server.py`](../../../modules/raymol_mcp/server.py))
+is MCP "Streamable HTTP" (JSON-RPC 2.0 over HTTP POST to `/mcp`, single `application/json`
+response). It is **hardcoded to bind `127.0.0.1`** (`server.py:230`). The host's MCP client
+(`~/.claude.json` → `mcpServers.raymol`) points at `http://127.0.0.1:51737/mcp`.
+
+Three factors decide whether the host can drive RayMol running in a mac-vm-test VM:
+
+| Factor | Status |
+|---|---|
+| VM networking (host→VM reachability) | ✅ tart default NAT; VM on `192.168.64.x`, host `192.168.64.1`; host→VM to arbitrary ports routable (SSH/scp already work; verified live: ping to a running pool VM, 0% loss). |
+| Transport (HTTP over TCP) | ✅ Crosses the VM boundary fine; host client speaks `--transport http`. |
+| **Bind address** | ❌ **Blocker.** Server binds VM-loopback (`127.0.0.1`), unreachable from the host. |
+
+**Verdict:** does not work today; one clean blocker (loopback bind).
+
+## Design
+
+Chosen: **Direct-HTTP driver** (host talks straight to the VM endpoint over HTTP; no MCP
+client re-registration, which would hit the mid-session reconnection wall) + a **new
+RayMol-repo skill** `.claude/skills/raymol-mac-vm/` (version-controlled, shipped in the PR;
+builds on the mac-vm-test / mac-vm-pool flow but keeps RayMol specifics in the repo).
+
+### Data flow
+
+```
+HOST (Claude Code session)                       VM (disposable clone, NAT 192.168.64.x)
+.claude/skills/raymol-mac-vm/                     RayMol.app (direct-exec launch w/ dev env)
+  ├─ SKILL.md   (orchestrates loop)                 └─ embedded Python raymol_mcp.server
+  └─ raymol-vm-mcp.py (driver) ──HTTP POST /mcp──▶       ThreadingHTTPServer(("0.0.0.0", port))
+        JSON-RPC 2.0 + Bearer token                       ↑ RAYMOL_MCP_BIND=0.0.0.0
+  discovery: ssh admin@$IP cat mcp.json ──────────────────↑ RAYMOL_MCP_AUTOTRUST=1
+        → {port, token}                                    ↑ RAYMOL_MCP_ENABLE=1
+  VM IP from pool acquire_vm handle
+```
+
+### Components
+
+**A. RayMol code (the enabling dev flags — in the PR)**
+- `modules/raymol_mcp/server.py:230` — bind host from env:
+  `bind_host = os.environ.get("RAYMOL_MCP_BIND") or "127.0.0.1"`, dev-only comment mirroring
+  the `RAYMOL_MCP_AUTOTRUST` note above. **Single load-bearing change.** Default = loopback,
+  unchanged for production.
+- `swiftui/PyMOLViewer/Shared/MCPServerManager.swift` — `autoStartIfEnabled` also starts when
+  `ProcessInfo…environment["RAYMOL_MCP_ENABLE"] == "1"`, so a fresh VM clone (UserDefault off)
+  brings the server up headlessly. Already inside `#if os(macOS) && !RAYMOL_MAS_RESTRICTED`.
+
+**B. `.claude/skills/raymol-mac-vm/raymol-vm-mcp.py`** — stdlib-only MCP-over-HTTP CLI:
+`discover` (ssh-reads `~/Library/Application Support/RayMol/mcp.json`), `cmd`, `py`, `state`,
+`capture <out.png>` (decodes base64 PNG to file), `search`, `register` (prints the
+`claude mcp add --transport http raymol-vm …` line for native use in a fresh session).
+Carries `Authorization: Bearer` + `Mcp-Session-Id`.
+
+**C. `.claude/skills/raymol-mac-vm/SKILL.md`** — orchestration: acquire (pool MCP) → two-stage
+host build (`build_macos.sh` core **then** xcodebuild — avoids the stale `libpymol_core.a`) →
+scp app in → **direct-exec launch with the three env vars** (via `tart exec … env … RayMol`,
+because `open`/Finder deliberately don't carry these vars) → discover → curl sanity-check →
+drive via helper → **always release**.
+
+### VM launch (env delivery)
+
+The three `RAYMOL_MCP_*` vars must reach the GUI app's process. A plain `launchctl setenv` over
+SSH does not reach the console Aqua session, so they're set in the console user's launchd domain
+(needs root; passwordless sudo works on the golden image), then `open` launches the app:
+
+```
+ssh admin@$IP '
+  CUID=$(id -u)
+  sudo launchctl asuser $CUID launchctl setenv RAYMOL_MCP_BIND 0.0.0.0
+  sudo launchctl asuser $CUID launchctl setenv RAYMOL_MCP_AUTOTRUST 1
+  sudo launchctl asuser $CUID launchctl setenv RAYMOL_MCP_ENABLE 1
+  open ~/Apps/RayMol.app'
+```
+
+**Verified 2026-07-04** (golden image macOS 15.7.7): the launched process carried all three vars,
+the server bound `*:51737`, and the host drove `fetch 1ubq` → cartoon → ray-traced capture end to
+end. (Direct-exec of the Mach-O with an `env` prefix is a plausible alternative but was not the
+verified path.)
+
+### Discovery
+
+```
+ssh -i ~/.mac-vm-pool/id_ed25519 admin@$IP \
+  'cat "$HOME/Library/Application Support/RayMol/mcp.json"'   # → {port, token}
+endpoint = http://$IP:$port/mcp     # $IP from the pool acquire handle
+```
+
+## Error handling
+- `acquire_vm` → `{queued:true}`: report the 2-VM cap, stop.
+- Build failure: surface output, release VM, do not proceed.
+- Endpoint unreachable: helper distinguishes connection-refused (not bound wide / not started
+  → check the three env vars), 401 (token mismatch), timeout (guest firewall — see open
+  question). Diagnostic: `ssh … lsof -nP -iTCP:$port -sTCP:LISTEN`.
+- VM release always runs, even on failure, after capturing an AX dump + screenshot.
+
+## Security
+`RAYMOL_MCP_BIND=0.0.0.0` is opt-in, dev-only, defaults to loopback. When set, the listener is
+reachable only from the host and at most one sibling VM on the NAT (not LAN/internet), and
+**every request still requires the bearer token** — no "trusted network skips auth" shortcut.
+Direct-HTTP driving persists nothing to `~/.claude.json`, so there's no per-VM token to leak or
+clean up. All new flags sit on the non-MAS side of `RAYMOL_MAS_RESTRICTED` (which already strips
+the whole `raymol_mcp` package from App Store builds).
+
+## Testing
+- **server.py bind (headless, host):** `RAYMOL_MCP_BIND=0.0.0.0 python -c "import raymol_mcp.server as s; s.start(0,'tok')"` → `lsof` shows `*:port`; unset → `127.0.0.1:port`.
+- **End-to-end acceptance (real VM):** acquire → build → launch → discover → `raymol-vm-mcp cmd "fetch 1ubq, async=0"` → `capture out.png` → verify PNG shows ubiquitin → release.
+- **Open question (resolve on first e2e run):** golden-image guest firewall on an arbitrary high
+  port. SSH:22 works, strongly implying inbound is open; the e2e curl settles it. If blocked, the
+  fix is a `socketfilterfw`/`pfctl` allowance baked into the golden image — a mac-vm-pool change,
+  out of this PR's scope.
+
+## Out of scope
+- iOS/iPadOS (MCP server is `#if os(macOS)`-gated).
+- Switching the pool to `--net-softnet` with explicit port-expose (tighter isolation; pool change).
+- Editing the generic, non-versioned `~/.claude/skills/mac-vm-test/SKILL.md`.

--- a/modules/raymol_mcp/server.py
+++ b/modules/raymol_mcp/server.py
@@ -1,8 +1,10 @@
 """Built-in MCP server for RayMol (stdlib-only, localhost, token-authed).
 
 Runs an http.server.ThreadingHTTPServer on 127.0.0.1 inside the embedded
-interpreter on a daemon thread. Speaks MCP "Streamable HTTP": JSON-RPC 2.0 over
-HTTP POST to /mcp, answered with a single application/json response (no SSE).
+interpreter on a daemon thread (override the bind host with the RAYMOL_MCP_BIND
+env var for dev/testing only -- see start()). Speaks MCP "Streamable HTTP":
+JSON-RPC 2.0 over HTTP POST to /mcp, answered with a single application/json
+response (no SSE).
 
 Threading: tool bodies call PyMOL's cmd API from this server thread. Safe because
 this is a real Python thread holding the GIL/API lock -- the model the old Raymond
@@ -226,8 +228,17 @@ def start(port, token):
         # no such variable), so production always requires the user's explicit
         # click. Set it only when launching the binary directly for testing.
         _trusted = os.environ.get("RAYMOL_MCP_AUTOTRUST") == "1"
+        # Dev/testing bind host: default 127.0.0.1 (loopback only). When
+        # RAYMOL_MCP_BIND is set (e.g. "0.0.0.0") the server binds a non-loopback
+        # interface so a client on another machine can reach it -- used to drive
+        # RayMol running inside a mac-vm-test VM from the host. Like
+        # RAYMOL_MCP_AUTOTRUST above, this env var is NEVER set in a shipped build
+        # (Finder / `open` launches carry no such variable), so production stays
+        # loopback-only. Set it only when launching the binary directly for testing.
+        # The bearer-token check still gates every request regardless of bind host.
+        bind_host = os.environ.get("RAYMOL_MCP_BIND") or "127.0.0.1"
         bind_port = port if port else 0
-        _httpd = ThreadingHTTPServer(("127.0.0.1", bind_port), _Handler)
+        _httpd = ThreadingHTTPServer((bind_host, bind_port), _Handler)
         _port = _httpd.server_address[1]
         _thread = threading.Thread(target=_httpd.serve_forever,
                                    name="raymol-mcp", daemon=True)

--- a/swiftui/PyMOLViewer/Shared/MCPServerManager.swift
+++ b/swiftui/PyMOLViewer/Shared/MCPServerManager.swift
@@ -47,8 +47,15 @@ final class MCPServerManager: ObservableObject {
 
     // Auto-start on launch if the user had it on. The engine inits asynchronously,
     // so retry on the main queue until it's ready (capped, like loadOpenedFile).
+    //
+    // Dev/testing: RAYMOL_MCP_ENABLE=1 in the process environment forces the server
+    // to start even when the UserDefault toggle is off — used to bring the server up
+    // headlessly in a fresh mac-vm-test VM clone (no UI to flip). Like
+    // RAYMOL_MCP_BIND / RAYMOL_MCP_AUTOTRUST (read by the Python server), this var is
+    // never present in a Finder/`open` launch, so it can't affect shipped builds.
     private func autoStartIfEnabled(attempt: Int) {
-        guard UserDefaults.standard.bool(forKey: "raymol.mcp.enabled") else { return }
+        let forced = ProcessInfo.processInfo.environment["RAYMOL_MCP_ENABLE"] == "1"
+        guard forced || UserDefaults.standard.bool(forKey: "raymol.mcp.enabled") else { return }
         guard let engine else { return }
         if engine.isReady {
             start()


### PR DESCRIPTION
## Why

Make the **mac-vm-test** skill the primary loop for macOS RayMol development. That requires the host Claude Code session to drive RayMol **while it runs inside a disposable macOS VM** via RayMol's built-in MCP server.

**It didn't work today, and I found exactly why.** Of the three deciding factors, two already worked and one blocked:

| Factor | Status |
|---|---|
| VM networking (host→VM) | ✅ tart default NAT routes host→VM to arbitrary ports (SSH/scp already prove it) |
| Transport (HTTP over TCP) | ✅ crosses the VM boundary; host client speaks `--transport http` |
| **Bind address** | ❌ server hardcoded to `127.0.0.1` (VM loopback) — unreachable from the host |

## What

**Dev flags** — all read only from the process environment, absent from Finder/`open` launches, and on the non-MAS side of `RAYMOL_MAS_RESTRICTED`, so they can't affect shipped or App Store builds:

- **`RAYMOL_MCP_BIND`** — server bind host (`modules/raymol_mcp/server.py`). Default `127.0.0.1` (unchanged for production); set `0.0.0.0` in the VM. The bearer token still gates **every** request regardless of bind host.
- **`RAYMOL_MCP_ENABLE=1`** — force the server to auto-start on a fresh VM clone even with the UI toggle off (`swiftui/.../MCPServerManager.swift`).
- **`RAYMOL_MCP_AUTOTRUST=1`** (existing) — skip the interactive "Allow" for a headless VM.

**Tooling** (`.claude/skills/raymol-mac-vm/`):
- `SKILL.md` — orchestrates the loop: acquire VM → host build → install → launch-with-dev-env → discover → drive → **always release**. Builds on mac-vm-test / mac-vm-pool.
- `raymol-vm-mcp.py` — a stdlib-only MCP-over-HTTP **driver** (`discover`/`ping`/`cmd`/`py`/`state`/`capture`/`search`/`register`). It talks JSON-RPC straight to the VM endpoint, so it works **in the current session** — avoiding the mid-session MCP re-registration wall (a freshly `claude mcp add`-ed server won't attach until `/mcp`/restart).

`docs/superpowers/specs/2026-07-03-raymol-mcp-vm-access-design.md` — design doc.

## Verification

- **Host unit checks:** `RAYMOL_MCP_BIND` default binds `127.0.0.1`, `=0.0.0.0` binds wide and is reachable cross-interface via the host LAN IP; wrong bearer token → **401** (auth boundary intact). Driver protocol (initialize/session/401/env-resolution) tested against a live server.
- **End-to-end in a disposable VM** (2026-07-04, golden image macOS 15.7.7): built the app, launched it in the VM with the three env vars (confirmed present in the process), server bound **`*:51737`**, then from the host: `discover` → `ping` → `fetch 1ubq` → cartoon/color → `capture` → ray-traced PNG of ubiquitin returned to the host. VM released.

## Security

`RAYMOL_MCP_BIND=0.0.0.0` is opt-in, dev-only, defaults to loopback. In a disposable NAT'd VM the listener is reachable only from the host (and at most one sibling VM), never the LAN/internet, and every request still requires the per-install bearer token — no "trusted network skips auth" shortcut. The direct driver persists nothing to `~/.claude.json`.

## Out of scope
iOS/iPadOS (MCP server is `#if os(macOS)`-gated); switching the pool to `--net-softnet` with explicit port-expose; editing the generic non-versioned `mac-vm-test` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)