### PR TITLE
fix(metal): restore real-time ray tracing + add RT quality controls

### DIFF
--- a/layer1/SceneRender.cpp
+++ b/layer1/SceneRender.cpp
@@ -2064,6 +2064,13 @@ void SceneRenderMetal(PyMOLGlobals* G)
         rtShadowEnabled, outlineCol[0], outlineCol[1], outlineCol[2],
         outlineWidth, dofEnabled, dofFocus, dofRange, temporalAO,
         upscaleEnabled, dofAperture);
+    // Real-time RT quality knobs (metal_rt_*): AO rays/pixel, AO radius (A),
+    // AO intensity, cast-shadow intensity — applied in RendererMetal::runPostChain.
+    G->Renderer->setRayTraceParams(
+        SettingGetGlobal_i(G, cSetting_metal_rt_samples),
+        SettingGetGlobal_f(G, cSetting_metal_rt_ao_radius),
+        SettingGetGlobal_f(G, cSetting_metal_rt_ao_intensity),
+        SettingGetGlobal_f(G, cSetting_metal_rt_shadow_intensity));
     // Lighting model — the Metal lit shaders read these instead of hard-coded
     // constants, so the Scene-panel lighting sliders take effect. Specular and
     // shininess must go through PyMOL's light-count adjustment (the same path

--- a/layer1/SettingInfo.h
+++ b/layer1/SettingInfo.h
@@ -931,6 +931,10 @@ enum {
   REC_b( 821, surface_contour_opaque                  , object    , true ),  /* Metal: surface outer-contour is fully opaque (crisp); off = the line picks up the surface transparency. */
   REC_b( 822, metal_ssao_cartoon                      , global    , false ), /* Metal: include cartoon/ribbon in the screen-space SSAO (crease/contour) pass. Default off => cartoons are excluded from SSAO darkening (avoids spurious contour lines on ribbon silhouettes/self-folds, #79); they still receive directional shadows, and surface pockets keep their AO. */
   REC_f( 823, metal_shadow_bias                       , global    , 1.0F ),  /* Metal: multiplier on the self-shadow depth bias. 1.0 = default. Raise (e.g. 2-4) if flat cartoon strands still show striped self-shadow "triangle" acne at steep/grazing angles; lower toward 0 for tighter contact shadows. */
+  REC_i( 824, metal_rt_samples                        , global    , 16 ),    /* Metal real-time RT: ambient-occlusion rays traced per pixel in the LIVE view (quality vs performance). Higher = smoother/less-noisy AO but slower. Offscreen PNG/movie export always traces at least 48. Clamped to 1..256. */
+  REC_f( 825, metal_rt_ao_radius                      , global    , 5.0F ),  /* Metal real-time RT: ambient-occlusion hemisphere radius in Angstroms (occlusion reach). Larger = broader pocket/cavity darkening; smaller = tight contact AO. */
+  REC_f( 826, metal_rt_ao_intensity                   , global    , 0.72F ), /* Metal real-time RT: ambient-occlusion darkening strength (0..1). */
+  REC_f( 827, metal_rt_shadow_intensity               , global    , 0.45F ), /* Metal real-time RT: cast-shadow darkening strength (0..1); still gated by metal_shadows. */
 
 #ifdef SETTINGINFO_IMPLEMENTATION
 #undef SETTINGINFO_IMPLEMENTATION

--- a/layerGraphics/Renderer.h
+++ b/layerGraphics/Renderer.h
@@ -321,6 +321,14 @@ public:
   {
   }
 
+  // Real-time ray-tracing quality knobs (metal_rt_* settings): AO rays/pixel,
+  // AO hemisphere radius (Angstroms), AO darkening strength, cast-shadow
+  // darkening strength. Fed each frame from SceneRender. Default: no-op.
+  virtual void setRayTraceParams(int samples, float aoRadius, float aoIntensity,
+      float shadowIntensity)
+  {
+  }
+
   // PyMOL lighting model (ambient/direct/reflect/specular/shininess). Default:
   // no-op (the GL renderer reads these settings itself). The Metal renderer
   // uploads them into its lit shaders so the Scene lighting sliders take effect.

--- a/layerGraphics/metal/RendererMetal.h
+++ b/layerGraphics/metal/RendererMetal.h
@@ -161,6 +161,8 @@ public:
       int upscaleEnabled = 0, float dofAperture = 14.0f) override;
   void setLightingParams(float ambient, float direct, float reflect,
       float specular, float shininess, float sssWrap = 0.0f) override;
+  void setRayTraceParams(int samples, float aoRadius, float aoIntensity,
+      float shadowIntensity) override;
 
   // Letterbox: render the scene into a centered sub-rect of the given aspect
   // (W/H) so a loaded .pse reproduces its saved-viewport framing. 0 = fill.
@@ -561,6 +563,12 @@ private:
   uint32_t _rtProtoIndexCount = 0;
   id<MTLRenderPipelineState> _rtAOPipeline = nil;       // pass A: raw AO -> R16Float
   id<MTLRenderPipelineState> _rtResolvePipeline = nil;  // pass B: blur AO + shadow/fog composite
+  bool _rtCompileTried = false;   // latch: attempt the RT library compile at most once
+  // Real-time RT quality knobs (metal_rt_* settings, set via setRayTraceParams).
+  int   _rtSamples = 16;           // AO rays/pixel (live); offscreen uses max(48, this)
+  float _rtAORadius = 5.0f;        // AO hemisphere radius (Angstroms)
+  float _rtAOIntensity = 0.72f;    // AO darkening strength (0..1)
+  float _rtShadowIntensity = 0.45f;// cast-shadow darkening strength (0..1)
   // Label/text rendering (screen-aligned textured glyph quads). Initialized to
   // nil — this is a C++ class under MRC, so id ivars are not zero-initialized.
   id<MTLRenderPipelineState> _labelPipeline = nil;

--- a/layerGraphics/metal/RendererMetal.mm
+++ b/layerGraphics/metal/RendererMetal.mm
@@ -801,8 +801,91 @@ void RendererMetal::endOffscreen()
 #pragma mark - Post-processing (offscreen scene target + fullscreen passes)
 // ---------------------------------------------------------------------------
 
+// Shared eye-space / normal reconstruction helpers used by BOTH the post-processing
+// library (kPostSrc) and the ray-tracing library (kRTSrc). Metal compiles each
+// newLibraryWithSource: as an independent translation unit with NO cross-library
+// symbol linking, so any helper that kRTSrc's rt_ao/rt_composite call MUST be
+// present in the RT source too. This block is prepended to both libraries at their
+// compile sites (see kPostSrc/kRTSrc newLibraryWithSource calls). It exists because
+// a prior refactor (#83/#87) moved these helpers into kPostSrc only and updated the
+// kRTSrc call sites without carrying the definitions across, which silently broke
+// the standalone RT library compile (undeclared identifiers) and disabled RT.
+static NSString* const kEyeReconSrc = @R"(
+#include <metal_stdlib>
+using namespace metal;
+
+// Eye-space position from a window depth at a given screen uv (the inverse of the
+// perspective projection; matches the reconstruction used by the shadow/AO passes).
+static float3 post_eye_pos(float2 uv, float d, float projA, float projB,
+                           float projX, float projY) {
+  float ez = -projB / ((2.0 * d - 1.0) + projA); // eye z (negative)
+  float ndcx = 2.0 * uv.x - 1.0;
+  float ndcy = 1.0 - 2.0 * uv.y;
+  return float3(ndcx * (-ez) / projX, ndcy * (-ez) / projY, ez);
+}
+
+// Robust eye-space surface normal from the depth buffer. Plain
+// cross(dfdx(p), dfdy(p)) uses the 2x2 quad derivative, which at a silhouette
+// straddles the depth discontinuity to the background/behind geometry: the
+// derivative blows up and the normal points sideways/garbage in a 1-2px band along
+// EVERY silhouette. In the screen-space shadow that corrupts the light-facing
+// faceGate, flipping it between ~0 and ~1 pixel-to-pixel along the aliased edge, so
+// the shadow term switches on/off and reads as a serrated lighter border on helices
+// and sticks. Instead, reconstruct the 4 axis-neighbours and, per axis, difference
+// against the neighbour on the CONTINUOUS side (smaller window-depth step) so the
+// stencil never crosses the silhouette. In the smooth interior this equals the old
+// derivative; only the edge band changes.
+static float3 post_eye_normal(depth2d<float> depthTex, sampler s, float2 uv,
+                              float2 invres, float cd, float3 cp, float projA,
+                              float projB, float projX, float projY) {
+  float2 ux = float2(invres.x, 0.0);
+  float2 uy = float2(0.0, invres.y);
+  float dl = depthTex.sample(s, uv - ux), dr = depthTex.sample(s, uv + ux);
+  float dd = depthTex.sample(s, uv - uy), du = depthTex.sample(s, uv + uy);
+  float3 gx = (abs(dl - cd) < abs(dr - cd))
+                  ? (cp - post_eye_pos(uv - ux, dl, projA, projB, projX, projY))
+                  : (post_eye_pos(uv + ux, dr, projA, projB, projX, projY) - cp);
+  float3 gy = (abs(dd - cd) < abs(du - cd))
+                  ? (cp - post_eye_pos(uv - uy, dd, projA, projB, projX, projY))
+                  : (post_eye_pos(uv + uy, du, projA, projB, projX, projY) - cp);
+  float3 n = normalize(cross(gx, gy));
+  if (n.z < 0.0) n = -n; // face toward camera
+  return n;
+}
+
+// Bilaterally-smoothed eye-space normal. A plain depth reconstruction of the
+// coarse cartoon mesh gives a FACETED (flat per-triangle) normal, which made
+// both the light-facing faceGate and the shadow-map self-comparison vary per
+// triangle — the "triangles under shadows". Averaging post_eye_normal over a
+// small neighbourhood, weighted by eye-Z similarity, smooths across the facets
+// (a near-continuous surface normal) but rejects samples across a real
+// silhouette (large depth jump -> ~0 weight), so the #83 edge behaviour is kept.
+static float3 post_eye_normal_smooth(depth2d<float> depthTex, sampler s, float2 uv,
+                                     float2 invres, float cd, float3 cp, float projA,
+                                     float projB, float projX, float projY) {
+  float3 nSum = post_eye_normal(depthTex, s, uv, invres, cd, cp,
+                                projA, projB, projX, projY);
+  float wSum = 1.0;
+  float ztol = max(0.02 * abs(cp.z), 0.05);
+  for (int j = -1; j <= 1; j++)
+    for (int i = -1; i <= 1; i++) {
+      if (i == 0 && j == 0) continue;
+      float2 o = float2(float(i), float(j)) * 2.0 * invres;
+      float dn = depthTex.sample(s, uv + o);
+      if (dn >= 0.99999) continue;
+      float3 pn = post_eye_pos(uv + o, dn, projA, projB, projX, projY);
+      float w = exp(-abs(pn.z - cp.z) / ztol);
+      nSum += post_eye_normal(depthTex, s, uv + o, invres, dn, pn,
+                              projA, projB, projX, projY) * w;
+      wSum += w;
+    }
+  return normalize(nSum);
+}
+)";
+
 // Fullscreen-triangle vertex shader + post-process fragment shaders. A single
-// library so all post pipelines share the vertex function.
+// library so all post pipelines share the vertex function. Compiled with the
+// shared kEyeReconSrc helpers prepended (post_eye_pos/normal/normal_smooth).
 static NSString* const kPostSrc = @R"(
 #include <metal_stdlib>
 using namespace metal;
@@ -955,73 +1038,10 @@ static float post_linear_depth(float d, float projA, float projB) {
   return -ez;                         // distance from camera (positive)
 }
 
-// Eye-space position from a window depth at a given screen uv (the inverse of the
-// perspective projection; matches the reconstruction used by the shadow/AO passes).
-static float3 post_eye_pos(float2 uv, float d, float projA, float projB,
-                           float projX, float projY) {
-  float ez = -projB / ((2.0 * d - 1.0) + projA); // eye z (negative)
-  float ndcx = 2.0 * uv.x - 1.0;
-  float ndcy = 1.0 - 2.0 * uv.y;
-  return float3(ndcx * (-ez) / projX, ndcy * (-ez) / projY, ez);
-}
-
-// Robust eye-space surface normal from the depth buffer. Plain
-// cross(dfdx(p), dfdy(p)) uses the 2x2 quad derivative, which at a silhouette
-// straddles the depth discontinuity to the background/behind geometry: the
-// derivative blows up and the normal points sideways/garbage in a 1-2px band along
-// EVERY silhouette. In the screen-space shadow that corrupts the light-facing
-// faceGate, flipping it between ~0 and ~1 pixel-to-pixel along the aliased edge, so
-// the shadow term switches on/off and reads as a serrated lighter border on helices
-// and sticks. Instead, reconstruct the 4 axis-neighbours and, per axis, difference
-// against the neighbour on the CONTINUOUS side (smaller window-depth step) so the
-// stencil never crosses the silhouette. In the smooth interior this equals the old
-// derivative; only the edge band changes.
-static float3 post_eye_normal(depth2d<float> depthTex, sampler s, float2 uv,
-                              float2 invres, float cd, float3 cp, float projA,
-                              float projB, float projX, float projY) {
-  float2 ux = float2(invres.x, 0.0);
-  float2 uy = float2(0.0, invres.y);
-  float dl = depthTex.sample(s, uv - ux), dr = depthTex.sample(s, uv + ux);
-  float dd = depthTex.sample(s, uv - uy), du = depthTex.sample(s, uv + uy);
-  float3 gx = (abs(dl - cd) < abs(dr - cd))
-                  ? (cp - post_eye_pos(uv - ux, dl, projA, projB, projX, projY))
-                  : (post_eye_pos(uv + ux, dr, projA, projB, projX, projY) - cp);
-  float3 gy = (abs(dd - cd) < abs(du - cd))
-                  ? (cp - post_eye_pos(uv - uy, dd, projA, projB, projX, projY))
-                  : (post_eye_pos(uv + uy, du, projA, projB, projX, projY) - cp);
-  float3 n = normalize(cross(gx, gy));
-  if (n.z < 0.0) n = -n; // face toward camera
-  return n;
-}
-
-// Bilaterally-smoothed eye-space normal. A plain depth reconstruction of the
-// coarse cartoon mesh gives a FACETED (flat per-triangle) normal, which made
-// both the light-facing faceGate and the shadow-map self-comparison vary per
-// triangle — the "triangles under shadows". Averaging post_eye_normal over a
-// small neighbourhood, weighted by eye-Z similarity, smooths across the facets
-// (a near-continuous surface normal) but rejects samples across a real
-// silhouette (large depth jump -> ~0 weight), so the #83 edge behaviour is kept.
-static float3 post_eye_normal_smooth(depth2d<float> depthTex, sampler s, float2 uv,
-                                     float2 invres, float cd, float3 cp, float projA,
-                                     float projB, float projX, float projY) {
-  float3 nSum = post_eye_normal(depthTex, s, uv, invres, cd, cp,
-                                projA, projB, projX, projY);
-  float wSum = 1.0;
-  float ztol = max(0.02 * abs(cp.z), 0.05);
-  for (int j = -1; j <= 1; j++)
-    for (int i = -1; i <= 1; i++) {
-      if (i == 0 && j == 0) continue;
-      float2 o = float2(float(i), float(j)) * 2.0 * invres;
-      float dn = depthTex.sample(s, uv + o);
-      if (dn >= 0.99999) continue;
-      float3 pn = post_eye_pos(uv + o, dn, projA, projB, projX, projY);
-      float w = exp(-abs(pn.z - cp.z) / ztol);
-      nSum += post_eye_normal(depthTex, s, uv + o, invres, dn, pn,
-                              projA, projB, projX, projY) * w;
-      wSum += w;
-    }
-  return normalize(nSum);
-}
+// post_eye_pos / post_eye_normal / post_eye_normal_smooth are defined once in the
+// shared kEyeReconSrc block, prepended to this library (and to kRTSrc) at compile
+// time — see the newLibraryWithSource call sites. Keeping a single copy is what
+// prevents the RT library from silently losing them again (the #83/#87 regression).
 
 fragment float4 post_ssao_fog(PostVOut in [[stage_in]],
     texture2d<float> colorTex [[texture(0)]],
@@ -1482,7 +1502,10 @@ void RendererMetal::buildPostPipelines()
 {
   if (_blitPipeline) return;
   NSError* err = nil;
-  id<MTLLibrary> lib = [_device newLibraryWithSource:kPostSrc options:nil error:&err];
+  // Prepend the shared eye/normal reconstruction helpers (kEyeReconSrc); this
+  // library and the RT library both compile from that single copy.
+  id<MTLLibrary> lib = [_device newLibraryWithSource:[kEyeReconSrc stringByAppendingString:kPostSrc]
+                                             options:nil error:&err];
   if (!lib) { NSLog(@"RendererMetal: post lib compile failed: %@", err); return; }
 
   if (!_postSampler) {
@@ -1601,6 +1624,18 @@ void RendererMetal::setLightingParams(float ambient, float direct,
   _lightSpecular = specular;
   _lightShininess = shininess;
   _sssWrap = sssWrap;
+}
+
+void RendererMetal::setRayTraceParams(int samples, float aoRadius,
+    float aoIntensity, float shadowIntensity)
+{
+  // Clamp defensively: nSamples bounds the per-pixel AO ray loop, so an absurd
+  // value would hang the GPU; intensities are [0,1] multipliers; radius > 0.
+  _rtSamples = samples < 1 ? 1 : (samples > 256 ? 256 : samples);
+  _rtAORadius = aoRadius < 0.1f ? 0.1f : aoRadius;
+  _rtAOIntensity = aoIntensity < 0.0f ? 0.0f : (aoIntensity > 1.0f ? 1.0f : aoIntensity);
+  _rtShadowIntensity =
+      shadowIntensity < 0.0f ? 0.0f : (shadowIntensity > 1.0f ? 1.0f : shadowIntensity);
 }
 
 // ---------------------------------------------------------------------------
@@ -2102,12 +2137,19 @@ void RendererMetal::ensureRayTracingAS()
   }
 
   // Lazily compile the RT resolve pipeline (separate library so the raytracing
-  // intersector code can't affect the main post library). If it fails, the RT
-  // pass is skipped and the SSAO/shadow path runs — zero regression.
-  if (_rtReady && !_rtResolvePipeline) {
+  // intersector code can't affect the main post library). Attempted at most ONCE
+  // (_rtCompileTried latch): a compile failure must NOT busy-recompile the source
+  // every frame (that was a real perf sink while RT was broken). If it fails the RT
+  // pass is skipped and the SSAO/shadow path runs — zero regression. kEyeReconSrc
+  // is prepended so rt_ao/rt_composite can call post_eye_pos/normal/normal_smooth.
+  if (_rtReady && !_rtResolvePipeline && !_rtCompileTried) {
+    _rtCompileTried = true;
     NSError* err = nil;
-    id<MTLLibrary> lib = [_device newLibraryWithSource:kRTSrc options:nil error:&err];
-    if (lib) {
+    id<MTLLibrary> lib = [_device newLibraryWithSource:[kEyeReconSrc stringByAppendingString:kRTSrc]
+                                               options:nil error:&err];
+    if (!lib) {
+      NSLog(@"RendererMetal RT: shader library failed to compile: %@", err);
+    } else {
       // Pass A: raw AO (.r) + traced light-visibility (.g) -> RG16Float.
       MTLRenderPipelineDescriptor* pa = [[MTLRenderPipelineDescriptor alloc] init];
       pa.vertexFunction = [lib newFunctionWithName:@"rt_vertex"];
@@ -2120,9 +2162,9 @@ void RendererMetal::ensureRayTracingAS()
       pd.fragmentFunction = [lib newFunctionWithName:@"rt_composite"];
       pd.colorAttachments[0].pixelFormat = MTLPixelFormatBGRA8Unorm;
       _rtResolvePipeline = [_device newRenderPipelineStateWithDescriptor:pd error:&err];
+      if (!_rtAOPipeline || !_rtResolvePipeline)
+        NSLog(@"RendererMetal RT: AO/composite pipeline failed: %@", err);
     }
-    if (!_rtAOPipeline || !_rtResolvePipeline)
-      NSLog(@"RendererMetal RT: AO/composite pipeline failed: %@", err);
   }
 }
 
@@ -2165,12 +2207,14 @@ void RendererMetal::runPostChain()
     u.bgFog[3] = doFog ? 1.0f : 0.0f;
     u.projA = _projA; u.projB = _projB; u.projX = _projX; u.projY = _projY;
     u.fogStart = _fogStart; u.fogEnd = _fogEnd;
-    u.aoRadius = 5.0f; u.aoIntensity = 0.72f;
-    u.shadowIntensity = doShadow ? 0.45f : 0.0f;
-    // 16 stratified (Hammersley) samples + the composite-pass blur is clean and
-    // shimmer-free; for the single-shot offscreen PNG (no temporal smoothing)
-    // trace more rays since each export frame stands alone.
-    u.nSamples = _offscreen ? 48.0f : 16.0f;
+    u.aoRadius = _rtAORadius; u.aoIntensity = _rtAOIntensity;
+    u.shadowIntensity = doShadow ? _rtShadowIntensity : 0.0f;
+    // AO rays/pixel: the live view uses metal_rt_samples (_rtSamples, default 16
+    // stratified Hammersley samples — clean and shimmer-free with the composite
+    // blur); the single-shot offscreen PNG (no temporal smoothing) traces more
+    // since each export frame stands alone, never fewer than 48.
+    u.nSamples = _offscreen ? (float)(_rtSamples > 48 ? _rtSamples : 48)
+                            : (float)_rtSamples;
     // Temporal AO: when enabled (and not a single-shot offscreen export), advance
     // the frame counter so rt_ao jitters each frame; the accumulate pass below
     // EMAs successive frames toward offscreen quality. Off => frame 0, which is

--- a/modules/pymol/appkit_inspector.py
+++ b/modules/pymol/appkit_inspector.py
@@ -51,6 +51,8 @@ REP_EXTRA_COLORS = {
 }
 
 SCENE_SETTINGS = ['metal_raytrace', 'metal_rt_shadows', 'metal_shadows', 'metal_ssao',
+                  'metal_rt_samples', 'metal_rt_ao_radius', 'metal_rt_ao_intensity',
+                  'metal_rt_shadow_intensity',
                   'metal_outline', 'metal_outline_width', 'metal_msaa',
                   'metal_tonemap', 'metal_exposure',
                   'metal_sss_wrap', 'metal_dof', 'metal_dof_focus',

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -188,7 +188,7 @@ struct SceneParam: Identifiable {
 
 enum SceneCatalog {
     // Ordered sub-groups shown inside the SCENE section (see panel reorg).
-    static let groups = ["Canvas", "Camera", "Lighting", "Shadows & AO", "Effects", "Quality"]
+    static let groups = ["Canvas", "Camera", "Lighting", "Shadows & AO", "Metal optimization", "Effects", "Quality"]
     static let params: [SceneParam] = [
         // --- Canvas: background + multi-object/state layout ---
         SceneParam(setting: "bg_rgb",     label: "Background", kind: .toggle, group: "Canvas", isColor: true,
@@ -226,17 +226,31 @@ enum SceneCatalog {
         SceneParam(setting: "metal_sss_wrap", label: "Subsurface wrap", kind: .slider, min: 0, max: 1, step: 0.05, decimals: 2, group: "Lighting",
                    help: "Wraps light past the terminator for a soft, waxy/translucent look. 0 = plain Lambert."),
 
-        // --- Shadows & AO: occlusion + the hardware-RT subsystem ---
+        // --- Shadows & AO: screen-space (non-RT) shadows + occlusion ---
         SceneParam(setting: "metal_shadows", label: "Shadows", kind: .toggle, group: "Shadows & AO",
                    help: "Real-time screen-space directional shadows."),
         SceneParam(setting: "metal_ssao",    label: "Ambient occlusion", kind: .toggle, group: "Shadows & AO",
                    help: "Screen-space ambient occlusion — darkens crevices and contact points for depth."),
-        SceneParam(setting: "metal_raytrace", label: "Ray tracing (AO + shadows)", kind: .toggle, group: "Shadows & AO",
-                   help: "Hardware ray tracing for higher-quality ambient occlusion and shadows. Requires a supported GPU; it powers the two options below."),
-        SceneParam(setting: "metal_rt_shadows", label: "RT hard shadows", kind: .toggle, group: "Shadows & AO", dependsOn: "metal_raytrace",
+
+        // --- Metal optimization: hardware ray tracing + GPU quality/perf knobs ---
+        SceneParam(setting: "metal_raytrace", label: "Ray tracing (AO + shadows)", kind: .toggle, group: "Metal optimization",
+                   help: "Hardware ray tracing for higher-quality ambient occlusion and shadows. Requires a supported GPU; it powers the options below."),
+        SceneParam(setting: "metal_rt_shadows", label: "RT hard shadows", kind: .toggle, group: "Metal optimization", dependsOn: "metal_raytrace",
                    help: "Trace crisp hard shadow rays instead of the shadow-map approximation. Needs ray tracing on."),
-        SceneParam(setting: "metal_temporal_ao", label: "Temporal AO", kind: .toggle, group: "Shadows & AO", dependsOn: "metal_raytrace",
+        SceneParam(setting: "metal_temporal_ao", label: "Temporal AO", kind: .toggle, group: "Metal optimization", dependsOn: "metal_raytrace",
                    help: "Accumulate ray-traced AO across frames while the view is still, for cleaner, smoother occlusion. Needs ray tracing on."),
+        SceneParam(setting: "metal_rt_samples", label: "RT quality (rays)", kind: .slider, min: 4, max: 128, step: 4, decimals: 0, group: "Metal optimization", dependsOn: "metal_raytrace",
+                   help: "Ambient-occlusion rays traced per pixel in the live view. Higher is smoother but slower — lower it on mobile for speed (exports always use at least 48)."),
+        SceneParam(setting: "metal_rt_ao_radius", label: "AO radius (Å)", kind: .slider, min: 1, max: 15, step: 0.5, decimals: 1, group: "Metal optimization", dependsOn: "metal_raytrace",
+                   help: "How far ambient occlusion reaches, in Angstroms. Larger darkens broad pockets and cavities; smaller keeps it to tight contact creases."),
+        SceneParam(setting: "metal_rt_ao_intensity", label: "AO strength", kind: .slider, min: 0, max: 1, step: 0.02, decimals: 2, group: "Metal optimization", dependsOn: "metal_raytrace",
+                   help: "Ambient-occlusion darkening amount."),
+        SceneParam(setting: "metal_rt_shadow_intensity", label: "RT shadow strength", kind: .slider, min: 0, max: 1, step: 0.02, decimals: 2, group: "Metal optimization", dependsOn: "metal_raytrace",
+                   help: "Cast-shadow darkening amount (still needs Shadows on)."),
+        SceneParam(setting: "metal_msaa",   label: "MSAA 4×", kind: .toggle, group: "Metal optimization",
+                   help: "4× multisample antialiasing — smoother edges at some GPU cost."),
+        SceneParam(setting: "metal_upscale", label: "Reduced-res upscale", kind: .toggle, group: "Metal optimization",
+                   help: "Render at reduced resolution and upscale (MetalFX) for better performance on slower GPUs."),
 
         // --- Effects: stylization + post-processing ---
         SceneParam(setting: "metal_outline", label: "Outline", kind: .toggle, group: "Effects",
@@ -256,11 +270,7 @@ enum SceneCatalog {
         SceneParam(setting: "depth_cue",  label: "Depth cue / fog", kind: .toggle, group: "Effects",
                    help: "Fade distant parts of the scene into the background to convey depth."),
 
-        // --- Quality: antialiasing / perf / tessellation ---
-        SceneParam(setting: "metal_msaa",   label: "MSAA 4×", kind: .toggle, group: "Quality",
-                   help: "4× multisample antialiasing — smoother edges at some GPU cost."),
-        SceneParam(setting: "metal_upscale", label: "Reduced-res upscale", kind: .toggle, group: "Quality",
-                   help: "Render at reduced resolution and upscale (MetalFX) for better performance on slower GPUs."),
+        // --- Quality: tessellation ---
         SceneParam(setting: "surface_quality", label: "Surface quality", kind: .segmented,
                    options: [("0", 0), ("1", 1), ("2", 2)], group: "Quality",
                    help: "Surface mesh detail: 0 = coarse/fast, 2 = fine/slow."),


### PR DESCRIPTION
## Summary

Real-time ray tracing (`metal_raytrace`) was **silently doing nothing to the image and making the app sluggish**. This PR fixes the root cause, exposes the RT quality knobs as settings, and reorganizes them into a **Metal optimization** panel section.

### Root cause (the bug)
The `kRTSrc` Metal shader library calls `post_eye_pos` / `post_eye_normal` / `post_eye_normal_smooth`, but those are defined only in the **separate** `kPostSrc` library. Metal does no cross-library source linking, so `kRTSrc` failed to compile, both RT pipelines stayed `nil`, and the `doRT` gate was permanently false. Meanwhile `_rtEnabled` stayed true, so per-frame geometry capture, the acceleration-structure build, and an always-failing shader recompile kept running — **no visual change + sluggish**. Regression from #83/#87, which moved the reconstruction helpers into `kPostSrc` only.

## Changes
- **Fix:** factor the shared eye/normal reconstruction helpers into a `kEyeReconSrc` MSL string prepended to **both** shader libraries (single canonical copy prevents the drift recurring). Add a one-shot compile latch so a failed compile can't busy-recompile every frame; split library-vs-pipeline failure logging.
- **Quality settings** (previously hardcoded constants, defaults unchanged): `metal_rt_samples` (AO rays/pixel), `metal_rt_ao_radius`, `metal_rt_ao_intensity`, `metal_rt_shadow_intensity` — threaded via a new `Renderer::setRayTraceParams` (clamped in `RendererMetal`).
- **UI:** new **Metal optimization** section with all ray-tracing controls + MSAA + reduced-res upscale; sliders for the new settings. Screen-space Shadows/AO stay in "Shadows & AO".
- **Persistence fix:** added the new settings to the scene-state poll (`SCENE_SETTINGS`) so the sliders don't reset to 0 on screen change.

## Verification
- `xcrun metal -c`: the buggy standalone `kRTSrc` fails with the exact `undeclared identifier 'post_eye_*'` errors; the fixed `kEyeReconSrc + kRTSrc` compiles; `kEyeReconSrc + kPostSrc` still compiles (no SSAO/shadow regression).
- **On Apple M3 Pro** (`supportsRaytracing=true`), replicating `ensureRayTracingAS`'s pipeline creation: before the fix `makeLibrary` throws; after, both `rt_ao`/`rt_composite` pipelines build → `doRT` reachable.
- macOS + iOS builds succeed; deployed and launched on iPhone 15 Pro.
- Note: a live-pixel A/B in-app couldn't be captured under headless automation (mac VM's paravirtual GPU has no RT; host MTKView won't composite when occluded/inactive) — verification is at the shader-compile / pipeline-build level on real RT hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)