### PR TITLE
fix(theme): built-in themes re-derive from presets (outline stays off)

### DIFF
--- a/swiftui/PyMOLViewer/Shared/ThemeManager.swift
+++ b/swiftui/PyMOLViewer/Shared/ThemeManager.swift
@@ -39,7 +39,13 @@ final class ThemeManager: ObservableObject {
         // across an app purge); fall back to id lookup, then Classic.
         if let data = d.data(forKey: activeFullKey),
            let full = try? JSONDecoder().decode(Theme.self, from: data) {
-            active = full
+            // Built-in themes are code-defined — edits fork to a custom id via
+            // saveCustom, so a built-in id is always meant to BE its preset. The
+            // cache must not pin a stale built-in look (e.g. a Paper saved before
+            // outline defaulted off would keep re-applying metal_outline=1), so
+            // re-derive built-ins from the current preset. Custom themes (their
+            // own ids) keep the cached JSON, preserving unsaved edits.
+            active = Theme.builtInPresets.first(where: { $0.id == full.id }) ?? full
         } else {
             let storedID = d.string(forKey: activeKey).flatMap { UUID(uuidString: $0) }
             let pool = Theme.builtInPresets + loadedCustom


### PR DESCRIPTION
The persisted activeFull cache pinned a stale built-in look — a Paper theme saved before outline defaulted off kept re-applying metal_outline=1 on launch, so users still saw outlines. Built-in themes are code-defined (edits fork to custom ids), so on load we now re-derive a built-in-id active theme from the current preset; custom themes keep their cached JSON. Verified: with Paper(outline:true) persisted, the app launches with metal_outline=off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)