### PR TITLE
feat(inspector): surface & clear per-atom transparency (#122)

### DIFF
--- a/docs/superpowers/specs/2026-07-07-per-atom-transparency-discoverability-design.md
+++ b/docs/superpowers/specs/2026-07-07-per-atom-transparency-discoverability-design.md
@@ -1,0 +1,76 @@
+# Per-atom transparency discoverability in the inspector
+
+**Date:** 2026-07-07
+**Issue:** [#122](https://github.com/javierbq/RayMol/issues/122) — "opaque cartoon objects render as semitransparent when two objects overlap"
+
+## Background — what #122 actually is
+
+The issue reported opaque cartoon rendering as semi-transparent when two objects
+overlap, hypothesising z-fighting. Reproducing it against the reporter's
+`stage2_compat.pse` showed the real cause: `dual_complex` has **per-atom
+`cartoon_transparency`** baked in (chains B/C = 0.35, part of chain A = 0.6),
+while APB27981 is opaque. The live viewport renders that transparency correctly;
+it is neither z-fighting nor a rendering bug.
+
+The reporter was misled because the object- and global-level `cartoon_transparency`
+both read `0` — there was **no way to tell per-atom transparency was set**, and
+the object-level transparency slider appeared not to work (per-atom values
+override it). (A separate observation: the CPU ray tracer renders these solid,
+i.e. it ignores per-atom `cartoon_transparency` — tracked separately.)
+
+This feature makes per-atom transparency **discoverable and clearable** in the
+inspector. It does not change how transparency renders.
+
+## Design
+
+### Detection — `modules/pymol/appkit_inspector.py`
+- `TRANSP_SETTINGS = ['cartoon_transparency', 'sphere_transparency', 'transparency']`
+  — the only transparency settings PyMOL supports **per-atom**. `ribbon_` and
+  `stick_transparency` are object-level only (verified: `alter s.stick_transparency`
+  raises "only atom-level settings can be set"), so they are excluded — they can
+  never carry per-atom overrides.
+- `REP_TRANSP` maps each rep to its setting (cartoon→cartoon_transparency,
+  spheres→sphere_transparency, surface/mesh/dots→transparency).
+- `transp_summary(obj)`: one `cmd.iterate` pass → `{setting: (min, max, over)}` of
+  the **effective** per-atom transparency (atom-level value if set, else the
+  object-level value). `over` = the range differs from the object-level value,
+  i.e. the slider misrepresents what's rendered. Reading `s.<setting>` resolves to
+  the object-level value for un-overridden atoms, so comparing the effective range
+  to the object-level value is what detects a genuine override (no false alarm
+  when per-atom == object-level).
+- `object_has_atom_transp(obj)`: true when any **active** rep has an override
+  (rep-gated so an override on a hidden rep doesn't flag). Drives the badge.
+- `_build` attaches `atom_transp = {setting, min, max}` to a rep when its setting
+  is overridden.
+
+### Data path — `swiftui/.../PyMOLEngine.swift`
+- The object-list poll (`OBJPANEL:` JSON) gains `has_transp: {obj: bool}` via
+  `object_has_atom_transp`, so the collapsed-row badge works without expanding.
+- `parseObjectDetailFeedback` parses `atom_transp` into `RepState.atomTransp`.
+
+### UI — `swiftui/.../ObjectPanel.swift`
+- `ObjectEntry.hasAtomTransp`, `RepState.atomTransp: AtomTransp?`.
+- **Badge**: an amber `drop.halffull` icon on the object row (visible collapsed)
+  when `hasAtomTransp`, with an explanatory tooltip.
+- **Detail row**: in `RepPropertyGrid`, directly under the matching transparency
+  slider (fallback: end of grid), an amber `per-atom: min–max` readout + a
+  **Clear** button.
+- **Clear** runs `unset <setting>, (<obj>)` + `rebuild <obj>` — the
+  atom-selection form removes per-atom overrides while keeping the object-level
+  slider value, restoring slider authority. (`alter, del s.<setting>` raises
+  SystemError and bare `unset(setting, obj)` only touches the object level, so
+  neither is used.)
+
+### Scope guard (YAGNI)
+No ray-tracer changes, no new settings, no change to how transparency renders —
+purely making existing behaviour discoverable and clearable.
+
+## Verification
+- Headless unit tests (`testing/tests/test_inspector_transparency.py`, 7 cases):
+  clean object, partial/uniform overrides, no-false-alarm when per-atom==slider,
+  Clear restores slider authority, rep-gating, non-atom-level exclusion.
+- Full data contract validated headlessly against the real `stage2_compat.pse`.
+- macOS build succeeds; functionally verified in an isolated VM against the PSE:
+  badge on `dual_complex` only, `per-atom: 0–0.6` detail row under the cartoon
+  Transparency slider, and Clear (unset 5825 atoms) → badge + row disappear and
+  the cartoon renders opaque.

--- a/modules/pymol/appkit_inspector.py
+++ b/modules/pymol/appkit_inspector.py
@@ -50,6 +50,19 @@ REP_EXTRA_COLORS = {
     'surface': ['surface_contour_color'],
 }
 
+# Transparency settings that PyMOL actually supports at the ATOM level, i.e. that
+# can carry per-atom overrides. ribbon_transparency and stick_transparency are
+# object-level only and can never differ per atom, so they are intentionally
+# excluded (they would never flag). `transparency` is the surface/mesh/dots one.
+REP_TRANSP = {
+    'cartoon': 'cartoon_transparency',
+    'spheres': 'sphere_transparency',
+    'surface': 'transparency',
+    'mesh': 'transparency',
+    'dots': 'transparency',
+}
+TRANSP_SETTINGS = ['cartoon_transparency', 'sphere_transparency', 'transparency']
+
 SCENE_SETTINGS = ['metal_raytrace', 'metal_rt_shadows', 'metal_shadows', 'metal_ssao',
                   'metal_rt_samples', 'metal_rt_ao_radius', 'metal_rt_ao_intensity',
                   'metal_rt_shadow_intensity',
@@ -147,10 +160,69 @@ def _color_setting_rgb(setting, fallback=(0.0, 0.0, 0.0)):
     return [float(t[0]), float(t[1]), float(t[2])]
 
 
+def transp_summary(obj):
+    """One pass over `obj`'s atoms → {setting: (min, max, over)} for the atom-level
+    transparency settings, where min/max are the EFFECTIVE per-atom transparency
+    (the atom-level value if set, else the object-level value) and `over` is True
+    when that range differs from the object-level value — i.e. per-atom overrides
+    make the object-level slider misleading. Settings with no atoms are omitted.
+
+    Reading `s.<setting>` in iterate always resolves to the object-level value when
+    no atom-level override exists (it never returns None here), so comparing the
+    effective range to the object-level value is what detects a genuine override.
+    """
+    objlv = {s: _num(s, obj) for s in TRANSP_SETTINGS}
+    mn = {s: None for s in TRANSP_SETTINGS}
+    mx = {s: None for s in TRANSP_SETTINGS}
+
+    def _visit(vals):
+        for i, s in enumerate(TRANSP_SETTINGS):
+            e = objlv[s] if vals[i] is None else float(vals[i])
+            if mn[s] is None or e < mn[s]:
+                mn[s] = e
+            if mx[s] is None or e > mx[s]:
+                mx[s] = e
+
+    expr = '_visit((%s))' % ', '.join('s.%s' % s for s in TRANSP_SETTINGS)
+    try:
+        cmd.iterate(obj, expr, space={'_visit': _visit})
+    except Exception:
+        return {}
+    out = {}
+    for s in TRANSP_SETTINGS:
+        if mn[s] is None:
+            continue
+        over = (round(mn[s], 4) != round(objlv[s], 4)) or (round(mx[s], 4) != round(objlv[s], 4))
+        out[s] = (round(mn[s], 4), round(mx[s], 4), over)
+    return out
+
+
+def object_has_atom_transp(obj):
+    """True when any ACTIVE rep of `obj` has a per-atom transparency override — the
+    signal for the collapsed-row badge. Rep-gated so an override on a hidden rep
+    (which the user can't see and the expanded card wouldn't show) doesn't flag.
+    The count_atoms probe runs only when an override exists (cheap short-circuit).
+    """
+    summ = transp_summary(obj)
+    for rep, setting in REP_TRANSP.items():
+        entry = summ.get(setting)
+        if entry and entry[2]:
+            try:
+                if cmd.count_atoms('(%s) & rep %s' % (obj, rep)) > 0:
+                    return True
+            except Exception:
+                pass
+    return False
+
+
 def _build(objs):
     detail = {}
     for o in objs:
         reps = []
+        # Effective per-atom transparency range per setting, computed once per
+        # object; attached to the rep whose transparency setting is overridden so
+        # the expanded card can show "per-atom: min–max" and a Clear action.
+        summ = transp_summary(o)
         for r in REPS:
             try:
                 present = cmd.count_atoms('(%s) & rep %s' % (o, r)) > 0
@@ -161,8 +233,12 @@ def _build(objs):
             vals = {s: _num(s, o) for s in REP_SETTINGS.get(r, [])}
             col = _rep_color(o, REP_COLOR[r]) if r in REP_COLOR else 'inherit'
             cols = {s: _rep_color(o, s) for s in REP_EXTRA_COLORS.get(r, [])}
-            reps.append({'rep': r, 'vis': 1, 'vals': vals, 'color': col,
-                         'colors': cols})
+            rep = {'rep': r, 'vis': 1, 'vals': vals, 'color': col, 'colors': cols}
+            tset = REP_TRANSP.get(r)
+            tsumm = summ.get(tset) if tset else None
+            if tsumm and tsumm[2]:
+                rep['atom_transp'] = {'setting': tset, 'min': tsumm[0], 'max': tsumm[1]}
+            reps.append(rep)
         detail[o] = reps
     scene = {s: _num(s, '') for s in SCENE_SETTINGS}
     scene['bg'] = _bg_rgb()

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -40,6 +40,17 @@ struct RepState: Equatable {
     var values: [String: Double]    // setting name → current value
     var color: String               // "inherit" or "#rrggbb"
     var settingColors: [String: String] = [:]  // extra color settings → "inherit"/"#rrggbb"
+    // Present when this rep has per-atom transparency overriding the object-level
+    // slider; carries the transparency setting name and the effective min–max range.
+    var atomTransp: AtomTransp? = nil
+}
+
+/// Effective per-atom transparency range for a rep whose object-level slider is
+/// overridden by atom-level settings (from appkit_inspector's `atom_transp`).
+struct AtomTransp: Equatable {
+    let setting: String   // e.g. "cartoon_transparency"
+    let min: Double
+    let max: Double
 }
 
 /// Global "Scene" parameters.
@@ -331,6 +342,10 @@ struct ObjectEntry: Identifiable, Equatable {
     // Number of coordinate states (NMR models / trajectory frames). >1 surfaces
     // the per-object STATE controls in the inspector. Defaults to 1.
     var stateCount: Int = 1
+    // True when an active rep has per-atom transparency overrides — drives the
+    // discoverability badge, since the object-level transparency slider then
+    // doesn't reflect what's rendered. See appkit_inspector.object_has_atom_transp.
+    var hasAtomTransp: Bool = false
 
     var displayName: String {
         if isSelection, let count = atomCount {
@@ -675,6 +690,10 @@ private enum PanelTheme {
     static var accentColor: Color { t.accent.color }
     static var headerColor: Color { t.panelBackground.blended(with: t.panelText, 0.6).color }
     static var disabledColor: Color { t.panelBackground.blended(with: t.panelText, 0.4).color }
+    // Amber accent for the per-atom transparency badge / detail row — a fixed hue
+    // (not the blue theme accent) that reads as "transparency" and stays legible
+    // on both light and dark panel themes.
+    static var atomTranspColor: Color { Color(.sRGB, red: 0.90, green: 0.66, blue: 0.30, opacity: 1) }
 }
 
 // Chrome for the compact A/S/H/L/C representation menu buttons so they read the
@@ -1666,6 +1685,17 @@ private struct ObjectRowContent: View {
                 .help("\(entry.stateCount) models / states")
         }
 
+        // Discoverability badge: this object has per-atom transparency overrides,
+        // so the object-level transparency slider doesn't reflect what's rendered.
+        // Visible even when the card is collapsed. Expand to see the range + Clear.
+        if entry.hasAtomTransp {
+            Image(systemName: "drop.halffull")
+                .font(.system(size: 10))
+                .foregroundColor(PanelTheme.atomTranspColor)
+                .help("Per-atom transparency is set — the object-level transparency slider won’t fully apply. Expand a representation to view the range or clear it.")
+                .accessibilityLabel("Per-atom transparency set")
+        }
+
         Spacer(minLength: 4)
 
         ActionMenuButton(name: entry.name)
@@ -1989,9 +2019,66 @@ private struct RepPropertyGrid: View {
             }
             ForEach(spec.properties) { p in
                 gridRow(p.label) { control(for: p) }
+                // Per-atom transparency detail sits directly under the matching
+                // transparency slider so it's clear the slider is only a baseline.
+                if let at = state.atomTransp, at.setting == p.setting {
+                    atomTranspRow(at)
+                }
+            }
+            // Fallback: surface the detail even if this rep's spec has no slider
+            // for its transparency setting (so the info is never lost).
+            if let at = state.atomTransp,
+               !spec.properties.contains(where: { $0.setting == at.setting }) {
+                atomTranspRow(at)
             }
         }
         .padding(.top, 2)
+    }
+
+    // "per-atom: min–max" readout + a Clear action, shown when atom-level
+    // transparency overrides the object-level slider for this rep.
+    @ViewBuilder
+    private func atomTranspRow(_ at: AtomTransp) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "drop.halffull").font(.system(size: 10))
+            Text("per-atom: \(rangeLabel(at))").font(.system(size: 10))
+            Spacer(minLength: 4)
+            Button(action: { clearAtomTransp(at.setting) }) {
+                Text("Clear")
+                    .font(.system(size: 10))
+                    .padding(.horizontal, 8).padding(.vertical, 1)
+                    .overlay(RoundedRectangle(cornerRadius: 4)
+                        .stroke(PanelTheme.atomTranspColor.opacity(0.55), lineWidth: 0.5))
+            }
+            .buttonStyle(.plain)
+        }
+        .foregroundColor(PanelTheme.atomTranspColor)
+        .padding(.leading, 84)   // align under the control column (label width 78 + gap)
+        .help("Some atoms set \(at.setting) individually, so the slider above only sets a baseline. Clear removes the per-atom values and hands control back to the slider.")
+    }
+
+    private func rangeLabel(_ at: AtomTransp) -> String {
+        let lo = fmtTransp(at.min), hi = fmtTransp(at.max)
+        return lo == hi ? lo : "\(lo)–\(hi)"
+    }
+
+    private func fmtTransp(_ v: Double) -> String {
+        var s = String(format: "%.2f", v)
+        if s.contains(".") {
+            while s.hasSuffix("0") { s.removeLast() }
+            if s.hasSuffix(".") { s.removeLast() }
+        }
+        return s
+    }
+
+    // Remove the per-atom overrides for `setting` on this object. The
+    // atom-selection form `unset(setting, (obj))` clears atom-level values while
+    // keeping the object-level slider value; a rebuild refreshes the baked
+    // cartoon/surface geometry, then re-poll so the row disappears promptly.
+    private func clearAtomTransp(_ setting: String) {
+        engine.runCommand("unset \(setting), (\(objName))")
+        engine.runCommand("rebuild \(objName)")
+        engine.refreshExpandedDetail()
     }
 
     @ViewBuilder
@@ -3047,6 +3134,7 @@ extension PyMOLEngine {
             let enabled: [String]
             let sel_counts: [String: Int]
             let nstate: [String: Int]?
+            let has_transp: [String: Bool]?
         }
 
         guard let payload = try? JSONDecoder().decode(PanelPayload.self, from: data) else {
@@ -3063,7 +3151,8 @@ extension PyMOLEngine {
                 isEnabled: enabledSet.contains(name),
                 isSelection: false,
                 atomCount: nil,
-                stateCount: max(payload.nstate?[name] ?? 1, 1)
+                stateCount: max(payload.nstate?[name] ?? 1, 1),
+                hasAtomTransp: payload.has_transp?[name] ?? false
             ))
         }
 

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -1135,8 +1135,10 @@ final class PyMOLEngine: ObservableObject {
             + "_en |= set(_cmd.get_names('public_selections', enabled_only=1) or [])\n"
             + "_sc = {s: _cmd.count_atoms(s) for s in _sels}\n"
             + "_ns = {o: _cmd.count_states('?' + o) for o in _objs}\n"
+            + "from pymol import appkit_inspector as _ai\n"
+            + "_ht = {o: _ai.object_has_atom_transp(o) for o in _objs}\n"
             + "print('OBJPANEL:' + json.dumps({'objects': _objs, 'selections': _sels, "
-            + "'enabled': list(_en), 'sel_counts': _sc, 'nstate': _ns}))"
+            + "'enabled': list(_en), 'sel_counts': _sc, 'nstate': _ns, 'has_transp': _ht}))"
         )
         refreshExpandedDetail()
         if sequenceVisible { fetchSequences() }
@@ -2117,8 +2119,10 @@ final class PyMOLEngine: ObservableObject {
             + "_en |= set(_cmd.get_names('public_selections', enabled_only=1) or [])\n"
             + "_sc = {s: _cmd.count_atoms(s) for s in _sels}\n"
             + "_ns = {o: _cmd.count_states('?' + o) for o in _objs}\n"
+            + "from pymol import appkit_inspector as _ai\n"
+            + "_ht = {o: _ai.object_has_atom_transp(o) for o in _objs}\n"
             + "print('OBJPANEL:' + json.dumps({'objects': _objs, 'selections': _sels, "
-            + "'enabled': list(_en), 'sel_counts': _sc, 'nstate': _ns}))"
+            + "'enabled': list(_en), 'sel_counts': _sc, 'nstate': _ns, 'has_transp': _ht}))"
         )
 
         pollDetails()
@@ -2172,12 +2176,21 @@ final class PyMOLEngine: ObservableObject {
                     if let cols = r["colors"] as? [String: Any] {
                         for (k, v) in cols { settingColors[k] = v as? String ?? "inherit" }
                     }
+                    var atomTransp: AtomTransp? = nil
+                    if let at = r["atom_transp"] as? [String: Any],
+                       let setting = at["setting"] as? String {
+                        atomTransp = AtomTransp(
+                            setting: setting,
+                            min: (at["min"] as? NSNumber)?.doubleValue ?? 0,
+                            max: (at["max"] as? NSNumber)?.doubleValue ?? 0)
+                    }
                     return RepState(
                         rep: r["rep"] as? String ?? "",
                         visible: ((r["vis"] as? NSNumber)?.intValue ?? 1) != 0,
                         values: values,
                         color: r["color"] as? String ?? "inherit",
-                        settingColors: settingColors)
+                        settingColors: settingColors,
+                        atomTransp: atomTransp)
                 }
             }
         }

--- a/testing/tests/test_inspector_transparency.py
+++ b/testing/tests/test_inspector_transparency.py
@@ -1,0 +1,83 @@
+"""Tests for pymol.appkit_inspector per-atom transparency discoverability.
+
+Covers the detection that drives the inspector's per-atom transparency badge and
+"per-atom: min-max" + Clear detail row (issue #122): transp_summary,
+object_has_atom_transp, and the atom_transp field attached by _build.
+"""
+
+from pymol import cmd, testing
+from pymol import appkit_inspector as ai
+
+
+class TestInspectorTransparency(testing.PyMOLTestCase):
+
+    def _peptide(self, name='pep'):
+        cmd.delete(name)
+        cmd.fab('ACDEFGHIKLMNPQRSTVWY', name)
+        cmd.dss(name)
+        cmd.show_as('cartoon', name)
+        return name
+
+    def testCleanObjectHasNoOverride(self):
+        o = self._peptide()
+        summ = ai.transp_summary(o)
+        self.assertFalse(summ['cartoon_transparency'][2])
+        self.assertFalse(ai.object_has_atom_transp(o))
+        cart = [r for r in ai._build([o])['detail'][o] if r['rep'] == 'cartoon'][0]
+        self.assertNotIn('atom_transp', cart)
+
+    def testPartialOverrideDetected(self):
+        o = self._peptide()
+        cmd.alter(o + ' and resi 1-10', 's.cartoon_transparency = 0.5')
+        # effective range spans object-level (0) .. override (0.5), flagged as over
+        self.assertEqual(ai.transp_summary(o)['cartoon_transparency'], (0.0, 0.5, True))
+        self.assertTrue(ai.object_has_atom_transp(o))
+        cart = [r for r in ai._build([o])['detail'][o] if r['rep'] == 'cartoon'][0]
+        self.assertEqual(cart['atom_transp'],
+                         {'setting': 'cartoon_transparency', 'min': 0.0, 'max': 0.5})
+
+    def testUniformOverrideDiffersFromSlider(self):
+        # every atom overridden to 0.5 while the object-level slider is still 0 ->
+        # still an override (the slider misrepresents what's rendered)
+        o = self._peptide()
+        cmd.alter(o, 's.cartoon_transparency = 0.5')
+        self.assertEqual(ai.transp_summary(o)['cartoon_transparency'], (0.5, 0.5, True))
+
+    def testOverrideEqualToSliderIsNotFlagged(self):
+        # per-atom value equal to the object-level value must NOT flag (no false alarm)
+        o = self._peptide()
+        cmd.alter(o, 's.cartoon_transparency = 0.5')
+        cmd.set('cartoon_transparency', 0.5, o)
+        self.assertFalse(ai.transp_summary(o)['cartoon_transparency'][2])
+        self.assertFalse(ai.object_has_atom_transp(o))
+
+    def testClearRestoresSliderAuthority(self):
+        # the Clear action runs `unset <setting>, (<obj>)`; verify it removes the
+        # per-atom overrides, keeps the object-level value, and lets the slider govern
+        o = self._peptide()
+        cmd.set('cartoon_transparency', 0.3, o)
+        cmd.alter(o + ' and resi 1-10', 's.cartoon_transparency = 0.7')
+        self.assertTrue(ai.transp_summary(o)['cartoon_transparency'][2])
+        cmd.unset('cartoon_transparency', '(%s)' % o)
+        c = ai.transp_summary(o)['cartoon_transparency']
+        self.assertEqual(c[:2], (0.3, 0.3))
+        self.assertFalse(c[2])
+        cmd.set('cartoon_transparency', 0.8, o)
+        self.assertEqual(ai.transp_summary(o)['cartoon_transparency'][:2], (0.8, 0.8))
+
+    def testFlagIsGatedByActiveRep(self):
+        # an override on a rep that isn't shown must not raise the badge
+        o = self._peptide()
+        cmd.alter(o + ' and resi 1-5', 's.sphere_transparency = 0.4')
+        self.assertFalse(ai.object_has_atom_transp(o))  # spheres hidden
+        cmd.show('spheres', o)
+        self.assertTrue(ai.object_has_atom_transp(o))    # spheres shown
+
+    def testNonAtomLevelSettingsExcluded(self):
+        # ribbon_/stick_transparency are object-level only and must not appear in
+        # the atom-level detection set (they can never carry per-atom overrides)
+        self.assertNotIn('ribbon_transparency', ai.TRANSP_SETTINGS)
+        self.assertNotIn('stick_transparency', ai.TRANSP_SETTINGS)
+        self.assertIn('cartoon_transparency', ai.TRANSP_SETTINGS)
+        self.assertIn('sphere_transparency', ai.TRANSP_SETTINGS)
+        self.assertIn('transparency', ai.TRANSP_SETTINGS)


### PR DESCRIPTION
## What & why

Investigating [#122](https://github.com/javierbq/RayMol/issues/122) ("opaque cartoon renders as semitransparent when two objects overlap") against the reporter's `stage2_compat.pse` showed the report is a **misdiagnosis** — it's neither z-fighting nor a rendering bug:

- `dual_complex` has **per-atom `cartoon_transparency`** baked into the PSE (chains B/C = `0.35`, part of chain A = `0.6`); APB27981 is opaque. The live viewport renders that transparency correctly.
- Object- and global-level `cartoon_transparency` both read `0`, so there was **no way to tell per-atom transparency was set**, and the object-level transparency slider appeared broken (per-atom values override it).

This PR makes per-atom transparency **discoverable and clearable** in the inspector. It does **not** change how transparency renders.

## Changes
- **`appkit_inspector.py`** — `transp_summary` + `object_has_atom_transp` detect per-atom overrides for the transparency settings PyMOL supports at the atom level (`cartoon_transparency`, `sphere_transparency`, `transparency`). `ribbon_`/`stick_transparency` are object-level only and excluded. `_build` attaches `atom_transp {setting, min, max}` to an overridden rep.
- **`ObjectPanel.swift`** — an amber `drop.halffull` **badge** on any object with overrides (visible even when collapsed), plus a **`per-atom: min–max`** readout and a **Clear** button under the rep's transparency slider. Clear runs `unset <setting>, (<obj>)` + `rebuild` (removes per-atom values, keeps the object-level slider value, restores slider authority).
- **`PyMOLEngine.swift`** — threads `has_transp` (object-list poll) and `atom_transp` (rep detail) through to the model.
- **`test_inspector_transparency.py`** — 7 headless cases (clean object, partial/uniform overrides, no false alarm when per-atom == slider, Clear restores slider authority, rep-gating, non-atom-level exclusion).

Design doc: `docs/superpowers/specs/2026-07-07-per-atom-transparency-discoverability-design.md`.

## Verification
- Headless unit tests pass (7/7); full data contract validated against the real `stage2_compat.pse`.
- macOS build succeeds; **functionally verified in an isolated macOS VM**: badge shows on `dual_complex` only, the `per-atom: 0–0.6` row appears under the cartoon Transparency slider, and clicking **Clear** (`unset cartoon_transparency, (dual_complex)` → 5825 atoms) removes the badge + row and the cartoon renders opaque.

## Note (out of scope)
Separately, the CPU ray tracer renders these solid — it appears to ignore per-atom `cartoon_transparency` while the live viewport honors it. Not addressed here; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)