### PR TITLE
feat(select): hover pre-selection preview (#165)

### DIFF
--- a/layer1/SceneRender.cpp
+++ b/layer1/SceneRender.cpp
@@ -2245,22 +2245,34 @@ void SceneRenderMetal(PyMOLGlobals* G)
 }
 
 // Draw a batch of selection-indicator points (overlay, no depth test) at the
-// given world coordinates with the active theme's selection color.
-static void SceneDrawMetalSelectionPoints(
-    PyMOLGlobals* G, const std::vector<float>& coords)
+// given world coordinates in `color` at `pointSize`. Shared by the committed
+// selection pass (selColor, 12px) and the hover-preview pass (preselColor, 9px).
+static void SceneDrawMetalSelectionPoints(PyMOLGlobals* G,
+    const std::vector<float>& coords, const float* color, float pointSize)
 {
   if (coords.empty())
     return;
   int nPoints = (int)(coords.size() / 3);
   G->Renderer->disable(pymol::Capability::DepthTest);
-  G->Renderer->pointSize(12.0f); // Retina: need ~2x for visible size
+  G->Renderer->pointSize(pointSize); // Retina: need ~2x for visible size
   G->Renderer->beginBatch(pymol::PrimitiveType::Points);
-  G->Renderer->batchColor4f(G->Renderer->selColor[0], G->Renderer->selColor[1],
-      G->Renderer->selColor[2], 1.0f);
+  G->Renderer->batchColor4f(color[0], color[1], color[2], 1.0f);
   for (int i = 0; i < nPoints; i++)
     G->Renderer->batchVertex3f(coords[i * 3], coords[i * 3 + 1], coords[i * 3 + 2]);
   G->Renderer->endBatch();
   G->Renderer->enable(pymol::Capability::DepthTest);
+}
+
+// Draw the transient hover-preview selection ('_preselect', issue #165) for the
+// current grid cell (or the whole scene when grid is inactive) in the
+// renderer's preselColor at a smaller point size than the committed pass. Called
+// BEFORE the committed selColor pass so an already-selected residue keeps its
+// committed pink color under the cursor (pink overdraws cyan).
+static void SceneDrawMetalPreselection(PyMOLGlobals* G)
+{
+  std::vector<float> coords;
+  ExecutiveGetNamedSelectionCoords(G, "_preselect", coords);
+  SceneDrawMetalSelectionPoints(G, coords, G->Renderer->preselColor, 9.0f);
 }
 
 void SceneRenderMetalSelections(PyMOLGlobals* G)
@@ -2281,9 +2293,12 @@ void SceneRenderMetalSelections(PyMOLGlobals* G)
         static_cast<std::uint32_t>(vpH)};
     for (int slot = I->grid.first_slot; slot <= I->grid.last_slot; ++slot) {
       SceneSetMetalGridCell(G, &I->grid, sceneVP, slot);
+      // Hover preview FIRST (distinct color/smaller size), then the committed
+      // selection ON TOP so pink wins where the two overlap.
+      SceneDrawMetalPreselection(G);
       std::vector<float> coords;
       ExecutiveGetSelectionCoords(G, coords);
-      SceneDrawMetalSelectionPoints(G, coords);
+      SceneDrawMetalSelectionPoints(G, coords, G->Renderer->selColor, 12.0f);
     }
     G->Renderer->disable(pymol::Capability::ScissorTest);
     G->Renderer->viewport(vpX, vpY, vpW, vpH);
@@ -2291,7 +2306,10 @@ void SceneRenderMetalSelections(PyMOLGlobals* G)
     return;
   }
 
+  // Hover preview FIRST (distinct color/smaller size), then the committed
+  // selection ON TOP so pink wins where the two overlap.
+  SceneDrawMetalPreselection(G);
   std::vector<float> coords;
   ExecutiveGetSelectionCoords(G, coords);
-  SceneDrawMetalSelectionPoints(G, coords);
+  SceneDrawMetalSelectionPoints(G, coords, G->Renderer->selColor, 12.0f);
 }

--- a/layer3/Executive.cpp
+++ b/layer3/Executive.cpp
@@ -8599,6 +8599,57 @@ private:
   GLfloat alpha_ref_before;
 };
 
+// Name of the transient hover-PREVIEW selection (modules/pymol/metal_pick.py
+// _PRESELECT). ExecutiveGetSelectionCoords skips it so the preview is never
+// drawn in the committed selection color; SceneDrawMetalPreselection gathers it
+// separately (via ExecutiveGetNamedSelectionCoords) in its own color/size.
+static const char kPreselectionName[] = "_preselect";
+
+// Gather the coordinates of one specific named selection's atoms (same grid-cell
+// filter and current-state logic as ExecutiveGetSelectionCoords, but restricted
+// to `name`). Used to draw the hover preview separately from the committed
+// selection. Appends 3 floats (x,y,z) per matching atom to `coords`.
+void ExecutiveGetNamedSelectionCoords(
+    PyMOLGlobals* G, const char* name, std::vector<float>& coords)
+{
+  auto I = G->Executive;
+
+  int sele = SelectorIndexByName(G, name);
+  if (sele < 0)
+    return;
+
+  for (auto& rec1 : pymol::make_list_adapter(I->Spec)) {
+    if (rec1.type != cExecObject || rec1.obj->type != cObjectMolecule)
+      continue;
+
+    // Same grid-cell filter as ExecutiveGetSelectionCoords: when grid is active,
+    // only collect coords for objects in the cell being rendered.
+    if (!SceneGetDrawFlagGrid(G, &G->Scene->grid, rec1.obj->grid_slot))
+      continue;
+
+    auto* obj = static_cast<ObjectMolecule*>(rec1.obj);
+    int curState = obj->getCurrentState();
+    if (curState < 0) curState = 0;
+    if (curState >= obj->NCSet) continue;
+
+    auto* cs = obj->CSet[curState];
+    if (!cs) continue;
+
+    for (int atIdx = 0; atIdx < obj->NAtom; atIdx++) {
+      if (!SelectorIsMember(G, obj->AtomInfo[atIdx].selEntry, sele))
+        continue;
+
+      int coordIdx = cs->atmToIdx(atIdx);
+      if (coordIdx < 0) continue;
+
+      const float* v = cs->coordPtr(coordIdx);
+      coords.push_back(v[0]);
+      coords.push_back(v[1]);
+      coords.push_back(v[2]);
+    }
+  }
+}
+
 void ExecutiveGetSelectionCoords(PyMOLGlobals* G, std::vector<float>& coords)
 {
   auto I = G->Executive;
@@ -8606,6 +8657,12 @@ void ExecutiveGetSelectionCoords(PyMOLGlobals* G, std::vector<float>& coords)
 
   for (auto& rec : pymol::make_list_adapter(I->Spec)) {
     if (rec.type != cExecSelection || !rec.visible)
+      continue;
+
+    // Skip the transient hover-preview selection — it is drawn separately (in a
+    // distinct color/size) by SceneDrawMetalPreselection, so it must never be
+    // painted in the committed selection color here.
+    if (strcmp(rec.name, kPreselectionName) == 0)
       continue;
 
     int sele = SelectorIndexByName(G, rec.name);

--- a/layer3/Executive.h
+++ b/layer3/Executive.h
@@ -555,6 +555,13 @@ void ExecutiveInvalidateSelectionIndicatorsCGO(PyMOLGlobals* G);
  * @param grid grid info
  */
 void ExecutiveGetSelectionCoords(PyMOLGlobals* G, std::vector<float>& coords);
+/**
+ * Gather the world coordinates of a single named selection's atoms (same
+ * grid-cell + current-state logic as ExecutiveGetSelectionCoords). Used to draw
+ * the transient hover-preview selection separately from the committed one.
+ */
+void ExecutiveGetNamedSelectionCoords(
+    PyMOLGlobals* G, const char* name, std::vector<float>& coords);
 void ExecutiveRenderSelections(
     PyMOLGlobals* G, int curState, int slot, GridInfo* grid);
 void ExecutiveHideSelections(PyMOLGlobals* G);

--- a/layerGraphics/Renderer.h
+++ b/layerGraphics/Renderer.h
@@ -225,6 +225,14 @@ public:
     selColor[0] = r; selColor[1] = g; selColor[2] = b;
   }
 
+  // RGB of the transient HOVER-PREVIEW indicator points (issue #165), drawn by
+  // SceneDrawMetalPreselection at a smaller point size BEFORE the committed
+  // selColor pass so pink wins on overlap. Fixed light-cyan by default.
+  float preselColor[3] = {0.40f, 0.85f, 1.0f};
+  void setPreselectionColor(float r, float g, float b) {
+    preselColor[0] = r; preselColor[1] = g; preselColor[2] = b;
+  }
+
   // VBO buffer cache — returns a cached buffer ID for the given key,
   // creating it from data if not already cached.
   virtual void invalidateVBOCache(uint64_t key) {}

--- a/modules/pymol/metal_pick.py
+++ b/modules/pymol/metal_pick.py
@@ -38,6 +38,14 @@ _DRAWN_REPS = ('rep spheres or rep sticks or rep lines or rep nb_spheres or '
                'rep nonbonded or rep surface or rep dots or rep mesh or '
                'rep ellipsoid or ((rep cartoon or rep ribbon) and (polymer or guide))')
 
+# Named selection that carries the transient hover PREVIEW (issue #165). The
+# leading underscore hides it from public object/selection lists AND is already
+# skipped by _pick_atom's `startswith('_')` filter, so it can never be picked
+# into. The renderer draws it in a distinct color/size (C++
+# SceneDrawMetalPreselection) BEFORE the committed 'sele' pass, so the pink
+# committed color always wins on overlap.
+_PRESELECT = '_preselect'
+
 
 def _pickdbg(ndc_x, ndc_y, aspect, best, ncand):
     """Append a pick diagnostic line to PYMOL_PICKDEBUG (debug harness only).
@@ -393,6 +401,32 @@ except Exception:
     pass
 
 
+def _mode_expr(best, mode):
+    """Expand a _pick_atom result tuple to a selection expression honoring
+    mouse_selection_mode (0 atom, 1 residue, 2 chain, 3 segment, 4 object,
+    5 molecule, 6 C-alpha). Shared by pick_at (commit into 'sele') and
+    hover_preview_at (transient '_preselect'), so both expand the pick to the
+    same scope for a given mode."""
+    _, obj, chain, resi, resn, segi, name, _sx, _sy = best
+    atom = '%s and resi %s and name %s' % (obj, resi, name)
+    if chain:
+        atom += ' and chain %s' % chain
+    res = ('%s and chain %s and resi %s' % (obj, chain, resi)) if chain \
+        else ('%s and resi %s' % (obj, resi))
+    if mode == 0:                                   # atom
+        return '(%s)' % atom
+    elif mode == 2:                                 # chain
+        return ('(%s and chain %s)' % (obj, chain)) if chain else '(%s)' % obj
+    elif mode == 3:                                 # segment
+        return ('(%s and segi %s)' % (obj, segi)) if segi else '(%s)' % obj
+    elif mode == 4:                                 # object
+        return '(%s)' % obj
+    elif mode == 5:                                 # molecule
+        return '(bymol (%s))' % atom
+    else:                                           # 1 residue / 6 C-alpha
+        return '(%s)' % res
+
+
 def pick_at(ndc_x, ndc_y, aspect):
     """Default tap: residue-level toggle into the active 'sele'."""
     from pymol import cmd
@@ -414,23 +448,12 @@ def pick_at(ndc_x, ndc_y, aspect):
             mode = int(cmd.get_setting_int('mouse_selection_mode'))
         except Exception:
             mode = 1
+        # atom expression reused below for click-to-focus (dof); the mode-scoped
+        # commit expression comes from the shared _mode_expr helper.
         atom = '%s and resi %s and name %s' % (obj, resi, name)
         if chain:
             atom += ' and chain %s' % chain
-        res = ('%s and chain %s and resi %s' % (obj, chain, resi)) if chain \
-            else ('%s and resi %s' % (obj, resi))
-        if mode == 0:                                   # atom
-            expr = '(%s)' % atom
-        elif mode == 2:                                 # chain
-            expr = ('(%s and chain %s)' % (obj, chain)) if chain else '(%s)' % obj
-        elif mode == 3:                                 # segment
-            expr = ('(%s and segi %s)' % (obj, segi)) if segi else '(%s)' % obj
-        elif mode == 4:                                 # object
-            expr = '(%s)' % obj
-        elif mode == 5:                                 # molecule
-            expr = '(bymol (%s))' % atom
-        else:                                           # 1 residue / 6 C-alpha
-            expr = '(%s)' % res
+        expr = _mode_expr(best, mode)
 
         # Toggle into/out of 'sele' (additive — matches Seeker toggle).
         exists = 'sele' in (cmd.get_names('selections') or [])
@@ -484,3 +507,31 @@ def pick_info_at(ndc_x, ndc_y, aspect):
             json.dump(out, f)
     except Exception:
         pass
+
+
+def hover_preview_at(ndc_x, ndc_y, aspect):
+    """Hover PREVIEW (issue #165): highlight what a click WOULD select, without
+    committing anything. Runs the same pick + mouse_selection_mode expansion as
+    pick_at, but writes the result to the transient '_preselect' selection
+    instead of 'sele'. Empty space clears the preview.
+
+    Deliberately touches ONLY '_preselect' — never 'sele' or 'pk1' — so the
+    committed selection is untouched as the pointer moves. The renderer draws
+    '_preselect' in a distinct color/size BEFORE the committed pink pass, so an
+    already-selected residue keeps its committed color under the cursor."""
+    from pymol import cmd
+    try:
+        best = _pick_atom(ndc_x, ndc_y, aspect)
+        if best is None:
+            # Empty space: clear the preview (leave 'sele' untouched).
+            cmd.select(_PRESELECT, 'none')
+            return
+
+        try:
+            mode = int(cmd.get_setting_int('mouse_selection_mode'))
+        except Exception:
+            mode = 1
+        cmd.select(_PRESELECT, _mode_expr(best, mode))
+        cmd.enable(_PRESELECT)
+    except Exception as e:
+        print('metal_pick hover error: %s' % e)

--- a/swiftui/PyMOLViewer/Bridge/PyMOLBridge.h
+++ b/swiftui/PyMOLViewer/Bridge/PyMOLBridge.h
@@ -31,6 +31,8 @@ void PyMOLBridge_Drag(PyMOLHandle instance, int x, int y, int modifiers);
 void PyMOLBridge_SetLetterboxAspect(PyMOLHandle instance, float aspect);
 // RGB (0..1) of the 3D selection indicator squares — set from the active theme.
 void PyMOLBridge_SetSelectionColor(PyMOLHandle instance, float r, float g, float b);
+// RGB (0..1) of the transient hover-preview indicator points (issue #165).
+void PyMOLBridge_SetPreselectionColor(PyMOLHandle instance, float r, float g, float b);
 void PyMOLBridge_CapturePNG(PyMOLHandle instance, const char* path);
 // Hi-res offscreen render → PNG: reshape PyMOL to width×height, render the full
 // Metal pipeline (all reps + hardware-RT AO/shadows) into offscreen targets at

--- a/swiftui/PyMOLViewer/Bridge/PyMOLBridge.mm
+++ b/swiftui/PyMOLViewer/Bridge/PyMOLBridge.mm
@@ -224,6 +224,14 @@ void PyMOLBridge_SetSelectionColor(PyMOLHandle h, float r, float g, float b)
     G->Renderer->setSelectionColor(r, g, b);
 }
 
+void PyMOLBridge_SetPreselectionColor(PyMOLHandle h, float r, float g, float b)
+{
+    if (!h) return;
+    PyMOLGlobals* G = PyMOL_GetGlobals(INST(h));
+    if (!G || !G->Renderer) return;
+    G->Renderer->setPreselectionColor(r, g, b);
+}
+
 void PyMOLBridge_CapturePNG(PyMOLHandle h, const char* path)
 {
     if (!h || !path) return;

--- a/swiftui/PyMOLViewer/Panels/MousePanel.swift
+++ b/swiftui/PyMOLViewer/Panels/MousePanel.swift
@@ -440,6 +440,27 @@ struct MousePanel: View {
                 }
 
             Spacer()
+
+            #if os(macOS)
+            // Compact "Hover" toggle: preview what a click would select as the
+            // pointer moves (issue #165). Turning it off also clears any lingering
+            // preview. macOS-only — iPad hover is a follow-up (see MetalViewport).
+            Text("Hover")
+                .font(.system(size: 9, design: .monospaced))
+                .foregroundColor(actionColor)
+            // NB: `Binding` is shadowed by a private typealias in this file, so
+            // fully qualify the SwiftUI Binding (matches modeHeader above).
+            Toggle("", isOn: SwiftUI.Binding(
+                get: { engine.hoverPreviewEnabled },
+                set: { on in
+                    engine.hoverPreviewEnabled = on
+                    if !on { engine.clearHoverPreview() }
+                }))
+                .toggleStyle(.switch)
+                .controlSize(.mini)
+                .labelsHidden()
+                .fixedSize()
+            #endif
         }
     }
 }

--- a/swiftui/PyMOLViewer/Shared/MetalViewport.swift
+++ b/swiftui/PyMOLViewer/Shared/MetalViewport.swift
@@ -104,6 +104,32 @@ class PyMOLMTKView: MTKView {
     override var acceptsFirstResponder: Bool { false }
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 
+    // Track pointer motion over the viewport so the hover pre-selection preview
+    // (issue #165) can update as the mouse moves WITHOUT any button held. A
+    // tracking area is required for mouseMoved/mouseExited to fire; recreate it
+    // on every layout change so it always spans the current visible bounds.
+    private var hoverTrackingArea: NSTrackingArea?
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let existing = hoverTrackingArea {
+            removeTrackingArea(existing)
+        }
+        let area = NSTrackingArea(
+            rect: .zero,
+            options: [.mouseMoved, .mouseEnteredAndExited, .activeInKeyWindow,
+                      .inVisibleRect],
+            owner: self, userInfo: nil)
+        addTrackingArea(area)
+        hoverTrackingArea = area
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        coordinator?.handleMouseMoved(event, in: self)
+    }
+    override func mouseExited(with event: NSEvent) {
+        coordinator?.handleMouseExited(event, in: self)
+    }
+
     override func mouseDown(with event: NSEvent) {
         coordinator?.handleMouseDown(event, in: self)
     }
@@ -210,6 +236,14 @@ struct MetalViewport: UIViewRepresentable {
         view.addGestureRecognizer(rotation)
         view.addGestureRecognizer(longPress)
 
+        // TODO(#165, iPad hover follow-up): add a UIHoverGestureRecognizer here
+        // (target: coordinator) so a trackpad/Apple-Pencil-hover on iPadOS drives
+        // the same hover pre-selection preview as macOS mouseMoved. Its .changed
+        // handler would compute NDC exactly like handleTap and call
+        // engine.hoverPreview(...); .ended would call engine.clearHoverPreview().
+        // Deferred: touch has no persistent cursor, so this only helps the
+        // pointer/pencil-hover case and needs its own gate against tap/drag.
+
         return view
     }
 
@@ -297,6 +331,11 @@ extension MetalViewport {
         private var gestureIsClip = false
         private let kClipSignX: CGFloat = 1
         private let kClipSignY: CGFloat = 1
+
+        // Hover pre-selection preview (issue #165): last view-point location fed
+        // to a preview, used to skip re-picking when the pointer barely moved.
+        // .zero is treated as "no prior move" (any first move re-picks).
+        private var lastHoverLoc: CGPoint = .zero
         #endif
 
         #if os(iOS)
@@ -429,8 +468,40 @@ extension MetalViewport {
             // PyMOL's mouse handling for an actual drag (rotate), so the
             // button-down is deferred to the first drag event (below). A pure
             // click selects via metal_pick in mouseUp instead.
+            // A committing click starts: drop any hover preview so it can't
+            // linger under (or fight) the committed selection.
+            engine?.clearHoverPreview()
+            lastHoverLoc = .zero
             mouseDownLoc = view.convert(event.locationInWindow, from: nil)
             didDrag = false
+        }
+
+        // Pointer moved over the viewport with no button held → refresh the hover
+        // pre-selection preview (issue #165). No-op while measuring or during a
+        // drag (didDrag guards the button-held drag path). Computes NDC EXACTLY
+        // like handleMouseUp — bottom-left origin, no Y flip — so the preview
+        // aligns with what a click would select. A sub-pixel move gate skips the
+        // re-pick when the pointer barely moved; the engine additionally
+        // debounces the actual Python pick.
+        func handleMouseMoved(_ event: NSEvent, in view: MTKView) {
+            guard engine?.measureMode == nil, !didDrag else { return }
+            let loc = view.convert(event.locationInWindow, from: nil)
+            if lastHoverLoc != .zero,
+               hypot(loc.x - lastHoverLoc.x, loc.y - lastHoverLoc.y) < 2 {
+                return
+            }
+            lastHoverLoc = loc
+            let w = view.bounds.width, h = view.bounds.height
+            guard w > 0, h > 0 else { return }
+            let ndcX = Float(loc.x / w) * 2 - 1
+            let ndcY = Float(loc.y / h) * 2 - 1
+            engine?.hoverPreview(ndcX, ndcY, Float(w / h))
+        }
+
+        // Pointer left the viewport → clear the preview so it doesn't linger.
+        func handleMouseExited(_ event: NSEvent, in view: MTKView) {
+            lastHoverLoc = .zero
+            engine?.clearHoverPreview()
         }
 
         func handleMouseUp(_ event: NSEvent, in view: MTKView) {
@@ -514,6 +585,10 @@ extension MetalViewport {
                 // First movement: now send the button-down (at the press point)
                 // so PyMOL enters rotate mode for this drag.
                 didDrag = true
+                // A rotate/drag begins: drop the hover preview (the pointer is no
+                // longer just hovering) and reset the move gate.
+                engine?.clearHoverPreview()
+                lastHoverLoc = .zero
                 let down = pymolPoint(in: view, at: mouseDownLoc)
                 engine?.button(PYMOL_BUTTON_LEFT, state: PYMOL_BUTTON_DOWN, x: down.0, y: down.1, modifiers: mods)
             }

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -129,6 +129,11 @@ final class PyMOLEngine: ObservableObject {
     // distance/angle/dihedral. measureStatus is the prompt/result shown in the UI.
     @Published var measureMode: MeasureKind? = nil
     @Published var measureStatus: String = ""
+    // Hover pre-selection preview (issue #165, macOS): when true, moving the
+    // pointer over the viewport highlights what a click WOULD select (in a
+    // distinct light-cyan) without committing to 'sele'. User-toggleable in the
+    // Mouse panel. When false, hoverPreview() is a no-op.
+    @Published var hoverPreviewEnabled = true
     // Full settings catalog for the searchable Settings panel (loaded on demand).
     @Published var settingsCatalog: [SettingItem] = []
     // The single detail view that is currently open (accordion: at most one).
@@ -1023,6 +1028,10 @@ final class PyMOLEngine: ObservableObject {
         if let inst = instance {
             let s = theme.selectionName
             PyMOLBridge_SetSelectionColor(inst, Float(s.r), Float(s.g), Float(s.b))
+            // Hover pre-selection preview color (issue #165): fixed light-cyan,
+            // NOT theme-derived, so it reads as distinct from the committed
+            // selection color under every theme.
+            PyMOLBridge_SetPreselectionColor(inst, 0.40, 0.85, 1.0)
         }
         let chains = theme.chainCycle.map { "(\($0.pymolTriplet))" }.joined(separator: ", ")
         let elems = theme.elementColors
@@ -1933,6 +1942,49 @@ final class PyMOLEngine: ObservableObject {
     func pick(ndcX: Float, ndcY: Float, aspect: Float) {
         guard let inst = instance else { return }
         PyMOLBridge_Pick(inst, ndcX, ndcY, aspect)
+    }
+
+    // MARK: - Hover pre-selection preview (issue #165)
+
+    // Trailing coalescer for the hover re-pick so a fast mouse sweep collapses to
+    // ~one pick every ~33 ms (mirrors MetalViewport.armPanEndDebounce). Plus a
+    // last-NDC gate so a barely-moved pointer doesn't re-pick at all — the actual
+    // projection over all atoms is the cost we're throttling.
+    private var hoverWork: DispatchWorkItem?
+    private var lastHoverNDC: (Float, Float)? = nil
+    private let kHoverDebounce = 0.033        // ~33 ms trailing coalesce
+    private let kHoverMinNDC: Float = 0.004   // sub-pixel move gate (NDC²-ish)
+
+    /// Update the hover pre-selection preview to what a click at (ndcX,ndcY)
+    /// would select, without committing to 'sele'. No-op while the feature is
+    /// disabled. Debounced + sub-pixel gated so a fast sweep doesn't spam the
+    /// Python projection pick.
+    func hoverPreview(_ ndcX: Float, _ ndcY: Float, _ aspect: Float) {
+        guard isReady, hoverPreviewEnabled else { return }
+        if let last = lastHoverNDC {
+            let dx = ndcX - last.0, dy = ndcY - last.1
+            if abs(dx) < kHoverMinNDC && abs(dy) < kHoverMinNDC { return }
+        }
+        lastHoverNDC = (ndcX, ndcY)
+        hoverWork?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            self?.runPython(
+                "from pymol import metal_pick as _mp; "
+                + "_mp.hover_preview_at(\(ndcX), \(ndcY), \(aspect))")
+        }
+        hoverWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + kHoverDebounce, execute: work)
+    }
+
+    /// Cancel any pending hover pick and empty the preview selection. Cheap and
+    /// idempotent — safe to call from mouse-down / drag-start / mouse-exit and
+    /// when the user toggles the feature off.
+    func clearHoverPreview() {
+        hoverWork?.cancel()
+        hoverWork = nil
+        lastHoverNDC = nil
+        guard isReady else { return }
+        runPython("from pymol import cmd as _c; _c.select('_preselect', 'none')")
     }
 
     /// iOS long-press: identify the atom/residue under the press (read-only —


### PR DESCRIPTION
Live hover pre-selection: as the cursor moves over the viewport (macOS), the atom / residue / chain a click **would** select is highlighted in a distinct light-cyan tint, without committing anything to `sele`.

Closes #165.

## Changes
- **`metal_pick.py`** — extracted the `mouse_selection_mode` expansion into a shared `_mode_expr(best, mode)` (so hover scope == click scope), and added `hover_preview_at(ndc, aspect)` that writes a **reserved, hidden `_preselect`** selection on a hit and clears it on empty space — never touching `sele`/`pk1`.
- **C++** — `ExecutiveGetNamedSelectionCoords` + excludes `_preselect` from the committed gather; a preselect render pass (`preselColor`, smaller points) drawn *before* the committed pink pass so pink wins on overlap; `Renderer.preselColor` + setter; `PyMOLBridge_SetPreselectionColor`.
- **MetalViewport** — `NSTrackingArea` + `mouseMoved`/`mouseExited` → throttled `engine.hoverPreview` (no-op while measuring/dragging; cleared on mouse-down).
- **PyMOLEngine** — `hoverPreview()`/`clearHoverPreview()` with a ~33 ms coalescer + move gate; `@Published hoverPreviewEnabled`; `applyTheme` sets the cyan tint.
- **MousePanel** — a "Hover" toggle next to the selection-mode control. iPad trackpad-hover is a documented follow-up.

## Validation (disposable macOS VM, via MCP + screenshot)
- ✅ **C++ core + app compile and link** with the new render pass/bridge (clean two-stage build), app runs without crash.
- ✅ **Pick scope correct** for each `mouse_selection_mode`: atom→1 atom, residue→5 atoms (== `resi 76`), chain→660 atoms (== whole `1ubq`). Confirms the shared `_mode_expr`.
- ✅ **Invariants**: `sele` is never touched by hovering; `_preselect` is hidden from `get_names('public_selections')`; hovering empty space clears it (5 → 0).
- ✅ **Distinct render**: live Metal frame shows the `_preselect` markers in light-cyan, distinct from a committed pink `sele`; the new MousePanel **Hover** toggle renders.
- ⚠️ Real `mouseMoved` firing on physical cursor motion can't be injected in the headless VM (no HID); the tracking-area wiring is verified by code, and the entire downstream chain (hover_preview_at → `_preselect` → distinct render) is validated above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
