### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @javierbq


### PR DESCRIPTION
## Summary
- Adds .github/CODEOWNERS naming @javierbq as owner of all paths.
- Enables branch protection to require code-owner approval on master, so any future collaborator's PR needs your sign-off before merging (self-approval on your own PRs still counts, so solo merges keep working).

## Test plan
- [ ] Merge this PR
- [ ] Update branch protection on master: require 1 approving review + code-owner review