### PR TITLE
fix: silence benign MCP ConnectionResetError traceback (#145)

### DIFF
--- a/modules/raymol_mcp/server.py
+++ b/modules/raymol_mcp/server.py
@@ -140,6 +140,14 @@ class _Handler(BaseHTTPRequestHandler):
     def log_message(self, *a):
         pass  # silence default stderr logging
 
+    def handle_one_request(self):
+        # A client hanging up mid-request (peer reset / broken pipe) is a benign,
+        # expected condition; swallow it quietly instead of dumping a traceback.
+        try:
+            super().handle_one_request()
+        except (ConnectionResetError, BrokenPipeError):
+            self.close_connection = True
+
     def _authed(self):
         return self.headers.get("Authorization", "") == "Bearer %s" % _token
 


### PR DESCRIPTION
## What
Override `handle_one_request` in the RayMol MCP server's request handler (`modules/raymol_mcp/server.py`) to quietly swallow `ConnectionResetError`/`BrokenPipeError` when a client disconnects mid-request, setting `close_connection = True` so the connection is torn down cleanly.

## Why
When a client hangs up mid-request, the bundled `http.server` reads on a dead socket and raises `ConnectionResetError: [Errno 54]`. That propagates to `socketserver`'s default `handle_error`, which dumps a full traceback to the terminal. This is a benign, expected condition; catching it in `handle_one_request` prevents the traceback without suppressing any unrelated errors.

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)