### PR TITLE
fix: tier-0 batch — camera preserve on dots/surface, panel subtitle, two-finger gestures (#192 #193 #194 #195)

### DIFF
--- a/modules/pymol/appkit_inspector.py
+++ b/modules/pymol/appkit_inspector.py
@@ -302,22 +302,18 @@ def widen_clip_for_surface(buffer=12.0):
     front-clipped by the atom-fit slab that orient/reset/load set (which would
     slice the surface front and expose the interior).
 
-    Re-fit tight to the visible content first (zoom buffer 0 — idempotent, keeps
-    the molecule the same size), THEN push the near/far planes out by `buffer`.
-    The zoom reset makes repeated calls non-accumulating; the direct plane move
-    (not a camera dolly) clears the shell without shrinking the molecule, and
-    moving BOTH planes keeps the slab centered so depth precision stays good.
-    No-op when no such rep is shown."""
+    Use `clip atoms, buffer, visible`: it sets the near/far planes from the
+    visible atoms' extent about their CURRENT camera positions plus `buffer`,
+    touching only the clip planes -- never the camera position, rotation, or
+    center of rotation. That preserves the user's current view (previously a
+    `zoom visible` here recentered/rezoomed the camera every time dots/surface
+    was shown -- issue #195). It is absolute (recomputed from atom extents each
+    call), so repeated calls don't accumulate. No-op when no such rep is shown."""
     try:
         if (cmd.count_atoms('rep surface') + cmd.count_atoms('rep mesh')
                 + cmd.count_atoms('rep dots')) > 0:
-            cmd.zoom('visible', 0.0, complete=1)   # reset slab to tight visible fit
-            # `clip near, +d` moves the near plane TOWARD the viewer (front -= d);
-            # `clip far, -d` moves the far plane AWAY (back += d). Together they
-            # WIDEN the slab so the ~solvent_radius surface shell at both faces is
-            # inside it. (The opposite signs would narrow the slab and clip the
-            # surface — and the interior — away.)
-            cmd.clip('near', float(buffer))
-            cmd.clip('far', -float(buffer))
+            # Widen the slab to enclose the visible atoms +/- buffer WITHOUT
+            # moving the camera: clip atoms only calls SceneClipSet(front, back).
+            cmd.clip('atoms', float(buffer), 'visible')
     except Exception:
         pass

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -110,15 +110,6 @@ private enum InspectorTab: String, CaseIterable, Identifiable {
         case .display: return "slider.horizontal.3"
         }
     }
-    /// One-line description shown under the segmented tab picker.
-    var blurb: String {
-        switch self {
-        case .objects: return "Structures, representations & model playback"
-        case .scenes:  return "Store & recall saved views"
-        case .movie:   return "Camera keyframes, scenes & model clips"
-        case .display: return "Background, lighting & effects"
-        }
-    }
 }
 
 private let landscapePanelTabSpecs: [PanelTabSpec] = [
@@ -1346,7 +1337,7 @@ struct ContentView: View {
     // fill a sensible fraction rather than collapsing to nothing).
     private func inspectorPortraitHeight(total: CGFloat) -> CGFloat {
         let floor: CGFloat = 150
-        // Segmented picker + blurb row + divider sit above the tab content.
+        // Segmented picker + clear/selection row + divider sit above the tab content.
         let chrome: CGFloat = 96
         func hug(_ tag: Int, cap: CGFloat) -> CGFloat {
             let content = paneHeights[tag].map { $0 + chrome }
@@ -2475,11 +2466,7 @@ struct ContentView: View {
             .padding(.top, 8)
             .padding(.bottom, 4)
             HStack(spacing: 8) {
-                Text(inspectorTab.blurb)
-                    .font(.system(size: 10))
-                    .foregroundColor(.secondary)
-                    .lineLimit(1)
-                Spacer(minLength: 8)
+                Spacer(minLength: 0)
                 // Clear selection + selection mode — here (shared chrome) so both
                 // are reachable from every tab.
                 ClearSelectionButton()

--- a/swiftui/PyMOLViewer/Shared/MetalViewport.swift
+++ b/swiftui/PyMOLViewer/Shared/MetalViewport.swift
@@ -54,6 +54,13 @@ struct MetalViewport: NSViewRepresentable {
         let magnify = NSMagnificationGestureRecognizer(
             target: context.coordinator,
             action: #selector(Coordinator.handleMagnification(_:)))
+        // Without a delegate AppKit treats magnify and rotate as mutually
+        // exclusive, so it arbitrates an ambiguous two-finger twist (which always
+        // carries an incidental pinch) to the first-added recognizer (magnify) and
+        // the twist never reaches handleRotationGesture — issue #192. The delegate
+        // below (shouldRecognizeSimultaneouslyWith) lets the pinch and twist
+        // components run together, mirroring the shipped iOS composition.
+        magnify.delegate = context.coordinator
         view.addGestureRecognizer(magnify)
 
         // Trackpad two-finger twist → Z-axis roll. Only acts while the engine's
@@ -63,6 +70,7 @@ struct MetalViewport: NSViewRepresentable {
         let rotate = NSRotationGestureRecognizer(
             target: context.coordinator,
             action: #selector(Coordinator.handleRotationGesture(_:)))
+        rotate.delegate = context.coordinator
         view.addGestureRecognizer(rotate)
 
         // Click-debug harness (PYMOL_AUTOCLICK="ndcx,ndcy[;ndcx,ndcy...]"): after
@@ -239,6 +247,15 @@ struct MetalViewport: UIViewRepresentable {
         twoPan.delegate = context.coordinator
         pinch.delegate = context.coordinator
         rotation.delegate = context.coordinator
+        // #193: a two-finger drag whose fingers land slightly staggered was being
+        // grabbed by the one-finger `pan` (rotate) first, which cancelled `twoPan`
+        // so no translation ever occurred. Make the one-finger rotate defer until
+        // the multi-finger pans fail, so a 2-finger translate / 3-finger clip wins
+        // when a second/third finger is present. (twoPan likewise defers to clipPan
+        // at the 2→3 finger boundary so a clip isn't briefly seen as a pan.)
+        pan.require(toFail: twoPan)
+        pan.require(toFail: clipPan)
+        twoPan.require(toFail: clipPan)
 
         view.addGestureRecognizer(tap)
         view.addGestureRecognizer(pan)
@@ -1201,6 +1218,25 @@ extension MetalViewport.Coordinator: UIGestureRecognizerDelegate {
             if gr is UIPinchGestureRecognizer || gr is UIRotationGestureRecognizer { return true }
             if let p = gr as? UIPanGestureRecognizer { return p.maximumNumberOfTouches == 2 }
             return false
+        }
+        return isTwoFinger(g) && isTwoFinger(other)
+    }
+}
+#endif
+
+#if os(macOS)
+// Mirror the iOS composition on macOS: without a delegate, AppKit treats the
+// magnify (pinch→zoom) and rotate (two-finger twist→Z-roll) recognizers as
+// mutually exclusive, so a real two-finger twist (which always carries an
+// incidental pinch) is arbitrated to the first-added recognizer (magnify) and
+// the twist never reaches handleRotationGesture — issue #192. Letting the
+// two-finger pair recognize simultaneously routes the twist's rotation
+// component to the Z-roll while any pinch component still zooms.
+extension MetalViewport.Coordinator: NSGestureRecognizerDelegate {
+    func gestureRecognizer(_ g: NSGestureRecognizer,
+                           shouldRecognizeSimultaneouslyWith other: NSGestureRecognizer) -> Bool {
+        func isTwoFinger(_ gr: NSGestureRecognizer) -> Bool {
+            gr is NSMagnificationGestureRecognizer || gr is NSRotationGestureRecognizer
         }
         return isTwoFinger(g) && isTwoFinger(other)
     }


### PR DESCRIPTION
## Summary

Batches the four open **tier-0** issues into one PR. Each was developed in its own worktree/branch and cherry-picked here as a single focused commit; the three fixes touch disjoint files (no overlap).

| # | Issue | Fix | File |
|---|-------|-----|------|
| #195 | Adding dots/surface resets the camera | `widen_clip_for_surface()` opened with `cmd.zoom('visible')`, recentering/rezooming on every dots/surface/mesh show. Replaced the zoom + relative near/far pushes with one camera-preserving `clip atoms, buffer, visible` (sets clip planes from the visible atoms' extent about their current camera positions; never touches camera pos/rotation/origin). | `modules/pymol/appkit_inspector.py` |
| #194 | Remove descriptive subtitle under the panel tab bar | Deleted `Text(inspectorTab.blurb)` from the shared `inspectorSwitcher` and removed the now-dead `InspectorTab.blurb` property. Clear (ⓧ) + selection-mode controls stay right-aligned in the same row. macOS + iPad (iPhone never rendered it). | `swiftui/PyMOLViewer/Shared/ContentView.swift` |
| #192 | macOS trackpad two-finger rotation broken | The `NSMagnificationGestureRecognizer` + `NSRotationGestureRecognizer` had no delegate, so AppKit made them mutually exclusive and arbitrated an ambiguous two-finger twist to magnify — the twist never reached the Z-roll handler. Set both recognizers' `delegate` and added an `NSGestureRecognizerDelegate` allowing the two-finger pair to recognize simultaneously (mirrors the shipped iOS composition). | `swiftui/PyMOLViewer/Shared/MetalViewport.swift` |
| #193 | Two-finger translation (pan) does not work | iOS: a two-finger drag with staggered touchdown was grabbed by the one-finger rotate recognizer first, cancelling the two-finger pan. Added `require(toFail:)` so the one-finger rotate defers to the 2-finger translate / 3-finger clip (and 2-finger pan defers to 3-finger clip). On macOS the two-finger pan is expected to recover via the #192 recognizer-coexistence change. | `swiftui/PyMOLViewer/Shared/MetalViewport.swift` |

## Testing

Tested in parallel across a disposable **macOS VM** and the **iOS Simulator**; the two gesture fixes are additionally build- + logic-verified (multi-finger trackpad/touch gestures cannot be synthesized in a VM/simulator, so their end-to-end acceptance is a hardware check).

- **#195 — PASS (definitive A/B, macOS VM via MCP).** With a distinctive camera set, `get_view()` before/after `show dots` shows camera elements 0–14 unchanged (pos `[6.0,-4.0,-9.52]`, origin `[0,0,0]`); only the clip planes widen (front `4.33→-6.00`, back `14.71→25.52`). Re-running the *old* `zoom visible` path on the same view moved the camera to `[0,0,-28.3]`, confirming the bug and the fix.
- **#194 — PASS (iPad Pro 11" Simulator).** Screenshot confirms the subtitle line is gone beneath the Objects/Scenes/Movie/Display tabs; the tabs and clear/selection-mode controls remain. Same shared `inspectorSwitcher` compiles for macOS.
- **#192 — build + logic verified.** macOS app compiles (the new `NSGestureRecognizerDelegate` conformance type-checks); the delegate predicate passes 6/6 against real AppKit recognizer instances (magnify+rotate compose; non-two-finger pairs stay exclusive). Final acceptance = two-finger twist on a real trackpad.
- **#193 — build verified.** iOS + macOS both compile with the `require(toFail:)` arbitration. Final acceptance = two-finger drag on a real iPad touchscreen / MacBook trackpad.

Closes #192
Closes #193
Closes #194
Closes #195
