### PR TITLE
fix(theme): outline off by default (build-independent, in bundled Python)

### DIFF
--- a/modules/pymol/raymol_theme.py
+++ b/modules/pymol/raymol_theme.py
@@ -48,7 +48,11 @@ def set_palette(bg=None, outline=False, flat_sheets=False, fancy_helices=False,
     if bg is not None:
         cmd.bg_color(_hex(bg))
     if apply_render_toggles:
-        cmd.set("metal_outline", 1 if outline else 0)
+        # Outline is OFF in every theme (product decision, RayMol 1.6.1). Force it
+        # off on theme apply regardless of the `outline` flag, so a stale cached
+        # theme (e.g. a pre-1.6.1 Paper persisted with outline on) can never
+        # re-enable it. `outline` is kept only for signature/back-compat.
+        cmd.set("metal_outline", 0)
         cmd.set("metal_raytrace", 1 if ray_trace else 0)
         cmd.set("metal_shadows", 1 if shadows else 0)
 

--- a/modules/pymol/raymol_theme.py
+++ b/modules/pymol/raymol_theme.py
@@ -47,12 +47,14 @@ def set_palette(bg=None, outline=False, flat_sheets=False, fancy_helices=False,
 
     if bg is not None:
         cmd.bg_color(_hex(bg))
+    # Outline is OFF in every theme (product decision, RayMol 1.6.1). Force it off
+    # UNCONDITIONALLY on every theme apply — OUTSIDE the apply_render_toggles gate
+    # — so it's off even on a restored/opened session (when render toggles are
+    # otherwise suppressed) and regardless of a stale compiled core default or a
+    # pre-1.6.1 cached theme. set_palette runs on every launch, so this is the
+    # reliable place to enforce it. `outline` is kept only for signature/back-compat.
+    cmd.set("metal_outline", 0)
     if apply_render_toggles:
-        # Outline is OFF in every theme (product decision, RayMol 1.6.1). Force it
-        # off on theme apply regardless of the `outline` flag, so a stale cached
-        # theme (e.g. a pre-1.6.1 Paper persisted with outline on) can never
-        # re-enable it. `outline` is kept only for signature/back-compat.
-        cmd.set("metal_outline", 0)
         cmd.set("metal_raytrace", 1 if ray_trace else 0)
         cmd.set("metal_shadows", 1 if shadows else 0)
 

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -2849,6 +2849,13 @@ struct ContentView: View {
     private func applyPersistedTheme() {
         themeManager.apply(engine: engine,
                            applyRenderToggles: !engine.suppressLaunchThemeRenderToggles)
+        // Outline is off by default in RayMol 1.6.1 and no theme enables it.
+        // Force it off unconditionally on launch — independent of the theme's
+        // render-toggle suppression AND of the (historically flaky) compiled core
+        // default — so a stale core / cached theme can never surface an outline
+        // the user didn't ask for. Users can still enable it live (Display ▸
+        // Effects); this only governs the default at launch.
+        engine.runCommand("set metal_outline, 0")
     }
 }
 

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -1107,7 +1107,9 @@ final class PyMOLEngine: ObservableObject {
         py += "    from pymol import cmd as _c\n"
         py += "    _c.bg_color('\(bgHex)')\n"
         if applyRenderToggles {
-            py += "    _c.set('metal_outline', \(theme.outline ? 1 : 0))\n"
+            // Outline is off in every theme (RayMol 1.6.1) — force off regardless
+            // of theme.outline, matching raymol_theme.set_palette.
+            py += "    _c.set('metal_outline', 0)\n"
             py += "    _c.set('metal_raytrace', \(theme.rayTrace ? 1 : 0)); _c.set('metal_shadows', \(theme.shadows ? 1 : 0))\n"
         }
         runPython(py)


### PR DESCRIPTION
## Problem
Outline still rendered **on** at launch in the signed 1.6.1 DMG despite the theme presets being set to `outline: false`, the ThemeManager re-derive fix, and a Swift launch force-off.

## Root cause
`raymol_theme.set_palette` set `metal_outline` via `cmd.set("metal_outline", 1 if outline else 0)` **inside** the `if apply_render_toggles:` gate. Two things conspired:
- Shipped DMGs carried a **persisted Paper theme with `outline=True`** (stale cached `activeFull`), so the `outline` flag passed in was `True`.
- macOS launches with the render-toggle gate **open** (autosave/resume is iOS-only), so that line ran and set outline **on**.

Separately, `make_dmg` was shipping **stale bundled Python** (the modules/ copy wasn't reliably refreshed), so earlier source fixes never reached the DMG.

## Fix
Force `metal_outline` **off unconditionally** in `set_palette`, **outside** the `apply_render_toggles` gate — so every theme apply (which runs on every launch; it always applies bg) forces outline off, regardless of the theme's `outline` flag, a stale cached theme, or a stale compiled-core default. This lives in the reliably-bundled Python, immune to the flaky Release Swift compile. The `outline` parameter is kept for signature/back-compat.

Also keeps the belt-and-suspenders Swift launch force-off (ContentView) and the earlier in-gate force-off.

## Verification (signed, notarized DMG)
Installed from a **freshly-mounted** DMG (all stale `hdiutil` mounts cleared) and probed via MCP:
- Empty launch → `metal_outline = off`, `bg = 0xffffff` (theme applied).
- Seeded-session relaunch → `metal_outline = off`.
- `set metal_outline, 1` at runtime still sticks for power users who want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)