### PR TITLE
feat(dist): Homebrew cask install (Closes #189)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ built on top.
   Dawn presets + custom themes) controlling both app chrome and molecular
   defaults.
 
+## Install (macOS)
+
+Install with [Homebrew](https://brew.sh):
+
+```sh
+brew install --cask javierbq/raymol/raymol
+```
+
+RayMol keeps itself up to date in-app (Sparkle), so a one-time install is all
+you need. Prefer a manual download? Grab the notarized DMG from the
+[latest release](https://github.com/javierbq/RayMol/releases/latest).
+
+Requires macOS 13 (Ventura) or newer. The iPad / iPhone app ships through the
+App Store.
+
 ## Building
 
 The cross-platform app lives in [`swiftui/`](swiftui) (Xcode project +

--- a/swiftui/publish_release.sh
+++ b/swiftui/publish_release.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
-# publish_release.sh — EdDSA-sign the notarized DMG, regenerate appcast.xml, and
-# publish the DMG + appcast to GitHub Releases on javierbq/RayMol.
+# publish_release.sh — EdDSA-sign the notarized DMG, regenerate appcast.xml,
+# publish the DMG + appcast to GitHub Releases on javierbq/RayMol, and bump the
+# Homebrew cask tap (javierbq/homebrew-raymol) so `brew` serves the new version.
 #
 # Run AFTER make_dmg.sh has produced a notarized RayMol-<VERSION>.dmg at the repo
 # root. The appcast feed served at
 #   https://github.com/javierbq/RayMol/releases/latest/download/appcast.xml
-# is what installed RayMol.app polls (SUFeedURL in Info.plist).
+# is what installed RayMol.app polls (SUFeedURL in Info.plist). The Homebrew cask
+# bump is the LAST step (it needs the release asset live); it is non-fatal and
+# can be skipped with SKIP_CASK=1.
 #
 # Usage:
 #   VERSION=1.1.0 BUILD=5 NOTES_FILE=docs/release-notes/v1.1.0.md \
@@ -26,6 +29,12 @@ VERSION="${VERSION:?Set VERSION, e.g. 1.1.0}"
 BUILD="${BUILD:?Set BUILD (CFBundleVersion), e.g. 5}"
 DMG="$ROOT/RayMol-$VERSION.dmg"
 APPCAST="$ROOT/appcast.xml"
+# RayMol also ships via a Homebrew Cask tap so users can
+#   brew install --cask javierbq/raymol/raymol
+# The cask pins an exact version + sha256 of the versioned DMG, so it is bumped
+# at the end of this script (after the GitHub release exists). SKIP_CASK=1 skips.
+CASK_TAP_REPO="${CASK_TAP_REPO:-javierbq/homebrew-raymol}"
+SKIP_CASK="${SKIP_CASK:-0}"
 
 [ -f "$DMG" ] || { echo "ERROR: $DMG not found (run make_dmg.sh first)"; exit 1; }
 
@@ -135,6 +144,45 @@ else
       --title "RayMol $VERSION" \
       --notes "${NOTES:-Automatic updates are here. RayMol now checks for new versions and installs them with one click — no more manual DMG downloads. Built on the open-source PyMOL engine.}"
   fi
+fi
+
+echo "RELEASE PUBLISHED → https://github.com/$REPO/releases/tag/v$VERSION"
+
+# == Bump the Homebrew cask =====================================================
+# Update version + sha256 in the tap's Casks/raymol.rb and push. Runs AFTER the
+# GitHub release is live (the cask URL resolves to that release's DMG asset).
+# NON-FATAL by design: the release itself already succeeded, so a tap hiccup
+# must not fail the run — it just prints a warning and tells you how to recover.
+if [ "$SKIP_CASK" = "1" ]; then
+  echo "== Skipping Homebrew cask bump (SKIP_CASK=1) =="
+else
+  echo "== Bump Homebrew cask ($CASK_TAP_REPO) =="
+  CASK_SHA="$(shasum -a 256 "$DMG" | awk '{print $1}')"
+  echo "  version=$VERSION sha256=$CASK_SHA"
+  CASK_TMP="$(mktemp -d -t raymol-cask)"
+  if gh repo clone "$CASK_TAP_REPO" "$CASK_TMP/tap" -- -q 2>/dev/null; then
+    CASK_FILE="$CASK_TMP/tap/Casks/raymol.rb"
+    if [ -f "$CASK_FILE" ]; then
+      # Rewrite only the version/sha256 lines (anchored to the stanza indent).
+      sed -i '' -E "s/^  version \".*\"/  version \"$VERSION\"/" "$CASK_FILE"
+      sed -i '' -E "s/^  sha256 \".*\"/  sha256 \"$CASK_SHA\"/" "$CASK_FILE"
+      if git -C "$CASK_TMP/tap" diff --quiet -- Casks/raymol.rb; then
+        echo "  cask already at $VERSION / $CASK_SHA — nothing to push"
+      else
+        git -C "$CASK_TMP/tap" add Casks/raymol.rb
+        git -C "$CASK_TMP/tap" commit -qm "raymol $VERSION"
+        git -C "$CASK_TMP/tap" push -q origin HEAD
+        echo "  pushed cask $VERSION → $CASK_TAP_REPO"
+      fi
+    else
+      echo "  WARNING: $CASK_FILE missing in tap; cask NOT bumped."
+    fi
+  else
+    echo "  WARNING: could not clone $CASK_TAP_REPO; cask NOT bumped."
+    echo "           Create the tap once, then bump by hand or re-run with"
+    echo "           SKIP_CASK unset. Users would otherwise get the old version."
+  fi
+  rm -rf "$CASK_TMP"
 fi
 
 echo "DONE → https://github.com/$REPO/releases/tag/v$VERSION"


### PR DESCRIPTION
## Homebrew install for RayMol — Closes #189

Requested via Slack (issue #189): let users install RayMol with Homebrew instead of hand-downloading the DMG.

RayMol is a GUI `.app` shipped as a notarized DMG, so this is a Homebrew **Cask** in a dedicated tap (Homebrew requires a `homebrew-<name>` repo). The tap is live at **[javierbq/homebrew-raymol](https://github.com/javierbq/homebrew-raymol)**:

```sh
brew install --cask javierbq/raymol/raymol
```

### This PR (in the RayMol repo)
- **`README.md`** — new *Install (macOS)* section with the `brew` command + manual DMG fallback.
- **`swiftui/publish_release.sh`** — after the GitHub release goes live, bump `version` + `sha256` in the tap's `Casks/raymol.rb` and push, so `brew` never serves a stale version. Non-fatal (a tap hiccup can't fail an already-published release) and skippable with `SKIP_CASK=1`.

### The cask (in the tap repo, already pushed)
- Templated URL on the existing versioned asset `RayMol-<version>.dmg`.
- `auto_updates true` so Homebrew defers to Sparkle for in-app updates.
- `livecheck` (`:github_latest`) so `brew` detects new releases.
- `zap` stanza covering the real `io.raymol.RayMol` prefs/caches/state paths.
- `depends_on macos: :ventura` (matches the 13.0 deployment target).

### Validation
- `brew style` — clean
- `brew audit --cask` (offline) — exit 0
- `brew audit --cask --online` — exit 0 (URL reachable, sha256 matches, `RayMol.app` artifact extracted)
- `brew livecheck` — `1.6.1 ==> 1.6.1`
- End-to-end `brew tap javierbq/raymol` from the real remote resolves the cask.

Not exercised: a literal `brew install --cask` on the dev machine (would need `--force` over the existing `/Applications/RayMol.app`); the online audit already mounts + extracts the DMG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)