### PR TITLE
feat(objects): whole-row toggle + optimistic enable/disable (#168)

### DIFF
--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -1002,16 +1002,17 @@ private struct ObjectRowView: View {
         .padding(.vertical, 2)
         .frame(height: kRowH)
         .background(isAlt ? PanelTheme.rowAltBackground : PanelTheme.rowBackground)
+        // Whole-row tap toggles enable. The trailing A/S/H/L/C controls consume
+        // their own taps (they sit above this gesture); only the dead Spacer gap
+        // falls through to here.
+        .contentShape(Rectangle())
+        .onTapGesture { toggleEnabled() }
         // Long-press (iOS) / right-click (macOS) opens the action menu.
         .contextMenu { actionMenuContent(actionMenuItems, name: entry.name, engine: engine) }
     }
 
     private func toggleEnabled() {
-        if entry.isEnabled {
-            engine.runCommand("disable \(entry.name)")
-        } else {
-            engine.runCommand("enable \(entry.name)")
-        }
+        engine.setObjectEnabled(entry.name, !entry.isEnabled)
     }
 }
 
@@ -1067,6 +1068,10 @@ private struct AllControlsRow: View {
         .padding(.vertical, 2)
         .frame(height: kRowH)
         .background(PanelTheme.rowBackground)
+        // Whole-row tap toggles ALL objects. The trailing A/S/H/L/C controls
+        // consume their own taps; only the dead Spacer gap falls through here.
+        .contentShape(Rectangle())
+        .onTapGesture { toggleAll() }
         .contextMenu { actionMenuContent(allActionMenuItems, name: "all", engine: engine) }
     }
 
@@ -1074,7 +1079,14 @@ private struct AllControlsRow: View {
     // targets exactly the current objects (not the "all" atom-selection), so it
     // works regardless of how enable/disable interpret the "all" keyword.
     private func toggleAll() {
-        let action = allEnabled ? "disable" : "enable"
+        let enable = !allEnabled
+        // Optimistic-first: flip every object's checkbox immediately (isEnabled
+        // is a var → instant re-render) so the whole "all" row updates this frame
+        // instead of waiting on the ~500ms pollObjects reconcile.
+        for idx in engine.objects.indices where !engine.objects[idx].isSelection {
+            engine.objects[idx].isEnabled = enable
+        }
+        let action = enable ? "enable" : "disable"
         engine.runPython(
             "from pymol import cmd as _c\n"
             + "for _o in (_c.get_names('objects') or []):\n"
@@ -1783,7 +1795,7 @@ private struct ObjectRowContent: View {
     }
 
     private func toggleEnabled() {
-        engine.runCommand(entry.isEnabled ? "disable \(entry.name)" : "enable \(entry.name)")
+        engine.setObjectEnabled(entry.name, !entry.isEnabled)
     }
 }
 
@@ -1829,6 +1841,13 @@ private struct ObjectCard: View {
             .padding(.vertical, 2)
             .frame(height: kRowH)
             .background(isAlt ? PanelTheme.rowAltBackground : PanelTheme.rowBackground)
+            // Whole HEADER-row tap toggles enable. Applied to the header HStack
+            // only (NOT the outer VStack) so the expanded rep-detail below stays
+            // interactive. The disclosure chevron Button and the trailing
+            // A/S/H/L/C controls consume their own taps (expand-only for the
+            // chevron); only the dead Spacer gap falls through to here.
+            .contentShape(Rectangle())
+            .onTapGesture { engine.setObjectEnabled(entry.name, !entry.isEnabled) }
             // Long-press (iOS) / right-click (macOS) opens the action menu.
             .contextMenu { actionMenuContent(actionMenuItems, name: entry.name, engine: engine) }
 

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -714,6 +714,29 @@ final class PyMOLEngine: ObservableObject {
 
     // MARK: - Commands
 
+    /// Toggle an object/selection's enabled state with an OPTIMISTIC UI update.
+    /// Flips the matching `objects[idx].isEnabled` immediately on the main thread
+    /// (ObjectEntry.isEnabled is a var → the checkbox re-renders this frame, no
+    /// waiting on the ~500ms pollObjects round-trip), THEN issues the actual
+    /// enable/disable command. The pollObjects/parseObjectPanelFeedback equality
+    /// guard reconciles the array later; since we already set the value the poll
+    /// will report, the reconcile is a no-op and there is no flicker.
+    func setObjectEnabled(_ name: String, _ enabled: Bool) {
+        // UI mutation must happen on the main thread (drives @Published).
+        if Thread.isMainThread {
+            if let idx = objects.firstIndex(where: { $0.name == name }) {
+                objects[idx].isEnabled = enabled
+            }
+        } else {
+            DispatchQueue.main.async {
+                if let idx = self.objects.firstIndex(where: { $0.name == name }) {
+                    self.objects[idx].isEnabled = enabled
+                }
+            }
+        }
+        runCommand(enabled ? "enable \(name)" : "disable \(name)")
+    }
+
     func runCommand(_ command: String) {
         guard isReady else { return }
         // A plain `png <file>` (ray=0) wants the RENDERED frame, but PyMOL's


### PR DESCRIPTION
Makes the whole object-list row a toggle target and removes the perceived checkbox latency.

Closes #168.

## Changes
- **`PyMOLEngine.setObjectEnabled(_:_:)`** — optimistically flips `objects[idx].isEnabled` on the main thread (checkbox re-renders that frame), then runs `enable`/`disable`. The existing `pollObjects` equality guard makes the ~500 ms reconcile a no-op, so no flicker — this kills the perceived toggle lag.
- **Whole-row hit target** — `.contentShape(Rectangle())` + `.onTapGesture` on the row *container* for all three row kinds: `ObjectRowView` (selections), the `ObjectCard` header (objects), and `AllControlsRow` ("all"). Trailing A/S/H/L/C menus/buttons keep their own hit-testing; only the previously-dead `Spacer` gap now toggles. The disclosure chevron stays expand-only.

## Validation (disposable macOS VM, via MCP + screenshot)
- ✅ Clean Debug build; app launches and runs without crash.
- ✅ Object panel renders correctly with two objects + the "all" row and A/S/H/L/C controls intact (no layout regression from the added row gesture) — verified by screenshot.
- ⚠️ The whole-row *tap* and the optimistic flip are **UI-gesture behaviors that can't be exercised in the headless VM**: SwiftUI's `onTapGesture` rows aren't accessibility-actionable and no HID event injection is available in this environment (AX clicks only actuate exposed buttons). Both are verified by code inspection; worth a quick manual tap check on a real display before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
