### PR TITLE
fix(scenes): silence bogus ScenePNG-Error on thumbnail store + wrap scene chip row (#113, #114)

### DIFF
--- a/layer1/Scene.cpp
+++ b/layer1/Scene.cpp
@@ -2061,16 +2061,26 @@ bool ScenePNG(PyMOLGlobals* G, pymol::zstring_view png, float dpi, int quiet,
       dpi = SettingGetGlobal_f(G, cSetting_image_dots_per_inch);
     auto screen_gamma = SettingGetGlobal_f(G, cSetting_png_screen_gamma);
     auto file_gamma = SettingGetGlobal_f(G, cSetting_png_file_gamma);
+    // outbuf != nullptr means we're capturing to an in-memory buffer (e.g.
+    // scene thumbnails) rather than a file, so there is no path to report and
+    // the "check directory" hint would be misleading (issue #113).
+    const bool to_buffer = (outbuf != nullptr);
     if(MyPNGWrite(png, *saveImage, dpi, format, quiet, screen_gamma, file_gamma, outbuf)) {
-      if(!quiet) {
+      if(!quiet && !to_buffer) {
         PRINTFB(G, FB_Scene, FB_Actions)
           " %s: wrote %dx%d pixel image to file \"%s\".\n", __func__,
           width, I->Image->getHeight(), png.c_str() ENDFB(G);
       }
-    } else {
+    } else if(!to_buffer) {
       PRINTFB(G, FB_Scene, FB_Errors)
         " %s-Error: error writing \"%s\"! Please check directory...\n", __func__,
         png.c_str() ENDFB(G);
+    } else if(!quiet) {
+      // In-memory capture failed (e.g. build without libpng). Callers that want
+      // this silent (scene thumbnails) pass quiet, so don't spam the console.
+      PRINTFB(G, FB_Scene, FB_Errors)
+        " %s-Error: error encoding %dx%d pixel image to memory buffer.\n",
+        __func__, width, I->Image->getHeight() ENDFB(G);
     }
   }
   return I->Image.get() != nullptr;

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -2544,25 +2544,24 @@ struct ScenesPane: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 10) {
                 // Scene chips with an inline "+" chip that stores the current
-                // view as a new scene (in line with the existing scenes).
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 8) {
-                        ForEach(sceneOrder, id: \.self) { name in
-                            sceneChip(name)
-                                .opacity(draggingScene == name ? 0.35 : 1)
-                                .onDrag {
-                                    draggingScene = name
-                                    return NSItemProvider(object: name as NSString)
-                                }
-                                .onDrop(of: ["public.text"],
-                                        delegate: SceneDropDelegate(item: name, order: $sceneOrder,
-                                                                    dragging: $draggingScene,
-                                                                    onReorder: applySceneOrder))
-                        }
-                        addChip
+                // view as a new scene (in line with the existing scenes). Chips
+                // wrap onto multiple rows rather than overflowing (issue #114).
+                FlowLayout(spacing: 8) {
+                    ForEach(sceneOrder, id: \.self) { name in
+                        sceneChip(name)
+                            .opacity(draggingScene == name ? 0.35 : 1)
+                            .onDrag {
+                                draggingScene = name
+                                return NSItemProvider(object: name as NSString)
+                            }
+                            .onDrop(of: ["public.text"],
+                                    delegate: SceneDropDelegate(item: name, order: $sceneOrder,
+                                                                dragging: $draggingScene,
+                                                                onReorder: applySceneOrder))
                     }
-                    .padding(.vertical, 4)
+                    addChip
                 }
+                .padding(.vertical, 4)
                 .onAppear { sceneOrder = engine.sceneNames }
                 .onChange(of: engine.sceneNames) { newNames in
                     // Resync only when the SET changes (scene added/removed); a
@@ -2734,6 +2733,60 @@ private struct SceneDropDelegate: DropDelegate {
         dragging = nil
         onReorder()
         return true
+    }
+}
+
+/// Left-aligned wrapping layout: places subviews left-to-right and wraps to a
+/// new row when the next subview would overflow the proposed width. Used for
+/// the scene-chip row so chips flow onto multiple rows instead of overflowing
+/// or requiring horizontal scrolling (issue #114).
+struct FlowLayout: Layout {
+    var spacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        var rowWidth: CGFloat = 0
+        var rowHeight: CGFloat = 0
+        var totalHeight: CGFloat = 0
+        var totalWidth: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if rowWidth > 0 && rowWidth + spacing + size.width > maxWidth {
+                // wrap to next row
+                totalWidth = max(totalWidth, rowWidth)
+                totalHeight += rowHeight + spacing
+                rowWidth = size.width
+                rowHeight = size.height
+            } else {
+                rowWidth += (rowWidth > 0 ? spacing : 0) + size.width
+                rowHeight = max(rowHeight, size.height)
+            }
+        }
+        totalWidth = max(totalWidth, rowWidth)
+        totalHeight += rowHeight
+        return CGSize(width: totalWidth, height: totalHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) {
+        let maxWidth = bounds.width
+        var x = bounds.minX
+        var y = bounds.minY
+        var rowHeight: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x > bounds.minX && x + size.width > bounds.minX + maxWidth {
+                // wrap to next row
+                x = bounds.minX
+                y += rowHeight + spacing
+                rowHeight = 0
+            }
+            subview.place(at: CGPoint(x: x, y: y), anchor: .topLeading,
+                          proposal: ProposedViewSize(size))
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #113 and #114.

## #113 — ScenePNG-Error spam on scene creation
`ScenePNG()` logged `error writing ""! Please check directory` on any in-memory buffer-capture failure — empty path, ignoring `quiet`. Now distinguishes buffer capture from file writes and gates the message on `!quiet`, so the scene-thumbnail path (`quiet=1`) no longer spams the console. The scene still stores fine (unchanged).
> ⚠️ **Touches the C++ core (`layer1/Scene.cpp`) — requires a core rebuild** (`swiftui/build_macos.sh` then xcodebuild).

## #114 — scene chip row overflow
Chip row now uses a wrapping `FlowLayout` instead of a single-row `HStack`; chips flow onto multiple rows. Drag-reorder preserved.

## Validation (isolated macOS VM)
- #113: stored 12 scenes — `scene stored as …` ×12, **zero** `ScenePNG-Error`. ✅ (Separate pre-existing headless-only `libpng IHDR 0×0` note filed below — not caused by this change.)
- #114: 12 scenes wrap into 3 rows, no clipping. ✅

_Note: in a 0×0 headless offscreen buffer the thumbnail encode still emits a distinct `libpng error: Invalid IHDR` line; that's an unrelated headless artifact, separate from the `ScenePNG-Error` this PR removes._

🤖 Generated with [Claude Code](https://claude.com/claude-code)