### PR TITLE
fix: remove Movie transport ⋯ overflow; Export to top bar, frame rate inline (#142)

### DIFF
--- a/swiftui/PyMOLViewer/Panels/TimelinePanel.swift
+++ b/swiftui/PyMOLViewer/Panels/TimelinePanel.swift
@@ -42,6 +42,9 @@ struct TimelinePanel: View {
     var forceCompact: Bool = false
 
     @State private var showClearConfirm = false
+    // Export the authored movie — lives on the top bar (right of the trashcan) so
+    // it's always visible in both the docked and expanded panel (issue #142).
+    @State private var showExport = false
 
     // Horizontal zoom: pixels-per-second = (viewportWidth / 10) * zoom, so zoom
     // 1 fits ~10 s across the lane. +/- steps; the lane scrolls when the movie is
@@ -146,6 +149,7 @@ struct TimelinePanel: View {
         }
         .background(TimelineTheme.bar)
         .sheet(isPresented: $showStatesSheet) { statesConfigSheet }
+        .sheet(isPresented: $showExport) { MovieExportSheet() }
         .onAppear {
             // Test affordance: auto-open the "Play models" modal so it can be
             // screenshotted on the sim (simctl can't tap). PYMOL_AUTOSTATESHEET=1.
@@ -195,6 +199,7 @@ struct TimelinePanel: View {
             addCameraButton
             zoomControl
             trashButton
+            exportButton
             if onExpand != nil { expandButton }
             if showsDone { doneButton }
         }
@@ -260,6 +265,23 @@ struct TimelinePanel: View {
         .disabled(engine.timelineItems.isEmpty)
         .help("Clear the timeline")
         .accessibilityLabel("Clear timeline")
+    }
+
+    // Export the authored movie to a file (MP4 / GIF). Pinned to the top bar,
+    // immediately right of the trashcan, so it's always visible in both the
+    // docked and expanded panel (issue #142). Disabled on an empty timeline.
+    private var exportButton: some View {
+        Button { showExport = true } label: {
+            Image(systemName: "square.and.arrow.up")
+                .font(.system(size: 15))
+                .frame(width: 30, height: 32)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .foregroundColor(engine.timelineItems.isEmpty ? TimelineTheme.dim : TimelineTheme.text)
+        .disabled(engine.timelineItems.isEmpty)
+        .help("Export the movie to a file")
+        .accessibilityLabel("Export movie")
     }
 
     // Open / collapse the full-width bottom dock (compact right-panel view only).

--- a/swiftui/PyMOLViewer/Panels/TransportBar.swift
+++ b/swiftui/PyMOLViewer/Panels/TransportBar.swift
@@ -115,7 +115,14 @@ struct TransportBar: View {
             if !inTimeline { scrubber }
             counter
             loopButton
-            overflowMenu
+            // In a timeline the frame rate lives inline on the transport row and
+            // Export moved to the panel's top bar, so the ⋯ overflow menu is gone
+            // (issue #142). The standalone (iPad floating) transport keeps it.
+            if inTimeline {
+                fpsMenu
+            } else {
+                overflowMenu
+            }
         }
         .padding(.horizontal, 12)
         .frame(height: 40)
@@ -253,17 +260,28 @@ struct TransportBar: View {
         .help(playback.movieLoop ? "Looping on — tap to turn off" : "Loop the movie")
     }
 
+    // Shared frame-rate picker + the "Show frame rate" HUD toggle. Folded into
+    // every fps control so both actions stay reachable now that the ⋯ overflow
+    // menu is gone (issue #142).
+    @ViewBuilder private var fpsMenuContent: some View {
+        Picker("Frame rate", selection: Binding(
+            get: { playback.movieFPS },
+            set: { engine.setMovieFPS($0) })) {
+            Text("30 fps").tag(30.0)
+            Text("15 fps").tag(15.0)
+            Text("5 fps").tag(5.0)
+            Text("1 fps").tag(1.0)
+            Text("0.3 fps").tag(0.3)
+        }
+        Divider()
+        Button { engine.setShowFrameRate(true) } label: {
+            Label("Show frame rate", systemImage: "speedometer")
+        }
+    }
+
     private var fpsMenu: some View {
         Menu {
-            Picker("Frame rate", selection: Binding(
-                get: { playback.movieFPS },
-                set: { engine.setMovieFPS($0) })) {
-                Text("30 fps").tag(30.0)
-                Text("15 fps").tag(15.0)
-                Text("5 fps").tag(5.0)
-                Text("1 fps").tag(1.0)
-                Text("0.3 fps").tag(0.3)
-            }
+            fpsMenuContent
         } label: {
             Label("\(fpsLabel) fps", systemImage: "gauge.with.dots.needle.67percent")
                 .font(.system(size: 12))
@@ -275,15 +293,7 @@ struct TransportBar: View {
     // Slim fps control for the packed timeline row (no gauge icon, "30fps").
     private var fpsMenuTight: some View {
         Menu {
-            Picker("Frame rate", selection: Binding(
-                get: { playback.movieFPS },
-                set: { engine.setMovieFPS($0) })) {
-                Text("30 fps").tag(30.0)
-                Text("15 fps").tag(15.0)
-                Text("5 fps").tag(5.0)
-                Text("1 fps").tag(1.0)
-                Text("0.3 fps").tag(0.3)
-            }
+            fpsMenuContent
         } label: {
             Text(fpsTightLabel)
                 .font(.system(size: 12, weight: .medium))


### PR DESCRIPTION
Closes #142

## What
- **Removed** the `⋯` overflow menu from the Movie/Timeline transport row.
- **Export Movie** now lives on the **TimelinePanel top bar, immediately right of the trashcan** (🗑). Because both the docked (`forceCompact`) and expanded panel share the same header, Export is always visible in both states.
- **Frame rate** now sits **inline on the transport controls row**: the wide `regularRow` (expanded macOS/iPad timeline) shows `fpsMenu`; the packed compact timeline row already carried `fpsMenuTight`.
- **Show frame rate** is folded into a shared `fpsMenuContent`, so it stays reachable from the inline frame-rate control now that the overflow is gone. *Make Movie* authoring remains available via the TimelinePanel composer (Append) and the existing Movie builder entry points.

## Why
The transport row hid Frame rate / Show frame rate / Make Movie / Export behind a `⋯` popover. This surfaces the important actions directly and pins Export where it's always visible.

## Scope
Only the **in-timeline** transport row changes. The standalone iPad floating transport (`inTimeline == false`) keeps its overflow menu unchanged.

## Verification
Change is layout/interaction only and was verified by code reading; it should be visually confirmed in a build (both docked and expanded Movie panel, macOS + iPad).

🤖 Generated with [Claude Code](https://claude.com/claude-code)