### PR TITLE
release: RayMol 1.6.0 (build 17)

### DIFF
--- a/docs/release-notes/v1.6.0.md
+++ b/docs/release-notes/v1.6.0.md
@@ -1,0 +1,57 @@
+## RayMol 1.6.0
+
+A big feature release: a Photos-style camera dock with real depth-of-field, a
+docked Timeline movie studio, multi-state (NMR/MD) support in movies, and a
+batch of inspector and rendering improvements.
+
+### Camera & lens
+- **New camera control dock.** A Photos-style strip docked at the bottom of the
+  viewport for framing and lens controls — collapses to icons, expands for the
+  sliders.
+- **Lens (focal length).** Dial the camera from wide-angle to telephoto (down to
+  12 mm) with a true dolly-zoom — it swaps perspective without re-zooming the
+  subject. Ortho is now a toggle right in the Lens row.
+- **Zoom (magnification) slider.** Absolute on-screen magnification, independent
+  of the lens.
+
+### Depth of field
+- **Autofocus.** Lock the focal plane to a selection and it tracks through zoom.
+- **DOF quality slider (1–4)**, defaulting to best, replacing the old on/off
+  toggle.
+- **Scatter-based bokeh** that spreads highlights past object edges for a
+  natural out-of-focus falloff. Transparent image export keeps DOF with a
+  halo-aware matte.
+
+### Movies & Timeline
+- **Timeline movie studio.** A docked multi-track editor for building movies —
+  drag-and-drop camera keyframes and scenes onto the timeline, with configurable
+  transitions. Lives in the right inspector with an expandable bottom dock.
+- **Multi-state (NMR / MD) objects.** Play through the models of an ensemble
+  with a "Play models" clip and per-object model playback, decoupled from the
+  movie transport. State-aware rebuilds are non-destructive.
+
+### Inspector
+- **Per-atom transparency.** The inspector now surfaces per-atom transparency
+  baked into a session and lets you clear it back to opaque.
+- **Representation controls populate reliably** when you expand a structure,
+  across every layout.
+- **Half-screen expand** for the object list, a dynamic state slider, and a
+  shared selection-mode menu.
+
+### Rendering
+- **Real-time ray tracing restored,** with quality controls — hardware-accelerated
+  ambient occlusion and shadows update live as you orbit.
+
+### macOS app
+- **Native right-click context menu** on the viewport.
+- **Help ▸ Contact Support…** opens a message to support@raymol.io.
+- **What's New splash** on update, and a narrower, tidier right inspector.
+
+### Fixes
+- **Scenes now capture and restore render settings** (DOF, lighting, Metal
+  toggles) per scene, and no longer throw a spurious thumbnail-save error.
+- **Restoring a saved session no longer clobbers its render toggles** when the
+  launch theme re-applies.
+- **The viewport stays in sync** while you drag the movie playhead.
+
+Built on the open-source PyMOL engine. Updates install automatically via the in-app updater (**Check for Updates…** in the app menu).

--- a/layer1/PyMOLObject.cpp
+++ b/layer1/PyMOLObject.cpp
@@ -997,7 +997,16 @@ void ObjectPrepareContext(pymol::CObject * I, RenderInfo * info)
           TTTFromViewElem(I->TTT, I->ViewElem + frame);
           I->TTTFlag = true;
         }
-        if(I->ViewElem[frame].state_flag) {
+        // Apply the movie's per-frame state track ONLY when the frame has
+        // CHANGED since we last wrote it for this object. Re-applying on every
+        // render at a static frame would overwrite an explicit per-object
+        // `set state, N, obj` (Objects-panel model inspection) before it could
+        // display, freezing the viewport on one model even as the state counter
+        // advances (issue #132). Movie play / scrub / export all advance the
+        // frame, so the sweep still drives them; only an idle movie stops
+        // fighting the user's manual state.
+        if(I->ViewElem[frame].state_flag && frame != I->LastStateFrame) {
+          I->LastStateFrame = frame;
           SettingCheckHandle(I->G, I->Setting);
           if(I->Setting) {
             /* note: this assumes that the state has already been

--- a/layer1/PyMOLObject.h
+++ b/layer1/PyMOLObject.h
@@ -90,6 +90,14 @@ struct CObject {
   int grid_slot = 0;
   CGO* gridSlotSelIndicatorsCGO = nullptr;
   int Grabbed = 0;
+  // Movie frame at which the ViewElem per-frame state track was last written
+  // into cSetting_state (see ObjectPrepareContext). Re-applying it on EVERY
+  // render at a STATIC frame would clobber an explicit per-object `set state`
+  // (the Objects-panel model inspection, which is decoupled from the movie) —
+  // freezing the viewport on one model while a movie sits idle (issue #132).
+  // The movie's own play / scrub / export all ADVANCE the frame, so the sweep
+  // still drives them. -1 = not yet applied.
+  int LastStateFrame = -1;
 
   // methods
   StateIndex_t getCurrentState() const;

--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -56,11 +56,11 @@
 		90F5E063444FBF4FF3770118 /* MCPStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1304C662D9011F7C4505FC /* MCPStatusView.swift */; };
 		946A8CF4D62A7AFFFA6E39A9 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 10CCAA289EA2934B267C337A /* PrivacyInfo.xcprivacy */; };
 		979AB10150CC62EE5E7962F9 /* MetalViewport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E9F8D36908E3216D1C8F893 /* MetalViewport.swift */; };
-		A6AD62F52FFDEBA100A9D33E /* RayMol.icon in Resources */ = {isa = PBXBuildFile; fileRef = A6AD62F42FFDEBA100A9D33E /* RayMol.icon */; };
-		A6AD62F62FFDEBA100A9D33E /* RayMol.icon in Resources */ = {isa = PBXBuildFile; fileRef = A6AD62F42FFDEBA100A9D33E /* RayMol.icon */; };
 		97F0B5805CD3B11723C7B43B /* whatsnew-152-timeline.png in Resources */ = {isa = PBXBuildFile; fileRef = 55094A33AFF9AEF5561CFD96 /* whatsnew-152-timeline.png */; };
+		9FE703EF6FD7C97884C299DF /* RayMol.icon in Resources */ = {isa = PBXBuildFile; fileRef = BB5ABD1A8C45E5BC97AB0B80 /* RayMol.icon */; };
 		AA36D034CEC68207CFC82340 /* WhatsNewModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4D170B35BCCF683A6B3D655 /* WhatsNewModal.swift */; };
 		ACBE8F70B980BCCE6730141A /* MovieBuilderSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ED5BFF3FEE9D6621BB40AE5 /* MovieBuilderSheet.swift */; };
+		B2697EF48D85EF14D4A19163 /* RayMol.icon in Resources */ = {isa = PBXBuildFile; fileRef = BB5ABD1A8C45E5BC97AB0B80 /* RayMol.icon */; };
 		B33C0620EDD48195A59B7DD8 /* MCPBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A18D8A6B0FB56FCD3C31211 /* MCPBridge.swift */; };
 		B84285B5FAD1A429B1FCEDBF /* 1ubq.cif in Resources */ = {isa = PBXBuildFile; fileRef = 1A55383922D69D691CA1BAB1 /* 1ubq.cif */; };
 		BA6C9B288CFD5EB53D0E0057 /* RayMolMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9371B6FFB30D6166234C678B /* RayMolMain.swift */; };
@@ -97,7 +97,6 @@
 
 /* Begin PBXFileReference section */
 		05C388F2E8B5A99F3CBFFC7E /* PyMOLViewer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PyMOLViewer.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		A6AD62F42FFDEBA100A9D33E /* RayMol.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = RayMol.icon; sourceTree = "<group>"; };
 		0ED5BFF3FEE9D6621BB40AE5 /* MovieBuilderSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieBuilderSheet.swift; sourceTree = "<group>"; };
 		104B50C66BDEB03C41A1CE47 /* CameraOverlayUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraOverlayUITests.swift; sourceTree = "<group>"; };
 		10CCAA289EA2934B267C337A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
@@ -131,6 +130,7 @@
 		B50D264C420888CBF7FDE633 /* CommandPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPanel.swift; sourceTree = "<group>"; };
 		B820FE9080BF73526A54CD66 /* TimelinePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelinePanel.swift; sourceTree = "<group>"; };
 		B9EC978B16F58D988575E206 /* MCPDrivingBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPDrivingBanner.swift; sourceTree = "<group>"; };
+		BB5ABD1A8C45E5BC97AB0B80 /* RayMol.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = RayMol.icon; sourceTree = "<group>"; };
 		C562306A5AD1EEDDBA931B98 /* TransportBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportBar.swift; sourceTree = "<group>"; };
 		C78CBBCC3AFAD0E62BBAA884 /* PyMOLViewer.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = PyMOLViewer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE692F1547C53D28B5F9A9AD /* MCPConnectSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPConnectSheet.swift; sourceTree = "<group>"; };
@@ -141,7 +141,7 @@
 		F2078076B68D28457409F7A5 /* RayMol.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RayMol.entitlements; sourceTree = "<group>"; };
 		F607D204A410CA38B84223BE /* RayMolUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RayMolUpdater.swift; sourceTree = "<group>"; };
 		FB1304C662D9011F7C4505FC /* MCPStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPStatusView.swift; sourceTree = "<group>"; };
-		"TEMP_043CFDEE-DE50-45E5-9715-5BCA2606AAAB" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
+		"TEMP_8158F08B-D4D3-474B-A84C-1D6EA3BA07E1" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -178,10 +178,10 @@
 		213C644D6AEEA6FB9B7C3B5E /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				A6AD62F42FFDEBA100A9D33E /* RayMol.icon */,
 				1A55383922D69D691CA1BAB1 /* 1ubq.cif */,
 				589928DEEE69075B965DB9F2 /* Assets.xcassets */,
 				57E9E81F5C4757D03AAF7ABD /* dylib-Info-template.plist */,
+				BB5ABD1A8C45E5BC97AB0B80 /* RayMol.icon */,
 				F16058D96E2773BE9A24C323 /* RayMol.svg */,
 				29DBC7BEEA492BFACB616C34 /* whatsnew-152-camera-dock.mp4 */,
 				55094A33AFF9AEF5561CFD96 /* whatsnew-152-timeline.png */,
@@ -263,10 +263,10 @@
 			path = Bridge;
 			sourceTree = "<group>";
 		};
-		"TEMP_6E13BB72-DEFE-4043-AEC5-7271830ED024" /* swiftui */ = {
+		"TEMP_55636D4C-447E-4271-BA62-4F4AB818144B" /* swiftui */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_043CFDEE-DE50-45E5-9715-5BCA2606AAAB" /* PyMOLBridge.xcconfig */,
+				"TEMP_8158F08B-D4D3-474B-A84C-1D6EA3BA07E1" /* PyMOLBridge.xcconfig */,
 			);
 			path = swiftui;
 			sourceTree = "<group>";
@@ -393,10 +393,10 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A6AD62F52FFDEBA100A9D33E /* RayMol.icon in Resources */,
 				F5F9A2124F71FDC7541A6BF8 /* 1ubq.cif in Resources */,
 				3D6FE0218915810960306973 /* Assets.xcassets in Resources */,
 				946A8CF4D62A7AFFFA6E39A9 /* PrivacyInfo.xcprivacy in Resources */,
+				B2697EF48D85EF14D4A19163 /* RayMol.icon in Resources */,
 				4BE37F7CA13DEB10F2AE62D6 /* RayMol.svg in Resources */,
 				8F33D1DB927644308CEF0C5B /* WhatsNew.json in Resources */,
 				E08AF23E9A696D29B94CA999 /* dylib-Info-template.plist in Resources */,
@@ -409,10 +409,10 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A6AD62F62FFDEBA100A9D33E /* RayMol.icon in Resources */,
 				B84285B5FAD1A429B1FCEDBF /* 1ubq.cif in Resources */,
 				7B6E4F8683D469C6984163AA /* Assets.xcassets in Resources */,
 				575E4E4792DE4C46A70ECE01 /* PrivacyInfo.xcprivacy in Resources */,
+				9FE703EF6FD7C97884C299DF /* RayMol.icon in Resources */,
 				8E33AC50510ECB1DA4277904 /* RayMol.svg in Resources */,
 				42F2467DC338FA8435632918 /* WhatsNew.json in Resources */,
 				5A20A6D21AA3CFAE2394BAB4 /* dylib-Info-template.plist in Resources */,
@@ -908,7 +908,7 @@
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = RayMol;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -922,7 +922,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.2;
+				MARKETING_VERSION = 1.6.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -938,7 +938,7 @@
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = RayMol;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -952,7 +952,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.2;
+				MARKETING_VERSION = 1.6.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -969,7 +969,7 @@
 				CODE_SIGN_ENTITLEMENTS = PyMOLViewer/RayMol.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_TEAM = VT99UQUQ89;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -985,7 +985,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.2;
+				MARKETING_VERSION = 1.6.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -1022,7 +1022,7 @@
 				CODE_SIGN_ENTITLEMENTS = PyMOLViewer/RayMol.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_TEAM = VT99UQUQ89;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1038,7 +1038,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.2;
+				MARKETING_VERSION = 1.6.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -1050,7 +1050,7 @@
 		};
 		76B7E9DB75E073D1E60928FA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_043CFDEE-DE50-45E5-9715-5BCA2606AAAB" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_8158F08B-D4D3-474B-A84C-1D6EA3BA07E1" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1135,7 +1135,7 @@
 		};
 		D8F44FDFF036013D2F03BA83 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_043CFDEE-DE50-45E5-9715-5BCA2606AAAB" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_8158F08B-D4D3-474B-A84C-1D6EA3BA07E1" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -2756,6 +2756,10 @@ struct ScenesPane: View {
                         .strokeBorder(TimelineTheme.accent.opacity(0.5),
                                       style: StrokeStyle(lineWidth: 1.5, dash: [4, 3]))
                 )
+                // Hit the whole dashed tile, not just the glyph: without this the
+                // transparent interior between the "+" and the border isn't
+                // tappable (the Image only hit-tests its rendered glyph). (#130)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .accessibilityLabel("New scene from current view")

--- a/swiftui/PyMOLViewer/Panels/TimelinePanel.swift
+++ b/swiftui/PyMOLViewer/Panels/TimelinePanel.swift
@@ -71,6 +71,11 @@ struct TimelinePanel: View {
     @State private var sheetLast = 0            // 0 = through the last model
     @State private var sheetDuration: Double = 8
 
+    // Scenes-palette overflow tracking → drives the horizontal-scroll edge fade
+    // (issue #131). Set from GeometryReader preferences below.
+    @State private var paletteContentW: CGFloat = 0
+    @State private var paletteViewportW: CGFloat = 0
+
     #if os(iOS)
     @Environment(\.horizontalSizeClass) private var hSize
     private var isCompact: Bool { forceCompact || hSize == .compact }
@@ -102,6 +107,21 @@ struct TimelinePanel: View {
                 ? Laid(item: it, index: i, frame: spans[i].start, endFrame: spans[i].end)
                 : nil
         }
+    }
+
+    // A slim gradient hugging the trailing edge of a horizontal scroll region to
+    // signal off-screen content — the resting cue that a row is scrollable, since
+    // the native macOS scrollbar only appears mid-scroll (issue #131). Purely
+    // decorative: never hit-tests, so it can't eat scroll/scrub gestures.
+    @ViewBuilder
+    private func trailingScrollFade() -> some View {
+        // Fade to the panel background so content appears to slide UNDER the
+        // chrome edge — theme-adaptive (reads correctly on light + dark), unlike
+        // a fixed black shadow which looks harsh on a light palette (#133).
+        LinearGradient(colors: [TimelineTheme.bar.opacity(0), TimelineTheme.bar],
+                       startPoint: .leading, endPoint: .trailing)
+            .frame(width: 24)
+            .allowsHitTesting(false)
     }
 
     var body: some View {
@@ -205,7 +225,7 @@ struct TimelinePanel: View {
                     .frame(width: 28, height: 30).contentShape(Rectangle())
             }
             .disabled(zoom <= minZoom * 1.001)
-            Rectangle().fill(Color.white.opacity(0.12)).frame(width: 1, height: 18)
+            Rectangle().fill(TimelineTheme.subtleFill).frame(width: 1, height: 18)
             Button { setZoom(zoom * 1.6) } label: {
                 Image(systemName: "plus")
                     .font(.system(size: 12, weight: .bold))
@@ -215,8 +235,8 @@ struct TimelinePanel: View {
         }
         .buttonStyle(.plain)
         .foregroundColor(TimelineTheme.text)
-        .background(Capsule().fill(Color.white.opacity(0.10)))
-        .overlay(Capsule().stroke(Color.white.opacity(0.08), lineWidth: 0.5))
+        .background(Capsule().fill(TimelineTheme.subtleFill))
+        .overlay(Capsule().stroke(TimelineTheme.subtleFill, lineWidth: 0.5))
         .accessibilityLabel("Zoom timeline")
         .help("Zoom the time ruler in / out")
     }
@@ -302,7 +322,7 @@ struct TimelinePanel: View {
             }
             .frame(width: labelW)
 
-            Rectangle().fill(Color.white.opacity(0.08)).frame(width: 1)
+            Rectangle().fill(TimelineTheme.subtleFill).frame(width: 1)
 
             GeometryReader { geo in
                 let w = geo.size.width
@@ -331,6 +351,11 @@ struct TimelinePanel: View {
                     // otherwise vertically greedy and would absorb the panel's slack,
                     // opening gaps above the ruler / below the lane.
                     .frame(height: rulerH + laneH)
+                    // Trailing fade when the lane is longer than the viewport, so
+                    // it's obvious the track scrolls horizontally (issue #131).
+                    .overlay(alignment: .trailing) {
+                        if cW > w + 1 { trailingScrollFade() }
+                    }
                     // Follow the playhead during playback (don't fight manual scroll).
                     .onChange(of: playback.currentFrame) { _ in
                         if playback.isPlaying {
@@ -643,7 +668,7 @@ struct TimelinePanel: View {
             .help("Saved scenes — tap to append to the timeline")
             .accessibilityLabel("Saved scenes")
 
-            Rectangle().fill(Color.white.opacity(0.08)).frame(width: 1)
+            Rectangle().fill(TimelineTheme.subtleFill).frame(width: 1)
 
             if engine.sceneNames.isEmpty {
                 Text("Store a scene to drop it onto the timeline")
@@ -660,7 +685,20 @@ struct TimelinePanel: View {
                         }
                     }
                     .padding(.horizontal, 8).padding(.vertical, 7)
+                    .background(GeometryReader { c in
+                        Color.clear.preference(key: PaletteContentWKey.self, value: c.size.width)
+                    })
                 }
+                // Trailing fade when the chips overflow the row, so it's obvious
+                // the scenes palette scrolls horizontally (issue #131).
+                .background(GeometryReader { v in
+                    Color.clear.preference(key: PaletteViewportWKey.self, value: v.size.width)
+                })
+                .overlay(alignment: .trailing) {
+                    if paletteContentW > paletteViewportW + 1 { trailingScrollFade() }
+                }
+                .onPreferenceChange(PaletteContentWKey.self) { paletteContentW = $0 }
+                .onPreferenceChange(PaletteViewportWKey.self) { paletteViewportW = $0 }
             }
         }
         .frame(height: 40)
@@ -672,7 +710,7 @@ struct TimelinePanel: View {
             .font(.system(size: 11)).lineLimit(1)
             .padding(.horizontal, 10).padding(.vertical, 4)
             .background(Capsule().fill(engine.currentScene == name
-                                       ? TimelineTheme.accent : Color.white.opacity(0.12)))
+                                       ? TimelineTheme.accent : TimelineTheme.subtleFill))
             .foregroundColor(engine.currentScene == name ? .black : TimelineTheme.text)
             .contentShape(Capsule())
             .onTapGesture { engine.appendSceneItem(name) }
@@ -767,7 +805,7 @@ struct TimelinePanel: View {
         .font(.system(size: 12))
         .fixedSize()
         .padding(.horizontal, 8).padding(.vertical, 5)
-        .background(Capsule().fill(Color.white.opacity(0.10)))
+        .background(Capsule().fill(TimelineTheme.subtleFill))
         .foregroundColor(TimelineTheme.text)
     }
 
@@ -942,6 +980,17 @@ struct TimelinePanel: View {
         if s < 1 { return String(format: "%.1fs", s) }
         return s.rounded() == s ? "\(Int(s))s" : String(format: "%.1fs", s)
     }
+}
+
+// Scenes-palette width measurement for the horizontal-scroll edge fade (#131):
+// content width vs. viewport width decide whether the trailing fade shows.
+private struct PaletteContentWKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { value = max(value, nextValue()) }
+}
+private struct PaletteViewportWKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { value = max(value, nextValue()) }
 }
 
 // Small downward-pointing triangle for the playhead head.

--- a/swiftui/PyMOLViewer/Panels/TransportBar.swift
+++ b/swiftui/PyMOLViewer/Panels/TransportBar.swift
@@ -25,8 +25,16 @@ enum TimelineTheme {
     // the rest of the inspector rather than a fixed dark gray. Kept slightly
     // translucent (0.96) since the docked timeline floats over the viewport.
     static var bar: Color { ThemeManager.shared.active.panelBackground.color.opacity(0.96) }
-    static let text = Color(white: 0.88)
-    static let dim = Color(white: 0.55)
+    // Foreground text / dimmed labels FOLLOW the active theme's panel text color
+    // (like the rest of the inspector) instead of a fixed near-white — otherwise
+    // ruler ticks, the header, row labels, the counter and scene chips wash out on
+    // a light theme (issue #133). `dim` is the same hue at reduced opacity so it
+    // stays legible on both light and dark palettes.
+    static var text: Color { ThemeManager.shared.active.panelText.color }
+    static var dim: Color { ThemeManager.shared.active.panelText.color.opacity(0.6) }
+    // Subtle fill for neutral chips / hairline separators, derived from the text
+    // color so it contrasts against the panel background on any theme.
+    static var subtleFill: Color { ThemeManager.shared.active.panelText.color.opacity(0.12) }
 }
 
 // Transport control sizing. The transport is embedded in the timeline, which on

--- a/swiftui/project.yml
+++ b/swiftui/project.yml
@@ -55,9 +55,15 @@ targets:
         ONLY_ACTIVE_ARCH: "NO"
         PRODUCT_NAME: RayMol
         PRODUCT_BUNDLE_IDENTIFIER: io.raymol.RayMol
+        # App icon: the Icon Composer bundle PyMOLViewer/Resources/RayMol.icon
+        # (added in PR #124). This MUST live in project.yml, not just the
+        # generated project.pbxproj — make_dmg.sh re-runs `xcodegen generate`
+        # at release time, so without it here the release reverts to the
+        # AppIcon.appiconset fallback. Applies to both macOS + iOS.
+        ASSETCATALOG_COMPILER_APPICON_NAME: RayMol
         INFOPLIST_GENERATION_MODE: GeneratedFile
-        MARKETING_VERSION: "1.5.2"
-        CURRENT_PROJECT_VERSION: 16
+        MARKETING_VERSION: "1.6.0"
+        CURRENT_PROJECT_VERSION: 17
         GENERATE_INFOPLIST_FILE: YES
         # Generate a launch screen so iOS renders at the device's NATIVE
         # resolution. Without it the app is letterboxed at a legacy size on


### PR DESCRIPTION
## RayMol 1.6.0 (build 17)

macOS / Sparkle release. Minor bump from 1.5.2 — 102 non-merge commits since v1.5.2 (41 feats, 28 fixes).

### This PR
- **Bump** `MARKETING_VERSION` → 1.6.0, `CURRENT_PROJECT_VERSION` → 17.
- **Release notes** `docs/release-notes/v1.6.0.md` (Sparkle dialog + GitHub release body).
- **Fix (release-blocker): wire the Icon Composer app icon into `project.yml`.** PR #124 set `ASSETCATALOG_COMPILER_APPICON_NAME = RayMol` only in the generated `project.pbxproj`. `make_dmg.sh` re-runs `xcodegen generate` at release time, so without the setting in `project.yml` the 1.6.0 DMG would silently revert to the old `AppIcon` fallback. Verified: rebuilt app carries `CFBundleIconName=RayMol` and the Icon Composer assets compile into `Assets.car`.

### Headline features (see release notes for full list)
Photos-style camera control dock (lens/zoom/DOF), depth-of-field suite (quality slider, autofocus, scatter bokeh), lens/focal-length dolly-zoom, docked Timeline movie studio, multi-state (NMR/MD) playback, per-atom transparency inspector, real-time ray tracing restore, native macOS right-click menu, What's New splash.

⚠️ **Do not merge yet** — additional pre-release fixes are pending and must land here (or on master) before the `v1.6.0` tag is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)