### PR TITLE
fix(#165): hover no longer deselects the committed selection

### DIFF
--- a/modules/pymol/metal_pick.py
+++ b/modules/pymol/metal_pick.py
@@ -523,15 +523,22 @@ def hover_preview_at(ndc_x, ndc_y, aspect):
     try:
         best = _pick_atom(ndc_x, ndc_y, aspect)
         if best is None:
-            # Empty space: clear the preview (leave 'sele' untouched).
-            cmd.select(_PRESELECT, 'none')
+            # Empty space: clear the preview (leave 'sele' untouched). enable=0:
+            # NEVER enable '_preselect' — cmd.enable is exclusive for selections
+            # and would DISABLE the committed 'sele', hiding its pink markers
+            # (the atoms stay in 'sele', which is why a click still appended).
+            # The renderer draws '_preselect' by atom membership regardless of
+            # its enabled flag, so the cyan preview still shows.
+            cmd.select(_PRESELECT, 'none', enable=0)
             return
 
         try:
             mode = int(cmd.get_setting_int('mouse_selection_mode'))
         except Exception:
             mode = 1
-        cmd.select(_PRESELECT, _mode_expr(best, mode))
-        cmd.enable(_PRESELECT)
+        # enable=0 and NO cmd.enable — see the note above: enabling '_preselect'
+        # would deselect the committed 'sele'. The C++ preselect pass renders it
+        # by name/membership regardless of enabled state.
+        cmd.select(_PRESELECT, _mode_expr(best, mode), enable=0)
     except Exception as e:
         print('metal_pick hover error: %s' % e)

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -2026,7 +2026,10 @@ final class PyMOLEngine: ObservableObject {
         hoverWork = nil
         lastHoverNDC = nil
         guard isReady else { return }
-        runPython("from pymol import cmd as _c; _c.select('_preselect', 'none')")
+        // enable=0: never enable '_preselect' — enabling a selection is exclusive
+        // and would disable the committed 'sele', hiding its markers. (The
+        // renderer draws '_preselect' by membership regardless of enabled state.)
+        runPython("from pymol import cmd as _c; _c.select('_preselect', 'none', enable=0)")
     }
 
     /// iOS long-press: identify the atom/residue under the press (read-only —


### PR DESCRIPTION
Hover's cmd.enable('_preselect') was exclusively disabling the committed 'sele' (markers vanished on mouse-move; atoms preserved so clicks still appended). Now creates '_preselect' with enable=0 and never enables it — the C++ preselect pass renders it by membership regardless of enabled state, so the cyan preview shows while 'sele' keeps its markers. Verified live via MCP: sele stays enabled through hit + empty-space hover, preselect still populates.