### PR TITLE
Get the iOS/iPadOS build working, bring it to parity with the macOS build

### DIFF
--- a/appkit/CMakeLists.txt
+++ b/appkit/CMakeLists.txt
@@ -83,7 +83,7 @@ else()
     # iOS: headers-only mode for static library compilation.
     # Use BeeWare Python.xcframework headers for iOS builds;
     # actual linking happens in the Xcode project.
-    set(BREW_PREFIX "/opt/homebrew")
+    set(BREW_PREFIX "${PYMOL_EXTERNAL_PREFIX}")
     set(PYMOL_IOS_DEPS "${CMAKE_SOURCE_DIR}/../deps_ios" CACHE PATH "iOS dependencies root")
 
     # Python headers from BeeWare Python.xcframework (3.13)

--- a/scripts/build_numpy_ios.sh
+++ b/scripts/build_numpy_ios.sh
@@ -25,7 +25,7 @@ set -euo pipefail
 NUMPY_VERSION="${NUMPY_VERSION:-2.4.6}"
 DEPLOY="${IOS_DEPLOYMENT_TARGET:-16.0}"
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-PYHOST="${PYHOST:-/opt/homebrew/bin/python3.13}"
+PYHOST="${PYHOST:-${PYMOL_EXTERNAL_PREFIX:-/opt/homebrew}/bin/python3.13}"
 WORK="$(mktemp -d)"
 OUT="$ROOT/deps_ios/numpy-ios"
 
@@ -33,7 +33,7 @@ PY_SIM_HDR="$ROOT/deps_ios/Python.xcframework/ios-arm64_x86_64-simulator/Python.
 PY_DEV_HDR="$ROOT/deps_ios/Python.xcframework/ios-arm64/Python.framework/Headers"
 
 echo ">> host python: $PYHOST"; "$PYHOST" --version
-"$PYHOST" -c "import meson, ninja" 2>/dev/null || {
+"$PYHOST" -c "import mesonbuild, ninja" 2>/dev/null || {
   echo "ERROR: install build tools first:  $PYHOST -m pip install meson ninja cython build"; exit 1; }
 
 echo ">> downloading numpy $NUMPY_VERSION sdist"

--- a/scripts/setup_ios_deps.sh
+++ b/scripts/setup_ios_deps.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# setup_ios_deps.sh — populate deps_ios/ end-to-end: embedded Python, cross-
+# compiled freetype/libpng, numpy, and Biopython, in dependency order. Mirrors
+# the one-command feel of fetch_macos_python.sh for the iOS side, which
+# unavoidably has more moving pieces (a cross-compiled dependency set, not a
+# single vendored Python). Re-run to refresh everything; each step is
+# individually idempotent.
+#
+# MacPorts (or any non-Homebrew prefix): export PYMOL_EXTERNAL_PREFIX=/opt/local
+# first — see swiftui/README.md's "Package-manager portability" section.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+echo "=== 1/4: fetch_ios_python.sh ==="
+"$ROOT/scripts/fetch_ios_python.sh"
+
+echo ""
+echo "=== 2/4: build_ios_deps.sh (freetype + libpng cross-compile) ==="
+"$ROOT/scripts/build_ios_deps.sh"
+
+echo ""
+echo "=== 3/4: build_numpy_ios.sh ==="
+"$ROOT/scripts/build_numpy_ios.sh"
+
+echo ""
+echo "=== 4/4: bundle_biopython.sh ==="
+"$ROOT/scripts/bundle_biopython.sh"
+
+echo ""
+echo "=== deps_ios/ ready — build the core next: swiftui/build_ios.sh [device] ==="

--- a/swiftui/README.md
+++ b/swiftui/README.md
@@ -98,7 +98,10 @@ sudo port select --set python3 python313
 Without that, CMake still finds a working `python3` by falling back to
 `/usr/bin/python3` (Xcode Command Line Tools), so this isn't a hard
 requirement — just worth knowing if you want the MacPorts interpreter used
-instead of the system one.
+instead of the system one. `scripts/build_numpy_ios.sh` has the identical
+fallback (`PYMOL_EXTERNAL_PREFIX/bin/python3.13` → nothing) and needs the
+selected interpreter to actually have `meson`/`ninja`/`cython` installed —
+see [Building for iOS](#building-for-ios) below.
 
 Why GLEW/GLUT don't factor into any of this: `PyMOLBridge.xcconfig` defines
 `_PYMOL_NO_OPENGL` for the macOS SDK (matching what the CMake core build
@@ -110,53 +113,125 @@ even compile (invisibly papered over on Homebrew machines that happened to
 have those headers installed already). They're not build-time dependencies
 of this app.
 
+The iOS `PYMOL_IOS` CMake branch and `scripts/build_numpy_ios.sh`'s `PYHOST`
+default both honor `PYMOL_EXTERNAL_PREFIX` the same way — MacPorts users pass
+it the same way as the macOS build, see below.
+
 ## Building for iOS
 
 The iOS app needs a gitignored `deps_ios/` populated with an embedded Python,
-cross-compiled freetype/libpng, and numpy — the iOS analogue of `deps_macos/`.
-Two scripts fetch/build the heavy pieces; the two after them layer Python
-packages on top. Run them **in order** (each depends on the previous):
+cross-compiled freetype/libpng, numpy, and (optionally) Biopython — the iOS
+analogue of `deps_macos/`. Unlike the macOS side's single Python download,
+this is a real cross-compiled dependency set with more moving pieces, so
+there's a wrapper that runs all of them in the right order:
 
-1. **Fetch the embedded Python.** One-time; re-run to refresh.
-   ```bash
-   scripts/fetch_ios_python.sh
-   ```
-   Downloads a [BeeWare Python-Apple-support](https://github.com/beeware/Python-Apple-support)
+```bash
+scripts/setup_ios_deps.sh
+# MacPorts: PYMOL_EXTERNAL_PREFIX=/opt/local scripts/setup_ios_deps.sh
+```
+
+That's the one-command equivalent of the macOS side's `fetch_macos_python.sh`
+— re-run it to refresh everything; each step underneath is independently
+idempotent. What it runs, in order (useful to know for troubleshooting, or to
+re-run just one step):
+
+1. **`scripts/fetch_ios_python.sh`** — downloads a
+   [BeeWare Python-Apple-support](https://github.com/beeware/Python-Apple-support)
    CPython 3.13 `Python.xcframework` (device + simulator slices) into
    `deps_ios/Python.xcframework`. The BeeWare release is **pinned** (`3.13-b12`)
    because b13+ moved the embedded stdlib to a `lib-<arch>/` layout the rest of
    the build doesn't expect — the script's layout guard rejects an incompatible
    release; see the header comment before overriding `PY_APPLE_SUPPORT_TAG`.
 
-2. **Cross-compile freetype + libpng.**
-   ```bash
-   scripts/build_ios_deps.sh
-   ```
-   Builds libpng 1.6.44 + freetype 2.13.3 for arm64 into `deps_ios/install`
-   (simulator SDK) and `deps_ios/install_device` (device SDK) — the
-   `PYMOL_IOS_DEPS{,_DEVICE}` paths in `PyMOLBridge.xcconfig`. zlib comes from
-   the iOS SDK. Needs Xcode + `cmake`.
+2. **`scripts/build_ios_deps.sh`** — cross-compiles libpng 1.6.44 + freetype
+   2.13.3 for arm64 into `deps_ios/install` (simulator SDK) and
+   `deps_ios/install_device` (device SDK) — the `PYMOL_IOS_DEPS{,_DEVICE}`
+   paths in `PyMOLBridge.xcconfig`. zlib comes from the iOS SDK. Needs Xcode +
+   `cmake`.
 
-3. **Cross-compile numpy.**
-   ```bash
-   scripts/build_numpy_ios.sh
-   ```
-   Stages numpy into `deps_ios/numpy-ios/{simulator,device}` (numpy ships no iOS
-   wheels). Requires a host CPython 3.13 with `meson ninja cython` installed.
+3. **`scripts/build_numpy_ios.sh`** — stages numpy into
+   `deps_ios/numpy-ios/{simulator,device}` (numpy ships no iOS wheels).
+   Requires a host CPython 3.13 with `meson`, `ninja`, and `cython` installed
+   **and resolvable on `PATH`** (`pip install --user meson ninja cython`
+   installs its console scripts to a user-site `bin/` directory that usually
+   isn't on `PATH` by default — pip will warn you about this at install time;
+   add that directory to `PATH` or the numpy meson build won't find `cython`).
 
-4. **Bundle Biopython** (optional; shared with the macOS app).
-   ```bash
-   scripts/bundle_biopython.sh
-   ```
-   Adds the pure-Python `Bio` subset into the xcframework's site-packages.
+4. **`scripts/bundle_biopython.sh`** (optional; shared with the macOS app) —
+   adds the pure-Python `Bio` subset into the xcframework's site-packages.
 
-5. **Build the C++ core**, then the app:
-   ```bash
-   cd swiftui && ./build_ios.sh            # simulator (arm64)
-   cd swiftui && ./build_ios.sh device     # device
-   xcodebuild -project PyMOLViewer.xcodeproj -scheme PyMOLViewer_iOS \
-       -configuration Debug -sdk iphonesimulator build
-   ```
+Everything under `deps_ios/` is gitignored and reproducible from these four
+steps; delete the directory and re-run `setup_ios_deps.sh` to rebuild from
+scratch.
 
-Everything under `deps_ios/` is gitignored and reproducible from steps 1–4;
-delete the directory and re-run to rebuild from scratch.
+### Building for the iOS Simulator
+
+This is the fast path — as simple as the macOS build, no Apple Developer
+account needed at all:
+
+```bash
+cd swiftui && ./build_ios.sh              # builds libpymol_core.a for the simulator
+xcodebuild -project PyMOLViewer.xcodeproj -scheme PyMOLViewer_iOS \
+    -configuration Debug -destination 'platform=iOS Simulator,name=iPad Pro 11-inch (M5)' build
+```
+
+The simulator build self-signs ("Sign to Run Locally") automatically —
+nothing below applies. To install and launch it once built:
+
+```bash
+APP=~/Library/Developer/Xcode/DerivedData/PyMOLViewer-*/Build/Products/Debug-iphonesimulator/RayMol.app
+xcrun simctl boot "<simulator UDID>"        # if not already booted
+xcrun simctl install "<simulator UDID>" "$APP"
+xcrun simctl launch "<simulator UDID>" io.raymol.RayMol
+```
+
+### Building for a physical iPad/iPhone
+
+This is where the iOS and macOS paths genuinely diverge, and it's not a gap
+in this build system — it's Apple's platform policy: any code you run on
+real iOS hardware must be signed with a registered Apple Developer identity,
+full stop. There's no equivalent hurdle on macOS ("Sign to Run Locally"
+works for a local Debug build there). If this is the **first time** this
+Mac + this device have been used for iOS development, expect a real,
+one-time setup dance before the build itself will succeed:
+
+1. **Enable Developer Mode on the device.** Settings → Privacy & Security →
+   Developer Mode → toggle on → the device restarts → confirm "Turn On"
+   after restart. Without this, `xcodebuild`/`devicectl` report the device as
+   `connected (no DDI)` and refuse to install anything.
+2. **Add your Apple ID to Xcode.** Xcode → Settings → Accounts → **+**. If
+   your account belongs to multiple teams (e.g. a personal free team and a
+   paid organization team), you'll choose which one signs the build — a free
+   personal team works for local testing but expires certificates every 7
+   days; a paid team doesn't.
+3. **Accept a pending Program License Agreement**, if the build fails with
+   `PLA Update available: You currently don't have access to this membership
+   resource.` Sign in at [developer.apple.com/account](https://developer.apple.com/account)
+   with the team's credentials and accept the agreement banner. Only an
+   Admin/Agent-role account on the team can usually do this.
+4. **Register the device**, if the build fails with `Device "<name>" isn't
+   registered in your developer account.` Try Xcode → Window → Devices and
+   Simulators → select the device → "Use for Development" first (often
+   auto-registers); otherwise an Admin/Agent on the team must add its UDID
+   manually at [developer.apple.com/account/resources/devices/add](https://developer.apple.com/account/resources/devices/add)
+   (`xcrun devicectl device info details --device <device-id>` prints the UDID).
+
+Once all of that's done (it's one-time per Mac+device+team combination), the
+actual build/install/launch:
+
+```bash
+cd swiftui && ./build_ios.sh device       # builds libpymol_core.a for device
+
+xcodebuild -project PyMOLViewer.xcodeproj -scheme PyMOLViewer_iOS -configuration Debug \
+    -destination 'id=<device-id>' -allowProvisioningUpdates \
+    DEVELOPMENT_TEAM=<TEAMID> CODE_SIGN_STYLE=Automatic build
+
+APP=~/Library/Developer/Xcode/DerivedData/PyMOLViewer-*/Build/Products/Debug-iphoneos/RayMol.app
+xcrun devicectl device install app --device <device-id> "$APP"
+xcrun devicectl device process launch --device <device-id> io.raymol.RayMol
+```
+
+`xcrun devicectl list devices` shows connected devices and their `<device-id>`.
+`DEVELOPMENT_TEAM`/`CODE_SIGN_STYLE` are passed on the command line rather
+than committed to `project.pbxproj`, since the right team ID is
+developer/organization-specific, not a shared project setting.

--- a/swiftui/build_ios.sh
+++ b/swiftui/build_ios.sh
@@ -20,11 +20,14 @@ else
 fi
 
 NCPU=$(sysctl -n hw.ncpu)
+# Homebrew by default; MacPorts users: export PYMOL_EXTERNAL_PREFIX=/opt/local
+PYMOL_EXTERNAL_PREFIX="${PYMOL_EXTERNAL_PREFIX:-/opt/homebrew}"
 
 echo "=== Building libpymol_core.a for iOS ($PLATFORM) ==="
 echo "  PYMOL_ROOT: ${PYMOL_ROOT}"
 echo "  BUILD_DIR:  ${BUILD_DIR}"
 echo "  Platform:   ${IOS_PLATFORM}"
+echo "  EXTERNAL_PREFIX: ${PYMOL_EXTERNAL_PREFIX}"
 echo ""
 
 mkdir -p "${BUILD_DIR}"
@@ -34,6 +37,7 @@ cmake "${PYMOL_ROOT}/appkit" \
     -DCMAKE_TOOLCHAIN_FILE="${PYMOL_ROOT}/appkit/ios.toolchain.cmake" \
     -DIOS_PLATFORM="${IOS_PLATFORM}" \
     -C "${PYMOL_ROOT}/appkit/CMakeLists_iOS.cmake" \
+    -DPYMOL_EXTERNAL_PREFIX="${PYMOL_EXTERNAL_PREFIX}" \
     -DCMAKE_BUILD_TYPE=Release
 
 cmake --build . --target pymol_core -j"${NCPU}"


### PR DESCRIPTION
## Summary

Gets the iOS/iPadOS build working end-to-end for the first time on a MacPorts
machine, and brings its developer experience as close to the macOS build's as
the platforms allow.

- **Parameterize the iOS CMake branch's Homebrew prefix by `PYMOL_EXTERNAL_PREFIX`**
  — `appkit/CMakeLists.txt`'s `PYMOL_IOS` branch hardcoded `/opt/homebrew`,
  the same class of bug already fixed on the macOS side (#125). Verified with
  a real device build: went from `glm/vec3.hpp not found` to a clean link.
- **Two real bugs in `scripts/build_numpy_ios.sh`**, found while verifying the
  above, each independently confirmed with a full cross-compile (not just the
  precheck):
  - The build-tools precheck did `import meson, ninja` — but `pip install meson`
    installs as `mesonbuild`, so the check failed even with meson correctly
    installed. Confirmed the correct import name with a clean venv install
    before fixing.
  - `PYHOST` defaulted to a hardcoded `/opt/homebrew/bin/python3.13`; now
    derives from `PYMOL_EXTERNAL_PREFIX` like everywhere else.
- **`scripts/setup_ios_deps.sh`** — a one-command wrapper running all four
  `deps_ios/` setup scripts in order, giving iOS the same one-command feel as
  `fetch_macos_python.sh` on macOS (it unavoidably has more moving pieces — a
  cross-compiled dependency set vs. a single vendored Python — but the
  *experience* of setting it up is now the same: one command).
- **`swiftui/README.md`** — documents the iOS build end-to-end for the first
  time: the simulator fast-path (no Apple Developer account needed, matching
  macOS's zero-friction local build) vs. physical-device deployment (the full
  first-time signing dance: Developer Mode, Xcode account, Program License
  Agreement, device registration — none of which was written down anywhere
  before this).

One thing this PR does *not* try to paper over: physical-device deployment
genuinely can't match macOS's simplicity, because it's Apple's platform
policy (real iOS hardware requires Developer Program signing), not a gap in
this build system. Documented thoroughly instead of pretended away.

Also filed while doing this work, both out of scope for this PR:
- #185 — iOS command console: smart quotes/dashes silently corrupt any
  command containing a string literal (found while verifying numpy on
  device). Real bug, but fixing it properly means redoing a UIKit text-field
  wrapper carefully enough not to reintroduce a prior regression (see issue
  for detail) — not a quick fix, deserves its own PR.

## Test plan
- [x] `PYMOL_EXTERNAL_PREFIX=/opt/local swiftui/build_ios.sh device` — went
      from a missing-glm build failure to a clean link.
- [x] Verified the `mesonbuild` import fix with a clean `pip install meson
      ninja` into a throwaway venv before changing the script.
- [x] Full re-run of the fixed `build_numpy_ios.sh` (no manual `PYHOST`
      override) produced both `deps_ios/numpy-ios/{simulator,device}/numpy`
      slices.
- [x] `scripts/setup_ios_deps.sh` run end-to-end, all four steps succeeded.
- [x] Built, installed, and launched on the iOS Simulator (iPad Pro 11-inch
      M5) — confirmed rendering (cartoon representation, sequence viewer,
      command console, Theme Studio all functional) via screenshot.
- [x] Built, signed (Outpace Bio Inc team), installed, and launched on a
      physical iPad (iPad17,1) — first on-device run on this Mac.
- [x] Re-verified the physical device build with the corrected numpy/Biopython
      bundle: `numpy.__version__` prints `2.4.6` on-device, matching the
      cross-compiled version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)