### PR TITLE
Add clear-selection button next to the Residues toggle (#112)

### DIFF
--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -767,6 +767,7 @@ struct ObjectPanel: View {
             if hSizeClass == .compact {
                 HStack(spacing: 8) {
                     Spacer()
+                    ClearSelectionButton()
                     SelectionModeMenu()
                 }
                 .padding(.horizontal, 8)
@@ -922,6 +923,31 @@ struct SelectionModeMenu: View {
         .repMenuChrome()
         .fixedSize()
         .help("Selection mode — what a tap selects")
+    }
+}
+
+/// One-tap "clear selection" — runs `deselect`, which hides the active
+/// selection markers (the pink `sele` indicators) without deleting any named
+/// selections. Lives right next to `SelectionModeMenu` in the shared inspector
+/// chrome (macOS/iPad) and the iPhone Object-panel header, so it's reachable
+/// from every tab. Dimmed and non-interactive when nothing is selected.
+struct ClearSelectionButton: View {
+    @EnvironmentObject var engine: PyMOLEngine
+    private var hasActiveSelection: Bool {
+        engine.objects.contains { $0.isSelection && $0.isEnabled }
+    }
+    var body: some View {
+        Button { engine.runCommand("deselect") } label: {
+            Image(systemName: "xmark.circle")
+                .font(.system(size: 10))
+                // Accent (blue) when there's something to clear — matches the
+                // panel's action buttons (A/S/H/L/C) — else dimmed grey.
+                .foregroundColor(hasActiveSelection ? PanelTheme.accentColor : PanelTheme.disabledColor)
+        }
+        .buttonStyle(.plain)
+        .disabled(!hasActiveSelection)
+        .fixedSize()
+        .help("Clear selection — hide the current selection markers")
     }
 }
 

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -2299,7 +2299,9 @@ struct ContentView: View {
                     .foregroundColor(.secondary)
                     .lineLimit(1)
                 Spacer(minLength: 8)
-                // Selection mode — here (shared chrome) so it's reachable from every tab.
+                // Clear selection + selection mode — here (shared chrome) so both
+                // are reachable from every tab.
+                ClearSelectionButton()
                 SelectionModeMenu()
             }
             .padding(.horizontal, 12)


### PR DESCRIPTION
## Summary
Adds a one-tap **clear-selection** button (`xmark.circle`) beside the selection-mode ("Residues") toggle in the shared panel header, so the current selection can be cleared from any tab — previously this was only reachable via the "all" row's action menu (or the macOS "Deselect all" menu item).

Closes #112.

## Behavior
- Runs `deselect` — **hides** the active selection markers (the pink `sele` indicators) **without deleting** any named selections (non-destructive).
- **Accent-blue** when a selection is active; **dimmed/disabled** (grey) when nothing is selected — matching the panel's `A/S/H/L/C` action-button language.
- Enabled state is driven by `engine.objects.contains { $0.isSelection && $0.isEnabled }`.

## Placement
Wired into both existing `SelectionModeMenu` sites so it shows on every tab:
- macOS/iPad shared inspector chrome (`ContentView.inspectorSwitcher`)
- iPhone Object-panel header (`ObjectPanel.panelBody`, compact size class)

## Verification
Functionally tested by building the macOS app and driving it in an isolated, disposable macOS VM (per project workflow):
- Button renders to the left of the "🖑 Residues" toggle. ✅
- **No selection** → button dimmed grey and non-interactive. ✅
- **Active selection** (`select sele, 1ubq and resi 1-20`) → button turns accent-blue. ✅
- Running `deselect` (the button's action) → markers hidden, button dims back to grey, and the `sele` selection **remains** in the SELECTIONS list (non-destructive). ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)