### PR TITLE
fix(timeline): live viewport sync while dragging the movie playhead (#115)

### DIFF
--- a/swiftui/PyMOLViewer/Panels/TimelinePanel.swift
+++ b/swiftui/PyMOLViewer/Panels/TimelinePanel.swift
@@ -371,9 +371,14 @@ struct TimelinePanel: View {
         .frame(width: contentW, height: rulerH)
         .overlay(alignment: .bottom) { Divider() }
         .contentShape(Rectangle())
+        // Drag the playhead: live-sync the viewport on every change (scrub drives
+        // the core frame immediately), commit + release the scrub lock on end. A
+        // zero-distance drag doubles as a tap-to-seek. minimumDistance 0 so the
+        // first touch already positions the playhead (no dead zone before drag).
         .gesture(
-            SpatialTapGesture(coordinateSpace: .named(laneSpace))
-                .onEnded { e in engine.seek(to: frame(atX: e.location.x, pps: pps)) }
+            DragGesture(minimumDistance: 0, coordinateSpace: .named(laneSpace))
+                .onChanged { g in engine.scrub(to: frame(atX: g.location.x, pps: pps)) }
+                .onEnded { _ in engine.endScrub() }
         )
     }
 


### PR DESCRIPTION
Fixes #115.

The timeline ruler had only a one-shot `SpatialTapGesture` (and the playhead had hit-testing disabled), so dragging never updated the viewport continuously. Replaced with a `DragGesture(minimumDistance: 0)` whose `onChanged` calls the existing `engine.scrub(to:)` live-scrub path (the same one `TransportBar`'s slider uses); `onEnded` commits via `endScrub()`. Tap-to-seek preserved (zero-distance drag).

**File:** `TimelinePanel.swift`. Swift-only.

## Validation (isolated macOS VM)
- Frame captures at 1/30/60 differ (viewport tracks the scrub target). ✅
- Real ruler drag moved the frame 1 → 120 with the playhead physically relocating. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)