### PR TITLE
feat(macos): Help ▸ Contact Support… (mailto:support@raymol.io)

### DIFF
--- a/swiftui/PyMOLViewer/Shared/PyMOLApp.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLApp.swift
@@ -137,6 +137,13 @@ struct PyMOLApp: App {
                 Button("Check for Updates…") { updater.checkForUpdates() }
             }
             #endif
+            // Contact Support: opens the user's default mail client, pre-addressed
+            // to support@raymol.io. Lands in the Help menu (the standard macOS spot
+            // for support links). NSWorkspace URL-open works in the sandboxed Mac
+            // App Store build too, so this isn't gated behind RAYMOL_MAS_RESTRICTED.
+            CommandGroup(after: .help) {
+                Button("Contact Support…") { contactSupport() }
+            }
             CommandGroup(after: .newItem) {
                 Button("Open…") {
                     NotificationCenter.default.post(name: .raymolOpenFile, object: nil)
@@ -209,6 +216,12 @@ struct PyMOLApp: App {
         credits.append(NSAttributedString(string: "      ·      ", attributes: base))
         credits.append(link("GitHub", "https://github.com/javierbq/RayMol"))
         NSApplication.shared.orderFrontStandardAboutPanel(options: [.credits: credits])
+    }
+
+    // Open the default mail client with a message pre-addressed to support.
+    private func contactSupport() {
+        guard let url = URL(string: "mailto:support@raymol.io") else { return }
+        _ = NSWorkspace.shared.open(url)
     }
     #endif
 


### PR DESCRIPTION
## What

Adds a **Contact Support…** item to the macOS **Help** menu that opens the user's default mail client pre-addressed to `support@raymol.io`.

## How

- New `CommandGroup(after: .help)` in `PyMOLApp.macCommands` → the item lands in the Help menu, the standard macOS spot for support links.
- Clicking it calls `NSWorkspace.shared.open(URL("mailto:support@raymol.io"))`.
- **Not** gated behind `RAYMOL_MAS_RESTRICTED` — `NSWorkspace` URL-open works in the sandboxed Mac App Store build too, so it ships in every macOS build.

## Verification

Host build + isolated disposable macOS VM (per the project's macOS testing workflow):

- ✅ `BUILD SUCCEEDED` for `PyMOLViewer_macOS` — no errors/warnings.
- ✅ Drove the app's menu bar over the accessibility API: Help menu contains `AXMenuItem – "Contact Support…"`.
- ✅ Pressing it launched Mail.app, confirming the `mailto:` was dispatched to the default mail client. (The fresh VM's Mail showed its account-setup assistant since no account is configured — a VM artifact; on a configured machine this opens a compose window addressed to `support@raymol.io`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)