### PR TITLE
Stop shipping the classic Tk/Qt GUIs in the native app bundle

### DIFF
--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		24169A74B9EBFD202258A5E4 /* PyMOLBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 356FC561FA1515B3D15A26E2 /* PyMOLBridge.mm */; };
 		300656C47AD9A9C18C129C42 /* SequencePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474D18A43D0D9A6BDD69EEFD /* SequencePanel.swift */; };
 		33C46A7EB6127A6A99D7048D /* TimelinePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B820FE9080BF73526A54CD66 /* TimelinePanel.swift */; };
+		36D99340CCDDAD7C67680476 /* whatsnew-161-hover.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 6E2FC2AD1A8FEE912986DF9D /* whatsnew-161-hover.mp4 */; };
 		3A8107D094C920B600681B74 /* ThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC5E722722DEF7FBB1D649F /* ThemeManager.swift */; };
 		3D6FE0218915810960306973 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 589928DEEE69075B965DB9F2 /* Assets.xcassets */; };
 		3E6C34959A3934D2DE3E080F /* RayMolUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = F607D204A410CA38B84223BE /* RayMolUpdater.swift */; };
@@ -65,6 +66,7 @@
 		B2697EF48D85EF14D4A19163 /* RayMol.icon in Resources */ = {isa = PBXBuildFile; fileRef = BB5ABD1A8C45E5BC97AB0B80 /* RayMol.icon */; };
 		B33C0620EDD48195A59B7DD8 /* MCPBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A18D8A6B0FB56FCD3C31211 /* MCPBridge.swift */; };
 		B84285B5FAD1A429B1FCEDBF /* 1ubq.cif in Resources */ = {isa = PBXBuildFile; fileRef = 1A55383922D69D691CA1BAB1 /* 1ubq.cif */; };
+		B84291E694521C66BCB749CD /* whatsnew-161-hover.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 6E2FC2AD1A8FEE912986DF9D /* whatsnew-161-hover.mp4 */; };
 		BA6C9B288CFD5EB53D0E0057 /* RayMolMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9371B6FFB30D6166234C678B /* RayMolMain.swift */; };
 		CCA9FAAAD0E59CE43443B7DA /* PyMOLGestureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8EE6573045A81CF52A9CDF5 /* PyMOLGestureUITests.swift */; };
 		CE45D81735E70E8FFFD49875 /* ThemeStudioPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85B66833BF167209A47B9C15 /* ThemeStudioPanel.swift */; };
@@ -118,6 +120,7 @@
 		58BAC08EBD7DD4DCB8C18EDC /* WhatsNewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewUITests.swift; sourceTree = "<group>"; };
 		5E9F8D36908E3216D1C8F893 /* MetalViewport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalViewport.swift; sourceTree = "<group>"; };
 		689CDE512811C244D4BA931B /* WhatsNew.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = WhatsNew.json; sourceTree = "<group>"; };
+		6E2FC2AD1A8FEE912986DF9D /* whatsnew-161-hover.mp4 */ = {isa = PBXFileReference; path = "whatsnew-161-hover.mp4"; sourceTree = "<group>"; };
 		75F059BB95517CE91BD3E26E /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		786939619F7871E32E2BB123 /* MCPDesktopInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPDesktopInstaller.swift; sourceTree = "<group>"; };
 		7D3E805AC2D63B01AB7EE29C /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
@@ -144,7 +147,7 @@
 		F2078076B68D28457409F7A5 /* RayMol.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RayMol.entitlements; sourceTree = "<group>"; };
 		F607D204A410CA38B84223BE /* RayMolUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RayMolUpdater.swift; sourceTree = "<group>"; };
 		FB1304C662D9011F7C4505FC /* MCPStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPStatusView.swift; sourceTree = "<group>"; };
-		"TEMP_4A621347-E6DA-47BC-9074-0F1E52430B4E" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
+		"TEMP_2AB7BC73-0C7E-44C6-92DD-9FEDE4583BF8" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -188,6 +191,7 @@
 				F16058D96E2773BE9A24C323 /* RayMol.svg */,
 				29DBC7BEEA492BFACB616C34 /* whatsnew-152-camera-dock.mp4 */,
 				55094A33AFF9AEF5561CFD96 /* whatsnew-152-timeline.png */,
+				6E2FC2AD1A8FEE912986DF9D /* whatsnew-161-hover.mp4 */,
 				689CDE512811C244D4BA931B /* WhatsNew.json */,
 			);
 			path = Resources;
@@ -267,10 +271,10 @@
 			path = Bridge;
 			sourceTree = "<group>";
 		};
-		"TEMP_1E610EC4-CCAE-4A50-9B0E-5573AE60DC1D" /* swiftui */ = {
+		"TEMP_CC631E74-B529-4A87-B189-5F55D0DDFBFD" /* swiftui */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_4A621347-E6DA-47BC-9074-0F1E52430B4E" /* PyMOLBridge.xcconfig */,
+				"TEMP_2AB7BC73-0C7E-44C6-92DD-9FEDE4583BF8" /* PyMOLBridge.xcconfig */,
 			);
 			path = swiftui;
 			sourceTree = "<group>";
@@ -406,6 +410,7 @@
 				E08AF23E9A696D29B94CA999 /* dylib-Info-template.plist in Resources */,
 				EB6435B2880C450F33F0291F /* whatsnew-152-camera-dock.mp4 in Resources */,
 				D3C5FDA51512154777B49DA2 /* whatsnew-152-timeline.png in Resources */,
+				36D99340CCDDAD7C67680476 /* whatsnew-161-hover.mp4 in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -422,6 +427,7 @@
 				5A20A6D21AA3CFAE2394BAB4 /* dylib-Info-template.plist in Resources */,
 				F4F8D45CBA50D16F783FBB4F /* whatsnew-152-camera-dock.mp4 in Resources */,
 				97F0B5805CD3B11723C7B43B /* whatsnew-152-timeline.png in Resources */,
+				B84291E694521C66BCB749CD /* whatsnew-161-hover.mp4 in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -601,7 +607,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "case \"$PLATFORM_NAME\" in iphone*) ;; *) exit 0 ;; esac\nset -e\nditto \"$SRCROOT/../modules\" \"$CODESIGNING_FOLDER_PATH/modules\"\nditto \"$SRCROOT/../data\" \"$CODESIGNING_FOLDER_PATH/data\"\n";
+			shellScript = "case \"$PLATFORM_NAME\" in iphone*) ;; *) exit 0 ;; esac\nset -e\nditto \"$SRCROOT/../modules\" \"$CODESIGNING_FOLDER_PATH/modules\"\n# pmg_tk/pmg_qt are the classic Tk/Qt desktop GUIs — dead weight here,\n# the native Metal/SwiftUI app never imports either.\nrm -rf \"$CODESIGNING_FOLDER_PATH/modules/pmg_tk\" \"$CODESIGNING_FOLDER_PATH/modules/pmg_qt\"\nditto \"$SRCROOT/../data\" \"$CODESIGNING_FOLDER_PATH/data\"\n";
 		};
 		88BA34A4D715F3339CB65D98 /* iOS: Prepare Python binary modules */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -658,7 +664,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "case \"$PLATFORM_NAME\" in iphone*) ;; *) exit 0 ;; esac\nset -e\nditto \"$SRCROOT/../modules\" \"$CODESIGNING_FOLDER_PATH/modules\"\nditto \"$SRCROOT/../data\" \"$CODESIGNING_FOLDER_PATH/data\"\n";
+			shellScript = "case \"$PLATFORM_NAME\" in iphone*) ;; *) exit 0 ;; esac\nset -e\nditto \"$SRCROOT/../modules\" \"$CODESIGNING_FOLDER_PATH/modules\"\n# pmg_tk/pmg_qt are the classic Tk/Qt desktop GUIs — dead weight here,\n# the native Metal/SwiftUI app never imports either.\nrm -rf \"$CODESIGNING_FOLDER_PATH/modules/pmg_tk\" \"$CODESIGNING_FOLDER_PATH/modules/pmg_qt\"\nditto \"$SRCROOT/../data\" \"$CODESIGNING_FOLDER_PATH/data\"\n";
 		};
 		B07CD62C5BBE02F19894A460 /* Sparkle: inject auto-update Info.plist keys (macOS, non-MAS) */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -735,7 +741,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "case \"$PLATFORM_NAME\" in macosx*) ;; *) exit 0 ;; esac\nset -e\nRES=\"$CODESIGNING_FOLDER_PATH/Contents/Resources\"\nmkdir -p \"$RES\"\nrsync -au --delete \"$SRCROOT/../deps_macos/python-standalone/python/\" \"$RES/python/\"\n# App Review compliance — prune from the embedded Python before signing:\n#  (2.5.1) The bundled Tcl/Tk's libtcl9tk9.0.dylib references the private\n#  AppKit symbol _NSWindowDidOrderOnScreenNotification. The native\n#  Metal/SwiftUI app never launches the legacy pmg_tk Tkinter GUI, so the\n#  whole Tcl/Tk stack is dead weight. Remove it.\nPYLIB=\"$RES/python/lib\"\nrm -rf \"$PYLIB\"/libtcl*.dylib \"$PYLIB\"/libtk*.dylib \\\n       \"$PYLIB\"/tcl* \"$PYLIB\"/tk* \"$PYLIB\"/itcl* \"$PYLIB\"/thread* \\\n       \"$PYLIB\"/python*/tkinter\nrm -f  \"$PYLIB\"/python*/lib-dynload/_tkinter*.so\n#  (2.5.2) CPython's stdlib urllib/parse.py lists 'itms-services' in\n#  uses_netloc; Apple's static scanner reads that literal as the app\n#  installing executable code via itms-services://. RayMol never uses the\n#  scheme — strip the token (no functional effect on URL parsing we do).\n/usr/bin/sed -i '' \"s/, 'itms-services'//g\" \"$PYLIB\"/python*/urllib/parse.py\nditto \"$SRCROOT/../modules\" \"$RES/modules\"\n# Mac App Store build: drop the MCP server package (compiled out of the app).\ncase \"${SWIFT_ACTIVE_COMPILATION_CONDITIONS:-}\" in *RAYMOL_MAS_RESTRICTED*) rm -rf \"$RES/modules/raymol_mcp\" ;; esac\nditto \"$SRCROOT/../data\" \"$RES/data\"\n# Mac App Store code-signing of the embedded Python. python-standalone\n# ships its own signatures (foreign team, no app-sandbox), and Xcode's\n# final signing doesn't re-sign files under Resources/. So re-sign every\n# embedded Mach-O with OUR identity + hardened runtime here (before the\n# bundle is sealed): nested EXECUTABLES (bin/) get the app-sandbox +\n# inherit entitlement (Apple requires every nested executable to carry\n# app-sandbox — error 90296); libraries (.dylib/.so) get our signature\n# without entitlements. Runs only when signing (skipped for unsigned CLI).\nif [ -n \"${EXPANDED_CODE_SIGN_IDENTITY:-}\" ]; then\n  ENT=\"$SRCROOT/PyMOLViewer/RayMolPython.entitlements\"\n  # Executables under the embedded python's bin/.\n  find \"$RES/python/bin\" -type f 2>/dev/null | while read -r f; do\n    /usr/bin/file \"$f\" | /usr/bin/grep -q \"Mach-O.*executable\" && \\\n      /usr/bin/codesign --force --sign \"$EXPANDED_CODE_SIGN_IDENTITY\" \\\n        -o runtime --timestamp=none --entitlements \"$ENT\" \"$f\" || true\n  done\n  # All embedded libraries / extension modules.\n  find \"$RES/python\" \\( -name \"*.dylib\" -o -name \"*.so\" \\) -type f | while read -r f; do\n    /usr/bin/codesign --force --sign \"$EXPANDED_CODE_SIGN_IDENTITY\" \\\n      -o runtime --timestamp=none \"$f\" || true\n  done\nfi\n";
+			shellScript = "case \"$PLATFORM_NAME\" in macosx*) ;; *) exit 0 ;; esac\nset -e\nRES=\"$CODESIGNING_FOLDER_PATH/Contents/Resources\"\nmkdir -p \"$RES\"\nrsync -au --delete \"$SRCROOT/../deps_macos/python-standalone/python/\" \"$RES/python/\"\n# App Review compliance — prune from the embedded Python before signing:\n#  (2.5.1) The bundled Tcl/Tk's libtcl9tk9.0.dylib references the private\n#  AppKit symbol _NSWindowDidOrderOnScreenNotification. The native\n#  Metal/SwiftUI app never launches the legacy pmg_tk Tkinter GUI, so the\n#  whole Tcl/Tk stack is dead weight. Remove it.\nPYLIB=\"$RES/python/lib\"\nrm -rf \"$PYLIB\"/libtcl*.dylib \"$PYLIB\"/libtk*.dylib \\\n       \"$PYLIB\"/tcl* \"$PYLIB\"/tk* \"$PYLIB\"/itcl* \"$PYLIB\"/thread* \\\n       \"$PYLIB\"/python*/tkinter\nrm -f  \"$PYLIB\"/python*/lib-dynload/_tkinter*.so\n#  (2.5.2) CPython's stdlib urllib/parse.py lists 'itms-services' in\n#  uses_netloc; Apple's static scanner reads that literal as the app\n#  installing executable code via itms-services://. RayMol never uses the\n#  scheme — strip the token (no functional effect on URL parsing we do).\n/usr/bin/sed -i '' \"s/, 'itms-services'//g\" \"$PYLIB\"/python*/urllib/parse.py\nditto \"$SRCROOT/../modules\" \"$RES/modules\"\n# pmg_tk/pmg_qt are the classic Tk/Qt desktop GUIs — dead weight here,\n# the native Metal/SwiftUI app never imports either.\nrm -rf \"$RES/modules/pmg_tk\" \"$RES/modules/pmg_qt\"\n# Mac App Store build: drop the MCP server package (compiled out of the app).\ncase \"${SWIFT_ACTIVE_COMPILATION_CONDITIONS:-}\" in *RAYMOL_MAS_RESTRICTED*) rm -rf \"$RES/modules/raymol_mcp\" ;; esac\nditto \"$SRCROOT/../data\" \"$RES/data\"\n# Mac App Store code-signing of the embedded Python. python-standalone\n# ships its own signatures (foreign team, no app-sandbox), and Xcode's\n# final signing doesn't re-sign files under Resources/. So re-sign every\n# embedded Mach-O with OUR identity + hardened runtime here (before the\n# bundle is sealed): nested EXECUTABLES (bin/) get the app-sandbox +\n# inherit entitlement (Apple requires every nested executable to carry\n# app-sandbox — error 90296); libraries (.dylib/.so) get our signature\n# without entitlements. Runs only when signing (skipped for unsigned CLI).\nif [ -n \"${EXPANDED_CODE_SIGN_IDENTITY:-}\" ]; then\n  ENT=\"$SRCROOT/PyMOLViewer/RayMolPython.entitlements\"\n  # Executables under the embedded python's bin/.\n  find \"$RES/python/bin\" -type f 2>/dev/null | while read -r f; do\n    /usr/bin/file \"$f\" | /usr/bin/grep -q \"Mach-O.*executable\" && \\\n      /usr/bin/codesign --force --sign \"$EXPANDED_CODE_SIGN_IDENTITY\" \\\n        -o runtime --timestamp=none --entitlements \"$ENT\" \"$f\" || true\n  done\n  # All embedded libraries / extension modules.\n  find \"$RES/python\" \\( -name \"*.dylib\" -o -name \"*.so\" \\) -type f | while read -r f; do\n    /usr/bin/codesign --force --sign \"$EXPANDED_CODE_SIGN_IDENTITY\" \\\n      -o runtime --timestamp=none \"$f\" || true\n  done\nfi\n";
 		};
 		D05A0E7275F836613C62A558 /* iOS: Install Python stdlib */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -773,7 +779,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "case \"$PLATFORM_NAME\" in macosx*) ;; *) exit 0 ;; esac\nset -e\nRES=\"$CODESIGNING_FOLDER_PATH/Contents/Resources\"\nmkdir -p \"$RES\"\nrsync -au --delete \"$SRCROOT/../deps_macos/python-standalone/python/\" \"$RES/python/\"\n# App Review compliance — prune from the embedded Python before signing:\n#  (2.5.1) The bundled Tcl/Tk's libtcl9tk9.0.dylib references the private\n#  AppKit symbol _NSWindowDidOrderOnScreenNotification. The native\n#  Metal/SwiftUI app never launches the legacy pmg_tk Tkinter GUI, so the\n#  whole Tcl/Tk stack is dead weight. Remove it.\nPYLIB=\"$RES/python/lib\"\nrm -rf \"$PYLIB\"/libtcl*.dylib \"$PYLIB\"/libtk*.dylib \\\n       \"$PYLIB\"/tcl* \"$PYLIB\"/tk* \"$PYLIB\"/itcl* \"$PYLIB\"/thread* \\\n       \"$PYLIB\"/python*/tkinter\nrm -f  \"$PYLIB\"/python*/lib-dynload/_tkinter*.so\n#  (2.5.2) CPython's stdlib urllib/parse.py lists 'itms-services' in\n#  uses_netloc; Apple's static scanner reads that literal as the app\n#  installing executable code via itms-services://. RayMol never uses the\n#  scheme — strip the token (no functional effect on URL parsing we do).\n/usr/bin/sed -i '' \"s/, 'itms-services'//g\" \"$PYLIB\"/python*/urllib/parse.py\nditto \"$SRCROOT/../modules\" \"$RES/modules\"\n# Mac App Store build: drop the MCP server package (compiled out of the app).\ncase \"${SWIFT_ACTIVE_COMPILATION_CONDITIONS:-}\" in *RAYMOL_MAS_RESTRICTED*) rm -rf \"$RES/modules/raymol_mcp\" ;; esac\nditto \"$SRCROOT/../data\" \"$RES/data\"\n# Mac App Store code-signing of the embedded Python. python-standalone\n# ships its own signatures (foreign team, no app-sandbox), and Xcode's\n# final signing doesn't re-sign files under Resources/. So re-sign every\n# embedded Mach-O with OUR identity + hardened runtime here (before the\n# bundle is sealed): nested EXECUTABLES (bin/) get the app-sandbox +\n# inherit entitlement (Apple requires every nested executable to carry\n# app-sandbox — error 90296); libraries (.dylib/.so) get our signature\n# without entitlements. Runs only when signing (skipped for unsigned CLI).\nif [ -n \"${EXPANDED_CODE_SIGN_IDENTITY:-}\" ]; then\n  ENT=\"$SRCROOT/PyMOLViewer/RayMolPython.entitlements\"\n  # Executables under the embedded python's bin/.\n  find \"$RES/python/bin\" -type f 2>/dev/null | while read -r f; do\n    /usr/bin/file \"$f\" | /usr/bin/grep -q \"Mach-O.*executable\" && \\\n      /usr/bin/codesign --force --sign \"$EXPANDED_CODE_SIGN_IDENTITY\" \\\n        -o runtime --timestamp=none --entitlements \"$ENT\" \"$f\" || true\n  done\n  # All embedded libraries / extension modules.\n  find \"$RES/python\" \\( -name \"*.dylib\" -o -name \"*.so\" \\) -type f | while read -r f; do\n    /usr/bin/codesign --force --sign \"$EXPANDED_CODE_SIGN_IDENTITY\" \\\n      -o runtime --timestamp=none \"$f\" || true\n  done\nfi\n";
+			shellScript = "case \"$PLATFORM_NAME\" in macosx*) ;; *) exit 0 ;; esac\nset -e\nRES=\"$CODESIGNING_FOLDER_PATH/Contents/Resources\"\nmkdir -p \"$RES\"\nrsync -au --delete \"$SRCROOT/../deps_macos/python-standalone/python/\" \"$RES/python/\"\n# App Review compliance — prune from the embedded Python before signing:\n#  (2.5.1) The bundled Tcl/Tk's libtcl9tk9.0.dylib references the private\n#  AppKit symbol _NSWindowDidOrderOnScreenNotification. The native\n#  Metal/SwiftUI app never launches the legacy pmg_tk Tkinter GUI, so the\n#  whole Tcl/Tk stack is dead weight. Remove it.\nPYLIB=\"$RES/python/lib\"\nrm -rf \"$PYLIB\"/libtcl*.dylib \"$PYLIB\"/libtk*.dylib \\\n       \"$PYLIB\"/tcl* \"$PYLIB\"/tk* \"$PYLIB\"/itcl* \"$PYLIB\"/thread* \\\n       \"$PYLIB\"/python*/tkinter\nrm -f  \"$PYLIB\"/python*/lib-dynload/_tkinter*.so\n#  (2.5.2) CPython's stdlib urllib/parse.py lists 'itms-services' in\n#  uses_netloc; Apple's static scanner reads that literal as the app\n#  installing executable code via itms-services://. RayMol never uses the\n#  scheme — strip the token (no functional effect on URL parsing we do).\n/usr/bin/sed -i '' \"s/, 'itms-services'//g\" \"$PYLIB\"/python*/urllib/parse.py\nditto \"$SRCROOT/../modules\" \"$RES/modules\"\n# pmg_tk/pmg_qt are the classic Tk/Qt desktop GUIs — dead weight here,\n# the native Metal/SwiftUI app never imports either.\nrm -rf \"$RES/modules/pmg_tk\" \"$RES/modules/pmg_qt\"\n# Mac App Store build: drop the MCP server package (compiled out of the app).\ncase \"${SWIFT_ACTIVE_COMPILATION_CONDITIONS:-}\" in *RAYMOL_MAS_RESTRICTED*) rm -rf \"$RES/modules/raymol_mcp\" ;; esac\nditto \"$SRCROOT/../data\" \"$RES/data\"\n# Mac App Store code-signing of the embedded Python. python-standalone\n# ships its own signatures (foreign team, no app-sandbox), and Xcode's\n# final signing doesn't re-sign files under Resources/. So re-sign every\n# embedded Mach-O with OUR identity + hardened runtime here (before the\n# bundle is sealed): nested EXECUTABLES (bin/) get the app-sandbox +\n# inherit entitlement (Apple requires every nested executable to carry\n# app-sandbox — error 90296); libraries (.dylib/.so) get our signature\n# without entitlements. Runs only when signing (skipped for unsigned CLI).\nif [ -n \"${EXPANDED_CODE_SIGN_IDENTITY:-}\" ]; then\n  ENT=\"$SRCROOT/PyMOLViewer/RayMolPython.entitlements\"\n  # Executables under the embedded python's bin/.\n  find \"$RES/python/bin\" -type f 2>/dev/null | while read -r f; do\n    /usr/bin/file \"$f\" | /usr/bin/grep -q \"Mach-O.*executable\" && \\\n      /usr/bin/codesign --force --sign \"$EXPANDED_CODE_SIGN_IDENTITY\" \\\n        -o runtime --timestamp=none --entitlements \"$ENT\" \"$f\" || true\n  done\n  # All embedded libraries / extension modules.\n  find \"$RES/python\" \\( -name \"*.dylib\" -o -name \"*.so\" \\) -type f | while read -r f; do\n    /usr/bin/codesign --force --sign \"$EXPANDED_CODE_SIGN_IDENTITY\" \\\n      -o runtime --timestamp=none \"$f\" || true\n  done\nfi\n";
 		};
 		D6E180B4CFF12A0215D1E81F /* iOS: Embed Python.framework */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1056,7 +1062,7 @@
 		};
 		76B7E9DB75E073D1E60928FA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_4A621347-E6DA-47BC-9074-0F1E52430B4E" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_2AB7BC73-0C7E-44C6-92DD-9FEDE4583BF8" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1141,7 +1147,7 @@
 		};
 		D8F44FDFF036013D2F03BA83 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_4A621347-E6DA-47BC-9074-0F1E52430B4E" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_2AB7BC73-0C7E-44C6-92DD-9FEDE4583BF8" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/swiftui/make_dmg.sh
+++ b/swiftui/make_dmg.sh
@@ -168,7 +168,10 @@ echo "== 1c/8  Sanity: verify the packaged app is NOT stale =="
 BUNDLED_MODULES="$APP/Contents/Resources/modules"
 [ -d "$BUNDLED_MODULES" ] || { echo "ERROR: no bundled modules at $BUNDLED_MODULES"; exit 1; }
 MODDIFF="$LOGDIR/modules-diff.log"
-if ! diff -rq -x '__pycache__' -x '*.pyc' -x '.DS_Store' \
+# pmg_tk/pmg_qt are intentionally pruned from the bundle (project.yml's resource
+# phase) but stay in source — exclude them here too, or every release fails this
+# check on that deliberate divergence.
+if ! diff -rq -x '__pycache__' -x '*.pyc' -x '.DS_Store' -x pmg_tk -x pmg_qt \
      "$PYMOL_ROOT/modules" "$BUNDLED_MODULES" >"$MODDIFF" 2>&1; then
   echo "ERROR: bundled Python (Contents/Resources/modules) does NOT match source"
   echo "       modules/ — the package is STALE. Differences (also in $MODDIFF):"

--- a/swiftui/project.yml
+++ b/swiftui/project.yml
@@ -272,6 +272,9 @@ targets:
           case "$PLATFORM_NAME" in iphone*) ;; *) exit 0 ;; esac
           set -e
           ditto "$SRCROOT/../modules" "$CODESIGNING_FOLDER_PATH/modules"
+          # pmg_tk/pmg_qt are the classic Tk/Qt desktop GUIs — dead weight here,
+          # the native Metal/SwiftUI app never imports either.
+          rm -rf "$CODESIGNING_FOLDER_PATH/modules/pmg_tk" "$CODESIGNING_FOLDER_PATH/modules/pmg_qt"
           ditto "$SRCROOT/../data" "$CODESIGNING_FOLDER_PATH/data"
       # macOS runtime packaging: payload under Contents/Resources (so the shared
       # bridge's config.home=<resourcePath>/python resolves to it). Guarded to
@@ -300,6 +303,9 @@ targets:
           #  scheme — strip the token (no functional effect on URL parsing we do).
           /usr/bin/sed -i '' "s/, 'itms-services'//g" "$PYLIB"/python*/urllib/parse.py
           ditto "$SRCROOT/../modules" "$RES/modules"
+          # pmg_tk/pmg_qt are the classic Tk/Qt desktop GUIs — dead weight here,
+          # the native Metal/SwiftUI app never imports either.
+          rm -rf "$RES/modules/pmg_tk" "$RES/modules/pmg_qt"
           # Mac App Store build: drop the MCP server package (compiled out of the app).
           case "${SWIFT_ACTIVE_COMPILATION_CONDITIONS:-}" in *RAYMOL_MAS_RESTRICTED*) rm -rf "$RES/modules/raymol_mcp" ;; esac
           ditto "$SRCROOT/../data" "$RES/data"


### PR DESCRIPTION
## Summary

First step of a longer-term effort to isolate a minimal PyMOL core that the
native Metal/SwiftUI apps actually depend on, separate from legacy classic-
desktop-GUI baggage carried over from the original PyMOL fork.

`pmg_tk`/`pmg_qt` (the classic Tk/Qt desktop GUIs) are confirmed unreachable
by the native app's actual build:
- `appkit/CMakeLists.txt` never references either.
- `layerGraphics/gl` (the classic OpenGL renderer) and the whole non-Metal
  AppKit desktop build path are excluded for both `PYMOL_IOS` and
  `PYMOL_METAL_ONLY` — the only two CMake configurations this app ships.

The adjacent bundling script already stripped the embedded Python's Tcl/Tk
*binaries* for exactly this reason (existing comment: "the native
Metal/SwiftUI app never launches the legacy pmg_tk Tkinter GUI, so the whole
Tcl/Tk stack is dead weight") — but the wholesale `ditto .../modules` copy
still shipped their Python *source* in every build regardless.

This only touches the app-bundling scripts (`project.yml` → regenerated
`project.pbxproj`) — nothing in the CMake build, nothing in `pip install .`,
nothing in the module source itself. Small, mechanical, easy to verify.

## Bigger picture (not in this PR)
Confirmed with Brian that the classic pip-installable Tk/Qt desktop
distribution is vestigial — not an actively shipped/supported RayMol product.
That opens up a larger cleanup opportunity (actually removing/archiving
`pmg_tk`, `pmg_qt`, `contrib/vr`, and the classic desktop OpenGL renderer
path from the tree, then reorganizing so the real "minimal PyMOL core" the
native apps depend on lives under one clear directory boundary, separate
from RayMol-original code). That's a bigger, shared-repo-visible decision
this PR intentionally doesn't make — happy to open a follow-up issue laying
out the reasoning if you want to discuss before anyone acts on it.

## Test plan
- [x] Regenerated `project.pbxproj` via `xcodegen generate` from the updated
      `project.yml`.
- [x] Rebuilt `PyMOLViewer_macOS` — succeeded.
- [x] Confirmed `modules/pmg_tk` and `modules/pmg_qt` are absent from the
      built `RayMol.app` bundle, while `modules/{pymol,chempy,pymol2,
      raymol_mcp}` remain present.
- [x] Launched the rebuilt app — runs normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)