### PR TITLE
fix(viewport/menu): native right-click context menu on macOS + drop Show 'everything' (#108, #109)

### DIFF
--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -1115,7 +1115,9 @@ private struct ShowButton: View {
             ForEach(Array(showHideOptions.enumerated()), id: \.offset) { _, opt in
                 if opt.label == "---" {
                     Divider()
-                } else if let rep = opt.rep {
+                } else if let rep = opt.rep, rep != "everything" {
+                    // "everything" is meaningful for Hide but not Show — you
+                    // can't turn on every representation at once sensibly.
                     Button(opt.label) {
                         engine.runCommand("show \(rep), \(name)")
                     }

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -386,47 +386,7 @@ struct ContentView: View {
                 // Timeline transport docked beneath it whenever there's more than
                 // one frame to play (states / trajectory / movie).
                 VStack(spacing: 0) {
-                    MetalViewport()
-                        .frame(minWidth: 400, minHeight: 360)
-                        .layoutPriority(1)
-                        .overlay(alignment: .top) {
-                            if engine.measureMode != nil { measureOverlay }
-                        }
-                        // Pick-debug crosshair: marks exactly where the last click
-                        // landed, so a screenshot shows click-vs-selection offset.
-                        .overlay { debugClickMarker }
-                        // Mouse-mode legend as a compact floating card at the
-                        // bottom-trailing corner, so it's reachable even when the
-                        // right column is collapsed (where MousePanel used to live).
-                        // Minimizable to a small mouse button to free up the view.
-                        .overlay(alignment: .bottomTrailing) { mouseLegendCard }
-                        // Opt-in glanceable scene buttons (Scenes inspector →
-                        // "Show scene buttons in viewport"). The iOS path wires
-                        // this in viewportView; macOS needs it here too. Flat 12pt
-                        // bottom padding: the TransportBar docks BELOW the viewport
-                        // frame (sibling in the VStack), so no transport clearance
-                        // is needed as on iOS.
-                        .overlay(alignment: .bottomLeading) {
-                            bottomLeadingViewportChrome
-                                .padding(.leading, 12)
-                                .padding(.bottom, 12)
-                        }
-                        .overlay(alignment: .bottom) {
-                            if showCameraPanel && !engine.objects.isEmpty {
-                                CameraDock(engine: engine, onClose: { withAnimation(.easeOut(duration: 0.22)) { showCameraPanel = false } })
-                                    .padding(.horizontal, 10)
-                                    .padding(.bottom, 12)
-                                    .transition(.move(edge: .bottom).combined(with: .opacity))
-                                    .gesture(DragGesture().onEnded { v in
-                                        if v.translation.height > 40 {
-                                            withAnimation(.easeOut(duration: 0.22)) { showCameraPanel = false }
-                                        }
-                                    })
-                            }
-                        }
-                        // Empty-state CTA centered in the VIEWPORT (not over the
-                        // docked timeline below it).
-                        .overlay { if engine.objects.isEmpty && !showThemeStudio { macEmptyState } }
+                    macViewport
                     // The docked bottom transport was removed: movie playback lives
                     // in the Movie tab, model stepping in the Object panel. Only the
                     // full timeline editor still docks here (when expanded).
@@ -541,6 +501,71 @@ struct ContentView: View {
                 showSceneButtons = true
             }
         }
+    }
+
+    // The macOS viewport: the Metal view plus its floating overlays and the
+    // right-click context menu. Extracted from macOSLayout's body so the
+    // type-checker can resolve each in isolation (the inline chain tripped the
+    // "unable to type-check in reasonable time" limit).
+    @ViewBuilder
+    private var macViewport: some View {
+        MetalViewport()
+            .frame(minWidth: 400, minHeight: 360)
+            .layoutPriority(1)
+            .overlay(alignment: .top) {
+                if engine.measureMode != nil { measureOverlay }
+            }
+            // Pick-debug crosshair: marks exactly where the last click landed,
+            // so a screenshot shows click-vs-selection offset.
+            .overlay { debugClickMarker }
+            // Mouse-mode legend as a compact floating card at the bottom-trailing
+            // corner, so it's reachable even when the right column is collapsed
+            // (where MousePanel used to live). Minimizable to free up the view.
+            .overlay(alignment: .bottomTrailing) { mouseLegendCard }
+            // Opt-in glanceable scene buttons (Scenes inspector → "Show scene
+            // buttons in viewport"). The iOS path wires this in viewportView;
+            // macOS needs it here too. Flat 12pt bottom padding: the TransportBar
+            // docks BELOW the viewport frame (sibling in the VStack), so no
+            // transport clearance is needed as on iOS.
+            .overlay(alignment: .bottomLeading) {
+                bottomLeadingViewportChrome
+                    .padding(.leading, 12)
+                    .padding(.bottom, 12)
+            }
+            .overlay(alignment: .bottom) {
+                if showCameraPanel && !engine.objects.isEmpty {
+                    CameraDock(engine: engine, onClose: { withAnimation(.easeOut(duration: 0.22)) { showCameraPanel = false } })
+                        .padding(.horizontal, 10)
+                        .padding(.bottom, 12)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                        .gesture(DragGesture().onEnded { v in
+                            if v.translation.height > 40 {
+                                withAnimation(.easeOut(duration: 0.22)) { showCameraPanel = false }
+                            }
+                        })
+                }
+            }
+            // Empty-state CTA centered in the VIEWPORT (not over the docked
+            // timeline below it).
+            .overlay { if engine.objects.isEmpty && !showThemeStudio { macEmptyState } }
+            // Right-click context menu: a right-click in the viewport picks the
+            // atom/residue under the cursor (or empty space) and sets
+            // engine.longPressHit; present the same native menu the iOS
+            // long-press uses. PyMOL's own pop-up menu is never drawn under this
+            // Metal backend (internal_gui=0).
+            .confirmationDialog(
+                engine.longPressHit?.title ?? "",
+                isPresented: Binding(get: { engine.longPressHit != nil },
+                                     set: { if !$0 { engine.longPressHit = nil } }),
+                titleVisibility: .visible,
+                presenting: engine.longPressHit
+            ) { hit in
+                longPressActions(hit)
+            }
+            .confirmationDialog("Color residue", isPresented: $showLongPressColor,
+                                titleVisibility: .visible) {
+                longPressColorActions()
+            }
     }
 
     // macOS empty-state CTA, mirroring the iOS overlay visuals. "Open File…" uses
@@ -695,6 +720,42 @@ struct ContentView: View {
         n.count > 8 ? String(n.prefix(7)) + "…" : n
     }
 
+    // Long-press / right-click context menu state (shared macOS + iOS): the color
+    // sub-sheet toggle + the residue sel it colors. Both platforms present the
+    // same menu from engine.longPressHit (iOS long-press, macOS right-click).
+    @State private var showLongPressColor = false
+    @State private var longPressColorSel: String?
+
+    // Buttons for the long-press / right-click context menu. Empty space →
+    // scene-level actions; a hit → residue-scoped actions on hit.sel (an
+    // obj/chain/resi selector). Shared by iOS (long-press) and macOS (right-click).
+    @ViewBuilder
+    private func longPressActions(_ hit: LongPressHit) -> some View {
+        if hit.isEmpty {
+            Button("Reset view") { engine.runCommand("reset") }
+            Button("Deselect all") { engine.runCommand("deselect") }
+        } else {
+            Button("Zoom to residue") { engine.runCommand("zoom (\(hit.sel)), animate=1") }
+            Button("Select residue") { engine.runCommand("select sele, (?sele) or (\(hit.sel))\nenable sele") }
+            Button("Label residue") { engine.runCommand("label first (\(hit.sel)), '\(hit.resn)\(hit.resi)'") }
+            Button("Hide residue") { engine.runCommand("hide everything, (\(hit.sel))") }
+            Button("Center here") { engine.runCommand("center (\(hit.sel))") }
+            Button("Color…") { longPressColorSel = hit.sel; showLongPressColor = true }
+        }
+        Button("Cancel", role: .cancel) {}
+    }
+
+    // Color choices for the "Color…" sub-sheet (a few presets + by-element).
+    @ViewBuilder
+    private func longPressColorActions() -> some View {
+        let sel = longPressColorSel ?? ""
+        ForEach(["red", "orange", "yellow", "green", "cyan", "blue", "magenta", "white"], id: \.self) { c in
+            Button(c.capitalized) { engine.runCommand("color \(c), (\(sel))") }
+        }
+        Button("By element") { engine.runCommand("python\nfrom pymol import util; util.cnc('(\(sel))')\npython end") }
+        Button("Cancel", role: .cancel) {}
+    }
+
     #if os(iOS)
     // Default to the Objects tab: a touch user tunes representations far more
     // than they type commands, and it avoids greeting them with console log text.
@@ -703,9 +764,6 @@ struct ContentView: View {
     @State private var fetchID = ""
     // Confirmation for the destructive "Clear session" reset action.
     @State private var showClearSessionConfirm = false
-    // Long-press context menu: the color sub-sheet + the residue sel it colors.
-    @State private var showLongPressColor = false
-    @State private var longPressColorSel: String?
     // iPhone: the transport floats as a 1-line peek over the viewport and
     // expands in place to the full multi-row control. (Ignored on regular-width
     // iPad, where the bar is always full.)
@@ -1964,35 +2022,6 @@ struct ContentView: View {
             }
             .accessibilityLabel("Reset")
         }
-    }
-
-    // Buttons for the long-press context menu. Empty space → scene-level actions;
-    // a hit → residue-scoped actions on hit.sel (an obj/chain/resi selector).
-    @ViewBuilder
-    private func longPressActions(_ hit: LongPressHit) -> some View {
-        if hit.isEmpty {
-            Button("Reset view") { engine.runCommand("reset") }
-            Button("Deselect all") { engine.runCommand("deselect") }
-        } else {
-            Button("Zoom to residue") { engine.runCommand("zoom (\(hit.sel)), animate=1") }
-            Button("Select residue") { engine.runCommand("select sele, (?sele) or (\(hit.sel))\nenable sele") }
-            Button("Label residue") { engine.runCommand("label first (\(hit.sel)), '\(hit.resn)\(hit.resi)'") }
-            Button("Hide residue") { engine.runCommand("hide everything, (\(hit.sel))") }
-            Button("Center here") { engine.runCommand("center (\(hit.sel))") }
-            Button("Color…") { longPressColorSel = hit.sel; showLongPressColor = true }
-        }
-        Button("Cancel", role: .cancel) {}
-    }
-
-    // Color choices for the long-press "Color…" sub-sheet (a few presets + by-element).
-    @ViewBuilder
-    private func longPressColorActions() -> some View {
-        let sel = longPressColorSel ?? ""
-        ForEach(["red", "orange", "yellow", "green", "cyan", "blue", "magenta", "white"], id: \.self) { c in
-            Button(c.capitalized) { engine.runCommand("color \(c), (\(sel))") }
-        }
-        Button("By element") { engine.runCommand("python\nfrom pymol import util; util.cnc('(\(sel))')\npython end") }
-        Button("Cancel", role: .cancel) {}
     }
 
     private func iosHandleImport(_ result: Result<[URL], Error>) {

--- a/swiftui/PyMOLViewer/Shared/MetalViewport.swift
+++ b/swiftui/PyMOLViewer/Shared/MetalViewport.swift
@@ -236,6 +236,12 @@ extension MetalViewport {
         // a drag (rotate). Point space, view coordinates.
         private var mouseDownLoc: CGPoint = .zero
         private var didDrag = false
+        // Right-button equivalents: a pure right-click raises the viewport
+        // context menu (CPU pick → engine.longPressHit), while a right-DRAG
+        // still drives PyMOL's clip (slab). The button-down is deferred to the
+        // first drag so a bare click never enters clip mode.
+        private var rightDownLoc: CGPoint = .zero
+        private var rightDidDrag = false
 
         // Trackpad pinch (NSMagnificationGestureRecognizer) → zoom via an
         // explicit camera dolly (engine.zoomBy). We can't use the scroll-wheel
@@ -504,20 +510,50 @@ extension MetalViewport {
         }
 
         func handleRightMouseDown(_ event: NSEvent, in view: MTKView) {
-            let pt = pymolPoint(in: view, at: view.convert(event.locationInWindow, from: nil))
-            let mods = pymolModifiers(event.modifierFlags.rawValue)
-            engine?.button(PYMOL_BUTTON_RIGHT, state: PYMOL_BUTTON_DOWN, x: pt.0, y: pt.1, modifiers: mods)
+            // Defer PyMOL's button-down: raising it here would immediately enter
+            // clip mode, and PyMOL's own pop-up menu is never rendered under this
+            // Metal backend (internal_gui=0). A bare right-click instead pops the
+            // native SwiftUI context menu in handleRightMouseUp; a right-DRAG
+            // starts the clip on first movement (handleRightMouseDragged).
+            rightDownLoc = view.convert(event.locationInWindow, from: nil)
+            rightDidDrag = false
         }
 
         func handleRightMouseUp(_ event: NSEvent, in view: MTKView) {
-            let pt = pymolPoint(in: view, at: view.convert(event.locationInWindow, from: nil))
+            let loc = view.convert(event.locationInWindow, from: nil)
             let mods = pymolModifiers(event.modifierFlags.rawValue)
-            engine?.button(PYMOL_BUTTON_RIGHT, state: PYMOL_BUTTON_UP, x: pt.0, y: pt.1, modifiers: mods)
+
+            if rightDidDrag {
+                // Finish the clip (slab) drag.
+                let pt = pymolPoint(in: view, at: loc)
+                engine?.button(PYMOL_BUTTON_RIGHT, state: PYMOL_BUTTON_UP, x: pt.0, y: pt.1, modifiers: mods)
+                return
+            }
+
+            // Pure right-click → identify the atom/residue under the cursor and
+            // publish it so ContentView shows the viewport context menu. NDC in
+            // view-point space, bottom-left origin (macOS views aren't flipped),
+            // matching the left-click pick — so no Y flip.
+            let w = view.bounds.width, h = view.bounds.height
+            guard w > 0, h > 0 else { return }
+            let ndcX = Float(loc.x / w) * 2 - 1
+            let ndcY = Float(loc.y / h) * 2 - 1
+            engine?.longPressPick(ndcX: ndcX, ndcY: ndcY, aspect: Float(w / h))
         }
 
         func handleRightMouseDragged(_ event: NSEvent, in view: MTKView) {
-            let pt = pymolPoint(in: view, at: view.convert(event.locationInWindow, from: nil))
+            let loc = view.convert(event.locationInWindow, from: nil)
             let mods = pymolModifiers(event.modifierFlags.rawValue)
+            let moved = hypot(loc.x - rightDownLoc.x, loc.y - rightDownLoc.y)
+            if !rightDidDrag {
+                // First real movement past the click threshold: now raise the
+                // deferred button-down (at the press point) to begin the clip.
+                guard moved >= 4 else { return }
+                rightDidDrag = true
+                let down = pymolPoint(in: view, at: rightDownLoc)
+                engine?.button(PYMOL_BUTTON_RIGHT, state: PYMOL_BUTTON_DOWN, x: down.0, y: down.1, modifiers: mods)
+            }
+            let pt = pymolPoint(in: view, at: loc)
             engine?.drag(x: pt.0, y: pt.1, modifiers: mods)
         }
 


### PR DESCRIPTION
Fixes #108 and #109.

## #108 — right-click viewport did nothing
RayMol runs `internal_gui=0`, so PyMOL's own OpenGL right-click popup never renders. This wires the macOS viewport right-click to the existing (previously iOS-only) CPU-pick + native `confirmationDialog` path:
- right-click an atom → residue-titled menu (Zoom / Select / Label residue)
- right-click empty space → Scene menu (Reset view / Deselect all)
- right-click **drag** → still clips the slab (no menu)

Shared long-press action builders were moved out of the `#if os(iOS)` gate; `macViewport` extracted to resolve a type-check timeout.

## #109 — Show submenu 'everything'
`everything` filtered out of the Show quick menu (kept in Hide, where it's meaningful).

**Files:** `MetalViewport.swift`, `ContentView.swift`, `ObjectPanel.swift`. Swift-only.

## Validation (isolated macOS VM)
- #108: atom → "LEU 69 · chain A" menu; empty → Scene menu; right-drag → clip. ✅
- #109: Show menu has no `everything`; Hide still does. ✅

_Follow-up idea: the residue menu currently exposes Zoom/Select/Label (the shared iOS action set); could be extended to the fuller desktop right-click tree later._

🤖 Generated with [Claude Code](https://claude.com/claude-code)