### PR TITLE
fix: show disabled-Play tooltip while Movie panel is open (#144)

### DIFF
--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -1884,9 +1884,17 @@ private struct ObjectCard: View {
                 }
                 .buttonStyle(.plain)
                 .disabled(engine.timelineMode)   // authoring a movie → model playback off
-                .help(engine.timelineMode
-                      ? "Model playback is off while the movie timeline is open — close it to inspect models"
-                      : (engine.playingObjects.contains(entry.name) ? "Pause" : "Play models"))
+                // A disabled Button swallows its own hover events, so `.help()` on
+                // it never fires. Wrap it so the tooltip lives on a non-disabled
+                // container that still receives hover while playback is off.
+                .allowsHitTesting(!engine.timelineMode)
+                .overlay {
+                    if engine.timelineMode {
+                        Color.clear.contentShape(Rectangle())
+                            .help("Model playback is off while the movie timeline is open — close it to inspect models")
+                    }
+                }
+                .help(engine.playingObjects.contains(entry.name) ? "Pause" : "Play models")
                 Spacer(minLength: 0)
                 Menu {
                     ForEach([1.0, 5.0, 10.0, 15.0, 30.0], id: \.self) { f in


### PR DESCRIPTION
## What
The per-object **Play** (model/state playback) control in the object inspector is disabled while the movie timeline is open. A `.help()` tooltip explaining why already existed, but it never appeared: a disabled SwiftUI `Button` swallows its own hover events, so `.help()` on the disabled button never fires.

## Why / fix
Route hit-testing away from the disabled button (`allowsHitTesting(false)` while `engine.timelineMode`) onto a transparent `Color.clear` overlay that carries the tooltip. Now hovering the grayed-out Play button shows:

> Model playback is off while the movie timeline is open — close it to inspect models

When the timeline is not open, the button stays fully interactive with its normal Pause / "Play models" tooltip.

## Verification
Needs visual verification — hover the disabled Play button in the object inspector with the Movie/Timeline panel open and confirm the tooltip appears.

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)