### PR TITLE
fix(movie-export): rebuild reps on-main before off-main render (no SIGSEGV)

### DIFF
--- a/swiftui/PyMOLViewer/Bridge/PyMOLBridge.h
+++ b/swiftui/PyMOLViewer/Bridge/PyMOLBridge.h
@@ -40,6 +40,10 @@ void PyMOLBridge_CapturePNG(PyMOLHandle instance, const char* path);
 // (WYSIWYG); 0 = force OFF; 1 = force ON for this export only (the live setting
 // is saved and restored, so the on-screen view is unchanged).
 void PyMOLBridge_RenderHiResPNG(PyMOLHandle instance, const char* path, int width, int height, int rayTraced);
+// Rebuild dirty object representations on the calling thread. Call on the MAIN
+// thread before an off-main renderHiResPNG so the rep rebuild (which touches the
+// Python C-API via the busy-status callback) doesn't run on the render queue.
+void PyMOLBridge_UpdateScene(PyMOLHandle instance);
 // Hardware ray-tracing capability of the active GPU. 1 = supported,
 // 0 = not supported, -1 = unknown (renderer not yet created). Lets the UI
 // gate the metal_raytrace toggle so it isn't offered where it does nothing.

--- a/swiftui/PyMOLViewer/Bridge/PyMOLBridge.mm
+++ b/swiftui/PyMOLViewer/Bridge/PyMOLBridge.mm
@@ -34,6 +34,7 @@ extern "C" {
 // OUTSIDE the extern "C" block below so the call resolves to the core's
 // C++ (mangled) symbol, not a C one.
 void SceneRenderMetal(PyMOLGlobals *G);
+void SceneUpdate(PyMOLGlobals *G, int force);   // layer1/Scene.cpp
 extern void ImmBatch_SetActiveRenderer(pymol::Renderer *r);
 
 // All PyMOLBridge_* entry points MUST have C linkage to match the Swift
@@ -541,6 +542,23 @@ void PyMOLBridge_RenderHiResPNG(PyMOLHandle h, const char* path,
     G->Option->winX = savedW;
     G->Option->winY = savedH;
     PyMOL_Reshape(INST(h), savedW, savedH, 0);
+}
+
+// Rebuild any dirty object representations for the current frame/state on the
+// CALLING thread. Movie export calls this on the main thread before dispatching
+// the GPU render to a background queue: SceneUpdate can trigger
+// ObjectMolecule::update() -> OrthoBusyFast -> PLockStatusAttempt, which calls
+// into the Python C-API. Under _PYMOL_EMBEDDED, PAutoBlock is a no-op (the main
+// thread owns the interpreter's GIL persistently), so that Python call is only
+// safe on the main thread — doing it on the render queue corrupts the Python
+// heap (SIGSEGV in _PyObject_Malloc). Running the rebuild here leaves the
+// subsequent off-main SceneRenderMetal with clean reps and no Python touch.
+void PyMOLBridge_UpdateScene(PyMOLHandle h)
+{
+    if (!h) return;
+    PyMOLGlobals *G = PyMOL_GetGlobals(INST(h));
+    if (!G) return;
+    SceneUpdate(G, false);
 }
 
 // --- Getters ---

--- a/swiftui/PyMOLViewer/Panels/MovieExportSheet.swift
+++ b/swiftui/PyMOLViewer/Panels/MovieExportSheet.swift
@@ -132,21 +132,28 @@ final class MovieExporter: ObservableObject {
         if idx > last { finish(); return }
         let captureIdx = idx, w = width, h = height, rt = rayTraced
         let png = frameDir.appendingPathComponent("f\(captureIdx).png")
-        // cmd.frame is a Python call — it MUST run on the main thread. The
-        // embedded interpreter uses PyMOL's PAutoBlock (a single shared thread
-        // state), NOT PyGILState_Ensure, so driving it from another queue
-        // corrupts the Python heap (verified: SIGSEGV in _PyObject_Malloc).
-        // Only the heavy, Python-FREE C++ render + encode go off-main. The frame
-        // is fully set here before the render is dispatched, so there's no overlap
-        // (and the next frame is only set after this one's render completes).
+        // Both of these MUST run on the main thread because they reach the Python
+        // C-API, and under _PYMOL_EMBEDDED the main thread owns the interpreter's
+        // GIL persistently (PAutoBlock is a no-op, NOT PyGILState_Ensure) — driving
+        // Python from the render queue corrupts the Python heap (SIGSEGV in
+        // _PyObject_Malloc):
+        //   1. cmd.frame(N) — advances to this frame's state.
+        //   2. updateScene() — rebuilds this frame's dirty reps now, on-main. The
+        //      rebuild goes ObjectMolecule::update -> OrthoBusyFast ->
+        //      PLockStatusAttempt (Python), so it must NOT happen inside the
+        //      off-main render. Doing it here leaves the off-main SceneRenderMetal
+        //      with clean reps and no Python touch.
+        // The frame is fully set and rebuilt before the render is dispatched, so
+        // there's no overlap (the next frame is only set after this render ends).
         engine.runPython("from pymol import cmd as _c\n_c.frame(\(captureIdx))")
+        engine.updateScene()
         renderQueue.async { [weak self, weak engine] in
             guard let self = self, let engine = engine else { return }
             // Off main, exclusive core access (live draw loop + feedback poll are
-            // gated by exportRenderActive). renderOneOffscreen is pure C++/Metal —
-            // it runs SceneUpdate to rebuild the just-set frame's reps, blocks on
-            // the GPU, and writes the PNG — no Python, so it's safe off the main
-            // thread and the UI stays responsive during the slow (RT) render.
+            // gated by exportRenderActive). The reps were already rebuilt on-main
+            // (updateScene above), so this render's SceneUpdate is a clean no-op —
+            // pure C++/Metal, no Python — safe off the main thread. It blocks on
+            // the GPU and writes the PNG while the UI stays responsive.
             engine.renderHiResPNG(png.path, width: w, height: h, rayTraced: rt)
             if let cg = self.loadCGImage(png) { self.appendFrame(cg, frameIndex: captureIdx) }   // encode off-main
             try? FileManager.default.removeItem(at: png)

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -891,6 +891,16 @@ final class PyMOLEngine: ObservableObject {
         PyMOLBridge_RenderHiResPNG(inst, path, Int32(width), Int32(height), Int32(rayTraced))
     }
 
+    // Rebuild dirty object representations for the current frame on the MAIN
+    // thread. Movie export calls this before its off-main renderHiResPNG so the
+    // rep rebuild — which reaches the Python C-API via the busy-status callback —
+    // runs where the embedded interpreter's GIL is held, not on the render queue.
+    // MUST be called on the main thread.
+    func updateScene() {
+        guard let inst = instance else { return }
+        PyMOLBridge_UpdateScene(inst)
+    }
+
     // Whether the active GPU supports hardware ray tracing. The UI gates the
     // metal_raytrace toggle on this so it isn't offered where it has no effect
     // (iOS Simulator, A-series iPads). Defaults to true when unknown (renderer


### PR DESCRIPTION
Movie export crashed with `SIGSEGV in _PyObject_Malloc`: the off-main render queue ran `SceneUpdate`, which reaches the Python C-API (`ObjectMolecule::update → OrthoBusyFast → PLockStatusAttempt`). Under `_PYMOL_EMBEDDED` the main thread owns the GIL persistently (`PAutoBlock` is a no-op), so Python from another queue corrupts the heap.

Fix: add `PyMOLBridge_UpdateScene` + `engine.updateScene()` and rebuild the frame's dirty reps on the **main** thread right after `cmd.frame()`, leaving the off-main `SceneRenderMetal` as a clean, Python-free no-op.

Verified working (movie export completes without crashing). Folded into the 1.6.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)