### PR TITLE
fix(macos): ⌘C copies image (menu command) + drop phantom toolbar slot (#162, #167)

### DIFF
--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -47,6 +47,7 @@ extension Notification.Name {
     static let raymolSaveSession  = Notification.Name("raymol.menu.saveSession")
     static let raymolSaveSessionAs = Notification.Name("raymol.menu.saveSessionAs")
     static let raymolExportImage  = Notification.Name("raymol.menu.exportImage")
+    static let raymolCopyImage    = Notification.Name("raymol.menu.copyImage")
     static let raymolToggleTimeline = Notification.Name("raymol.menu.toggleTimeline")
     static let mcpOpenConnectSheet = Notification.Name("raymol.mcp.openConnectSheet")
     // Posted by the macOS app-menu item and the iOS Settings row to open the
@@ -484,7 +485,7 @@ struct ContentView: View {
             panelToggles
             exportMenu
             #if !RAYMOL_MAS_RESTRICTED
-            ToolbarItem(placement: .automatic) {
+            ToolbarItem(placement: .primaryAction) {
                 MCPStatusView()
             }
             #endif
@@ -496,6 +497,7 @@ struct ContentView: View {
         .onReceive(NotificationCenter.default.publisher(for: .raymolSaveSession)) { _ in saveSession() }
         .onReceive(NotificationCenter.default.publisher(for: .raymolSaveSessionAs)) { _ in saveSessionAs() }
         .onReceive(NotificationCenter.default.publisher(for: .raymolExportImage)) { _ in saveImage(size: exportSize(scale: 2)) }
+        .onReceive(NotificationCenter.default.publisher(for: .raymolCopyImage)) { _ in copyImageToClipboard() }
         .onReceive(NotificationCenter.default.publisher(for: .raymolToggleTimeline)) { _ in
             withAnimation(.easeInOut(duration: 0.2)) { engine.timelineMode.toggle() }
         }
@@ -2403,17 +2405,6 @@ struct ContentView: View {
     }
     #endif
 
-    private var macThemeToolbar: some ToolbarContent {
-        ToolbarItem {
-            Button {
-                withAnimation(.easeInOut(duration: 0.2)) { showThemeStudio.toggle() }
-            } label: {
-                Label("Theme", systemImage: "circle.lefthalf.filled")
-            }
-            .help("Theme studio")
-        }
-    }
-
     private var macMeasureToolbar: some ToolbarContent {
         // Leading, beside Open — mirrors the iOS top-left pair (Open · Measure).
         ToolbarItem(placement: .navigation) {
@@ -2444,7 +2435,12 @@ struct ContentView: View {
     // toggle is "Inspector" (sidebar icon), NOT "Objects" — Objects is now a SEGMENT
     // inside the inspector switcher, so the toolbar must not duplicate it.
     private var panelToggles: some ToolbarContent {
-        ToolbarItemGroup {
+        // Explicit .primaryAction keeps these in the trailing cluster next to the
+        // other primaryAction items (Timeline, Export, MCP status) so SwiftUI does
+        // not insert a phantom empty slot at the default/primaryAction boundary.
+        // Fallback if the phantom slot persists: wrap all four trailing items
+        // (panelToggles + exportMenu + MCP status) in one ToolbarItemGroup(placement: .primaryAction).
+        ToolbarItemGroup(placement: .primaryAction) {
             Toggle(isOn: $showCommandPanel) {
                 Label("Console", systemImage: "terminal")
             }
@@ -2474,12 +2470,13 @@ struct ContentView: View {
                 } label: {
                     Label("Save Image", systemImage: "photo")
                 }
+                // ⌘C lives on the File-menu command (raymolCopyImage) so the
+                // shortcut fires reliably; this toolbar button is for discoverability.
                 Button {
                     copyImageToClipboard()
                 } label: {
                     Label("Copy Image to Clipboard", systemImage: "doc.on.clipboard")
                 }
-                .keyboardShortcut("c", modifiers: .command)
                 // Render options in a submenu whose toggles DON'T dismiss the
                 // menu (flip both before exporting). dismiss-disabled is iOS-only.
                 #if os(iOS)

--- a/swiftui/PyMOLViewer/Shared/PyMOLApp.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLApp.swift
@@ -171,6 +171,11 @@ struct PyMOLApp: App {
                 Button("Export Image…") {
                     NotificationCenter.default.post(name: .raymolExportImage, object: nil)
                 }.keyboardShortcut("e", modifiers: [.command, .shift])
+                // ⌘C as a real menu command (not a toolbar-Menu button) so the
+                // shortcut fires reliably; mirrors how Export Image works above.
+                Button("Copy Image to Clipboard") {
+                    NotificationCenter.default.post(name: .raymolCopyImage, object: nil)
+                }.keyboardShortcut("c", modifiers: .command)
                 Divider()
                 Button("Clear Session") {
                     NotificationCenter.default.post(name: .raymolClearSession, object: nil)


### PR DESCRIPTION
Two macOS toolbar/menu fixes.

Closes #162, closes #167.

## #162 — ⌘C copies the image
Root cause (not a 1.6.0 regression — the code is byte-identical since v1.5.2): the ⌘C shortcut was declared on a Button nested inside a **toolbar `Menu`**, which SwiftUI doesn't register app-wide (it only fired while that menu was open). Fixed by promoting it to a real menu-bar command — a `Notification.Name.raymolCopyImage` posted from a File-menu `Button("Copy Image to Clipboard")` carrying `.keyboardShortcut("c", .command)`, received by an `.onReceive` that calls `copyImageToClipboard()` (mirrors ⇧⌘E Export Image). The redundant inline shortcut on the toolbar Menu button was removed (button kept for discoverability).

## #167 — phantom toolbar slot
The empty trailing-toolbar slot was an AppKit placement-boundary artifact from mixing default/`.automatic` items among `.primaryAction` ones. The whole trailing cluster is now uniform `.primaryAction` (panelToggles group + MCPStatusView). The unused `macThemeToolbar` (zero call sites) was removed.

## Validation (disposable macOS VM, via MCP + AX + screenshot)
- ✅ **#162 proven end-to-end**: the File menu shows *Copy Image to Clipboard* bound to ⌘C (`AXMenuItemCmdChar=C, modifiers=⌘`); invoking it replaced sentinel clipboard text with real image data (`TIFF/PNG/JPEG picture …`). Menu key-equivalents fire from the app globally (verified).
- ✅ **#167 fixed toolbar is clean**: accessibility enumeration of the toolbar lists exactly the intended items — Open, Measure, Timeline, Console, Sequence, Inspector, Export, RayMol MCP — with **no empty/unlabeled button**. App builds and runs; `macThemeToolbar` removal caused no regression.
- ⚠️ The *original* phantom-slot artifact is AppKit-version/width-dependent and I couldn't force it to reproduce in the headless VM for a strict before/after; the fixed state is verifiably clean and the change is low-risk. Quick manual glance on a real display recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
