### PR TITLE
fix: horizontal-scroll affordance for timeline track, scenes palette & viewport chip row (#131)

### DIFF
--- a/swiftui/PyMOLViewer/Panels/TimelinePanel.swift
+++ b/swiftui/PyMOLViewer/Panels/TimelinePanel.swift
@@ -109,19 +109,26 @@ struct TimelinePanel: View {
         }
     }
 
-    // A slim gradient hugging the trailing edge of a horizontal scroll region to
-    // signal off-screen content — the resting cue that a row is scrollable, since
-    // the native macOS scrollbar only appears mid-scroll (issue #131). Purely
-    // decorative: never hit-tests, so it can't eat scroll/scrub gestures.
-    @ViewBuilder
-    private func trailingScrollFade() -> some View {
-        // Fade to the panel background so content appears to slide UNDER the
-        // chrome edge — theme-adaptive (reads correctly on light + dark), unlike
-        // a fixed black shadow which looks harsh on a light palette (#133).
-        LinearGradient(colors: [TimelineTheme.bar.opacity(0), TimelineTheme.bar],
-                       startPoint: .leading, endPoint: .trailing)
-            .frame(width: 24)
-            .allowsHitTesting(false)
+    // Symmetric edge-fade for a horizontal scroll region, applied as a `.mask`
+    // (matches the floating scene-chip row in ContentView, issue #131). Unlike the
+    // opaque trailing overlay above, a mask dissolves the CONTENT to true
+    // transparency, so it reads correctly over the timeline's translucent chrome
+    // regardless of the backing color AND cues the leading edge once the row has
+    // been scrolled off its start. Pass `active` false when the row fits, so a
+    // non-overflowing row is never clipped. The gradient runs leading→trailing;
+    // masks don't hit-test, so scroll/scrub gestures are untouched.
+    private func scrollFadeMask(_ active: Bool) -> LinearGradient {
+        LinearGradient(
+            stops: active
+                ? [
+                    .init(color: .clear, location: 0),
+                    .init(color: .black, location: 0.05),
+                    .init(color: .black, location: 0.95),
+                    .init(color: .clear, location: 1),
+                  ]
+                // Fully opaque (no fade) so a row that fits isn't clipped.
+                : [.init(color: .black, location: 0), .init(color: .black, location: 1)],
+            startPoint: .leading, endPoint: .trailing)
     }
 
     var body: some View {
@@ -351,11 +358,10 @@ struct TimelinePanel: View {
                     // otherwise vertically greedy and would absorb the panel's slack,
                     // opening gaps above the ruler / below the lane.
                     .frame(height: rulerH + laneH)
-                    // Trailing fade when the lane is longer than the viewport, so
-                    // it's obvious the track scrolls horizontally (issue #131).
-                    .overlay(alignment: .trailing) {
-                        if cW > w + 1 { trailingScrollFade() }
-                    }
+                    // Symmetric edge-fade when the lane is longer than the viewport,
+                    // so it's obvious the track scrolls horizontally (issue #131) —
+                    // trailing at rest, leading too once scrolled off the start.
+                    .mask(scrollFadeMask(cW > w + 1))
                     // Follow the playhead during playback (don't fight manual scroll).
                     .onChange(of: playback.currentFrame) { _ in
                         if playback.isPlaying {
@@ -689,14 +695,13 @@ struct TimelinePanel: View {
                         Color.clear.preference(key: PaletteContentWKey.self, value: c.size.width)
                     })
                 }
-                // Trailing fade when the chips overflow the row, so it's obvious
-                // the scenes palette scrolls horizontally (issue #131).
+                // Symmetric edge-fade when the chips overflow the row, so it's
+                // obvious the scenes palette scrolls horizontally (issue #131) —
+                // mirrors the floating scene-chip row's mask in ContentView.
                 .background(GeometryReader { v in
                     Color.clear.preference(key: PaletteViewportWKey.self, value: v.size.width)
                 })
-                .overlay(alignment: .trailing) {
-                    if paletteContentW > paletteViewportW + 1 { trailingScrollFade() }
-                }
+                .mask(scrollFadeMask(paletteContentW > paletteViewportW + 1))
                 .onPreferenceChange(PaletteContentWKey.self) { paletteContentW = $0 }
                 .onPreferenceChange(PaletteViewportWKey.self) { paletteViewportW = $0 }
             }

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -700,6 +700,21 @@ struct ContentView: View {
             ScrollViewReader { proxy in
                 ScrollView(.horizontal, showsIndicators: false) { sceneOverlayRow }
                     .frame(width: 230)
+                    // Fade both edges so a half-chip dissolves under the pill's
+                    // rim — the resting cue that this row scrolls, since the
+                    // native scrollbar only shows mid-scroll (issue #131). A
+                    // symmetric mask reads correctly over the translucent
+                    // material regardless of the backing color.
+                    .mask(
+                        LinearGradient(
+                            stops: [
+                                .init(color: .clear, location: 0),
+                                .init(color: .black, location: 0.06),
+                                .init(color: .black, location: 0.94),
+                                .init(color: .clear, location: 1),
+                            ],
+                            startPoint: .leading, endPoint: .trailing)
+                    )
                     .onAppear { proxy.scrollTo(engine.currentScene, anchor: .center) }
                     .onChange(of: engine.currentScene) { s in
                         withAnimation(.easeInOut(duration: 0.2)) { proxy.scrollTo(s, anchor: .center) }


### PR DESCRIPTION
## What
Adds a symmetric edge-fade affordance to every horizontally-scrolling row named in issue #131, so each reads as scrollable at rest:

1. **Docked timeline track** (camera keyframes / scene lane, `TimelinePanel.swift`)
2. **Scenes palette** (the `001`–`006` … chip row, `TimelinePanel.swift`)
3. **Floating in-viewport scene chip row** (the `sceneButtonsOverlay` pill, `ContentView.swift`)

All three use the same technique: a `LinearGradient` applied as a `.mask` that dissolves the content to true transparency at the leading and trailing edges.

## Why
These rows scroll horizontally once their content overflows, but there was no resting cue — the native macOS scrollbar only appears mid-scroll, so users didn't realize more content existed off-screen (issue #131). The mask dissolves a half-chip/half-lane under each edge, the standard "scroll for more" signal, and now also cues the leading edge once a row is scrolled off its start.

A **mask** (rather than an opaque gradient fading to a solid backing color) is used because both the floating pill and the docked timeline chrome are translucent (`.ultraThinMaterial` / `panelBackground.opacity(0.96)`), where no fixed backing color would read correctly. In `TimelinePanel.swift` this replaces the earlier trailing-only opaque overlay (`trailingScrollFade()`), which faded only the trailing edge and depended on the backing color matching.

The fade is gated on the existing overflow checks (`cW > w + 1` for the track; `paletteContentW > paletteViewportW + 1` for the palette; the `ViewThatFits` scrolling branch for the viewport pill), so a row that already fits is never clipped. Masks don't hit-test, so scroll/scrub gestures are untouched.

## Verification
Layout/visual change — needs to be seen in the running macOS app (VM visual verification) to confirm the fades render correctly over the translucent material, cue both edges as expected, and don't clip selected chips or the timeline scrollbar oddly.

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)