### PR TITLE
Address remaining MacPorts review feedback from #125

### DIFF
--- a/appkit/CMakeLists.txt
+++ b/appkit/CMakeLists.txt
@@ -293,10 +293,10 @@ if(GLM_INCLUDE)
 endif()
 
 if(PYMOL_LIBXML AND NOT PYMOL_IOS)
-    find_library(XML2_LIB xml2 HINTS /opt/homebrew/lib)
+    find_library(XML2_LIB xml2 HINTS /opt/homebrew/lib ${PYMOL_EXTERNAL_PREFIX}/lib)
     find_path(XML2_INCLUDE libxml/parser.h
         PATH_SUFFIXES libxml2
-        HINTS /opt/homebrew/include)
+        HINTS /opt/homebrew/include ${PYMOL_EXTERNAL_PREFIX}/include)
     if(XML2_LIB AND XML2_INCLUDE)
         target_compile_definitions(pymol_core PRIVATE _HAVE_LIBXML)
         target_include_directories(pymol_core PRIVATE ${XML2_INCLUDE})

--- a/appkit/CMakeLists.txt
+++ b/appkit/CMakeLists.txt
@@ -113,7 +113,7 @@ file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/generated)
 
 # For iOS / metal-only, find the host Python to run the shader generator
 if(PYMOL_IOS OR PYMOL_METAL_ONLY)
-    find_program(HOST_PYTHON python3 HINTS /opt/homebrew/bin /usr/bin)
+    find_program(HOST_PYTHON python3 HINTS /opt/homebrew/bin ${PYMOL_EXTERNAL_PREFIX}/bin /usr/bin)
 else()
     set(HOST_PYTHON ${Python3_EXECUTABLE})
 endif()

--- a/appkit/CMakeLists.txt
+++ b/appkit/CMakeLists.txt
@@ -262,7 +262,8 @@ target_compile_options(pymol_core PRIVATE ${PYMOL_COMPILE_FLAGS})
 option(PYMOL_OPENMP "Parallelize surface sampling with OpenMP" ON)
 if(PYMOL_OPENMP AND NOT PYMOL_IOS)
     find_path(LIBOMP_INCLUDE omp.h
-        HINTS /opt/homebrew/opt/libomp/include /usr/local/opt/libomp/include)
+        HINTS /opt/homebrew/opt/libomp/include /usr/local/opt/libomp/include
+              ${PYMOL_EXTERNAL_PREFIX}/include/libomp ${PYMOL_EXTERNAL_PREFIX}/opt/libomp/include)
     if(LIBOMP_INCLUDE)
         target_compile_definitions(pymol_core PRIVATE PYMOL_OPENMP)
         target_compile_options(pymol_core PRIVATE -Xpreprocessor -fopenmp)

--- a/swiftui/PyMOLBridge.xcconfig
+++ b/swiftui/PyMOLBridge.xcconfig
@@ -11,6 +11,14 @@ PYMOL_ROOT = $(SRCROOT)/..
 // in) next to this file with e.g.:
 //   PYMOL_EXTERNAL_PREFIX = /opt/local
 //   PYMOL_LIBOMP_STATIC = /opt/local/lib/libomp/libomp.a
+//
+// PYMOL_LIBOMP_STATIC does NOT derive correctly from PYMOL_EXTERNAL_PREFIX
+// alone — Homebrew's keg layout ships a static libomp.a under opt/libomp/lib,
+// while MacPorts ships only a dynamic libomp.dylib under lib/libomp, a
+// structurally different layout, not just a different prefix. Anyone setting
+// PYMOL_EXTERNAL_PREFIX to a non-Homebrew prefix MUST also override
+// PYMOL_LIBOMP_STATIC explicitly (it can hold a full "-L... -lomp" flag pair
+// instead of a bare path, e.g. "-L/opt/local/lib/libomp -lomp").
 PYMOL_EXTERNAL_PREFIX = /opt/homebrew
 PYMOL_LIBOMP_STATIC = $(PYMOL_EXTERNAL_PREFIX)/opt/libomp/lib/libomp.a
 #include? "PyMOLBridge.local.xcconfig"

--- a/swiftui/README.md
+++ b/swiftui/README.md
@@ -1,0 +1,118 @@
+# RayMol native macOS/iOS app
+
+This directory holds the native SwiftUI/Metal app (`PyMOLViewer.xcodeproj`) — a
+separate build from the classic `pip install .` PyMOL Python package described
+in the top-level `CLAUDE.md`. It embeds a standalone Python and a Metal-only
+build of the PyMOL C++ core (`libpymol_core.a`) directly into a native app
+bundle, rather than building a `_cmd` Python extension module.
+
+There is currently no CI coverage for this build — it's local-only, built and
+tested by hand.
+
+## Building for macOS
+
+1. **Install build-time dependencies.** These are headers/libraries needed
+   only to compile `libpymol_core.a` and link the app — Python itself is
+   vendored separately (next step), and OpenGL/GLEW/GLUT are never used (the
+   app is Metal-only; see [Package-manager portability](#package-manager-portability)
+   below for why that matters more than it sounds).
+
+   Homebrew:
+   ```bash
+   brew install glm libpng freetype libomp
+   ```
+   MacPorts:
+   ```bash
+   sudo port install glm libpng freetype libomp
+   ```
+
+2. **Fetch the embedded Python.** One-time; re-run to refresh.
+   ```bash
+   scripts/fetch_macos_python.sh
+   ```
+   Downloads a `python-build-standalone` CPython 3.13 release into the
+   gitignored `deps_macos/python-standalone/python`.
+
+3. **Build the C++ core.**
+   ```bash
+   swiftui/build_macos.sh
+   ```
+   CMake-configures and builds `build_macos_swiftui/libpymol_core.a` — a
+   Metal-only, `_PYMOL_NO_OPENGL` static library. MacPorts users: see below,
+   you'll need an env var here too.
+
+4. **Build the app in Xcode**, or via the command line:
+   ```bash
+   cd swiftui
+   xcodebuild -project PyMOLViewer.xcodeproj -scheme PyMOLViewer_macOS \
+       -configuration Debug -destination 'platform=macOS' build
+   ```
+
+## Package-manager portability
+
+`swiftui/PyMOLBridge.xcconfig` (the Xcode-side build settings) and
+`appkit/CMakeLists.txt` (the CMake core build) both default to Homebrew's
+`/opt/homebrew` prefix for headers/libraries that aren't vendored in
+`deps_macos/` — glm, libpng, freetype, libomp. This is controlled by a single
+override point, `PYMOL_EXTERNAL_PREFIX`, rather than being hardcoded.
+
+**If you're on Homebrew, you don't need to do anything** — the defaults
+already point at `/opt/homebrew`.
+
+**If you're on MacPorts** (or any other non-Homebrew prefix), two things need
+the override, because Xcode and CMake read config independently:
+
+1. For the CMake core build, set the env var when running `build_macos.sh`:
+   ```bash
+   PYMOL_EXTERNAL_PREFIX=/opt/local swiftui/build_macos.sh
+   ```
+2. For the Xcode app build, create a gitignored local override —
+   `swiftui/PyMOLBridge.local.xcconfig` — since Xcode reads its own config
+   independently of the shell env var above:
+   ```
+   PYMOL_EXTERNAL_PREFIX = /opt/local
+   PYMOL_LIBOMP_STATIC = -L/opt/local/lib/libomp -lomp
+   ```
+
+That second line is the one non-obvious part, worth explaining rather than
+just asserting: `PYMOL_LIBOMP_STATIC` can't be derived from
+`PYMOL_EXTERNAL_PREFIX` alone, because Homebrew and MacPorts don't just put
+`libomp` in different *locations* — they ship structurally different
+*artifacts*. Homebrew ships a static `libomp.a` under a keg-style
+`opt/libomp/lib`; MacPorts ships only a dynamic `libomp.dylib` under
+`lib/libomp`, no static archive at all. There's no single path formula that
+produces both shapes, so this has to be a full linker-flag override
+(`-L<dir> -lomp`) rather than a bare path substitution. If you're on a
+prefix that *does* ship a static `libomp.a` in a Homebrew-shaped layout, a
+bare path like `/your/prefix/opt/libomp/lib/libomp.a` works fine too — the
+variable accepts either form.
+
+One more MacPorts-specific gotcha, unrelated to `PYMOL_EXTERNAL_PREFIX`:
+`appkit/CMakeLists.txt` also locates a host Python3 interpreter to run the
+shader-text generator at configure time. MacPorts installs versioned binaries
+(`python3.13`, `python3.14`) with no generic `python3` in `/opt/local/bin`
+unless you've run:
+```bash
+sudo port select --set python3 python313
+```
+Without that, CMake still finds a working `python3` by falling back to
+`/usr/bin/python3` (Xcode Command Line Tools), so this isn't a hard
+requirement — just worth knowing if you want the MacPorts interpreter used
+instead of the system one.
+
+Why GLEW/GLUT don't factor into any of this: `PyMOLBridge.xcconfig` defines
+`_PYMOL_NO_OPENGL` for the macOS SDK (matching what the CMake core build
+already does for this target), which compiles out the real-OpenGL branch of
+`layer0/os_gl.h` — including its `GL/glew.h`/`GL/glut.h` includes — entirely.
+Earlier revisions of this build lacked that macro on the Xcode side, which
+silently pulled in the real-GL code path instead and required GLEW/GLUT to
+even compile (invisibly papered over on Homebrew machines that happened to
+have those headers installed already). They're not build-time dependencies
+of this app.
+
+## iOS
+
+Blocked on `deps_ios/` (a BeeWare-built `Python.xcframework` plus
+cross-compiled freetype/libpng for device and simulator) — there's currently
+no script or documented process to populate it. See issue #123 for status
+before attempting an iOS build.


### PR DESCRIPTION
## Summary

#125 merged before these commits were pushed — it landed the OpenMP macro fix and the initial `PYMOL_EXTERNAL_PREFIX` introduction, but not the fixes for the two OpenMP gaps you flagged in that review (https://github.com/javierbq/RayMol/pull/125#pullrequestreview-4651347843), or a third instance of the same bug pattern found afterward, or the build documentation. This PR is exactly those four commits, based on current master.

- **Complete OpenMP discovery and linking for non-Homebrew prefixes** — `appkit/CMakeLists.txt`'s `omp.h` HINTS now include `${PYMOL_EXTERNAL_PREFIX}/include/libomp`; `PyMOLBridge.xcconfig`'s comment now explicitly says `PYMOL_LIBOMP_STATIC` can't be derived from the prefix alone (Homebrew ships a static `.a`, MacPorts only a dynamic `.dylib`, structurally different layouts) and must be overridden separately.
- **Parameterize libxml2 discovery HINTS** — same bug pattern, found while auditing the rest of the build system; currently dormant since `build_macos.sh` passes `-DPYMOL_LIBXML=OFF`, but the branch isn't gated on `PYMOL_METAL_ONLY` so it does apply to this target if ever turned on.
- **Parameterize `HOST_PYTHON` discovery** — same pattern again, reachable by this build path; confirmed with `port select --set python3 python313` that it now resolves to the MacPorts interpreter instead of silently falling back to `/usr/bin/python3`.
- **Add `swiftui/README.md`** — no documentation existed anywhere for this build (`CLAUDE.md` only covers the classic `pip install .` package). Covers the full flow end-to-end plus the MacPorts-specific overrides, including *why* each one is shaped the way it is, not just the values.

Also filed while auditing the rest of the build system for the same pattern:
- #135 (`build.sh`'s divergent `HOMEBREW_PREFIX` naming + a "keep in sync" comment — explicitly optional/non-blocking per your original review)
- #140 (the identical OpenMP-Homebrew-only bug in `setup.py`'s `pip install .` path — a different build system, deserves its own PR)

## Test plan
- [x] Rebuilt `libpymol_core.a` via `PYMOL_EXTERNAL_PREFIX=/opt/local swiftui/build_macos.sh` — confirmed `-- PyMOL OpenMP enabled (libomp headers: /opt/local/include/libomp)`.
- [x] Full `xcodebuild` of `PyMOLViewer_macOS` succeeded; confirmed `libomp.dylib` is bundled and linked (`otool -L`).
- [x] Configure-only test with `-DPYMOL_LIBXML=ON -DPYMOL_EXTERNAL_PREFIX=/opt/local` — `XML2_LIB`/`XML2_INCLUDE` both resolve to the MacPorts install.
- [x] Confirmed via `port select` that `HOST_PYTHON` resolves to the MacPorts interpreter when one is selected.
- [x] Re-verified GLEW/GLUT are not actual build dependencies of this target (only ever pulled in by the OpenGL macro mismatch #125 already fixed) before documenting that in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)