### PR TITLE
fix(ui): consistent panel theming + visible mouse-card minimize button (#110, #111)

### DIFF
--- a/swiftui/PyMOLViewer/Panels/TransportBar.swift
+++ b/swiftui/PyMOLViewer/Panels/TransportBar.swift
@@ -20,7 +20,11 @@ enum TimelineTheme {
     // read. Views that should recolor live on a theme switch already observe
     // ThemeManager; others pick it up on their next render.
     static var accent: Color { ThemeManager.shared.active.accent.color }
-    static let bar = Color(.sRGB, red: 0.10, green: 0.11, blue: 0.12, opacity: 0.96)
+    // Timeline / transport surface — follows the ACTIVE THEME's panel background
+    // (like the Objects panel) so the Movie tab and docked timeline chrome match
+    // the rest of the inspector rather than a fixed dark gray. Kept slightly
+    // translucent (0.96) since the docked timeline floats over the viewport.
+    static var bar: Color { ThemeManager.shared.active.panelBackground.color.opacity(0.96) }
     static let text = Color(white: 0.88)
     static let dim = Color(white: 0.55)
 }

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -314,16 +314,29 @@ struct ContentView: View {
             .help("Show mouse controls")
             .padding(8)
         } else {
+            // The minimize button lives in a reserved trailing gutter (top-right),
+            // NOT overlaid on the panel: MousePanel's mode Picker uses
+            // `maxWidth: .infinity`, so its `.menu` chevron would otherwise run
+            // into the corner and blend with / hide the "−" (issue #111). The
+            // gutter guarantees the button is a distinct, clearly-separated
+            // affordance the picker can't reach.
             ZStack(alignment: .topTrailing) {
                 MousePanel()
                     .frame(width: 220)
+                    // Reserve space on the right so the picker chevron stops short
+                    // of the corner where the minimize button sits.
+                    .padding(.trailing, 22)
                     .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8))
                     .overlay(RoundedRectangle(cornerRadius: 8)
                         .strokeBorder(Color.white.opacity(0.08), lineWidth: 0.5))
                 Button { withAnimation(.easeInOut(duration: 0.15)) { mouseLegendCollapsed = true } } label: {
+                    // Two-tone: a strong (primary) minus glyph over a subtly tinted
+                    // circle. The old single-tone `.secondary` fill was nearly
+                    // invisible against the translucent header (issue #111).
                     Image(systemName: "minus.circle.fill")
-                        .font(.system(size: 13))
-                        .foregroundStyle(.secondary)
+                        .font(.system(size: 14, weight: .semibold))
+                        .symbolRenderingMode(.palette)
+                        .foregroundStyle(Color.primary, Color.primary.opacity(0.18))
                         .padding(4)
                 }
                 .buttonStyle(.plain)
@@ -2268,6 +2281,11 @@ struct ContentView: View {
                 }
             }
         }
+        // Shared panel background so every tab (Objects / Scenes / Movie / Display)
+        // matches. ObjectPanel/TimelinePanel paint their own opaque background on
+        // top; the Scenes/Display ScrollViews are transparent, so without this they
+        // fell through to the window's default chrome (a mismatched dark gray).
+        .background(themeManager.active.panelBackground.color)
         // Auto-stop model/movie playback when entering the Movie tab or expanding
         // the timeline dock (you're authoring now, not inspecting the ensemble).
         .onChange(of: inspectorTab) { tab in


### PR DESCRIPTION
Fixes #110 and #111.

## #110 — inconsistent panel background across tabs
Objects/Scenes/Movie/Display now share the theme's `panelBackground` token. Root cause: the macOS `inspectorSwitcher` had no background (fell through to window chrome) while iOS already wrapped it, and the Movie tab used a hardcoded gray via `TimelineTheme.bar`.

## #111 — mouse-card minimize button hidden
High-contrast two-tone palette glyph + a reserved 22pt trailing gutter so the `−` button no longer collides with the Mouse/Trackpad picker's chevron.

**Files:** `ContentView.swift`, `TransportBar.swift`. Swift-only (no core rebuild).

## Validation (isolated macOS VM)
- #110: cycled all 4 tabs — consistent background. ✅
- #111: re-validated after the gutter fix — `−` clearly visible and separated from the picker chevron. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)