### PR TITLE
fix(move): gizmo unusable after trackpad two-finger pan/roll (stale hit-test cache)

### DIFF
--- a/swiftui/PyMOLViewer/Shared/MetalViewport.swift
+++ b/swiftui/PyMOLViewer/Shared/MetalViewport.swift
@@ -909,6 +909,13 @@ extension MetalViewport {
             panActive = false
             engine?.button(gestureButton, state: PYMOL_BUTTON_UP,
                            x: panCursorX, y: panCursorY, modifiers: gestureMods)
+            // A two-finger pan is a scene translation, so the 3D gizmo CGO moved on
+            // screen while its cached 2D hit-test geometry (engine.gizmo) did not.
+            // Re-emit it so a hover/grab after panning maps to the handle the user
+            // now sees. Matches the refresh already done on orbit mouseUp and
+            // pinch-end; no-op outside Move mode. (Clip drags don't move the gizmo,
+            // but the refresh is harmless and this is the shared settle point.)
+            engine?.refreshGizmo()
         }
 
         @objc func handleMagnification(_ gesture: NSMagnificationGestureRecognizer) {
@@ -947,6 +954,9 @@ extension MetalViewport {
                 engine?.runPython("from pymol import cmd as _c; _c.turn('z', \(deg))")
             case .ended, .cancelled:
                 lastRoll = 0
+                // The Z-roll rotated the view, so the gizmo moved on screen; resync
+                // its cached hit-test geometry (no-op outside Move mode).
+                engine?.refreshGizmo()
             default:
                 break
             }


### PR DESCRIPTION
## Summary

Fixes a **macOS Move-mode regression** introduced by the move-mode merge (#191, current master `f6fd1902f`), **independent of** PR #199 (tier-0). After a **trackpad two-finger pan** or **two-finger Z-roll**, the gizmo becomes unusable: hovering highlights the wrong handle, and dragging a handle does nothing (the object neither rotates nor translates).

## Root cause (confirmed, not inferred)

The move-mode gizmo caches its 2D hit-test geometry (`engine.gizmo`, emitted by `metal_move` → `pymol_gizmo.json`). It is only re-emitted on discrete events: orbit mouseUp (`MetalViewport.swift:613`), pinch-end (`:945`), and drag begin/end. Two camera-moving trackpad gestures were **missed**:

- **Two-finger pan** → `endTrackpadPan()` (a scene translation that moves the rendered 3D gizmo) never called `refreshGizmo()`.
- **Two-finger Z-roll** → `handleRotationGesture` `.ended` never called `refreshGizmo()`.

After such a gesture the rendered gizmo (re-projected every frame from the live camera) and the cached hit-test geometry disagree. `handleMouseMoved` → `gizmoHit()` then maps the cursor to a **stale** handle (wrong-element hover), and `handleMouseDown` sets `moveHandle = gizmoHit(...) = nil`, so `handleMouseDragged` falls to the empty-space **camera-orbit** branch and never calls `gizmoBeginDrag`/`gizmoUpdateDrag` → rotate/translate do nothing.

**Verified empirically** (macOS VM, via MCP, data level): after `metal_move.set_active`, the gizmo center NDC is `[0.0193, …]`; after `cmd.turn 45` with no refresh it stays `[0.0193, …]` (stale); after `refresh()` it re-syncs to `[0.012, …]`. Also confirmed the deployed core is current (Metal object-TTT push present — object moves on `cmd.translate(object=, camera=0)`), ruling out the stale-core hypothesis. Bug is in master, **not** caused by the tier-0 commits.

## Fix

Call `engine.refreshGizmo()` (self-guarded to Move mode) at both missed gesture-ends, matching the existing orbit/pinch refresh. One call per gesture-end (not per-tick) — no added lag.

## Testing

- Mechanism verified headlessly (above). Build compiles.
- **End-to-end grab acceptance requires a real trackpad** — multi-finger gestures can't be synthesized in a VM/Simulator (same ceiling as #192/#193).

## Note on the paired "hover not indicating selection" report
Being tracked separately — the selection/preselection **marker render** could not be confirmed headlessly (no mouse-hover injection in the VM; paravirtual-GPU rendering doubt; host window capture unavailable). Investigation continuing.
