### PR TITLE
chore(skills): add raymol-download-stats skill

### DIFF
--- a/.claude/skills/raymol-download-stats/SKILL.md
+++ b/.claude/skills/raymol-download-stats/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: raymol-download-stats
+description: Use when checking RayMol GitHub release download counts, DMG install stats, or auto-updater vs manual download breakdown across releases.
+---
+
+# RayMol Download Stats
+
+Fetches DMG download counts from GitHub releases and renders a markdown table broken down by auto-updater (versioned DMG, pulled by Sparkle) vs manual installs (`RayMol.dmg`).
+
+## Usage
+
+Run the script from anywhere in the repo:
+
+```bash
+python3 .claude/skills/raymol-download-stats/get_stats.py
+```
+
+Requires `gh` CLI authenticated to the `javierbq/RayMol` repo.
+
+## Output format
+
+| Release | Published | Auto-updater | Manual | Total |
+|---------|-----------|-------------|--------|-------|
+| v1.x.x  | Mon DD    | N           | N      | N     |
+| **Total** | | **N** | **N** | **N** |
+
+- **Auto-updater**: versioned asset (e.g. `RayMol-1.4.1.dmg`) fetched by Sparkle on existing installs
+- **Manual**: `RayMol.dmg` — the always-latest asset downloaded by new users from the releases page
+- `—` in Manual means that release had no `RayMol.dmg` asset (e.g. v1.1.0)

--- a/.claude/skills/raymol-download-stats/get_stats.py
+++ b/.claude/skills/raymol-download-stats/get_stats.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Fetch RayMol GitHub release DMG download stats and print a markdown table."""
+import json, subprocess, sys
+
+result = subprocess.run(
+    ["gh", "api", "/repos/javierbq/RayMol/releases"],
+    capture_output=True, text=True
+)
+if result.returncode != 0:
+    print(result.stderr, file=sys.stderr)
+    sys.exit(1)
+
+releases = json.loads(result.stdout)
+
+rows = []
+for r in releases:
+    dmgs = [a for a in r.get("assets", []) if a["name"].endswith(".dmg")]
+    if not dmgs:
+        continue
+    tag = r["tag_name"]
+    published = r["published_at"][:10]
+    versioned = next((a["download_count"] for a in dmgs if a["name"] != "RayMol.dmg"), 0)
+    manual = next((a["download_count"] for a in dmgs if a["name"] == "RayMol.dmg"), None)
+    total = versioned + (manual if manual is not None else 0)
+    rows.append((tag, published, versioned, manual, total))
+
+print("| Release | Published | Auto-updater | Manual | Total |")
+print("|---------|-----------|-------------|--------|-------|")
+auto_sum = manual_sum = total_sum = 0
+for tag, published, versioned, manual, total in rows:
+    manual_str = "—" if manual is None else str(manual)
+    print(f"| {tag} | {published[5:]} | {versioned} | {manual_str} | {total} |")
+    auto_sum += versioned
+    manual_sum += manual if manual is not None else 0
+    total_sum += total
+
+print(f"| **Total** | | **{auto_sum}** | **{manual_sum}** | **{total_sum}** |")


### PR DESCRIPTION
## What
Adds the `raymol-download-stats` skill to version control. It was living untracked on disk (never committed on any branch) — this checks it in so it travels with the repo.

The skill fetches DMG download counts from GitHub releases and renders a markdown table broken down by **auto-updater** (Sparkle-pulled versioned DMG) vs **manual** installs (`RayMol.dmg`).

## Files
- `.claude/skills/raymol-download-stats/SKILL.md` — skill doc + usage
- `.claude/skills/raymol-download-stats/get_stats.py` — shells out to `gh api /repos/javierbq/RayMol/releases`; uses existing `gh` auth, **no credentials in the file**

## Notes
Unrelated to the MCP/VM work in #98 — split out into its own PR as requested. No code changes to RayMol itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)