### PR TITLE
fix(release): harden macOS DMG build against shipping stale code

### DIFF
--- a/.claude/skills/cut-macos-release/SKILL.md
+++ b/.claude/skills/cut-macos-release/SKILL.md
@@ -13,7 +13,7 @@ The default rhythm is **prep → test → publish**: stage everything and build 
 
 1. **Never `git push` directly to `master`.** The repo convention (CLAUDE.md) forbids it and the harness is expected to block it. The bump, release notes, and appcast commit ALL go through a PR (`gh pr create` → `gh pr merge --merge`). **Tag** pushes (`git push origin vX.Y.Z`) are fine — only default-**branch** pushes are gated. "Release" from the user does NOT authorize a direct push.
 2. **Build from the exact tagged commit.** The scripts resolve their root from the script's own location, so building from the wrong directory or an un-synced worktree silently ships the wrong bits. After the PR merges, re-sync the worktree to `origin/master` and assert its `HEAD` equals the release tag's commit before building (Step 5).
-3. **Rebuild the C++ core, then the app (two stages).** `xcodebuild`/`make_dmg.sh` only *link* a prebuilt `libpymol_core.a`; they never rebuild it. If any C++/Metal file changed since the last core build, run `swiftui/build_macos.sh` first — and verify the `.a` is actually fresh — or you ship a binary missing those changes with no error (this shipped a broken v1.3.0).
+3. **The C++ core is a separate build from the app.** `make_dmg.sh` now rebuilds it **clean** automatically (step 0: `CLEAN=1 build_macos.sh`) and asserts the packaged bundle isn't stale, so the shipped DMG is self-protecting — pass `SKIP_CORE_BUILD=1` only if you just built it clean yourself. The catch is the **Step-2 RC**: that's a plain Debug `xcodebuild` which only *links* a prebuilt `libpymol_core.a`, so you must run `swiftui/build_macos.sh` yourself before it (add `CLEAN=1` if a setting *default* changed in `SettingInfo.h`) — skip that and the RC tests stale bits (a stale core shipped a broken v1.3.0; an incremental core also once compiled `metal_outline` defaulting `true` while source said `false`).
 4. **The build number must strictly increase past the last PUBLISHED build.** Sparkle compares updates on `CURRENT_PROJECT_VERSION`. Don't trust a hand-typed number: read it from the built app and compare against the live appcast's last `sparkle:version` (Step 6). A non-increasing build publishes cleanly but is silently never offered.
 5. **Verify before you publish, verify the live feed after.** Confirm the app inside the DMG is the intended version, notarized, stapled, and carries the Sparkle key — then, post-publish, confirm `/latest/download/appcast.xml` serves the new version.
 
@@ -23,7 +23,7 @@ See `references/gotchas.md` for the full failure-mode catalog and recovery recip
 
 - **Version:** `swiftui/project.yml` — `MARKETING_VERSION` (e.g. `1.5.1`) and `CURRENT_PROJECT_VERSION` (integer build). This is the xcodegen source of truth; `project.pbxproj` is regenerated from it and carries the same version strings across its build configs.
 - **Release notes:** `docs/release-notes/vX.Y.Z.md` — Markdown, spliced into the appcast and used as the GitHub release body. See `references/release-notes-style.md`.
-- **Scripts** (`swiftui/`): `build_macos.sh` (rebuild core `.a`, no env vars), `make_dmg.sh` (Release build → Developer-ID sign → notarize → DMG), `publish_release.sh` (EdDSA-sign → write `appcast.xml` → GitHub release).
+- **Scripts** (`swiftui/`): `build_macos.sh` (rebuild core `.a`; `CLEAN=1` wipes the build dir first — required when a setting default changed), `make_dmg.sh` (clean core → clean Release build → Developer-ID sign → notarize → DMG; auto-rebuilds the core clean + runs a stale-bundle sanity check, honors `SKIP_CORE_BUILD=1`, logs to `build_dmg_logs/`), `publish_release.sh` (EdDSA-sign → write `appcast.xml` → GitHub release).
 - **Live auto-update feed:** the release **asset** at `https://github.com/javierbq/RayMol/releases/latest/download/appcast.xml` (NOT the tracked repo copy — that's optional bookkeeping that drifts).
 
 Version numbers below (`X.Y.Z`, build `N`) are placeholders — always read the live values, never assume the examples are current.
@@ -65,9 +65,10 @@ git worktree add -b release/X.Y.Z ../raymol-release-X.Y.Z origin/master
 cd ../raymol-release-X.Y.Z
 WT=$(pwd)                                  # reused in later steps
 ```
-A worktree doesn't get git-ignored deps/build dirs, so wire them up (target the real main-repo path on this machine):
+A worktree doesn't get git-ignored deps/build dirs, so wire them up. Resolve the main clone from git rather than hardcoding a path — this works on any machine/checkout:
 ```bash
-[ -e deps_macos ] || ln -s /Users/jcastellanos/repos/RayMol/deps_macos deps_macos
+MAIN_REPO=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)   # the main clone that owns the git-ignored deps
+[ -e deps_macos ] || ln -s "$MAIN_REPO/deps_macos" deps_macos
 test -e deps_macos/python-standalone/python/include/python3.13/Python.h && echo "deps OK"
 ```
 
@@ -81,7 +82,7 @@ Bump the version and write notes:
 
 Build the RC and open it (two-stage — non-negotiable #3). Prefer delegating to the `multiplatform-build-deployer` agent, instructing it to build **from `$WT`, not the main repo**:
 ```bash
-bash swiftui/build_macos.sh                             # rebuild core from THIS checkout
+bash swiftui/build_macos.sh                             # rebuild core from THIS checkout (CLEAN=1 if a setting default changed)
 ( cd swiftui && xcodegen generate )                     # regenerate pbxproj with the new version
 xcodebuild -project swiftui/PyMOLViewer.xcodeproj -scheme PyMOLViewer_macOS \
   -configuration Debug -derivedDataPath swiftui/build_mac_dd CODE_SIGNING_ALLOWED=NO build
@@ -113,7 +114,7 @@ git tag -a vX.Y.Z -m "release: RayMol X.Y.Z (build N) — <one-line>" origin/mas
 git push origin vX.Y.Z          # tag pushes are allowed
 ```
 
-## Step 5 — Re-sync, rebuild core, build the notarized DMG
+## Step 5 — Re-sync and build the notarized DMG
 
 Build **from the exact tagged commit** (non-negotiable #2). Re-sync the worktree and assert identity first:
 ```bash
@@ -124,17 +125,12 @@ git -C "$WT" reset --hard origin/master
 ```
 (The reset drops the local bump commit in favor of the merged version — same content — and re-drops the deps symlink only if it was tracked; it isn't, so it survives.)
 
-Rebuild the core from the final checkout and **verify the `.a` is fresh** (non-negotiable #3):
-```bash
-bash "$WT/swiftui/build_macos.sh"
-stat -f '%Sm' "$WT/build_macos_swiftui/libpymol_core.a"   # must be from THIS run, newer than the release commit
-```
-Then build the DMG (20–40 min — run in the background; absolute path so it can't build the wrong checkout):
+Build the DMG (20–40 min — run in the background; absolute path so it can't build the wrong checkout). `make_dmg.sh` now rebuilds the core **clean** itself (step 0), so no separate `build_macos.sh` run is needed — the shipped DMG can't link a stale core:
 ```bash
 DEVID="Developer ID Application: Javier Castellanos (VT99UQUQ89)" \
   VERSION=X.Y.Z NOTARY_PROFILE=RayMol-notary bash "$WT/swiftui/make_dmg.sh"
 ```
-`make_dmg.sh` on master builds from any checkout (pinned `-derivedDataPath`) and packages mount-free (`hdiutil makehybrid`). Output: `$WT/RayMol-X.Y.Z.dmg`. It locates Sparkle's `generate_keys` inside resolved SPM DerivedData; if it errors "not found", the RC build in Step 2 should have resolved it — otherwise run `xcodebuild -resolvePackageDependencies`.
+`make_dmg.sh` clean-builds `libpymol_core.a`, does a clean Release build, and — **before** the long notarization — asserts the bundled `Contents/Resources/modules` byte-match source `modules/` and the app's version equals `VERSION`, so a stale or mislabeled package fails fast instead of burning ~40 min. It builds from any checkout (pinned `-derivedDataPath`), packages mount-free (`hdiutil makehybrid`), and captures build output to `build_dmg_logs/` (not `/dev/null`). Output: `$WT/RayMol-X.Y.Z.dmg`. It locates Sparkle's `generate_keys` inside resolved SPM DerivedData; if it errors "not found", run `xcodebuild -resolvePackageDependencies`. (If you *just* built the core clean yourself, pass `SKIP_CORE_BUILD=1` to skip the rebuild.)
 
 ## Step 6 — Verify the DMG BEFORE publishing
 

--- a/.claude/skills/cut-macos-release/references/gotchas.md
+++ b/.claude/skills/cut-macos-release/references/gotchas.md
@@ -3,11 +3,15 @@
 Hard-won lessons from cutting v1.3–v1.5.x. Read the relevant entry when a step misbehaves.
 
 ## Stale `libpymol_core.a` — ships a binary missing C++ changes, no error
-`xcodebuild` and `make_dmg.sh` only **link** the prebuilt `build_macos_swiftui/libpymol_core.a`; they never rebuild it. If any C++/Metal file (`layer*`, `layerGraphics/`) changed since the last core build, the change is silently absent at runtime even though the build reports SUCCESS. This shipped a broken v1.3.0 (a merged fix was in the source but not the `.a`) → had to hotfix v1.3.1.
-**Cure:** run `swiftui/build_macos.sh` from the final release checkout before `make_dmg.sh`. Verify `stat -f '%Sm' build_macos_swiftui/libpymol_core.a` is newer than your last C++ edit / the release commit.
+Historically `xcodebuild`/`make_dmg.sh` only **linked** the prebuilt `build_macos_swiftui/libpymol_core.a` and never rebuilt it, so a changed C++/Metal file (`layer*`, `layerGraphics/`) was silently absent at runtime even though the build reported SUCCESS (shipped a broken v1.3.0 → hotfix v1.3.1). Worse, an *incremental* core can be **mtime-fresh but content-stale**: the generated settings table isn't reliably recompiled, so a changed default in `layer1/SettingInfo.h` ships wrong (`metal_outline` compiled `true` while source said `false` in 1.6.1) — an mtime check does NOT catch this.
+**Status:** `make_dmg.sh` step 0 now rebuilds the core **clean** (`CLEAN=1 build_macos.sh`) by default, which cures both the missing-change and the stale-default cases for the shipped DMG. Pass `SKIP_CORE_BUILD=1` to opt out (only if you just built it clean yourself). The **Step-2 RC** still uses a plain Debug `xcodebuild` that only links, so build the core yourself first — with `CLEAN=1` when a setting default changed.
+
+## Stale bundled Python — ships old `.py` under `Resources/modules`, no error
+The macOS resource phase copies `modules/` into the app with `ditto` in a `basedOnDependencyAnalysis:false` phase. Reusing `build_mac_release_dd` incrementally can skip it, so a changed bundled module ships stale while the build reports SUCCESS (1.6.1 shipped an old `raymol_theme.py` even though the source and a Debug build were fresh).
+**Status:** `make_dmg.sh` now clears `build_mac_release_dd/Build` and does a `clean build` (fresh compile + guaranteed re-copy), and step 1c asserts `Contents/Resources/modules` byte-matches source `modules/` (excluding `__pycache__`/`.pyc`/`.DS_Store`) **before** notarizing — a stale copy fails fast. Full build output goes to `build_dmg_logs/` (no longer `/dev/null`), so a failure or stale-skip is visible.
 
 ## Wrong checkout — built the wrong branch's code + version
-`make_dmg.sh`/`build_macos.sh`/`publish_release.sh` compute `PYMOL_ROOT` from the **script's own location**. On v1.4.1, running the release from the main repo (`cd /Users/jcastellanos/repos/RayMol`) while it was on a different branch built that branch's app at the old version — notarized fine, wrong bits. 
+`make_dmg.sh`/`build_macos.sh`/`publish_release.sh` compute `PYMOL_ROOT` from the **script's own location**. On v1.4.1, running the release from the main clone (`cd <main-repo-root>`) while it was on a different branch built that branch's app at the old version — notarized fine, wrong bits. 
 **Cure:** run the scripts by absolute path *inside the release worktree*, and always verify `build_dmg/RayMol.app/Contents/Info.plist` shows the intended version BEFORE publishing.
 
 ## Direct push to master is BLOCKED

--- a/swiftui/build_macos.sh
+++ b/swiftui/build_macos.sh
@@ -2,6 +2,14 @@
 # build_macos.sh — build libpymol_core.a for native macOS (arm64), Metal-only
 # (NO_OPENGL), compiled against the embedded python-build-standalone 3.13 headers.
 # The static lib links nothing; linking happens in the Xcode app via the xcconfig.
+#
+# CLEAN=1 wipes the build dir before configuring. Use it whenever a setting
+# DEFAULT changed (layer1/SettingInfo.h) — an incremental build does NOT reliably
+# recompile the generated settings table, so it can ship a stale default with a
+# fresh-looking mtime and no error (this shipped metal_outline compiled `true`
+# while source said `false` in 1.6.1). The release path (make_dmg.sh) always
+# builds clean for exactly this reason. Incremental (the default) keeps day-to-day
+# dev fast.
 set -euo pipefail
 
 PYMOL_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -12,6 +20,12 @@ NCPU=$(sysctl -n hw.ncpu)
 PYMOL_EXTERNAL_PREFIX="${PYMOL_EXTERNAL_PREFIX:-/opt/homebrew}"
 
 test -d "$PY" || { echo "ERROR: run scripts/fetch_macos_python.sh first ($PY missing)"; exit 1; }
+
+CLEAN="${CLEAN:-0}"
+case "$CLEAN" in
+  1|true|yes|on) echo "== Clean core build (rm -rf $BUILD_DIR) =="; rm -rf "$BUILD_DIR" ;;
+  *)             echo "== Incremental core build (set CLEAN=1 if a setting default changed) ==" ;;
+esac
 
 mkdir -p "$BUILD_DIR"
 cd "$BUILD_DIR"

--- a/swiftui/make_dmg.sh
+++ b/swiftui/make_dmg.sh
@@ -40,11 +40,23 @@ RELEASE_DD="$PYMOL_ROOT/build_mac_release_dd"
 DERIVED="$RELEASE_DD/Build/Products/Release"
 ENTITLEMENTS="$SWIFTUI/RayMol_DeveloperID.entitlements"
 WORK="$PYMOL_ROOT/build_dmg"
+CORE_BUILD="$PYMOL_ROOT/build_macos_swiftui"   # libpymol_core.a the Xcode build links
+LOGDIR="$PYMOL_ROOT/build_dmg_logs"            # build logs (kept out of $WORK, which we wipe)
 APPNAME="RayMol"
-VERSION="${VERSION:-1.0.0}"
+# Track whether the caller pinned a version. If they did, we assert it matches the
+# packaged app's Info.plist below (a mismatch = a wrong/stale package); if they
+# didn't, we adopt the app's own CFBundleShortVersionString so the DMG name +
+# appcast can't silently disagree with what's inside the bundle.
+if [ -n "${VERSION:-}" ]; then VERSION_EXPLICIT=1; else VERSION_EXPLICIT=0; fi
+VERSION="${VERSION:-}"
+# SKIP_CORE_BUILD=1 skips the clean core rebuild below — use ONLY when you just
+# built the core clean yourself; the app still links whatever is in $CORE_BUILD.
+SKIP_CORE_BUILD="${SKIP_CORE_BUILD:-0}"
 
 : "${DEVID:?Set DEVID to your 'Developer ID Application: NAME (TEAMID)' identity}"
 NOTARY_PROFILE="${NOTARY_PROFILE:-RayMol-notary}"
+
+mkdir -p "$LOGDIR"
 
 # --- Preflight (hardening after the 1.2.1 build got tripped up) ---------------
 # Keep the Mac awake for the whole run. This script has two multi-minute Apple
@@ -66,6 +78,27 @@ if ! xcrun notarytool history --keychain-profile "$NOTARY_PROFILE" >/dev/null 2>
 fi
 # ------------------------------------------------------------------------------
 
+echo "== 0/8  Build a clean C++ core (libpymol_core.a) =="
+# The Xcode build only LINKS $CORE_BUILD/libpymol_core.a; it never rebuilds it.
+# An incremental core can ship a stale setting default with a fresh mtime and no
+# error (this shipped metal_outline=true in 1.6.1). Build it CLEAN here so the
+# packaged app can't link a stale core. Override with SKIP_CORE_BUILD=1 only when
+# you just built it clean yourself.
+CORELOG="$LOGDIR/build_macos_core.log"
+case "$SKIP_CORE_BUILD" in
+  1|true|yes|on)
+    echo "  SKIP_CORE_BUILD set — using existing $CORE_BUILD/libpymol_core.a"
+    [ -f "$CORE_BUILD/libpymol_core.a" ] || { echo "ERROR: no libpymol_core.a at $CORE_BUILD (unset SKIP_CORE_BUILD)"; exit 1; }
+    ;;
+  *)
+    echo "  (full core build log → $CORELOG)"
+    if ! CLEAN=1 bash "$SWIFTUI/build_macos.sh" >"$CORELOG" 2>&1; then
+      echo "ERROR: clean core build failed. Last 40 lines of $CORELOG:"; tail -40 "$CORELOG"; exit 1
+    fi
+    [ -f "$CORE_BUILD/libpymol_core.a" ] || { echo "ERROR: core build produced no libpymol_core.a at $CORE_BUILD (see $CORELOG)"; exit 1; }
+    ;;
+esac
+
 echo "== 1/8  Build Release app (unsigned; we Developer-ID-sign below) =="
 # Regenerate the Xcode project from project.yml first: this script builds the
 # .xcodeproj directly (unlike build.sh, it does not run xcodegen), so without
@@ -77,12 +110,24 @@ if command -v xcodegen >/dev/null 2>&1; then
 else
   echo "  WARNING: xcodegen not found — building the existing .xcodeproj as-is."
 fi
-xcodebuild -project "$SWIFTUI/PyMOLViewer.xcodeproj" -scheme PyMOLViewer_macOS \
+# Clean before building. Reused DerivedData does NOT reliably recompile changed
+# Swift or re-run the resource-copy phases (basedOnDependencyAnalysis:false), so
+# an incremental Release shipped stale Swift + a stale bundled raymol_theme.py in
+# 1.6.1. `rm -rf Build/` drops the old built product (keeping SourcePackages so
+# SPM/Sparkle isn't re-fetched) and `clean build` resets xcodebuild's own graph;
+# the 1c sanity step below proves the fresh copy actually happened. Full output
+# goes to a log (never /dev/null) so a build failure or stale-skip is visible.
+rm -rf "$RELEASE_DD/Build"
+XCLOG="$LOGDIR/xcodebuild-release.log"
+echo "  (full xcodebuild output → $XCLOG)"
+if ! xcodebuild -project "$SWIFTUI/PyMOLViewer.xcodeproj" -scheme PyMOLViewer_macOS \
   -configuration Release -destination 'platform=macOS,arch=arm64' \
   -derivedDataPath "$RELEASE_DD" \
-  CODE_SIGNING_ALLOWED=NO build >/dev/null
+  CODE_SIGNING_ALLOWED=NO clean build >"$XCLOG" 2>&1; then
+  echo "ERROR: Release build failed. Last 60 lines of $XCLOG:"; tail -60 "$XCLOG"; exit 1
+fi
 SRC_APP="$DERIVED/$APPNAME.app"
-[ -d "$SRC_APP" ] || { echo "ERROR: built app not found at $SRC_APP"; exit 1; }
+[ -d "$SRC_APP" ] || { echo "ERROR: built app not found at $SRC_APP (see $XCLOG)"; exit 1; }
 
 rm -rf "$WORK"; mkdir -p "$WORK"
 cp -R "$SRC_APP" "$WORK/$APPNAME.app"
@@ -112,6 +157,36 @@ ED_PUB="$("$GEN_KEYS" -p 2>/dev/null)"
 GOT="$(/usr/bin/plutil -extract SUPublicEDKey raw "$PLIST" 2>/dev/null)"
 [ "$GOT" = "$ED_PUB" ] || { echo "ERROR: SUPublicEDKey injection/verification failed."; exit 1; }
 echo "  SUPublicEDKey=$ED_PUB injected + verified in $PLIST"
+
+echo "== 1c/8  Sanity: verify the packaged app is NOT stale =="
+# Runs BEFORE signing/notarization so a stale package fails fast instead of
+# burning ~40 min of Apple notarization on a bad build.
+# (1) Bundled Python must byte-match source. The macOS resource phase copies
+#     modules/ with `ditto` in a basedOnDependencyAnalysis:false phase that a
+#     reused build can skip — that shipped a stale raymol_theme.py in 1.6.1.
+#     After a clean build the copy must be identical; assert it.
+BUNDLED_MODULES="$APP/Contents/Resources/modules"
+[ -d "$BUNDLED_MODULES" ] || { echo "ERROR: no bundled modules at $BUNDLED_MODULES"; exit 1; }
+MODDIFF="$LOGDIR/modules-diff.log"
+if ! diff -rq -x '__pycache__' -x '*.pyc' -x '.DS_Store' \
+     "$PYMOL_ROOT/modules" "$BUNDLED_MODULES" >"$MODDIFF" 2>&1; then
+  echo "ERROR: bundled Python (Contents/Resources/modules) does NOT match source"
+  echo "       modules/ — the package is STALE. Differences (also in $MODDIFF):"
+  cat "$MODDIFF"
+  exit 1
+fi
+echo "  bundled modules/ byte-match source (fresh)"
+# (2) The packaged app's version must agree with the version we name the DMG /
+#     appcast after. Caller pinned it → a mismatch is fatal; otherwise adopt the
+#     app's own version so the two can't silently diverge.
+APP_VER="$(/usr/bin/plutil -extract CFBundleShortVersionString raw "$PLIST" 2>/dev/null || true)"
+[ -n "$APP_VER" ] || { echo "ERROR: could not read CFBundleShortVersionString from $PLIST"; exit 1; }
+if [ "$VERSION_EXPLICIT" = 1 ]; then
+  [ "$VERSION" = "$APP_VER" ] || { echo "ERROR: packaging VERSION=$VERSION but app Info.plist is $APP_VER"; exit 1; }
+else
+  VERSION="$APP_VER"
+fi
+echo "  packaging version = $VERSION (matches app CFBundleShortVersionString)"
 
 echo "== 2/8  Sign every embedded Mach-O, deepest path first =="
 # Enumerate ALL real files, keep the Mach-O ones (incl. extensionless


### PR DESCRIPTION
## Problem

`swiftui/make_dmg.sh` reused `build_mac_release_dd` incrementally and piped `xcodebuild` to `/dev/null`, which silently shipped **stale code** in a notarized DMG:

- **Stale Swift + bundled Python** — incremental Release builds don't reliably recompile changed Swift, and the `basedOnDependencyAnalysis:false` `ditto` resource phase can skip re-copying `modules/`. RayMol 1.6.1 shipped an old `raymol_theme.py` even though source + a Debug build were fresh.
- **Content-stale C++ core** — `build_macos_swiftui/libpymol_core.a` went stale for a `SettingInfo.h` default (`metal_outline` compiled `true` while source said `false`) with a *fresh mtime*, so an mtime check couldn't catch it.

Both cost hours during the 1.6.1 outline fix.

## Changes

**`swiftui/make_dmg.sh`**
- **Clean core (step 0):** builds `libpymol_core.a` clean by default (`CLEAN=1 build_macos.sh`); overridable with `SKIP_CORE_BUILD=1`. Closes the content-stale-core trap.
- **Clean Release build:** `rm -rf "$RELEASE_DD/Build"` + `clean build` (keeps `SourcePackages/` so SPM/Sparkle isn't re-fetched). Forces fresh Swift compile + resource re-copy.
- **No more `/dev/null`:** core + `xcodebuild` output captured to `build_dmg_logs/`; on failure prints the tail and aborts.
- **Pre-notarization sanity (step 1c):** asserts bundled `Contents/Resources/modules` byte-match source `modules/` (excl. `__pycache__`/`.pyc`/`.DS_Store`) and app `CFBundleShortVersionString` == packaging `VERSION`. Fails fast *before* the ~40-min notarization instead of shipping a stale/mislabeled package.

**`swiftui/build_macos.sh`**
- Adds `CLEAN=1` support (`rm -rf "$BUILD_DIR"`) + header note documenting that setting-default changes require a clean core.

**`.claude/skills/cut-macos-release/` (skill docs)**
- Synced to the hardened scripts (non-negotiable #3, "Where things live", Step 2/5, gotchas: stale-core updated + new "stale bundled Python" entry).
- Made the deps symlink **portable** — resolves the main clone via `git rev-parse --git-common-dir` instead of a hardcoded `/Users/...` path.

## Verification

- `bash -n` clean on both scripts.
- Exercised the new logic in isolation: modules-diff ignores `__pycache__`/`.pyc`/`.DS_Store` noise yet catches a stale `.py`; a real `ditto` copy of the actual `modules/` tree byte-matches source (no false positives); all three version branches behave; `case` truthy parsing works; `git rev-parse --git-common-dir` resolves to the main clone from a worktree.
- **Not** run end-to-end (that cuts a real signed, notarized DMG ~40 min needing the Developer-ID cert + notary profile). Changes are shell control-flow, verified piece-by-piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)