### PR TITLE
build(ios): scripted deps_ios bring-up (fetch Python + cross-compile freetype/libpng) (#123)

### DIFF
--- a/scripts/build_ios_deps.sh
+++ b/scripts/build_ios_deps.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# build_ios_deps.sh — cross-compile libpng + freetype for iOS (arm64) into
+#   deps_ios/install         (iphonesimulator SDK, platform 7)
+#   deps_ios/install_device  (iphoneos SDK,        platform 2)
+# so swiftui/PyMOLBridge.xcconfig (PYMOL_IOS_DEPS / PYMOL_IOS_DEPS_DEVICE) can
+# link -lfreetype/-lpng16 for each iOS SDK. This is the iOS analogue of the
+# deps_macos/ Homebrew libs used by the macOS app. Re-run to refresh.
+#
+# Both are built with CMake's native iOS cross-compile support (CMAKE_SYSTEM_NAME
+# =iOS). zlib comes from the iOS SDK (libz.tbd) — no separate build. libpng is
+# built FIRST because freetype's PNG support (FT_DISABLE_PNG=OFF) links against
+# it; freetype is then pointed at the just-built libpng via PNG_LIBRARY /
+# PNG_PNG_INCLUDE_DIR. HarfBuzz/Brotli/bzip2 are disabled (not needed and not
+# cross-built here) — mirrors the original bring-up.
+#
+# Versions match what shipped: freetype 2.13.3, libpng 1.6.44. Override with
+# FREETYPE_VERSION / LIBPNG_VERSION. Deployment target via IOS_DEPLOYMENT_TARGET.
+#
+# Requires: Xcode + command-line tools (cmake, xcrun), curl, tar.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+DEPS="$REPO/deps_ios"
+FREETYPE_VERSION="${FREETYPE_VERSION:-2.13.3}"
+LIBPNG_VERSION="${LIBPNG_VERSION:-1.6.44}"
+DEPLOY="${IOS_DEPLOYMENT_TARGET:-16.0}"
+
+command -v cmake >/dev/null || { echo "ERROR: cmake not found (brew install cmake / port install cmake)"; exit 1; }
+
+FREETYPE_URL="https://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.xz"
+LIBPNG_URL="https://downloads.sourceforge.net/project/libpng/libpng16/${LIBPNG_VERSION}/libpng-${LIBPNG_VERSION}.tar.xz"
+
+mkdir -p "$DEPS"
+cd "$DEPS"
+
+fetch_src () {   # $1=url  $2=srcdir
+  local URL="$1" SRC="$2" TARBALL
+  TARBALL="$(basename "$URL")"
+  if [ ! -d "$SRC" ]; then
+    echo ">> downloading $TARBALL"
+    curl -fL -o "$TARBALL" "$URL"
+    tar -xf "$TARBALL"
+    rm -f "$TARBALL"
+  fi
+}
+
+fetch_src "$LIBPNG_URL"   "libpng-${LIBPNG_VERSION}"
+fetch_src "$FREETYPE_URL" "freetype-${FREETYPE_VERSION}"
+
+# $1 = "simulator" | "device"  -> sets SDK + install prefix, builds both libs.
+build_slice () {
+  local KIND="$1" SDK PREFIX
+  case "$KIND" in
+    simulator) SDK="iphonesimulator"; PREFIX="$DEPS/install" ;;
+    device)    SDK="iphoneos";        PREFIX="$DEPS/install_device" ;;
+    *) echo "ERROR: unknown slice $KIND"; exit 1 ;;
+  esac
+  echo "==================== iOS $KIND ($SDK) -> $PREFIX ===================="
+
+  local COMMON=(
+    -G "Unix Makefiles"
+    -DCMAKE_SYSTEM_NAME=iOS
+    -DCMAKE_OSX_ARCHITECTURES=arm64
+    -DCMAKE_OSX_SYSROOT="$SDK"
+    -DCMAKE_OSX_DEPLOYMENT_TARGET="$DEPLOY"
+    -DCMAKE_INSTALL_PREFIX="$PREFIX"
+    -DCMAKE_BUILD_TYPE=Release
+  )
+
+  # --- libpng (first: freetype links against it) ---
+  local PNGBUILD="$DEPS/build_libpng_${KIND}"
+  rm -rf "$PNGBUILD"
+  cmake -S "libpng-${LIBPNG_VERSION}" -B "$PNGBUILD" "${COMMON[@]}" \
+    -DPNG_SHARED=OFF -DPNG_FRAMEWORK=OFF -DPNG_TESTS=OFF
+  cmake --build "$PNGBUILD" --target install
+
+  # --- freetype (points at the libpng we just installed) ---
+  local FTBUILD="$DEPS/build_freetype_${KIND}"
+  rm -rf "$FTBUILD"
+  cmake -S "freetype-${FREETYPE_VERSION}" -B "$FTBUILD" "${COMMON[@]}" \
+    -DFT_DISABLE_HARFBUZZ=ON -DFT_DISABLE_BROTLI=ON -DFT_DISABLE_BZIP2=ON \
+    -DFT_DISABLE_PNG=OFF -DFT_DISABLE_ZLIB=OFF \
+    -DPNG_PNG_INCLUDE_DIR="$PREFIX/include" \
+    -DPNG_LIBRARY="$PREFIX/lib/libpng16.a"
+  cmake --build "$FTBUILD" --target install
+
+  test -f "$PREFIX/lib/libpng16.a"   || { echo "ERROR: $KIND libpng16.a missing"; exit 1; }
+  test -f "$PREFIX/lib/libfreetype.a" || { echo "ERROR: $KIND libfreetype.a missing"; exit 1; }
+  echo ">> $KIND OK:"
+  lipo -archs "$PREFIX/lib/libfreetype.a"
+}
+
+build_slice simulator
+build_slice device
+
+echo ""
+echo ">> done. iOS deps staged:"
+echo "     $DEPS/install         (simulator: libpng16.a, libfreetype.a)"
+echo "     $DEPS/install_device  (device:    libpng16.a, libfreetype.a)"

--- a/scripts/fetch_ios_python.sh
+++ b/scripts/fetch_ios_python.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# fetch_ios_python.sh — download a BeeWare CPython 3.13 Python.xcframework
+# (github.com/beeware/Python-Apple-support) for embedding in the iOS
+# PyMOLViewer app. Extracts to deps_ios/Python.xcframework (gitignored),
+# which carries both slices the build expects:
+#     ios-arm64                    (device)
+#     ios-arm64_x86_64-simulator   (simulator)
+# each with Python.framework/{Python dylib, Headers}, the stdlib under
+# lib/python3.13, and the BeeWare platform-config/_sysconfigdata. This is the
+# iOS analogue of scripts/fetch_macos_python.sh. Re-run to refresh.
+#
+# This fetches the PRISTINE framework only. numpy and Biopython are layered in
+# afterwards by separate scripts (they depend on this xcframework existing):
+#     scripts/build_ios_deps.sh     freetype + libpng (deps_ios/install{,_device})
+#     scripts/build_numpy_ios.sh    numpy   -> deps_ios/numpy-ios/{simulator,device}
+#     scripts/bundle_biopython.sh   Biopython Bio/ -> into the xcframework
+# See swiftui/README.md ("iOS") for the full ordered bring-up.
+#
+# The tag is PINNED (below) rather than "latest" on purpose: BeeWare's 3.13-b13
+# moved the embedded stdlib from <slice>/lib/python3.13 to <slice>/lib-<arch>/
+# python3.13. The rest of the iOS build integration — the "Prepare Python binary
+# modules" phase, the interpreter's config.home, and scripts/bundle_biopython.sh
+# (which writes into <slice>/lib/python3.13/site-packages) — all assume the old
+# lib/python3.13 layout. 3.13-b12 is the newest release that still uses it.
+# Override with PY_APPLE_SUPPORT_TAG only if you've also updated those consumers;
+# the layout guard below rejects an incompatible release loudly.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+DEST="$REPO/deps_ios"
+PY_MINOR="3.13"
+
+TAG="${PY_APPLE_SUPPORT_TAG:-3.13-b12}"
+BUILD="${TAG#${PY_MINOR}-}"   # e.g. 3.13-b12 -> b12
+URL="https://github.com/beeware/Python-Apple-support/releases/download/${TAG}/Python-${PY_MINOR}-iOS-support.${BUILD}.tar.gz"
+
+mkdir -p "$DEST"
+cd "$DEST"
+echo ">> Downloading $URL"
+curl -fL -o python-ios.tar.gz "$URL"
+
+echo ">> Extracting Python.xcframework"
+rm -rf Python.xcframework
+tar -xzf python-ios.tar.gz Python.xcframework   # tarball has it at the top level
+rm -f python-ios.tar.gz
+
+# Sanity: both slices present with the dylib, headers, and stdlib — and the
+# stdlib is at the lib/python3.13 layout the rest of the build assumes (see the
+# header note; b13+ use lib-<arch> and would silently break bundling/import).
+for SLICE in ios-arm64 ios-arm64_x86_64-simulator; do
+  BASE="Python.xcframework/$SLICE"
+  test -f "$BASE/Python.framework/Python"   || { echo "ERROR: $SLICE Python dylib missing"; exit 1; }
+  test -d "$BASE/Python.framework/Headers"  || { echo "ERROR: $SLICE Headers missing"; exit 1; }
+  if [ ! -d "$BASE/lib/python${PY_MINOR}" ]; then
+    echo "ERROR: $SLICE stdlib not at lib/python${PY_MINOR} (got $(cd "$BASE" && echo lib*/python${PY_MINOR} 2>/dev/null))."
+    echo "       $TAG uses an incompatible layout; pin PY_APPLE_SUPPORT_TAG=3.13-b12."
+    exit 1
+  fi
+done
+
+echo "OK: $DEST/Python.xcframework  (BeeWare $TAG)"
+lipo -archs Python.xcframework/ios-arm64_x86_64-simulator/Python.framework/Python

--- a/swiftui/README.md
+++ b/swiftui/README.md
@@ -110,9 +110,53 @@ even compile (invisibly papered over on Homebrew machines that happened to
 have those headers installed already). They're not build-time dependencies
 of this app.
 
-## iOS
+## Building for iOS
 
-Blocked on `deps_ios/` (a BeeWare-built `Python.xcframework` plus
-cross-compiled freetype/libpng for device and simulator) — there's currently
-no script or documented process to populate it. See issue #123 for status
-before attempting an iOS build.
+The iOS app needs a gitignored `deps_ios/` populated with an embedded Python,
+cross-compiled freetype/libpng, and numpy — the iOS analogue of `deps_macos/`.
+Two scripts fetch/build the heavy pieces; the two after them layer Python
+packages on top. Run them **in order** (each depends on the previous):
+
+1. **Fetch the embedded Python.** One-time; re-run to refresh.
+   ```bash
+   scripts/fetch_ios_python.sh
+   ```
+   Downloads a [BeeWare Python-Apple-support](https://github.com/beeware/Python-Apple-support)
+   CPython 3.13 `Python.xcframework` (device + simulator slices) into
+   `deps_ios/Python.xcframework`. The BeeWare release is **pinned** (`3.13-b12`)
+   because b13+ moved the embedded stdlib to a `lib-<arch>/` layout the rest of
+   the build doesn't expect — the script's layout guard rejects an incompatible
+   release; see the header comment before overriding `PY_APPLE_SUPPORT_TAG`.
+
+2. **Cross-compile freetype + libpng.**
+   ```bash
+   scripts/build_ios_deps.sh
+   ```
+   Builds libpng 1.6.44 + freetype 2.13.3 for arm64 into `deps_ios/install`
+   (simulator SDK) and `deps_ios/install_device` (device SDK) — the
+   `PYMOL_IOS_DEPS{,_DEVICE}` paths in `PyMOLBridge.xcconfig`. zlib comes from
+   the iOS SDK. Needs Xcode + `cmake`.
+
+3. **Cross-compile numpy.**
+   ```bash
+   scripts/build_numpy_ios.sh
+   ```
+   Stages numpy into `deps_ios/numpy-ios/{simulator,device}` (numpy ships no iOS
+   wheels). Requires a host CPython 3.13 with `meson ninja cython` installed.
+
+4. **Bundle Biopython** (optional; shared with the macOS app).
+   ```bash
+   scripts/bundle_biopython.sh
+   ```
+   Adds the pure-Python `Bio` subset into the xcframework's site-packages.
+
+5. **Build the C++ core**, then the app:
+   ```bash
+   cd swiftui && ./build_ios.sh            # simulator (arm64)
+   cd swiftui && ./build_ios.sh device     # device
+   xcodebuild -project PyMOLViewer.xcodeproj -scheme PyMOLViewer_iOS \
+       -configuration Debug -sdk iphonesimulator build
+   ```
+
+Everything under `deps_ios/` is gitignored and reproducible from steps 1–4;
+delete the directory and re-run to rebuild from scratch.


### PR DESCRIPTION
## What & why

The iOS SwiftUI app expects a gitignored `deps_ios/` (BeeWare `Python.xcframework`, cross-compiled freetype/libpng, numpy) to already exist, but — unlike the macOS side (`scripts/fetch_macos_python.sh`) — there was **no scripted or documented way to populate it**. A new contributor had to reverse-engineer the original bring-up, and `scripts/build_numpy_ios.sh` depended on `Python.xcframework` with no predecessor to create it.

This adds the two missing scripts and documents the full ordered pipeline in `swiftui/README.md`.

## Changes

- **`scripts/fetch_ios_python.sh`** — downloads the [BeeWare Python-Apple-support](https://github.com/beeware/Python-Apple-support) CPython 3.13 `Python.xcframework` (device + simulator) into `deps_ios/`. **Pinned to `3.13-b12`**: b13+ moved the embedded stdlib to a `lib-<arch>/` layout that breaks `bundle_biopython.sh` (writes to `<slice>/lib/python3.13/site-packages`), the interpreter's `config.home`, and the "Prepare Python binary modules" phase. A layout guard rejects an incompatible release loudly; `PY_APPLE_SUPPORT_TAG` overrides.
- **`scripts/build_ios_deps.sh`** — cross-compiles libpng 1.6.44 + freetype 2.13.3 (arm64) into `deps_ios/install` (simulator SDK) and `deps_ios/install_device` (device SDK) via CMake's iOS support — the `PYMOL_IOS_DEPS{,_DEVICE}` paths in `PyMOLBridge.xcconfig`. libpng built first; freetype pointed at it with PNG support enabled; zlib from the iOS SDK.
- **`swiftui/README.md`** — replaces the "Blocked / see #123" note with the ordered 5-step iOS bring-up (fetch Python → freetype/libpng → numpy → Biopython → build core + app).

## How it was derived & verified

Recipe reconstructed from the on-disk build trees (freetype/libpng `CMakeCache.txt` flags, BeeWare `_sysconfigdata`), then **both scripts run end-to-end in a scratch repo** (not clobbering the working `deps_ios/`):

- `fetch_ios_python.sh` → correct `lib/python3.13` layout for both slices (sim slice carries `x86_64 arm64`).
- `build_ios_deps.sh` → `libfreetype.a` + `libpng16.a` for both slices; objects verified at **platform 7 (simulator)** and **platform 2 (iOS device)**; freetype built with `FT_CONFIG_OPTION_USE_PNG`. Output tree matches the existing `deps_ios/install` lib set.

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)