### PR TITLE
fix(inspector): populate representation controls on expand across all layouts (#107)

### DIFF
--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -888,10 +888,10 @@ struct ContentView: View {
             // visible (the panel's ScrollView covers any remaining overflow);
             // restore the user's size when everything collapses.
             .onChange(of: engine.expandedDetail) { detail in
-                // Poll the just-expanded object's rep detail immediately so its
-                // representation list shows at once (don't wait for the next
-                // ~500ms poll tick, which a heavy surface build can delay).
-                if detail != nil { engine.refreshExpandedDetail() }
+                // The immediate rep-detail poll on expand is fired from
+                // PyMOLEngine.expandedDetail's didSet (so every layout — incl.
+                // macOS, which has no such observer — populates at once, #107).
+                // Here we only drive the iPhone panel auto-grow.
                 // Only the iPhone (compact) bottom panel auto-grows; the iPad
                 // mac-style right column scrolls its own content at fixed width.
                 guard hSize == .compact else { return }

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -134,7 +134,19 @@ final class PyMOLEngine: ObservableObject {
     // The single detail view that is currently open (accordion: at most one).
     // nil = none, `sceneDetailKey` = the SCENE card, otherwise an object name.
     // Drives which object the detail poll queries (collapsed = cheap).
-    @Published var expandedDetail: String? = nil
+    // Poll the just-expanded object's rep detail IMMEDIATELY here (at the source)
+    // rather than waiting up to ~500ms for the next pollObjects tick — a heavy
+    // surface build can starve that timer and the card lingers on "No
+    // representations shown" / renders empty (#107). Doing it in didSet (instead
+    // of a per-layout view .onChange) guarantees EVERY expand path fires the
+    // refresh: iOS, macOS (whose layout had no such observer — the empty-panel
+    // bug), session restore, and the PYMOL_AUTOEXPAND test hook.
+    @Published var expandedDetail: String? = nil {
+        didSet {
+            guard expandedDetail != oldValue, expandedDetail != nil else { return }
+            refreshExpandedDetail()
+        }
+    }
     // Sentinel for "the SCENE card is the open detail view" — a control char so
     // it can never collide with a real object name.
     static let sceneDetailKey = "\u{1}scene"


### PR DESCRIPTION
Fixes #107.

Expanding an object row only set `PyMOLEngine.expandedDetail`; the immediate detail refresh was wired via an `.onChange` inside `iPadOSLayout` **only**, so the separate `macOSLayout` never triggered it and fell back to the throttled ~500ms poll — hence the slow / stuck-empty expand on macOS. Moved the refresh into a `didSet` on `expandedDetail` so every expand path (macOS, iOS, session restore, `PYMOL_AUTOEXPAND` test hook) populates immediately.

**Files:** `PyMOLEngine.swift`, `ContentView.swift`. Swift-only.

## Validation (isolated macOS VM)
- 10 collapse→expand cycles via the real chevron: representation controls populated 7/7 every time; collapse genuinely emptied them. Never once empty. ✅

_Residual (documented): won't remove slowness while a heavy surface is mid-build — that blocks the main thread by design (embedded core GIL model); the panel now populates as soon as the main thread frees. Separate constraint._

🤖 Generated with [Claude Code](https://claude.com/claude-code)