### PR TITLE
fix: add 'to molecule'/'to selection' Align submenu entries (#147)

### DIFF
--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -428,6 +428,12 @@ private indirect enum ActionMenuItem {
     case action(label: String, key: String)
     case separator
     case submenu(label: String, children: [ActionMenuItem])
+    // Dynamic submenus whose children are the currently-loaded molecule
+    // objects / public selections (built at render time from engine.objects),
+    // mirroring desktop PyMOL's "to molecule (*/CA)" / "to selection (*/CA)"
+    // align entries.
+    case alignToMolecule(label: String)
+    case alignToSelection(label: String)
 }
 
 private let actionMenuItems: [ActionMenuItem] = [
@@ -473,6 +479,9 @@ private let actionMenuItems: [ActionMenuItem] = [
         .action(label: "pi-cation",                 key: "find_pi_cation"),
     ]),
     .submenu(label: "Align", children: [
+        .alignToMolecule(label: "to molecule (*/CA)"),
+        .alignToSelection(label: "to selection (*/CA)"),
+        .separator,
         .action(label: "enabled to this (*/CA)",  key: "align_enabled"),
         .action(label: "all to this (*/CA)",      key: "align_all"),
         .separator,
@@ -1106,8 +1115,48 @@ private func actionMenuContent(_ items: [ActionMenuItem], name: String, engine: 
             Menu(label) {
                 AnyView(actionMenuContent(children, name: name, engine: engine))  // AnyView breaks recursive opaque-type inference
             }
+        case .alignToMolecule(let label):
+            // Candidate targets: every OTHER loaded molecule object (mirrors
+            // desktop PyMOL's align_to_object). Empty when nothing else is loaded.
+            Menu(label) {
+                let targets = engine.objects.filter { !$0.isSelection && $0.name != name }
+                if targets.isEmpty {
+                    Button("(no other molecules)") {}.disabled(true)
+                } else {
+                    ForEach(targets) { target in
+                        Button(target.name) {
+                            runAlignCommand(mobile: name, target: target.name, engine: engine)
+                        }
+                    }
+                }
+            }
+        case .alignToSelection(let label):
+            // Candidate targets: every public selection (mirrors desktop PyMOL's
+            // align_to_sele). Empty when no selections exist.
+            Menu(label) {
+                let targets = engine.objects.filter { $0.isSelection && $0.name != name }
+                if targets.isEmpty {
+                    Button("(no selections)") {}.disabled(true)
+                } else {
+                    ForEach(targets) { target in
+                        Button(target.name) {
+                            runAlignCommand(mobile: name, target: target.name, engine: engine)
+                        }
+                    }
+                }
+            }
         }
     }
+}
+
+/// Align one object onto a target molecule/selection over polymer CA atoms,
+/// creating an alignment object (mirrors desktop PyMOL's align_to_object /
+/// align_to_sele in modules/pymol/menu.py).
+private func runAlignCommand(mobile: String, target: String, engine: PyMOLEngine) {
+    let cmd = "python\ncmd.align(\"polymer and name CA and (\(mobile))\", "
+        + "\"polymer and name CA and (\(target))\", quiet=0, "
+        + "object=\"aln_\(mobile)_to_\(target)\", reset=1)\npython end"
+    engine.runCommand(cmd)
 }
 
 private struct ActionMenuButton: View {


### PR DESCRIPTION
## What
Adds the two missing primary entries to the object context-menu **Align** submenu, restoring parity with desktop PyMOL:

- **to molecule (*/CA)** — dynamic submenu listing every other loaded molecule object
- **to selection (*/CA)** — dynamic submenu listing every public selection

They appear at the top of the Align submenu (above "enabled to this" / "all to this"), matching desktop PyMOL's layout.

## Why
Legacy PyMOL's `sele_align` menu (`modules/pymol/menu.py`) exposes `to molecule` / `to selection` as the primary align actions — align this object onto another molecule or onto the current selection. RayMol's SwiftUI Align submenu only had the `mass_align` ("enabled/all to this") and `intra_fit` entries.

## How
- New `ActionMenuItem` cases `alignToMolecule` / `alignToSelection` that build their children at render time from `engine.objects` (filtered by `isSelection`), skipping the object itself.
- Each candidate runs `cmd.align("polymer and name CA and (<mobile>)", "polymer and name CA and (<target>)", quiet=0, object="aln_<mobile>_to_<target>", reset=1)`, identical to `align_to_object` / `align_to_sele` in `menu.py`.
- Empty states show a disabled placeholder ("(no other molecules)" / "(no selections)").

## Verification
Code-reading only (no build per task constraints). Menu is dynamic/interactive, so it should be visually confirmed in a build: open a session with 2+ molecules (and a selection), right-click an object → Align → verify the two new submenus populate and aligning works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)