### PR TITLE
Photos-style camera control dock (all platforms)

### DIFF
--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -2315,10 +2315,11 @@ struct CameraDock: View {
         .padding(.horizontal, 14)
         .padding(.top, 10)
         .padding(.bottom, 12)
-        // A centered, content-scaled card rather than a full-width bar. The bottom
-        // overlay centers it horizontally; this cap keeps it from spanning the
-        // whole viewport (esp. on iPad/macOS). Floor is set by the icon strip.
-        .frame(maxWidth: 320)
+        // Hug the icon strip tightly when collapsed (a compact centered pill); when
+        // a control is open, expand to fit the slider submenu, capped so it never
+        // spans the whole viewport. The bottom overlay centers it either way.
+        .fixedSize(horizontal: open == nil, vertical: false)
+        .frame(maxWidth: open == nil ? nil : 320)
         .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
         .overlay(RoundedRectangle(cornerRadius: 22, style: .continuous)
             .strokeBorder(.white.opacity(0.14), lineWidth: 0.5))

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -200,13 +200,6 @@ enum CameraCommands {
 enum SceneCatalog {
     // Ordered sub-groups shown inside the SCENE section (see panel reorg).
     static let groups = ["Canvas", "Camera", "Lighting", "Shadows & AO", "Metal optimization", "Effects", "Quality"]
-    // Ordered subset shown in the viewport Camera overlay (a shortcut to the
-    // most-used camera controls). Deliberately omits metal_dof_range and
-    // depth_cue, which remain in the full inspector.
-    static let cameraOverlayKeys = [
-        "field_of_view", "zoom", "ortho", "metal_dof",
-        "metal_dof_autofocus", "metal_dof_focus", "metal_dof_aperture", "metal_dof_quality",
-    ]
     // Viewport camera dock (see CameraDock): the always-visible strip icons, in
     // order. DOF's sub-controls are rendered by DOFSubPanelContent, not as strip
     // icons. metal_dof_quality is intentionally absent — it defaults to best (4)
@@ -2065,10 +2058,10 @@ struct SceneCard: View {
 
 }
 
-// MARK: - Shared scene-setting row + Camera overlay
+// MARK: - Shared scene-setting row + Camera dock
 
 // One scene-setting row (label + control + help), shared by the inspector's
-// Scene section (SceneCard) and the viewport Camera overlay (CameraControlsView).
+// Scene section (SceneCard) and the viewport camera dock (CameraDock).
 // Self-hides when its dependsOn parent toggle is off, so callers render it
 // unconditionally.
 struct SceneParamRow: View {
@@ -2214,43 +2207,184 @@ struct SceneParamRow: View {
     }
 }
 
-// Content of the viewport Camera overlay (popover on macOS/iPad, bottom sheet on
-// iPhone). Reuses SceneParamRow for the curated camera params, then a Reset view
-// action. Reads/writes go through PyMOLEngine exactly as the inspector does.
-struct CameraControlsView: View {
+// The Depth-of-field sub-panel shown inside the camera dock when "Depth" is
+// selected. Enabled + Auto lock share the top row (both switches); Focus and
+// Aperture reuse the inspector rows and self-hide (dependsOn: metal_dof) until
+// DOF is enabled. Quality is intentionally not here — it lives in the inspector.
+struct DOFSubPanelContent: View {
     @ObservedObject var engine: PyMOLEngine
+    private var dofOn: Bool { (engine.sceneState.values["metal_dof"] ?? 0) > 0.5 }
 
     var body: some View {
-        // Pure content (no background / outer padding): the macOS popover and the
-        // iOS glassy card each supply their own chrome. Tight spacing keeps it
-        // vertically compact — it hugs its content rather than filling a sheet.
-        VStack(alignment: .leading, spacing: 3) {
+        VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 8) {
-                Image(systemName: "camera")
-                Text("Camera").font(.system(size: 15, weight: .medium))
+                Image(systemName: "camera.metering.center.weighted")
+                Text("Depth of field").font(.system(size: 13, weight: .medium))
                 Spacer()
             }
             .foregroundColor(PanelTheme.textColor)
             .padding(.bottom, 2)
 
-            ForEach(SceneCatalog.cameraOverlayKeys, id: \.self) { key in
-                if let p = SceneCatalog.param(for: key) {
-                    SceneParamRow(param: p, engine: engine)
+            HStack(spacing: 20) {
+                dofToggle("Enabled", key: "metal_dof", id: "dof.enabled", enabled: true) { on in
+                    engine.runCommand("set metal_dof, \(on ? 1 : 0)")
                 }
+                dofToggle("Auto lock", key: "metal_dof_autofocus", id: "dof.autolock", enabled: dofOn) { on in
+                    engine.runCommand(CameraCommands.setAutofocus(on))
+                }
+                Spacer()
             }
 
-            Button { engine.runCommand("reset") } label: {
-                HStack(spacing: 8) {
-                    Image(systemName: "dot.viewfinder")
-                    Text("Reset view")
-                    Spacer()
-                }
-                .font(.system(size: 13, weight: .medium))
-                .foregroundColor(PanelTheme.selectionTextColor)
-                .padding(.top, 6)
-                .contentShape(Rectangle())
+            if let focus = SceneCatalog.param(for: "metal_dof_focus") {
+                SceneParamRow(param: focus, engine: engine)
             }
-            .buttonStyle(.plain)
+            if let aperture = SceneCatalog.param(for: "metal_dof_aperture") {
+                SceneParamRow(param: aperture, engine: engine)
+            }
+        }
+    }
+
+    private func dofToggle(_ label: String, key: String, id: String,
+                           enabled: Bool, onToggle: @escaping (Bool) -> Void) -> some View {
+        HStack(spacing: 6) {
+            Text(label).font(.system(size: 11)).foregroundColor(PanelTheme.textColor)
+            ToggleSetting(value: engine.sceneState.values[key] ?? 0, onToggle: onToggle)
+                .accessibilityIdentifier(id)
+                .accessibilityLabel(label)
+        }
+        .disabled(!enabled)
+        .opacity(enabled ? 1 : 0.45)
+    }
+}
+
+// Bottom-docked camera control strip (Photos-app "Adjust" model): a row of icon
+// buttons where one control opens at a time above the strip. Reuses SceneParamRow
+// for every slider control so all camera logic stays in one place. Used on all
+// platforms via ContentView's bottom overlay.
+struct CameraDock: View {
+    @ObservedObject var engine: PyMOLEngine
+    // Which control's surface is open above the strip. nil = strip only.
+    // "ortho" toggles instantly and never becomes `open`.
+    @State private var open: String? = nil
+
+    private var orthoOn: Bool { (engine.sceneState.values["ortho"] ?? 0) > 0.5 }
+    private var dofOn: Bool { (engine.sceneState.values["metal_dof"] ?? 0) > 0.5 }
+
+    var body: some View {
+        VStack(spacing: 8) {
+            if let key = open {
+                Group {
+                    if key == "metal_dof" {
+                        DOFSubPanelContent(engine: engine)
+                    } else if let p = SceneCatalog.param(for: key) {
+                        SceneParamRow(param: p, engine: engine)
+                    }
+                }
+                .padding(.horizontal, 4)
+                Divider().overlay(PanelTheme.textColor.opacity(0.15))
+            }
+            HStack(spacing: 10) {
+                ForEach(SceneCatalog.cameraStripKeys, id: \.self) { stripIcon($0) }
+                stripAction(icon: "dot.viewfinder", label: "Reset", id: "camDock.reset") {
+                    engine.runCommand("reset")
+                }
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.top, 10)
+        .padding(.bottom, 12)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 22, style: .continuous)
+            .strokeBorder(.white.opacity(0.14), lineWidth: 0.5))
+        .animation(.easeOut(duration: 0.18), value: open)
+    }
+
+    private func tap(_ key: String) {
+        switch key {
+        case "ortho":
+            let newVal = orthoOn ? 0 : 1
+            engine.runCommand("set ortho, \(newVal)")
+            if newVal == 1 && open == "field_of_view" { open = nil }  // Lens is inert in ortho
+        default:
+            open = (open == key) ? nil : key
+        }
+    }
+
+    @ViewBuilder
+    private func stripIcon(_ key: String) -> some View {
+        let selected = (open == key)
+        let on = (key == "ortho" && orthoOn)
+        let active = selected || on
+        let disabled = (key == "field_of_view" && orthoOn)
+        Button { tap(key) } label: {
+            VStack(spacing: 3) {
+                ZStack(alignment: .topTrailing) {
+                    Image(systemName: SceneCatalog.cameraIcon(for: key))
+                        .font(.system(size: 17))
+                        .foregroundColor(active ? .black : PanelTheme.buttonText)
+                        .frame(width: 42, height: 42)
+                        .background(active ? PanelTheme.selectionTextColor : PanelTheme.buttonBackground,
+                                    in: Circle())
+                    if key == "metal_dof" && dofOn {
+                        Circle().fill(PanelTheme.selectionTextColor)
+                            .frame(width: 9, height: 9)
+                            .overlay(Circle().strokeBorder(.white, lineWidth: 1))
+                            .offset(x: 2, y: -2)
+                    }
+                }
+                Text(shortLabel(key)).font(.system(size: 10))
+                    .foregroundColor(active ? PanelTheme.selectionTextColor : PanelTheme.textColor)
+            }
+        }
+        .buttonStyle(.plain)
+        .disabled(disabled)
+        .opacity(disabled ? 0.4 : 1)
+        .accessibilityIdentifier(axID(key))
+        .accessibilityLabel(fullLabel(key))
+    }
+
+    private func stripAction(icon: String, label: String, id: String,
+                             action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            VStack(spacing: 3) {
+                Image(systemName: icon)
+                    .font(.system(size: 17))
+                    .foregroundColor(PanelTheme.buttonText)
+                    .frame(width: 42, height: 42)
+                    .background(PanelTheme.buttonBackground, in: Circle())
+                Text(label).font(.system(size: 10)).foregroundColor(PanelTheme.textColor)
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(id)
+        .accessibilityLabel("Reset view")
+    }
+
+    private func shortLabel(_ key: String) -> String {
+        switch key {
+        case "field_of_view": return "Lens"
+        case "zoom":          return "Zoom"
+        case "ortho":         return "Ortho"
+        case "metal_dof":     return "Depth"
+        default:              return key
+        }
+    }
+    private func fullLabel(_ key: String) -> String {
+        switch key {
+        case "field_of_view": return "Lens"
+        case "zoom":          return "Zoom"
+        case "ortho":         return "Orthographic"
+        case "metal_dof":     return "Depth of field"
+        default:              return key
+        }
+    }
+    private func axID(_ key: String) -> String {
+        switch key {
+        case "field_of_view": return "camDock.lens"
+        case "zoom":          return "camDock.zoom"
+        case "ortho":         return "camDock.ortho"
+        case "metal_dof":     return "camDock.depth"
+        default:              return "camDock.\(key)"
         }
     }
 }

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -2315,6 +2315,10 @@ struct CameraDock: View {
         .padding(.horizontal, 14)
         .padding(.top, 10)
         .padding(.bottom, 12)
+        // A centered, content-scaled card rather than a full-width bar. The bottom
+        // overlay centers it horizontally; this cap keeps it from spanning the
+        // whole viewport (esp. on iPad/macOS). Floor is set by the icon strip.
+        .frame(maxWidth: 320)
         .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
         .overlay(RoundedRectangle(cornerRadius: 22, style: .continuous)
             .strokeBorder(.white.opacity(0.14), lineWidth: 0.5))

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -204,7 +204,7 @@ enum SceneCatalog {
     // order. DOF's sub-controls are rendered by DOFSubPanelContent, not as strip
     // icons. metal_dof_quality is intentionally absent — it defaults to best (4)
     // and lives only in the inspector's Scene → Camera group.
-    static let cameraStripKeys = ["ortho", "field_of_view", "zoom", "metal_dof"]
+    static let cameraStripKeys = ["field_of_view", "zoom", "metal_dof"]
 
     // SF Symbol for each strip control.
     static func cameraIcon(for setting: String) -> String {
@@ -2279,6 +2279,13 @@ struct CameraDock: View {
                 Group {
                     if key == "metal_dof" {
                         DOFSubPanelContent(engine: engine)
+                    } else if key == "field_of_view", let p = SceneCatalog.param(for: key) {
+                        // Lens row: Ortho toggle on the left; the Lens slider greys
+                        // itself out (via SceneParamRow) while Ortho is on.
+                        HStack(spacing: 10) {
+                            orthoToggle
+                            SceneParamRow(param: p, engine: engine)
+                        }
                     } else if let p = SceneCatalog.param(for: key) {
                         SceneParamRow(param: p, engine: engine)
                     }
@@ -2303,22 +2310,35 @@ struct CameraDock: View {
     }
 
     private func tap(_ key: String) {
-        switch key {
-        case "ortho":
-            let newVal = orthoOn ? 0 : 1
-            engine.runCommand("set ortho, \(newVal)")
-            if newVal == 1 && open == "field_of_view" { open = nil }  // Lens is inert in ortho
-        default:
-            open = (open == key) ? nil : key
+        open = (open == key) ? nil : key
+    }
+
+    // Ortho lives in the Lens row (perspective vs orthographic). Toggling it greys
+    // the Lens slider (SceneParamRow self-disables field_of_view while ortho is on).
+    private var orthoToggle: some View {
+        Button {
+            engine.runCommand("set ortho, \(orthoOn ? 0 : 1)")
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: "cube")
+                Text("Ortho")
+            }
+            .font(.system(size: 12))
+            .foregroundColor(orthoOn ? .black : PanelTheme.buttonText)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .background(orthoOn ? PanelTheme.selectionTextColor : PanelTheme.buttonBackground,
+                        in: Capsule())
         }
+        .buttonStyle(.plain)
+        .fixedSize()
+        .accessibilityIdentifier("camDock.ortho")
+        .accessibilityLabel("Orthographic")
     }
 
     @ViewBuilder
     private func stripIcon(_ key: String) -> some View {
-        let selected = (open == key)
-        let on = (key == "ortho" && orthoOn)
-        let active = selected || on
-        let disabled = (key == "field_of_view" && orthoOn)
+        let active = (open == key)
         Button { tap(key) } label: {
             VStack(spacing: 3) {
                 ZStack(alignment: .topTrailing) {
@@ -2340,8 +2360,6 @@ struct CameraDock: View {
             }
         }
         .buttonStyle(.plain)
-        .disabled(disabled)
-        .opacity(disabled ? 0.4 : 1)
         .accessibilityIdentifier(axID(key))
         .accessibilityLabel(fullLabel(key))
     }

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -204,7 +204,7 @@ enum SceneCatalog {
     // order. DOF's sub-controls are rendered by DOFSubPanelContent, not as strip
     // icons. metal_dof_quality is intentionally absent — it defaults to best (4)
     // and lives only in the inspector's Scene → Camera group.
-    static let cameraStripKeys = ["field_of_view", "zoom", "ortho", "metal_dof"]
+    static let cameraStripKeys = ["ortho", "field_of_view", "zoom", "metal_dof"]
 
     // SF Symbol for each strip control.
     static func cameraIcon(for setting: String) -> String {
@@ -2264,6 +2264,8 @@ struct DOFSubPanelContent: View {
 // platforms via ContentView's bottom overlay.
 struct CameraDock: View {
     @ObservedObject var engine: PyMOLEngine
+    // Dismisses the whole dock (the ✕ close button).
+    let onClose: () -> Void
     // Which control's surface is open above the strip. nil = strip only.
     // "ortho" toggles instantly and never becomes `open`.
     @State private var open: String? = nil
@@ -2286,8 +2288,8 @@ struct CameraDock: View {
             }
             HStack(spacing: 10) {
                 ForEach(SceneCatalog.cameraStripKeys, id: \.self) { stripIcon($0) }
-                stripAction(icon: "dot.viewfinder", label: "Reset", id: "camDock.reset") {
-                    engine.runCommand("reset")
+                stripAction(icon: "xmark", label: "Close", id: "camDock.close") {
+                    onClose()
                 }
             }
         }

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -216,6 +216,7 @@ enum SceneCatalog {
         default:              return "slider.horizontal.3"
         }
     }
+
     static func param(for setting: String) -> SceneParam? {
         params.first { $0.setting == setting }
     }
@@ -2357,7 +2358,7 @@ struct CameraDock: View {
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier(id)
-        .accessibilityLabel("Reset view")
+        .accessibilityLabel(label)
     }
 
     private func shortLabel(_ key: String) -> String {

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -186,6 +186,17 @@ struct SceneParam: Identifiable {
     var help: String = ""
 }
 
+// Camera-control command strings shared by the inspector row and the camera dock,
+// so the DOF auto-lock action has a single source of truth.
+enum CameraCommands {
+    // Auto-lock focus: enabling snapshots the current selection into "dof_focus"
+    // (the target the renderer tracks each frame); disabling just clears the flag.
+    static func setAutofocus(_ on: Bool) -> String {
+        on ? "select dof_focus, (sele)\nset metal_dof_autofocus, 1"
+           : "set metal_dof_autofocus, 0"
+    }
+}
+
 enum SceneCatalog {
     // Ordered sub-groups shown inside the SCENE section (see panel reorg).
     static let groups = ["Canvas", "Camera", "Lighting", "Shadows & AO", "Metal optimization", "Effects", "Quality"]
@@ -196,6 +207,22 @@ enum SceneCatalog {
         "field_of_view", "zoom", "ortho", "metal_dof",
         "metal_dof_autofocus", "metal_dof_focus", "metal_dof_aperture", "metal_dof_quality",
     ]
+    // Viewport camera dock (see CameraDock): the always-visible strip icons, in
+    // order. DOF's sub-controls are rendered by DOFSubPanelContent, not as strip
+    // icons. metal_dof_quality is intentionally absent — it defaults to best (4)
+    // and lives only in the inspector's Scene → Camera group.
+    static let cameraStripKeys = ["field_of_view", "zoom", "ortho", "metal_dof"]
+
+    // SF Symbol for each strip control.
+    static func cameraIcon(for setting: String) -> String {
+        switch setting {
+        case "field_of_view": return "camera.aperture"
+        case "zoom":          return "plus.magnifyingglass"
+        case "ortho":         return "cube"
+        case "metal_dof":     return "camera.metering.center.weighted"
+        default:              return "slider.horizontal.3"
+        }
+    }
     static func param(for setting: String) -> SceneParam? {
         params.first { $0.setting == setting }
     }
@@ -2084,9 +2111,7 @@ struct SceneParamRow: View {
                     // the locked target the renderer tracks each frame (see the
                     // SceneRender auto-focus block). Disabling just clears the flag.
                     ToggleSetting(value: v) { on in
-                        engine.runCommand(on
-                            ? "select dof_focus, (sele)\nset metal_dof_autofocus, 1"
-                            : "set metal_dof_autofocus, 0")
+                        engine.runCommand(CameraCommands.setAutofocus(on))
                     }
                 } else {
                     ToggleSetting(value: v) { on in engine.runCommand("set \(p.setting), \(on ? 1 : 0)") }

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -1304,6 +1304,9 @@ private struct LabeledSlider: View {
     let value: Double
     let onLive: (Double) -> Void
     let onCommit: (Double) -> Void
+    // When set, caps the slider's width (used by the camera dock); nil = fill the
+    // available width, the inspector's default.
+    var sliderMaxWidth: CGFloat? = nil
 
     @State private var local: Double = 0
     @State private var text: String = ""
@@ -1327,6 +1330,7 @@ private struct LabeledSlider: View {
             .controlSize(.mini)
             #endif
                 #endif
+            .frame(maxWidth: sliderMaxWidth)
             TextField("", text: $text)
                 .textFieldStyle(.plain)
                 .multilineTextAlignment(.trailing)
@@ -2068,6 +2072,8 @@ struct SceneCard: View {
 struct SceneParamRow: View {
     let param: SceneParam
     @ObservedObject var engine: PyMOLEngine
+    // Caps the slider width (camera dock passes a fixed value); nil = fill.
+    var sliderMaxWidth: CGFloat? = nil
 
     var body: some View {
         if let dep = param.dependsOn, (engine.sceneState.values[dep] ?? 0) <= 0.5 {
@@ -2125,7 +2131,8 @@ struct SceneParamRow: View {
                                                     min: p.min, max: p.max, step: p.step, decimals: p.decimals),
                                   value: fovToMM(fovDeg),
                                   onLive: { engine.runCommand("set_fov \(String(format: "%.3f", mmToFOV($0)))") },
-                                  onCommit: { engine.runCommand("set_fov \(String(format: "%.3f", mmToFOV($0)))") })
+                                  onCommit: { engine.runCommand("set_fov \(String(format: "%.3f", mmToFOV($0)))") },
+                                  sliderMaxWidth: sliderMaxWidth)
                         .disabled(orthoOn)
                         .opacity(orthoOn ? 0.4 : 1.0)
                 } else if p.setting == "zoom" {
@@ -2141,7 +2148,8 @@ struct SceneParamRow: View {
                                                     min: p.min, max: p.max, step: p.step, decimals: p.decimals),
                                   value: zoomMag(camDist: camDist, radius: radius, fovDeg: fovDeg),
                                   onLive: { engine.setZoomMagnification($0, radius: radius, fovDeg: fovDeg) },
-                                  onCommit: { engine.setZoomMagnification($0, radius: radius, fovDeg: fovDeg) })
+                                  onCommit: { engine.setZoomMagnification($0, radius: radius, fovDeg: fovDeg) },
+                                  sliderMaxWidth: sliderMaxWidth)
                         .disabled(!zoomReady)
                         .opacity(zoomReady ? 1.0 : 0.4)
                 } else {
@@ -2152,7 +2160,8 @@ struct SceneParamRow: View {
                                                     min: p.min, max: p.max, step: p.step, decimals: p.decimals),
                                   value: v,
                                   onLive: { engine.runCommand("set \(p.setting), \(fmtScene($0, p))") },
-                                  onCommit: { engine.runCommand("set \(p.setting), \(fmtScene($0, p))") })
+                                  onCommit: { engine.runCommand("set \(p.setting), \(fmtScene($0, p))") },
+                                  sliderMaxWidth: sliderMaxWidth)
                         .disabled(dofAuto)
                         .opacity(dofAuto ? 0.4 : 1.0)
                 }
@@ -2240,10 +2249,10 @@ struct DOFSubPanelContent: View {
             }
 
             if let focus = SceneCatalog.param(for: "metal_dof_focus") {
-                SceneParamRow(param: focus, engine: engine)
+                SceneParamRow(param: focus, engine: engine, sliderMaxWidth: 200)
             }
             if let aperture = SceneCatalog.param(for: "metal_dof_aperture") {
-                SceneParamRow(param: aperture, engine: engine)
+                SceneParamRow(param: aperture, engine: engine, sliderMaxWidth: 200)
             }
         }
     }
@@ -2287,10 +2296,10 @@ struct CameraDock: View {
                         // itself out (via SceneParamRow) while Ortho is on.
                         HStack(spacing: 10) {
                             orthoToggle
-                            SceneParamRow(param: p, engine: engine)
+                            SceneParamRow(param: p, engine: engine, sliderMaxWidth: 200)
                         }
                     } else if let p = SceneCatalog.param(for: key) {
-                        SceneParamRow(param: p, engine: engine)
+                        SceneParamRow(param: p, engine: engine, sliderMaxWidth: 200)
                     }
                 }
                 .padding(.horizontal, 4)

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -2072,8 +2072,10 @@ struct SceneCard: View {
 struct SceneParamRow: View {
     let param: SceneParam
     @ObservedObject var engine: PyMOLEngine
-    // Caps the slider width (camera dock passes a fixed value); nil = fill.
-    var sliderMaxWidth: CGFloat? = nil
+    // Compact layout for the camera dock: natural-width label and no trailing
+    // Spacer, so the slider fills the row instead of splitting the space with a
+    // Spacer (the dock card bounds the overall width). Inspector uses the default.
+    var compact: Bool = false
 
     var body: some View {
         if let dep = param.dependsOn, (engine.sceneState.values[dep] ?? 0) <= 0.5 {
@@ -2131,8 +2133,7 @@ struct SceneParamRow: View {
                                                     min: p.min, max: p.max, step: p.step, decimals: p.decimals),
                                   value: fovToMM(fovDeg),
                                   onLive: { engine.runCommand("set_fov \(String(format: "%.3f", mmToFOV($0)))") },
-                                  onCommit: { engine.runCommand("set_fov \(String(format: "%.3f", mmToFOV($0)))") },
-                                  sliderMaxWidth: sliderMaxWidth)
+                                  onCommit: { engine.runCommand("set_fov \(String(format: "%.3f", mmToFOV($0)))") })
                         .disabled(orthoOn)
                         .opacity(orthoOn ? 0.4 : 1.0)
                 } else if p.setting == "zoom" {
@@ -2148,8 +2149,7 @@ struct SceneParamRow: View {
                                                     min: p.min, max: p.max, step: p.step, decimals: p.decimals),
                                   value: zoomMag(camDist: camDist, radius: radius, fovDeg: fovDeg),
                                   onLive: { engine.setZoomMagnification($0, radius: radius, fovDeg: fovDeg) },
-                                  onCommit: { engine.setZoomMagnification($0, radius: radius, fovDeg: fovDeg) },
-                                  sliderMaxWidth: sliderMaxWidth)
+                                  onCommit: { engine.setZoomMagnification($0, radius: radius, fovDeg: fovDeg) })
                         .disabled(!zoomReady)
                         .opacity(zoomReady ? 1.0 : 0.4)
                 } else {
@@ -2160,8 +2160,7 @@ struct SceneParamRow: View {
                                                     min: p.min, max: p.max, step: p.step, decimals: p.decimals),
                                   value: v,
                                   onLive: { engine.runCommand("set \(p.setting), \(fmtScene($0, p))") },
-                                  onCommit: { engine.runCommand("set \(p.setting), \(fmtScene($0, p))") },
-                                  sliderMaxWidth: sliderMaxWidth)
+                                  onCommit: { engine.runCommand("set \(p.setting), \(fmtScene($0, p))") })
                         .disabled(dofAuto)
                         .opacity(dofAuto ? 0.4 : 1.0)
                 }
@@ -2209,9 +2208,10 @@ struct SceneParamRow: View {
             Text(label)
                 .font(.system(size: 10))
                 .foregroundColor(PanelTheme.textColor)
-                .frame(width: 110, alignment: .leading)
+                .frame(width: compact ? nil : 110, alignment: .leading)
+                .fixedSize(horizontal: compact, vertical: false)
             content()
-            Spacer(minLength: 0)
+            if !compact { Spacer(minLength: 0) }
             if !help.isEmpty { HelpButton(text: help) }
         }
     }
@@ -2249,10 +2249,10 @@ struct DOFSubPanelContent: View {
             }
 
             if let focus = SceneCatalog.param(for: "metal_dof_focus") {
-                SceneParamRow(param: focus, engine: engine, sliderMaxWidth: 200)
+                SceneParamRow(param: focus, engine: engine, compact: true)
             }
             if let aperture = SceneCatalog.param(for: "metal_dof_aperture") {
-                SceneParamRow(param: aperture, engine: engine, sliderMaxWidth: 200)
+                SceneParamRow(param: aperture, engine: engine, compact: true)
             }
         }
     }
@@ -2296,10 +2296,10 @@ struct CameraDock: View {
                         // itself out (via SceneParamRow) while Ortho is on.
                         HStack(spacing: 10) {
                             orthoToggle
-                            SceneParamRow(param: p, engine: engine, sliderMaxWidth: 200)
+                            SceneParamRow(param: p, engine: engine, compact: true)
                         }
                     } else if let p = SceneCatalog.param(for: key) {
-                        SceneParamRow(param: p, engine: engine, sliderMaxWidth: 200)
+                        SceneParamRow(param: p, engine: engine, compact: true)
                     }
                 }
                 .padding(.horizontal, 4)
@@ -2319,7 +2319,7 @@ struct CameraDock: View {
         // a control is open, expand to fit the slider submenu, capped so it never
         // spans the whole viewport. The bottom overlay centers it either way.
         .fixedSize(horizontal: open == nil, vertical: false)
-        .frame(maxWidth: open == nil ? nil : 320)
+        .frame(maxWidth: open == nil ? nil : 360)
         .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
         .overlay(RoundedRectangle(cornerRadius: 22, style: .continuous)
             .strokeBorder(.white.opacity(0.14), lineWidth: 0.5))

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -1316,7 +1316,11 @@ private struct LabeledSlider: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            Slider(value: $local, in: prop.min...prop.max, step: prop.step,
+            // Continuous (no `step`): a stepped Slider draws busy tick marks on
+            // macOS. Values are rounded for display (fmt) and when applied
+            // (fmtScene / the mm/zoom mappings), so dropping the step only removes
+            // the ticks, not the effective granularity.
+            Slider(value: $local, in: prop.min...prop.max,
                    onEditingChanged: { began in
                        editing = began
                        if !began { onCommit(local) }

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -2230,8 +2230,11 @@ struct DOFSubPanelContent: View {
                 dofToggle("Enabled", key: "metal_dof", id: "dof.enabled", enabled: true) { on in
                     engine.runCommand("set metal_dof, \(on ? 1 : 0)")
                 }
-                dofToggle("Auto lock", key: "metal_dof_autofocus", id: "dof.autolock", enabled: dofOn) { on in
-                    engine.runCommand(CameraCommands.setAutofocus(on))
+                HStack(spacing: 5) {
+                    dofToggle("Auto lock", key: "metal_dof_autofocus", id: "dof.autolock", enabled: dofOn) { on in
+                        engine.runCommand(CameraCommands.setAutofocus(on))
+                    }
+                    HelpButton(text: "Auto lock focus keeps the current selection in sharp focus. Select the atoms you want sharp, then turn this on — the focus point tracks that selection as the camera moves. Off lets you set the focus distance by hand with the slider below.")
                 }
                 Spacer()
             }

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -2434,6 +2434,7 @@ struct ContentView: View {
         }
         .buttonStyle(.plain)
         .accessibilityLabel("Camera settings")
+        .accessibilityIdentifier("camera")
     }
 
     // Bottom-left viewport chrome: optional scene buttons stacked above the camera

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -2440,10 +2440,13 @@ struct ContentView: View {
         Button { withAnimation(.easeOut(duration: 0.22)) { showCameraPanel.toggle() } } label: {
             Image(systemName: "camera")
                 .font(.system(size: 20))
-                .foregroundStyle(.white.opacity(showCameraPanel ? 0.95 : 0.6))
+                // Frosted disc (like the mouse-legend button / toolbars) so the chip
+                // stays visible on any viewport background. The old translucent-white
+                // fill vanished against bright, busy scenes (e.g. dense orange sticks).
+                .foregroundStyle(showCameraPanel ? AnyShapeStyle(Color.accentColor) : AnyShapeStyle(.primary))
                 .frame(width: 46, height: 46)
-                .background(.white.opacity(showCameraPanel ? 0.22 : 0.12), in: Circle())
-                .overlay(Circle().strokeBorder(.white.opacity(0.28), lineWidth: 0.5))
+                .background(.ultraThinMaterial, in: Circle())
+                .overlay(Circle().strokeBorder(.white.opacity(showCameraPanel ? 0.5 : 0.18), lineWidth: 0.5))
         }
         .buttonStyle(.plain)
         .accessibilityLabel("Camera settings")

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -388,6 +388,19 @@ struct ContentView: View {
                                 .padding(.leading, 12)
                                 .padding(.bottom, 12)
                         }
+                        .overlay(alignment: .bottom) {
+                            if showCameraPanel && !engine.objects.isEmpty {
+                                CameraDock(engine: engine)
+                                    .padding(.horizontal, 10)
+                                    .padding(.bottom, engine.hasTimeline ? 84 : 12)
+                                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                                    .gesture(DragGesture().onEnded { v in
+                                        if v.translation.height > 40 {
+                                            withAnimation(.easeOut(duration: 0.22)) { showCameraPanel = false }
+                                        }
+                                    })
+                            }
+                        }
                     if engine.hasTimeline {
                         Divider()
                         TransportBar()
@@ -1439,14 +1452,20 @@ struct ContentView: View {
                     // Sit clear ABOVE the transport bar (don't overlap it).
                     .padding(.bottom, engine.hasTimeline ? 96 : 12)
             }
-            // iPhone camera overlay: a glassy floating card docked near the bottom
-            // (no dimming scrim, unlike a system sheet). iPad (regular) uses the
-            // popover attached to the chip instead.
+            // Camera control dock: a bottom-docked icon strip (one control open at
+            // a time). Same component on iPhone / iPad. Drag down or tap the chip
+            // to dismiss.
             .overlay(alignment: .bottom) {
-                if showCameraPanel && hSize == .compact && !engine.objects.isEmpty {
-                    cameraGlassCard
+                if showCameraPanel && !engine.objects.isEmpty {
+                    CameraDock(engine: engine)
+                        .padding(.horizontal, 10)
                         .padding(.bottom, engine.hasTimeline ? 84 : 10)
                         .transition(.move(edge: .bottom).combined(with: .opacity))
+                        .gesture(DragGesture().onEnded { v in
+                            if v.translation.height > 40 {
+                                withAnimation(.easeOut(duration: 0.22)) { showCameraPanel = false }
+                            }
+                        })
                 }
             }
             .overlay(alignment: .bottomTrailing) {
@@ -2427,62 +2446,9 @@ struct ContentView: View {
                 sceneButtonsOverlay
             }
             if !engine.objects.isEmpty {
-                cameraPanelPresentation(cameraButton)
+                cameraButton
             }
         }
-    }
-
-    // Popover on regular width (macOS always; iPad), bottom sheet on compact
-    // (iPhone). hSize is iOS-only in this file, so it's referenced only in the
-    // iOS branch; macOS always uses a popover.
-    @ViewBuilder
-    private func cameraPanelPresentation<V: View>(_ content: V) -> some View {
-        #if os(macOS)
-        content.popover(isPresented: $showCameraPanel, arrowEdge: .bottom) {
-            CameraControlsView(engine: engine).padding(14).frame(width: 300)
-        }
-        #else
-        // iPad (regular): a popover. iPhone (compact): the chip alone — the glassy
-        // floating card (cameraGlassCard) is presented as a viewport overlay so it
-        // doesn't dim the background and can be translucent, unlike a system sheet.
-        if hSize == .regular {
-            content.popover(isPresented: $showCameraPanel, arrowEdge: .bottom) {
-                CameraControlsView(engine: engine).padding(14).frame(width: 300)
-            }
-        } else {
-            content
-        }
-        #endif
-    }
-
-    // iPhone: the camera controls as a glassy floating card near the bottom — no
-    // dimming scrim (unlike a system sheet), translucent so the molecule shows
-    // through, and content-sized (compact). The grab handle taps or drags down to
-    // dismiss.
-    private var cameraGlassCard: some View {
-        VStack(spacing: 0) {
-            Capsule()
-                .fill(.white.opacity(0.45))
-                .frame(width: 40, height: 5)
-                .padding(.vertical, 9)
-                .frame(maxWidth: .infinity)
-                .contentShape(Rectangle())
-                .onTapGesture { withAnimation(.easeOut(duration: 0.22)) { showCameraPanel = false } }
-            CameraControlsView(engine: engine)
-                .padding(.horizontal, 16)
-                .padding(.bottom, 16)
-        }
-        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
-        .overlay(RoundedRectangle(cornerRadius: 22, style: .continuous)
-            .strokeBorder(.white.opacity(0.14), lineWidth: 0.5))
-        .padding(.horizontal, 10)
-        .gesture(
-            DragGesture().onEnded { v in
-                if v.translation.height > 40 {
-                    withAnimation(.easeOut(duration: 0.22)) { showCameraPanel = false }
-                }
-            }
-        )
     }
 
     private func initializeEngine() {

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -195,6 +195,9 @@ struct ContentView: View {
     @EnvironmentObject private var themeManager: ThemeManager
     @State private var showThemeStudio = false   // inline Theme studio (replaces a panel region)
     @AppStorage("mouseLegendCollapsed") private var mouseLegendCollapsed = false
+    // Pending auto-minimize of the expanded mouse legend (fires ~1s after the
+    // pointer leaves it); cancelled if the pointer returns.
+    @State private var mouseLegendCollapseWork: DispatchWorkItem?
     @State private var showObjectPanel = true
     @State private var showCommandPanel = true
 
@@ -317,6 +320,16 @@ struct ContentView: View {
                 .help("Minimize")
             }
             .padding(8)
+            .onHover { hovering in
+                mouseLegendCollapseWork?.cancel()
+                guard !hovering else { return }
+                // Auto-minimize ~1s after the pointer leaves the expanded legend.
+                let work = DispatchWorkItem {
+                    withAnimation(.easeInOut(duration: 0.15)) { mouseLegendCollapsed = true }
+                }
+                mouseLegendCollapseWork = work
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: work)
+            }
         }
     }
 
@@ -390,7 +403,7 @@ struct ContentView: View {
                         }
                         .overlay(alignment: .bottom) {
                             if showCameraPanel && !engine.objects.isEmpty {
-                                CameraDock(engine: engine)
+                                CameraDock(engine: engine, onClose: { withAnimation(.easeOut(duration: 0.22)) { showCameraPanel = false } })
                                     .padding(.horizontal, 10)
                                     .padding(.bottom, engine.hasTimeline ? 84 : 12)
                                     .transition(.move(edge: .bottom).combined(with: .opacity))
@@ -1457,7 +1470,7 @@ struct ContentView: View {
             // to dismiss.
             .overlay(alignment: .bottom) {
                 if showCameraPanel && !engine.objects.isEmpty {
-                    CameraDock(engine: engine)
+                    CameraDock(engine: engine, onClose: { withAnimation(.easeOut(duration: 0.22)) { showCameraPanel = false } })
                         .padding(.horizontal, 10)
                         .padding(.bottom, engine.hasTimeline ? 84 : 10)
                         .transition(.move(edge: .bottom).combined(with: .opacity))

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -2442,8 +2442,8 @@ struct ContentView: View {
                 .font(.system(size: 20))
                 .foregroundStyle(.white.opacity(showCameraPanel ? 0.95 : 0.6))
                 .frame(width: 46, height: 46)
-                .background(.white.opacity(showCameraPanel ? 0.22 : 0.12), in: RoundedRectangle(cornerRadius: 12))
-                .overlay(RoundedRectangle(cornerRadius: 12).strokeBorder(.white.opacity(0.28), lineWidth: 0.5))
+                .background(.white.opacity(showCameraPanel ? 0.22 : 0.12), in: Circle())
+                .overlay(Circle().strokeBorder(.white.opacity(0.28), lineWidth: 0.5))
         }
         .buttonStyle(.plain)
         .accessibilityLabel("Camera settings")

--- a/swiftui/PyMOLViewerUITests/CameraOverlayUITests.swift
+++ b/swiftui/PyMOLViewerUITests/CameraOverlayUITests.swift
@@ -36,7 +36,7 @@ final class CameraOverlayUITests: XCTestCase {
         Thread.sleep(forTimeInterval: 1.5)
         attach("strip_2_open")
 
-        for id in ["camDock.lens", "camDock.zoom", "camDock.ortho", "camDock.depth", "camDock.reset"] {
+        for id in ["camDock.ortho", "camDock.lens", "camDock.zoom", "camDock.depth", "camDock.close"] {
             XCTAssertTrue(app.buttons[id].waitForExistence(timeout: 5), "Strip icon '\(id)' not found")
         }
         // No surface open yet → no slider present (Objects panel is closed).
@@ -118,20 +118,22 @@ final class CameraOverlayUITests: XCTestCase {
                        "'DOF quality' must not appear in the camera dock")
     }
 
-    // MARK: - Reset does not crash
+    // MARK: - Close button dismisses the dock
 
-    func testResetNoCrash() throws {
+    func testCloseButtonDismissesDock() throws {
         app.launch()
         XCTAssertTrue(waitForRender(timeout: 30), "molecule never rendered")
         cameraChipButton().tap()
         Thread.sleep(forTimeInterval: 1.5)
 
-        let reset = app.buttons["camDock.reset"]
-        XCTAssertTrue(reset.waitForExistence(timeout: 5), "Reset icon not found")
-        reset.tap()
-        Thread.sleep(forTimeInterval: 1.5)
-        XCTAssertEqual(app.state, .runningForeground, "App crashed after Reset")
-        attach("strip_7_reset")
+        let close = app.buttons["camDock.close"]
+        XCTAssertTrue(close.waitForExistence(timeout: 5), "Close icon not found")
+        close.tap()
+        Thread.sleep(forTimeInterval: 1.0)
+        // Dock is dismissed: its strip icons are gone.
+        XCTAssertFalse(app.buttons["camDock.lens"].exists, "Dock did not dismiss after Close")
+        XCTAssertEqual(app.state, .runningForeground, "App crashed after Close")
+        attach("strip_7_close")
     }
 
     // MARK: - Zoom slider changes the on-screen molecule size

--- a/swiftui/PyMOLViewerUITests/CameraOverlayUITests.swift
+++ b/swiftui/PyMOLViewerUITests/CameraOverlayUITests.swift
@@ -1,22 +1,11 @@
-// CameraOverlayUITests.swift — functional verification of the camera chip overlay
-// and CameraControlsView bottom sheet on iPhone (compact size class).
+// CameraOverlayUITests.swift — functional verification of the camera chip and the
+// bottom-docked camera control strip (CameraDock) on iPhone (compact size class).
 //
-// AX tree findings (from CameraAXDumpTests):
-//   - Camera chip: id='camera', label='Camera settings'
-//   - Sheet switches: EMPTY id/label — located by index (0=Ortho, 1=DOF, 2+= sub-rows)
-//   - Sheet slider:   EMPTY id/label — only slider in app when sheet is open
-//   - Row labels are staticTexts: "Camera", "Lens (mm)", "Orthographic", "Depth of field"
-//   - Reset view is a button with label='Reset view'
-//
-// Steps verified:
-//   1. Camera chip renders at viewport bottom-left when structure is loaded.
-//   2. Tapping the chip opens a bottom sheet with Camera header, Lens slider,
-//      Orthographic row, Depth of field row, and Reset view button.
-//   3. Toggling "Depth of field" (switch index 1) ON reveals four sub-rows.
-//   4. Toggling "Orthographic" (switch index 0) ON disables the Lens slider.
-//   5. "Reset view" button tap does not crash the app.
-//   6. "Zoom (×)" row appears under "Lens (mm)", slider index 1; dragging right
-//      zooms in (molecule bigger), dragging left zooms out (molecule smaller).
+// AX contract (see CameraDock):
+//   - Camera chip:  id='camera', label='Camera settings'
+//   - Strip icons:  id='camDock.lens' / '.zoom' / '.ortho' / '.depth' / '.reset'
+//   - DOF toggles:  id='dof.enabled' / 'dof.autolock'
+//   - Open control: the only slider in the app when a slider surface is open.
 
 import XCTest
 
@@ -29,224 +18,151 @@ final class CameraOverlayUITests: XCTestCase {
         app = XCUIApplication()
         app.launchEnvironment["PYMOL_AUTOLOAD"] = "1ubq.cif"
         app.launchEnvironment["PYMOL_AUTOPANEL"] = "closed"
-        // Suppress the first-run gesture-coach overlay: on a fresh simulator it
-        // auto-appears once the structure loads and its dimming background swallows
-        // the first tap, so tapping the camera chip would dismiss the coach instead
-        // of opening the panel.
         app.launchEnvironment["PYMOL_SKIP_GESTURE_HELP"] = "1"
         app.launchEnvironment["PYMOL_AUTOCMD"] = "hide everything; show cartoon; orient"
     }
 
-    // MARK: - Step 1+2: chip visible, tap opens sheet
+    // MARK: - Chip opens a strip of icons, no surface yet
 
-    func testStep1And2_CameraChipOpensSheet() throws {
+    func testChipOpensStrip() throws {
         app.launch()
-        XCTAssertTrue(waitForRender(timeout: 30), "molecule never rendered — app may have crashed at launch")
+        XCTAssertTrue(waitForRender(timeout: 30), "molecule never rendered")
 
-        // Step 1: chip must be present (gated on objects being loaded)
         let chip = cameraChipButton()
-        XCTAssertTrue(chip.waitForExistence(timeout: 10),
-                      "Camera chip button (id='camera') not found at viewport bottom-left")
-        attach("cam_ov_1_chip")
+        XCTAssertTrue(chip.waitForExistence(timeout: 10), "Camera chip not found")
+        attach("strip_1_chip")
 
-        // Step 2: tap chip, verify sheet contents
         chip.tap()
-        Thread.sleep(forTimeInterval: 2.0)
-        attach("cam_ov_2_open")
-
-        // Header "Camera" as static text
-        XCTAssertTrue(app.staticTexts["Camera"].waitForExistence(timeout: 5),
-                      "Sheet 'Camera' header staticText not found")
-
-        // "Lens (mm)" label row
-        XCTAssertTrue(app.staticTexts["Lens (mm)"].waitForExistence(timeout: 5),
-                      "'Lens (mm)' label not found in sheet")
-
-        // Slider (only one when sheet is open)
-        XCTAssertTrue(app.sliders.firstMatch.waitForExistence(timeout: 5),
-                      "Lens slider not found in sheet")
-
-        // "Orthographic" label row
-        XCTAssertTrue(app.staticTexts["Orthographic"].waitForExistence(timeout: 5),
-                      "'Orthographic' label not found in sheet")
-
-        // "Depth of field" label row
-        XCTAssertTrue(app.staticTexts["Depth of field"].waitForExistence(timeout: 5),
-                      "'Depth of field' label not found in sheet")
-
-        // Reset view button
-        XCTAssertTrue(app.buttons["Reset view"].waitForExistence(timeout: 5),
-                      "'Reset view' button not found in sheet")
-
-        // The sheet's two core toggles are present (Objects panel may add more switches
-        // to the AX tree globally, so we verify by label presence, not by count).
-        attach("cam_ov_2_sheet_verified")
-    }
-
-    // MARK: - Step 3: DOF toggle reveals sub-rows
-
-    func testStep3_DepthOfFieldSubRows() throws {
-        app.launch()
-        XCTAssertTrue(waitForRender(timeout: 30), "molecule never rendered")
-
-        cameraChipButton().tap()
-        Thread.sleep(forTimeInterval: 2.0)
-
-        // Verify DOF label exists (sheet is open)
-        XCTAssertTrue(app.staticTexts["Depth of field"].waitForExistence(timeout: 5),
-                      "Sheet did not open — DOF label not found")
-
-        // Sub-rows should NOT be present before enabling DOF
-        XCTAssertFalse(app.staticTexts["Auto lock focus"].exists,
-                       "Sub-rows should be hidden before DOF is enabled")
-
-        // DOF is switch index 1 (after Orthographic at index 0)
-        let dofSwitch = app.switches.element(boundBy: 1)
-        XCTAssertTrue(dofSwitch.waitForExistence(timeout: 3), "DOF switch (index 1) not found")
-        dofSwitch.tap()
-        Thread.sleep(forTimeInterval: 1.0)
-        attach("cam_ov_3_dof")
-
-        // Four sub-rows must appear as static text labels. (High-quality DOF is now
-        // a "DOF quality" slider rather than a toggle — see metal_dof_quality.)
-        //   "Auto lock focus", "DOF focus (0=auto)", "DOF aperture (blur)", "DOF quality"
-        XCTAssertTrue(app.staticTexts["Auto lock focus"].waitForExistence(timeout: 5),
-                      "'Auto lock focus' sub-row not found after DOF enabled")
-        XCTAssertTrue(
-            app.staticTexts.matching(NSPredicate(format: "label BEGINSWITH 'DOF focus'")).firstMatch.waitForExistence(timeout: 3),
-            "'DOF focus' sub-row not found after DOF enabled")
-        XCTAssertTrue(
-            app.staticTexts.matching(NSPredicate(format: "label BEGINSWITH 'DOF aperture'")).firstMatch.waitForExistence(timeout: 3),
-            "'DOF aperture' sub-row not found after DOF enabled")
-        XCTAssertTrue(
-            app.staticTexts.matching(NSPredicate(format: "label BEGINSWITH 'DOF quality'")).firstMatch.waitForExistence(timeout: 3),
-            "'DOF quality' sub-row not found after DOF enabled")
-
-        attach("cam_ov_3_dof_verified")
-    }
-
-    // MARK: - Step 4: Orthographic disables Lens slider
-
-    func testStep4_OrthographicGreysOutLens() throws {
-        app.launch()
-        XCTAssertTrue(waitForRender(timeout: 30), "molecule never rendered")
-
-        cameraChipButton().tap()
-        Thread.sleep(forTimeInterval: 2.0)
-
-        XCTAssertTrue(app.staticTexts["Orthographic"].waitForExistence(timeout: 5),
-                      "Sheet did not open — Orthographic label not found")
-
-        let slider = app.sliders.firstMatch
-        XCTAssertTrue(slider.waitForExistence(timeout: 3), "Lens slider not found")
-
-        // Lens slider should be enabled in perspective mode
-        XCTAssertTrue(slider.isEnabled,
-                      "Lens slider should be enabled in perspective mode — already disabled?")
-
-        // Orthographic is switch index 0
-        let orthoSwitch = app.switches.element(boundBy: 0)
-        XCTAssertTrue(orthoSwitch.waitForExistence(timeout: 3), "Orthographic switch (index 0) not found")
-        orthoSwitch.tap()
-        Thread.sleep(forTimeInterval: 0.8)
-        attach("cam_ov_4_ortho")
-
-        // Lens slider should now be disabled
-        XCTAssertFalse(slider.isEnabled,
-                       "Lens slider should be DISABLED in orthographic mode")
-        attach("cam_ov_4_ortho_verified")
-    }
-
-    // MARK: - Step 5: Reset view does not crash
-
-    func testStep5_ResetViewNoCrash() throws {
-        app.launch()
-        XCTAssertTrue(waitForRender(timeout: 30), "molecule never rendered")
-
-        cameraChipButton().tap()
-        Thread.sleep(forTimeInterval: 2.0)
-
-        let resetBtn = app.buttons["Reset view"]
-        XCTAssertTrue(resetBtn.waitForExistence(timeout: 5), "'Reset view' button not found")
-        resetBtn.tap()
         Thread.sleep(forTimeInterval: 1.5)
+        attach("strip_2_open")
 
-        XCTAssertEqual(app.state, .runningForeground, "App crashed or went to background after Reset view")
-        attach("cam_ov_5_reset")
-    }
-
-    // MARK: - Step 6: Zoom (×) row appears; drag right zooms in, left zooms out
-
-    func testStep6_ZoomSlider() throws {
-        app.launch()
-        XCTAssertTrue(waitForRender(timeout: 30), "molecule never rendered")
-
-        // Open the camera panel
-        cameraChipButton().tap()
-        Thread.sleep(forTimeInterval: 2.0)
-
-        // 1. Verify "Zoom (×)" label exists
-        XCTAssertTrue(app.staticTexts["Zoom (×)"].waitForExistence(timeout: 5),
-                      "'Zoom (×)' label not found in camera panel — row not rendered")
-        attach("zoom_1_panel")
-
-        // 2. Verify the slider index 1 (Zoom) exists.
-        //    cameraOverlayKeys order: field_of_view(slider0), zoom(slider1), ortho(switch0), dof(switch1)
-        let zoomSlider = app.sliders.element(boundBy: 1)
-        XCTAssertTrue(zoomSlider.waitForExistence(timeout: 3),
-                      "Zoom slider (sliders[1]) not found")
-
-        // Capture baseline viewport pixel signature before any drag
-        let baselineSig = viewportMoleculeSize()
-
-        // 3. Drag right (zoom in): normalizedOffset 0→0.75 on the zoom slider
-        zoomSlider.adjust(toNormalizedSliderPosition: 0.75)
-        Thread.sleep(forTimeInterval: 1.5)
-        attach("zoom_2_in")
-        let zoomedInSig = viewportMoleculeSize()
-
-        // 4. Drag left (zoom out): normalizedOffset 0.75→0.1
-        zoomSlider.adjust(toNormalizedSliderPosition: 0.10)
-        Thread.sleep(forTimeInterval: 1.5)
-        attach("zoom_3_out")
-        let zoomedOutSig = viewportMoleculeSize()
-
-        // Verify: zoomed-in size > baseline AND zoomed-out size < baseline
-        // viewportMoleculeSize returns count of bright (molecule) pixels in center viewport
-        XCTAssertGreaterThan(zoomedInSig, baselineSig,
-                             "Molecule did not get larger after dragging Zoom slider right (in). baseline=\(baselineSig) zoomedIn=\(zoomedInSig)")
-        XCTAssertLessThan(zoomedOutSig, baselineSig,
-                          "Molecule did not get smaller after dragging Zoom slider left (out). baseline=\(baselineSig) zoomedOut=\(zoomedOutSig)")
-
-        // 5. Independence check: reset zoom to ~1× (normalizedOffset ≈ 0.13 for 1× on 0.5–8 range)
-        //    Then drag Lens slider (index 0) and confirm Zoom slider position is unchanged
-        let lensMag1Pos = (1.0 - 0.5) / (8.0 - 0.5)  // ~0.067
-        zoomSlider.adjust(toNormalizedSliderPosition: lensMag1Pos)
-        Thread.sleep(forTimeInterval: 0.8)
-        let zoomPosBefore = zoomSlider.value as? String ?? ""
-
-        let lensSlider = app.sliders.element(boundBy: 0)
-        lensSlider.adjust(toNormalizedSliderPosition: 0.8)  // long telephoto
-        Thread.sleep(forTimeInterval: 1.0)
-        let zoomPosAfter = zoomSlider.value as? String ?? ""
-        attach("zoom_4_independence")
-
-        // Zoom slider value should be close to what it was before Lens change.
-        // XCUIElement slider .value is a string "N%" on iOS. We just check it's not wildly different.
-        // (Lens dollies camera but Zoom control stays put — that's the independence invariant.)
-        // If values differ by > 20 percentage points something is wrong.
-        if !zoomPosBefore.isEmpty && !zoomPosAfter.isEmpty {
-            let beforePct = Double(zoomPosBefore.replacingOccurrences(of: "%", with: "")) ?? 50
-            let afterPct  = Double(zoomPosAfter.replacingOccurrences(of: "%", with: ""))  ?? 50
-            XCTAssertLessThan(abs(afterPct - beforePct), 20.0,
-                              "Zoom slider moved significantly when only Lens was changed (before=\(zoomPosBefore) after=\(zoomPosAfter)). Zoom and Lens are not independent.")
+        for id in ["camDock.lens", "camDock.zoom", "camDock.ortho", "camDock.depth", "camDock.reset"] {
+            XCTAssertTrue(app.buttons[id].waitForExistence(timeout: 5), "Strip icon '\(id)' not found")
         }
+        // No surface open yet → no slider present (Objects panel is closed).
+        XCTAssertFalse(app.sliders.firstMatch.exists, "A slider is open before any icon was tapped")
+    }
+
+    // MARK: - Lens/Zoom open a single slider, one at a time
+
+    func testLensAndZoomOpenSingleSlider() throws {
+        app.launch()
+        XCTAssertTrue(waitForRender(timeout: 30), "molecule never rendered")
+        cameraChipButton().tap()
+        Thread.sleep(forTimeInterval: 1.5)
+
+        app.buttons["camDock.lens"].tap()
+        Thread.sleep(forTimeInterval: 0.8)
+        XCTAssertTrue(app.sliders.firstMatch.waitForExistence(timeout: 3), "Lens slider did not open")
+        attach("strip_3_lens")
+
+        // Tapping the active icon again collapses the surface.
+        app.buttons["camDock.lens"].tap()
+        Thread.sleep(forTimeInterval: 0.8)
+        XCTAssertFalse(app.sliders.firstMatch.exists, "Lens slider did not collapse on second tap")
+
+        app.buttons["camDock.zoom"].tap()
+        Thread.sleep(forTimeInterval: 0.8)
+        XCTAssertTrue(app.sliders.firstMatch.waitForExistence(timeout: 3), "Zoom slider did not open")
+        attach("strip_4_zoom")
+    }
+
+    // MARK: - Ortho toggles and disables Lens
+
+    func testOrthoDisablesLens() throws {
+        app.launch()
+        XCTAssertTrue(waitForRender(timeout: 30), "molecule never rendered")
+        cameraChipButton().tap()
+        Thread.sleep(forTimeInterval: 1.5)
+
+        let lens = app.buttons["camDock.lens"]
+        XCTAssertTrue(lens.waitForExistence(timeout: 5), "Lens icon not found")
+        XCTAssertTrue(lens.isEnabled, "Lens should be enabled in perspective mode")
+
+        app.buttons["camDock.ortho"].tap()
+        Thread.sleep(forTimeInterval: 1.0)
+        attach("strip_5_ortho")
+        XCTAssertFalse(lens.isEnabled, "Lens should be disabled in orthographic mode")
+
+        // Turn ortho back off so the run leaves a clean state.
+        app.buttons["camDock.ortho"].tap()
+    }
+
+    // MARK: - Depth opens the sub-panel; enabling reveals Focus; no quality control
+
+    func testDepthSubPanel() throws {
+        app.launch()
+        XCTAssertTrue(waitForRender(timeout: 30), "molecule never rendered")
+        cameraChipButton().tap()
+        Thread.sleep(forTimeInterval: 1.5)
+
+        app.buttons["camDock.depth"].tap()
+        Thread.sleep(forTimeInterval: 0.8)
+        XCTAssertTrue(app.staticTexts["Depth of field"].waitForExistence(timeout: 3),
+                      "DOF sub-panel header not shown")
+
+        let enabled = app.switches["dof.enabled"]
+        XCTAssertTrue(enabled.waitForExistence(timeout: 3), "DOF 'Enabled' toggle not found")
+
+        // Focus/aperture are hidden until DOF is enabled.
+        XCTAssertFalse(app.staticTexts.matching(NSPredicate(format: "label BEGINSWITH 'DOF focus'")).firstMatch.exists,
+                       "Focus row should be hidden before DOF is enabled")
+        enabled.tap()
+        Thread.sleep(forTimeInterval: 1.0)
+        attach("strip_6_dof")
+        XCTAssertTrue(app.staticTexts.matching(NSPredicate(format: "label BEGINSWITH 'DOF focus'")).firstMatch.waitForExistence(timeout: 3),
+                      "Focus row not revealed after enabling DOF")
+
+        // Quality was moved to the inspector — it must NOT appear in the dock.
+        XCTAssertFalse(app.staticTexts["DOF quality"].exists,
+                       "'DOF quality' must not appear in the camera dock")
+    }
+
+    // MARK: - Reset does not crash
+
+    func testResetNoCrash() throws {
+        app.launch()
+        XCTAssertTrue(waitForRender(timeout: 30), "molecule never rendered")
+        cameraChipButton().tap()
+        Thread.sleep(forTimeInterval: 1.5)
+
+        let reset = app.buttons["camDock.reset"]
+        XCTAssertTrue(reset.waitForExistence(timeout: 5), "Reset icon not found")
+        reset.tap()
+        Thread.sleep(forTimeInterval: 1.5)
+        XCTAssertEqual(app.state, .runningForeground, "App crashed after Reset")
+        attach("strip_7_reset")
+    }
+
+    // MARK: - Zoom slider changes the on-screen molecule size
+
+    func testZoomChangesView() throws {
+        app.launch()
+        XCTAssertTrue(waitForRender(timeout: 30), "molecule never rendered")
+        cameraChipButton().tap()
+        Thread.sleep(forTimeInterval: 1.5)
+
+        app.buttons["camDock.zoom"].tap()
+        Thread.sleep(forTimeInterval: 0.8)
+        let zoom = app.sliders.firstMatch
+        XCTAssertTrue(zoom.waitForExistence(timeout: 3), "Zoom slider not open")
+
+        let baseline = viewportMoleculeSize()
+        zoom.adjust(toNormalizedSliderPosition: 0.75)
+        Thread.sleep(forTimeInterval: 1.5)
+        let zoomedIn = viewportMoleculeSize()
+        attach("strip_8_zoomin")
+        zoom.adjust(toNormalizedSliderPosition: 0.10)
+        Thread.sleep(forTimeInterval: 1.5)
+        let zoomedOut = viewportMoleculeSize()
+
+        XCTAssertGreaterThan(zoomedIn, baseline, "Molecule did not grow when zooming in")
+        XCTAssertLessThan(zoomedOut, baseline, "Molecule did not shrink when zooming out")
     }
 
     // MARK: - Helpers
 
     private func cameraChipButton() -> XCUIElement {
-        // From AX dump: id='camera', label='Camera settings'
         let byID = app.buttons["camera"]
         if byID.exists { return byID }
         return app.buttons["Camera settings"]
@@ -262,58 +178,36 @@ final class CameraOverlayUITests: XCTestCase {
     private func waitForRender(timeout: TimeInterval) -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
-            if viewportSignature().contains(where: { $0 > 40 }) { return true }
+            if viewportMoleculeSize() > 200 { return true }
             Thread.sleep(forTimeInterval: 0.5)
         }
         return false
     }
 
-    private func viewportSignature() -> [UInt8] {
-        guard let cg = XCUIScreen.main.screenshot().image.cgImage else { return [] }
-        let w = cg.width, h = cg.height
-        let crop = CGRect(x: 0, y: Int(Double(h) * 0.10),
-                          width: w, height: Int(Double(h) * 0.50))
-        guard let region = cg.cropping(to: crop) else { return [] }
-        let sw = 32, sh = 32
-        var buf = [UInt8](repeating: 0, count: sw * sh)
-        guard let ctx = CGContext(data: &buf, width: sw, height: sh,
-                                  bitsPerComponent: 8, bytesPerRow: sw,
-                                  space: CGColorSpaceCreateDeviceGray(),
-                                  bitmapInfo: CGImageAlphaInfo.none.rawValue) else { return [] }
-        ctx.draw(region, in: CGRect(x: 0, y: 0, width: sw, height: sh))
-        return buf
-    }
-
-    /// Count colorful molecule pixels in the center 60% of the viewport.
-    /// The rainbow-cartoon 1ubq sits on a black background, so bright/colorful
-    /// pixels are a good proxy for "how much molecule is on screen".
-    /// Returns the pixel count; a bigger number means the molecule fills more area.
+    // Count COLORFUL (saturated) pixels in the center viewport — a background-
+    // independent proxy for "how much molecule is on screen". The 1ubq cartoon is
+    // vividly colored (spectrum/green), whereas the viewport background (white or
+    // black, depending on theme) and the grey UI chrome are near-neutral (low
+    // saturation). Counting max-min channel spread instead of raw brightness makes
+    // the zoom-size assertions work regardless of the theme's background color.
     private func viewportMoleculeSize() -> Int {
         guard let cg = XCUIScreen.main.screenshot().image.cgImage else { return 0 }
         let w = cg.width, h = cg.height
-        // Crop to center 60% horizontally × top 65% vertically (viewport, not panel).
-        let cropX = Int(Double(w) * 0.20)
-        let cropY = Int(Double(h) * 0.05)
-        let cropW = Int(Double(w) * 0.60)
-        let cropH = Int(Double(h) * 0.60)
-        let crop = CGRect(x: cropX, y: cropY, width: cropW, height: cropH)
+        let crop = CGRect(x: Int(Double(w) * 0.20), y: Int(Double(h) * 0.05),
+                          width: Int(Double(w) * 0.60), height: Int(Double(h) * 0.60))
         guard let region = cg.cropping(to: crop) else { return 0 }
-
-        // Render into an RGBA buffer at 1:1 scale
-        let pw = cropW, ph = cropH
+        let pw = region.width, ph = region.height
         var buf = [UInt8](repeating: 0, count: pw * ph * 4)
         guard let ctx = CGContext(data: &buf, width: pw, height: ph,
                                   bitsPerComponent: 8, bytesPerRow: pw * 4,
                                   space: CGColorSpaceCreateDeviceRGB(),
                                   bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue) else { return 0 }
         ctx.draw(region, in: CGRect(x: 0, y: 0, width: pw, height: ph))
-
-        // Count pixels that are clearly non-black (molecule > background).
-        // Background is pure black (0,0,0); molecule pixels exceed 40 in any channel.
         var count = 0
         for i in stride(from: 0, to: buf.count, by: 4) {
-            let r = buf[i], g = buf[i+1], b = buf[i+2]
-            if Int(r) + Int(g) + Int(b) > 60 { count += 1 }
+            let r = Int(buf[i]), g = Int(buf[i+1]), b = Int(buf[i+2])
+            let hi = max(r, g, b), lo = min(r, g, b)
+            if hi - lo > 40 { count += 1 }   // saturated → part of the molecule
         }
         return count
     }

--- a/swiftui/PyMOLViewerUITests/CameraOverlayUITests.swift
+++ b/swiftui/PyMOLViewerUITests/CameraOverlayUITests.swift
@@ -36,9 +36,11 @@ final class CameraOverlayUITests: XCTestCase {
         Thread.sleep(forTimeInterval: 1.5)
         attach("strip_2_open")
 
-        for id in ["camDock.ortho", "camDock.lens", "camDock.zoom", "camDock.depth", "camDock.close"] {
+        for id in ["camDock.lens", "camDock.zoom", "camDock.depth", "camDock.close"] {
             XCTAssertTrue(app.buttons[id].waitForExistence(timeout: 5), "Strip icon '\(id)' not found")
         }
+        // Ortho is no longer a strip icon — it lives in the Lens row.
+        XCTAssertFalse(app.buttons["camDock.ortho"].exists, "Ortho should not be in the strip")
         // No surface open yet → no slider present (Objects panel is closed).
         XCTAssertFalse(app.sliders.firstMatch.exists, "A slider is open before any icon was tapped")
     }
@@ -67,25 +69,29 @@ final class CameraOverlayUITests: XCTestCase {
         attach("strip_4_zoom")
     }
 
-    // MARK: - Ortho toggles and disables Lens
+    // MARK: - Ortho (in the Lens row) greys the Lens slider
 
-    func testOrthoDisablesLens() throws {
+    func testOrthoGreysLensSlider() throws {
         app.launch()
         XCTAssertTrue(waitForRender(timeout: 30), "molecule never rendered")
         cameraChipButton().tap()
         Thread.sleep(forTimeInterval: 1.5)
 
-        let lens = app.buttons["camDock.lens"]
-        XCTAssertTrue(lens.waitForExistence(timeout: 5), "Lens icon not found")
-        XCTAssertTrue(lens.isEnabled, "Lens should be enabled in perspective mode")
+        // Open the Lens row; the Ortho toggle lives there (not in the strip).
+        app.buttons["camDock.lens"].tap()
+        Thread.sleep(forTimeInterval: 0.8)
+        let slider = app.sliders.firstMatch
+        XCTAssertTrue(slider.waitForExistence(timeout: 3), "Lens slider not found")
+        XCTAssertTrue(slider.isEnabled, "Lens slider should be enabled in perspective mode")
 
-        app.buttons["camDock.ortho"].tap()
+        let ortho = app.buttons["camDock.ortho"]
+        XCTAssertTrue(ortho.waitForExistence(timeout: 3), "Ortho toggle not found in the Lens row")
+        ortho.tap()
         Thread.sleep(forTimeInterval: 1.0)
         attach("strip_5_ortho")
-        XCTAssertFalse(lens.isEnabled, "Lens should be disabled in orthographic mode")
+        XCTAssertFalse(slider.isEnabled, "Lens slider should be greyed out in orthographic mode")
 
-        // Turn ortho back off so the run leaves a clean state.
-        app.buttons["camDock.ortho"].tap()
+        ortho.tap()  // restore perspective for a clean state
     }
 
     // MARK: - Depth opens the sub-panel; enabling reveals Focus; no quality control


### PR DESCRIPTION
Redesigns RayMol's camera controls on **all platforms** (iPhone / iPad / macOS) from a full-width bottom card / anchored popover into a **Photos-style bottom-docked control dock** where **one control opens at a time**. Fixes the original feedback that the overlay took too much space, was hard to close, and covered too much of the viewer.

Builds on the merged #101 (camera + DOF suite). Spec + plan (already in `master` via #101):
- `docs/superpowers/specs/2026-07-06-camera-controls-photos-strip-design.md`
- `docs/superpowers/plans/2026-07-06-camera-controls-photos-strip.md`

## The dock
- **`CameraDock`** (new, `ObjectPanel.swift`): a frosted `.ultraThinMaterial` card docked bottom-center. Icon strip: `Lens · Zoom · Depth · ✕ Close`.
- **Dynamic, centered width:** hugs the icon strip tightly when collapsed (a compact pill); expands (capped, no overflow) to fit the slider submenu when a control is open.
- **Lens / Zoom** open a single reused `SceneParamRow` slider (`compact` layout — natural-width label, no trailing Spacer, so the slider fills the row); tapping the active icon collapses it.
- **Ortho** lives as a toggle in the **Lens row** (perspective vs orthographic); enabling it greys the Lens slider. The Lens strip icon stays enabled so the row can always be reopened.
- **Depth** opens `DOFSubPanelContent`: `Enabled` + `Auto lock` side by side (with a help popover explaining autofocus), then `Focus` + `Aperture` sliders (revealed once DOF is on).
- **Camera chip** toggles the dock; a downward drag also dismisses. The chip is a frosted circular disc so it stays visible on any background.
- **No control-logic duplication** — every control reuses `SceneParamRow`; the only extracted command helper is `CameraCommands.setAutofocus`.
- **`DOF quality`** relocated to the inspector's Scene → Camera group; its setting default bumped `1 → 4` (`SettingInfo.h` / `RendererMetal.h`).
- **macOS mouse-controls legend** now auto-minimizes ~1s after the pointer leaves the expanded card.
- **Removed** the old `cameraGlassCard`, `cameraPanelPresentation` popover, `CameraControlsView`, and `cameraOverlayKeys`.

## Verification
- iOS simulator: `CameraOverlayUITests` **6/6** (TDD RED→GREEN): chip → strip, single-slider open/collapse, Ortho greys the Lens slider, DOF sub-panel (+ quality excluded), Close dismisses, Zoom changes the view.
- macOS: functionally verified in an isolated VM (dock states, DOF bokeh, Ortho, slider length) — snapshots captured.
- Both `PyMOLViewer_iOS` and `PyMOLViewer_macOS` build cleanly; installed + exercised on a physical iPhone 15 Pro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
