### PR TITLE
release: RayMol 1.6.1 (build 18)

### DIFF
--- a/docs/release-notes/v1.6.1.md
+++ b/docs/release-notes/v1.6.1.md
@@ -1,0 +1,32 @@
+## RayMol 1.6.1
+
+Selection and interaction polish: live hover highlighting, quicker object
+toggling, and a batch of selection, menu, and toolbar fixes.
+
+### Selecting
+- **Hover pre-selection preview.** Move the cursor over the structure and the
+  atom, residue, or chain a click *would* select is highlighted live in a
+  distinct cyan tint, matching the current selection mode — nothing is committed
+  until you click. Toggle it with **Hover** in the mouse (Selecting) controls.
+- **Esc clears the selection.** Press Esc to clear the current selection from
+  anywhere — it works even while the command line has focus, and still dismisses
+  an open dialog first.
+- **One-click clear.** The selection chip's ⊗ now deletes the selection outright
+  — removing both the markers and the lingering `(sele)` entry — with a tooltip
+  to match.
+
+### Objects
+- **Toggle a structure from anywhere on its row.** Click anywhere in an object's
+  row — not just the checkbox — to show or hide it, and the checkbox now flips
+  instantly with no lag.
+
+### Camera
+- **Auto-lock focus from the right-click menu.** Right-click (or long-press) a
+  residue and choose **Auto-lock focus** to lock depth-of-field onto it.
+
+### Fixes
+- **Fixed: ⌘C copies the rendered image** to the clipboard again — it's a proper
+  menu command now (*File ▸ Copy Image to Clipboard*).
+- **Fixed: removed a stray empty button** from the top toolbar.
+
+Built on the open-source PyMOL engine. Updates install automatically via the in-app updater (**Check for Updates…** in the app menu).

--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -141,7 +141,7 @@
 		F2078076B68D28457409F7A5 /* RayMol.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RayMol.entitlements; sourceTree = "<group>"; };
 		F607D204A410CA38B84223BE /* RayMolUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RayMolUpdater.swift; sourceTree = "<group>"; };
 		FB1304C662D9011F7C4505FC /* MCPStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPStatusView.swift; sourceTree = "<group>"; };
-		"TEMP_8158F08B-D4D3-474B-A84C-1D6EA3BA07E1" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
+		"TEMP_2CD50F39-021D-4094-80D8-CCA4E625FE9F" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -263,10 +263,10 @@
 			path = Bridge;
 			sourceTree = "<group>";
 		};
-		"TEMP_55636D4C-447E-4271-BA62-4F4AB818144B" /* swiftui */ = {
+		"TEMP_0399BBAC-ECC6-406E-A17B-847D9A9A4A1C" /* swiftui */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_8158F08B-D4D3-474B-A84C-1D6EA3BA07E1" /* PyMOLBridge.xcconfig */,
+				"TEMP_2CD50F39-021D-4094-80D8-CCA4E625FE9F" /* PyMOLBridge.xcconfig */,
 			);
 			path = swiftui;
 			sourceTree = "<group>";
@@ -908,7 +908,7 @@
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = RayMol;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -922,7 +922,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -938,7 +938,7 @@
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = RayMol;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -952,7 +952,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -969,7 +969,7 @@
 				CODE_SIGN_ENTITLEMENTS = PyMOLViewer/RayMol.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				DEVELOPMENT_TEAM = VT99UQUQ89;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -985,7 +985,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -1022,7 +1022,7 @@
 				CODE_SIGN_ENTITLEMENTS = PyMOLViewer/RayMol.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				DEVELOPMENT_TEAM = VT99UQUQ89;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1038,7 +1038,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -1050,7 +1050,7 @@
 		};
 		76B7E9DB75E073D1E60928FA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_8158F08B-D4D3-474B-A84C-1D6EA3BA07E1" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_2CD50F39-021D-4094-80D8-CCA4E625FE9F" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1135,7 +1135,7 @@
 		};
 		D8F44FDFF036013D2F03BA83 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_8158F08B-D4D3-474B-A84C-1D6EA3BA07E1" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_2CD50F39-021D-4094-80D8-CCA4E625FE9F" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/swiftui/project.yml
+++ b/swiftui/project.yml
@@ -62,8 +62,8 @@ targets:
         # AppIcon.appiconset fallback. Applies to both macOS + iOS.
         ASSETCATALOG_COMPILER_APPICON_NAME: RayMol
         INFOPLIST_GENERATION_MODE: GeneratedFile
-        MARKETING_VERSION: "1.6.0"
-        CURRENT_PROJECT_VERSION: 17
+        MARKETING_VERSION: "1.6.1"
+        CURRENT_PROJECT_VERSION: 18
         GENERATE_INFOPLIST_FILE: YES
         # Generate a launch screen so iOS renders at the device's NATIVE
         # resolution. Without it the app is letterboxed at a legacy size on


### PR DESCRIPTION
Version bump + release notes for 1.6.1 (selection/interaction polish: hover preview, one-click chip delete, Esc-clears, whole-row toggle, auto-lock focus menu, ⌘C copy-image, toolbar cleanup).