### PR TITLE
release: RayMol 1.6.0 appcast

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -6,31 +6,73 @@
     <description>RayMol macOS updates</description>
     <language>en</language>
     <item>
-      <title>RayMol 1.5.2</title>
+      <title>RayMol 1.6.0</title>
       <description xml:lang="en" sparkle:format="markdown"><![CDATA[
-## RayMol 1.5.2
+## RayMol 1.6.0
 
-A follow-up rendering fix for cartoon shadows at steep angles, plus a cleaner app icon.
+A big feature release: a Photos-style camera dock with real depth-of-field, a
+docked Timeline movie studio, multi-state (NMR/MD) support in movies, and a
+batch of inspector and rendering improvements.
 
-- **Fixed: striped shadow speckle on flat cartoon strands at grazing angles.**
-  With Metal shadows enabled, near edge-on β-strands could still show a faint
-  striped self-shadow pattern that the 1.5.1 fix didn't fully reach. The default
-  self-shadow bias now ramps up further on the steepest facets, clearing the
-  speckle — while shadows cast *between* elements (helix onto sheet, sticks onto
-  surface) and contact shadows are left untouched.
-- **New: `metal_shadow_bias` setting.** A global multiplier (default 1.0) on the
-  self-shadow bias, for the rare structure where the speckle persists.
-  `set metal_shadow_bias, 2` (up to ~4) from the command line dials it out.
-- **Fixed: app icon showed white square corners.** The macOS app icon now has
-  properly rounded, transparent corners in the Dock and Finder.
+### Camera & lens
+- **New camera control dock.** A Photos-style strip docked at the bottom of the
+  viewport for framing and lens controls — collapses to icons, expands for the
+  sliders.
+- **Lens (focal length).** Dial the camera from wide-angle to telephoto (down to
+  12 mm) with a true dolly-zoom — it swaps perspective without re-zooming the
+  subject. Ortho is now a toggle right in the Lens row.
+- **Zoom (magnification) slider.** Absolute on-screen magnification, independent
+  of the lens.
+
+### Depth of field
+- **Autofocus.** Lock the focal plane to a selection and it tracks through zoom.
+- **DOF quality slider (1–4)**, defaulting to best, replacing the old on/off
+  toggle.
+- **Scatter-based bokeh** that spreads highlights past object edges for a
+  natural out-of-focus falloff. Transparent image export keeps DOF with a
+  halo-aware matte.
+
+### Movies & Timeline
+- **Timeline movie studio.** A docked multi-track editor for building movies —
+  drag-and-drop camera keyframes and scenes onto the timeline, with configurable
+  transitions. Lives in the right inspector with an expandable bottom dock.
+- **Multi-state (NMR / MD) objects.** Play through the models of an ensemble
+  with a "Play models" clip and per-object model playback, decoupled from the
+  movie transport. State-aware rebuilds are non-destructive.
+
+### Inspector
+- **Per-atom transparency.** The inspector now surfaces per-atom transparency
+  baked into a session and lets you clear it back to opaque.
+- **Representation controls populate reliably** when you expand a structure,
+  across every layout.
+- **Half-screen expand** for the object list, a dynamic state slider, and a
+  shared selection-mode menu.
+- **Clear-selection button** sits next to the Residues toggle to wipe the
+  active selection in one tap.
+
+### Rendering
+- **Real-time ray tracing restored,** with quality controls — hardware-accelerated
+  ambient occlusion and shadows update live as you orbit.
+
+### macOS app
+- **Native right-click context menu** on the viewport.
+- **Help ▸ Contact Support…** opens a message to support@raymol.io.
+- **What's New splash** on update, and a narrower, tidier right inspector.
+
+### Fixes
+- **Scenes now capture and restore render settings** (DOF, lighting, Metal
+  toggles) per scene, and no longer throw a spurious thumbnail-save error.
+- **Restoring a saved session no longer clobbers its render toggles** when the
+  launch theme re-applies.
+- **The viewport stays in sync** while you drag the movie playhead.
 
 Built on the open-source PyMOL engine. Updates install automatically via the in-app updater (**Check for Updates…** in the app menu).
 ]]></description>
-      <pubDate>Thu, 02 Jul 2026 20:45:44 +0000</pubDate>
-      <sparkle:version>16</sparkle:version>
-      <sparkle:shortVersionString>1.5.2</sparkle:shortVersionString>
+      <pubDate>Wed, 08 Jul 2026 20:54:45 +0000</pubDate>
+      <sparkle:version>17</sparkle:version>
+      <sparkle:shortVersionString>1.6.0</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
-      <enclosure url="https://github.com/javierbq/RayMol/releases/download/v1.5.2/RayMol-1.5.2.dmg" type="application/octet-stream" sparkle:edSignature="5gq7Xk2A3gEj3QzcL2K3C07oJWXVJrM7bKtesBr6aVRS+vUy82OntX4upYdghL6t2T0vGNe4oUrS+D5bpP7qBA==" length="55902911" />
+      <enclosure url="https://github.com/javierbq/RayMol/releases/download/v1.6.0/RayMol-1.6.0.dmg" type="application/octet-stream" sparkle:edSignature="5lCb6XFygRWjaIOeOjz42fjIgNzUQH8OJRgVK3CI6TrYPftia+Eb2aUOpg2nMFhRGnDGaKyuhqTVZOXj8v5xAg==" length="57628349" />
     </item>
   </channel>
 </rss>


### PR DESCRIPTION
Bookkeeping: sync the tracked appcast.xml with the published 1.6.0 release asset (the live feed is the release asset).