### PR TITLE
fix: remove empty toolbar button left of Movie timeline (#146)

### DIFF
--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -477,10 +477,10 @@ struct ContentView: View {
         .toolbar {
             // Leading — tools (mirrors the iOS top-left): Open · Measure.
             macOpenToolbar
-            macMovieToolbar
             macMeasureToolbar
             // Trailing — view toggles, then actions, then status. (Theme moved into
             // the Display segment, mirroring iOS Settings → Themes.)
+            macMovieToolbar
             panelToggles
             exportMenu
             #if !RAYMOL_MAS_RESTRICTED
@@ -2415,7 +2415,7 @@ struct ContentView: View {
     // works from a cold start (no movie yet), unlike the transport, which is
     // gated behind hasTimeline. The ⌥⌘M shortcut lives on the Movie menu command.
     private var macMovieToolbar: some ToolbarContent {
-        ToolbarItem {
+        ToolbarItem(placement: .primaryAction) {
             Button {
                 withAnimation(.easeInOut(duration: 0.2)) { engine.timelineMode.toggle() }
             } label: {


### PR DESCRIPTION
Closes #146

### What
The macOS top toolbar showed an empty/blank circular button immediately to the left of the Movie timeline (⌥⌘M) control.

### Why
In the single macOS `.toolbar { … }` (ContentView.swift), `macMovieToolbar` was declared with a default (`.automatic`) placement while sitting **between** the two `.navigation`-placed leading tools (`macOpenToolbar`, `macMeasureToolbar`). Mixing a default-placement item among `.navigation` items makes AppKit reserve an extra, empty toolbar slot at the leading/trailing boundary — the reported phantom button. There was no literally-empty `ToolbarItem` in source; it was a placement artifact.

### Fix
- Moved `macMovieToolbar` out of the leading block into the trailing cluster (right where the trailing items begin).
- Gave it an explicit `.primaryAction` placement, matching its trailing siblings (`exportMenu`, etc.).

The leading group is now purely `.navigation` (Open · Measure); the trailing cluster starts cleanly at the Movie timeline control. The clapperboard timeline toggle behaves exactly as before — no action lost.

### Verification
Code-reading only (no build in this step). This is a layout/placement change to a native macOS `SwiftUI` toolbar, so it should be visually confirmed in a build that the phantom slot is gone and the timeline toggle still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)