### PR TITLE
Make macOS native build portable across package managers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ dd_ios
 # per-user Xcode UI state (should never be tracked)
 xcuserdata
 
+# per-developer package-manager prefix override (see PyMOLBridge.xcconfig)
+PyMOLBridge.local.xcconfig
+
 # scratch test structures / session transcripts at repo root
 /*.cif
 /*.pdb

--- a/appkit/CMakeLists.txt
+++ b/appkit/CMakeLists.txt
@@ -38,6 +38,11 @@ endif()
 # Homebrew Python. Builds only pymol_core (no AppKit executable).
 option(PYMOL_METAL_ONLY "Native macOS Metal-only build (no OpenGL)" OFF)
 
+# External package-manager prefix for build-time headers/libs not vendored in
+# deps_macos/deps_ios (freetype, libpng, glm, GLEW). Homebrew by default;
+# override with -DPYMOL_EXTERNAL_PREFIX=/opt/local for MacPorts.
+set(PYMOL_EXTERNAL_PREFIX "/opt/homebrew" CACHE PATH "External package-manager prefix (Homebrew/MacPorts)")
+
 # Options
 option(PYMOL_LIBXML "Enable libxml2 (COLLADA)" ON)
 option(PYMOL_VMD_PLUGINS "Enable VMD plugins" ON)
@@ -51,7 +56,7 @@ if(PYMOL_METAL_ONLY)
     # PyMOLBridge.xcconfig. Python headers come from the staged
     # python-build-standalone tree (PYMOL_PYTHON_INCLUDE_DIR); png/freetype
     # headers from Homebrew (build-time only).
-    set(BREW_PREFIX "/opt/homebrew")
+    set(BREW_PREFIX "${PYMOL_EXTERNAL_PREFIX}")
     set(Python3_INCLUDE_DIRS "${PYMOL_PYTHON_INCLUDE_DIR}")
     set(Python3_NumPy_INCLUDE_DIRS "")
     set(PNG_INCLUDE_DIRS "${BREW_PREFIX}/include/libpng16" "${BREW_PREFIX}/include")

--- a/swiftui/PyMOLBridge.xcconfig
+++ b/swiftui/PyMOLBridge.xcconfig
@@ -38,11 +38,15 @@ PYMOL_GENERATED_FLAGS[sdk=macosx*] = -I$(PYMOL_BUILD_MACOS)/generated
 PYMOL_GENERATED_FLAGS[sdk=iphoneos*] = -I$(PYMOL_BUILD_IOS_DEVICE)/generated
 PYMOL_GENERATED_FLAGS[sdk=iphonesimulator*] = -I$(PYMOL_BUILD_IOS)/generated
 
-// On iOS, define _PYMOL_NO_OPENGL and _PYMOL_IOS to compile out GL code (Metal-only)
-PYMOL_IOS_FLAGS[sdk=iphoneos*] = -D_PYMOL_NO_OPENGL -D_PYMOL_IOS
-PYMOL_IOS_FLAGS[sdk=iphonesimulator*] = -D_PYMOL_NO_OPENGL -D_PYMOL_IOS
+// Compile out real-GL code (Metal-only) with the same macros the CMake core
+// build uses (appkit/CMakeLists.txt PYMOL_IOS / PYMOL_METAL_ONLY branches) —
+// the bridge file must agree with libpymol_core.a on this or shared headers
+// like layer0/os_gl.h produce mismatched types between the two.
+PYMOL_NOGL_FLAGS[sdk=macosx*] = -D_PYMOL_NO_OPENGL -D_PYMOL_METAL_ONLY
+PYMOL_NOGL_FLAGS[sdk=iphoneos*] = -D_PYMOL_NO_OPENGL -D_PYMOL_IOS
+PYMOL_NOGL_FLAGS[sdk=iphonesimulator*] = -D_PYMOL_NO_OPENGL -D_PYMOL_IOS
 
-OTHER_CPLUSPLUSFLAGS = $(inherited) $(PYMOL_INCLUDE_FLAGS) $(PYMOL_GENERATED_FLAGS) $(PYMOL_IOS_FLAGS)
+OTHER_CPLUSPLUSFLAGS = $(inherited) $(PYMOL_INCLUDE_FLAGS) $(PYMOL_GENERATED_FLAGS) $(PYMOL_NOGL_FLAGS)
 
 // --- Linker flags ---
 // iOS cross-compiled dependencies

--- a/swiftui/PyMOLBridge.xcconfig
+++ b/swiftui/PyMOLBridge.xcconfig
@@ -6,6 +6,15 @@
 
 PYMOL_ROOT = $(SRCROOT)/..
 
+// External package-manager prefix (Homebrew by default). For MacPorts or a
+// custom prefix, create PyMOLBridge.local.xcconfig (gitignored, not checked
+// in) next to this file with e.g.:
+//   PYMOL_EXTERNAL_PREFIX = /opt/local
+//   PYMOL_LIBOMP_STATIC = /opt/local/lib/libomp/libomp.a
+PYMOL_EXTERNAL_PREFIX = /opt/homebrew
+PYMOL_LIBOMP_STATIC = $(PYMOL_EXTERNAL_PREFIX)/opt/libomp/lib/libomp.a
+#include? "PyMOLBridge.local.xcconfig"
+
 // Platform-conditional build directories
 PYMOL_BUILD_MACOS = $(SRCROOT)/../build_macos_swiftui
 // PYMOL_BUILD_IOS = iphonesimulator core; PYMOL_BUILD_IOS_DEVICE = iphoneos core
@@ -15,7 +24,7 @@ PYMOL_BUILD_IOS_DEVICE = $(SRCROOT)/../build_ios_device
 // --- Library search paths (platform-conditional) ---
 // macOS: the NO_OPENGL+Metal core (build_macos_swiftui) + embedded standalone
 // Python 3.13; /opt/homebrew/lib only supplies freetype/png at LINK time.
-LIBRARY_SEARCH_PATHS[sdk=macosx*] = $(PYMOL_BUILD_MACOS) $(SRCROOT)/../deps_macos/python-standalone/python/lib /opt/homebrew/lib
+LIBRARY_SEARCH_PATHS[sdk=macosx*] = $(PYMOL_BUILD_MACOS) $(SRCROOT)/../deps_macos/python-standalone/python/lib $(PYMOL_EXTERNAL_PREFIX)/lib
 LIBRARY_SEARCH_PATHS[sdk=iphoneos*] = $(PYMOL_BUILD_IOS_DEVICE)
 LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*] = $(PYMOL_BUILD_IOS)
 
@@ -24,7 +33,7 @@ LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*] = $(PYMOL_BUILD_IOS)
 LD_RUNPATH_SEARCH_PATHS[sdk=macosx*] = $(inherited) @executable_path/../Resources/python/lib
 
 // --- C++/ObjC++ include paths ---
-PYMOL_INCLUDE_FLAGS_COMMON = -I$(PYMOL_ROOT)/include -I$(PYMOL_ROOT)/include/pymol -I$(PYMOL_ROOT)/ov/src -I$(PYMOL_ROOT)/layer0 -I$(PYMOL_ROOT)/layer1 -I$(PYMOL_ROOT)/layer2 -I$(PYMOL_ROOT)/layer3 -I$(PYMOL_ROOT)/layer4 -I$(PYMOL_ROOT)/layer5 -I$(PYMOL_ROOT)/layerGraphics -I$(PYMOL_ROOT)/layerGraphics/gl -I$(PYMOL_ROOT)/layerGraphics/metal -I$(PYMOL_ROOT)/contrib -I$(PYMOL_ROOT)/contrib/pocketfft -I/opt/homebrew/include
+PYMOL_INCLUDE_FLAGS_COMMON = -I$(PYMOL_ROOT)/include -I$(PYMOL_ROOT)/include/pymol -I$(PYMOL_ROOT)/ov/src -I$(PYMOL_ROOT)/layer0 -I$(PYMOL_ROOT)/layer1 -I$(PYMOL_ROOT)/layer2 -I$(PYMOL_ROOT)/layer3 -I$(PYMOL_ROOT)/layer4 -I$(PYMOL_ROOT)/layer5 -I$(PYMOL_ROOT)/layerGraphics -I$(PYMOL_ROOT)/layerGraphics/gl -I$(PYMOL_ROOT)/layerGraphics/metal -I$(PYMOL_ROOT)/contrib -I$(PYMOL_ROOT)/contrib/pocketfft -I$(PYMOL_EXTERNAL_PREFIX)/include
 
 // Python headers: macOS uses Homebrew 3.14, iOS uses BeeWare 3.13
 PYMOL_PYTHON_INC[sdk=macosx*] = -I$(SRCROOT)/../deps_macos/python-standalone/python/include/python3.13
@@ -76,7 +85,7 @@ PYMOL_CORE_LDFLAGS = -lpymol_core -framework Metal -framework MetalKit -framewor
 // so the linker uses the archive, not the .dylib) to resolve the OpenMP symbols
 // from pymol_core's parallel surface sampling — no dylib to bundle/sign, so the
 // App Store build stays self-contained.
-PYMOL_PLATFORM_LDFLAGS[sdk=macosx*] = -lfreetype -lpng16 -lz -lpython3.13 /opt/homebrew/opt/libomp/lib/libomp.a
+PYMOL_PLATFORM_LDFLAGS[sdk=macosx*] = -lfreetype -lpng16 -lz -lpython3.13 $(PYMOL_LIBOMP_STATIC)
 // iOS: cross-compiled dependencies + Python dylib linked by path
 PYMOL_PLATFORM_LDFLAGS[sdk=iphoneos*] = -lfreetype -lpng16 -lz $(PYMOL_PYTHON_DYLIB)
 PYMOL_PLATFORM_LDFLAGS[sdk=iphonesimulator*] = -lfreetype -lpng16 -lz $(PYMOL_PYTHON_DYLIB)

--- a/swiftui/build_macos.sh
+++ b/swiftui/build_macos.sh
@@ -8,6 +8,8 @@ PYMOL_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PY="$PYMOL_ROOT/deps_macos/python-standalone/python"
 BUILD_DIR="$PYMOL_ROOT/build_macos_swiftui"
 NCPU=$(sysctl -n hw.ncpu)
+# Homebrew by default; MacPorts users: export PYMOL_EXTERNAL_PREFIX=/opt/local
+PYMOL_EXTERNAL_PREFIX="${PYMOL_EXTERNAL_PREFIX:-/opt/homebrew}"
 
 test -d "$PY" || { echo "ERROR: run scripts/fetch_macos_python.sh first ($PY missing)"; exit 1; }
 
@@ -17,6 +19,7 @@ cmake "$PYMOL_ROOT/appkit" \
     -DPYMOL_METAL_ONLY=ON -DPYMOL_IOS=OFF \
     -DPYMOL_LIBXML=OFF -DPYMOL_VMD_PLUGINS=ON -DPYMOL_MSGPACKC=OFF \
     -DPYMOL_PYTHON_INCLUDE_DIR="$PY/include/python3.13" \
+    -DPYMOL_EXTERNAL_PREFIX="$PYMOL_EXTERNAL_PREFIX" \
     -DCMAKE_OSX_ARCHITECTURES=arm64 \
     -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
     -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
## Summary
- `PyMOLBridge.xcconfig` and `appkit/CMakeLists.txt` hardcoded `/opt/homebrew` for freetype/libpng/glm/libomp, which breaks the native macOS SwiftUI build for MacPorts users (`/opt/local`). Introduces an overridable `PYMOL_EXTERNAL_PREFIX` (CMake cache var + xcconfig variable, defaulting to `/opt/homebrew`), with an optional gitignored `swiftui/PyMOLBridge.local.xcconfig` for per-developer overrides and a `PYMOL_EXTERNAL_PREFIX` env var read by `swiftui/build_macos.sh`.
- Fixes a latent macro mismatch: the CMake core build always compiles `libpymol_core.a` with `_PYMOL_NO_OPENGL`/`_PYMOL_METAL_ONLY` for this target, but the Xcode-side compile of `PyMOLBridge.mm` only defined that macro for iOS SDKs, never `macosx`. This let the macOS bridge file silently compile down the real-GL code path (masked on Homebrew machines that happen to have `GL/glew.h`/`GL/glut.h` on the include path) instead of agreeing with the Metal-only core it links against.

## Test plan
- [x] Installed MacPorts equivalents (`glm glew libpng freetype libomp`) on a machine with no Homebrew.
- [x] Populated `deps_macos/python-standalone` via `scripts/fetch_macos_python.sh`.
- [x] Built `libpymol_core.a` via `PYMOL_EXTERNAL_PREFIX=/opt/local swiftui/build_macos.sh`.
- [x] Built `PyMOLViewer_macOS` via `xcodebuild` using a local `PyMOLBridge.local.xcconfig` pointing at `/opt/local` — succeeded end-to-end.
- [x] Launched the built app and confirmed it runs.
- [x] Confirmed the default (no override) behavior is unchanged — `PYMOL_EXTERNAL_PREFIX` defaults to `/opt/homebrew` everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)