### PR TITLE
docs(release-notes): note clear-selection button in 1.6.0

### DIFF
--- a/docs/release-notes/v1.6.0.md
+++ b/docs/release-notes/v1.6.0.md
@@ -37,6 +37,8 @@ batch of inspector and rendering improvements.
   across every layout.
 - **Half-screen expand** for the object list, a dynamic state slider, and a
   shared selection-mode menu.
+- **Clear-selection button** sits next to the Residues toggle to wipe the
+  active selection in one tap.
 
 ### Rendering
 - **Real-time ray tracing restored,** with quality controls — hardware-accelerated


### PR DESCRIPTION
Re-cutting the (never-published) 1.6.0 release at the current master tip so it includes work that landed after the original tag — notably the clear-selection button (#134) plus macOS build-portability and an OpenGL-macro fix.

This PR only updates `docs/release-notes/v1.6.0.md` to mention the clear-selection button. After merge, the `v1.6.0` tag will be moved to this tip and the notarized DMG + appcast published (the live feed currently still serves 1.5.2 — 1.6.0 has shipped to no one yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)