### PR TITLE
feat(camera): Auto-lock focus in residue right-click menu (#164)

### DIFF
--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -209,6 +209,12 @@ enum CameraCommands {
         on ? "select dof_focus, (sele)\nset metal_dof_autofocus, 1"
            : "set metal_dof_autofocus, 0"
     }
+
+    // Auto-lock focus on a specific selection: retarget "dof_focus" to `sel` and
+    // enable DOF + autofocus so the lock is immediately visible.
+    static func lockFocus(on sel: String) -> String {
+        "select dof_focus, (\(sel))\nset metal_dof, 1\nset metal_dof_autofocus, 1"
+    }
 }
 
 enum SceneCatalog {

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -794,6 +794,7 @@ struct ContentView: View {
             Button("Label residue") { engine.runCommand("label first (\(hit.sel)), '\(hit.resn)\(hit.resi)'") }
             Button("Hide residue") { engine.runCommand("hide everything, (\(hit.sel))") }
             Button("Center here") { engine.runCommand("center (\(hit.sel))") }
+            Button("Auto-lock focus") { engine.runCommand(CameraCommands.lockFocus(on: hit.sel)) }
             Button("Color…") { longPressColorSel = hit.sel; showLongPressColor = true }
         }
         Button("Cancel", role: .cancel) {}


### PR DESCRIPTION
Adds **Auto-lock focus** to the residue right-click / long-press context menu (between *Center here* and *Color…*). One edit to the shared `longPressActions(_:)` builder covers both macOS and iOS.

Closes #164.

It retargets the DOF focus selection to the picked residue and enables DOF + autofocus so the lock is immediately visible, via a new single-source-of-truth helper `CameraCommands.lockFocus(on:)`:
```
select dof_focus, (<hit.sel>)
set metal_dof, 1
set metal_dof_autofocus, 1
```
Unlike the existing Scene-panel *Auto lock focus* toggle (which snapshots the current `sele` and needs an off→on to re-target), this retargets straight to the residue under the cursor.

## Validation (disposable macOS VM, via MCP)
- ✅ Ran the exact commands the menu item issues against `resi 40`: `metal_dof` off→**on**, `metal_dof_autofocus` off→**on**, `dof_focus` set to exactly the residue's 9 atoms (`count_atoms dof_focus == count_atoms "resi 40" == 9`), and `sele` left untouched. The retarget behaves as designed.
- ⚠️ Triggering the item through the actual right-click menu needs a synthesized HID right-click, which isn't available in the headless VM; the menu Button → `CameraCommands.lockFocus(on: hit.sel)` wiring is verified by code inspection and the command effect is proven above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
