### PR TITLE
release: RayMol 1.7.1 (build 20)

### DIFF
--- a/docs/release-notes/v1.7.1.md
+++ b/docs/release-notes/v1.7.1.md
@@ -1,0 +1,33 @@
+## RayMol 1.7.1
+
+A feature release: a new Move mode for repositioning objects with an on-screen
+gizmo, one-line install and updates via Homebrew, and a batch of selection and
+picking correctness fixes.
+
+### Move mode
+- **Reposition an object with an on-screen gizmo.** *Mouse ▸ Move Objects* (⌃M)
+  enters Move mode: drag the 3D gizmo to translate or rotate a single object
+  rigidly, without disturbing the rest of the scene. The gizmo is sized to the
+  object, and the handle you hover or grab grows so it's clear what you've got.
+  It's non-destructive — leaving the mode returns you to normal camera control.
+- **Adjustable gizmo frame.** Set a custom origin and inclination for the gizmo
+  when you need to rotate about something other than the object's center.
+
+### Selecting
+- **Fixed: the hover preview no longer disappears** once a selection is active —
+  live hover highlighting keeps working after you've selected something.
+- **Fixed: selection markers stay visible through the clip slab.** What *is*
+  selected is always shown, even when clipped away, while only what's actually
+  in view remains clickable.
+- **Fixed: the right residue is picked on multi-state (NMR/MD) objects** when
+  you're viewing a state other than the first — hover and click now match the
+  model on screen.
+
+### Installing
+- **Install and update via Homebrew:** `brew install --cask javierbq/raymol/raymol`.
+
+### macOS app
+- **Smaller download.** The legacy Tk/Qt Python GUIs are no longer bundled in
+  the app.
+
+Built on the open-source PyMOL engine. Updates install automatically via the in-app updater (**Check for Updates…** in the app menu).

--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -153,7 +153,7 @@
 		F2078076B68D28457409F7A5 /* RayMol.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RayMol.entitlements; sourceTree = "<group>"; };
 		F607D204A410CA38B84223BE /* RayMolUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RayMolUpdater.swift; sourceTree = "<group>"; };
 		FB1304C662D9011F7C4505FC /* MCPStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPStatusView.swift; sourceTree = "<group>"; };
-		"TEMP_8C7ED3A9-6E65-48B0-9972-200D9C0284AD" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
+		"TEMP_5E7E2DCC-5575-4E8D-88BB-68C2D4C34F48" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -279,10 +279,10 @@
 			path = Bridge;
 			sourceTree = "<group>";
 		};
-		"TEMP_7726E70B-3B84-4710-BEC7-A74861EC4F5B" /* swiftui */ = {
+		"TEMP_80C523CE-E459-48E6-BE68-B201588A4D5E" /* swiftui */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_8C7ED3A9-6E65-48B0-9972-200D9C0284AD" /* PyMOLBridge.xcconfig */,
+				"TEMP_5E7E2DCC-5575-4E8D-88BB-68C2D4C34F48" /* PyMOLBridge.xcconfig */,
 			);
 			path = swiftui;
 			sourceTree = "<group>";
@@ -932,7 +932,7 @@
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = RayMol;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -946,7 +946,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.7.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -962,7 +962,7 @@
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = RayMol;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -976,7 +976,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.7.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -993,7 +993,7 @@
 				CODE_SIGN_ENTITLEMENTS = PyMOLViewer/RayMol.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEVELOPMENT_TEAM = VT99UQUQ89;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1009,7 +1009,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.7.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -1046,7 +1046,7 @@
 				CODE_SIGN_ENTITLEMENTS = PyMOLViewer/RayMol.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEVELOPMENT_TEAM = VT99UQUQ89;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1062,7 +1062,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.7.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -1074,7 +1074,7 @@
 		};
 		76B7E9DB75E073D1E60928FA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_8C7ED3A9-6E65-48B0-9972-200D9C0284AD" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_5E7E2DCC-5575-4E8D-88BB-68C2D4C34F48" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1159,7 +1159,7 @@
 		};
 		D8F44FDFF036013D2F03BA83 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_8C7ED3A9-6E65-48B0-9972-200D9C0284AD" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_5E7E2DCC-5575-4E8D-88BB-68C2D4C34F48" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/swiftui/project.yml
+++ b/swiftui/project.yml
@@ -62,8 +62,8 @@ targets:
         # AppIcon.appiconset fallback. Applies to both macOS + iOS.
         ASSETCATALOG_COMPILER_APPICON_NAME: RayMol
         INFOPLIST_GENERATION_MODE: GeneratedFile
-        MARKETING_VERSION: "1.7.0"
-        CURRENT_PROJECT_VERSION: 19
+        MARKETING_VERSION: "1.7.1"
+        CURRENT_PROJECT_VERSION: 20
         GENERATE_INFOPLIST_FILE: YES
         # Generate a launch screen so iOS renders at the device's NATIVE
         # resolution. Without it the app is letterboxed at a legacy size on


### PR DESCRIPTION
Bumps to **1.7.1 / build 20**. Code-identical maintenance re-release of 1.7.0.

**Why:** 1.7.0 was rolled back to prerelease after a report that it auto-loaded 1UBQ + entered Move mode on launch. Investigation showed that was **dev-session contamination** (a leftover MCP-driven instance), not a real regression — the shipped build launches clean (verified: source has no autoload path outside test env vars; the notarized app loads 0 objects on a clean launch). 1.7.1 re-establishes the release with a new build number so the 1.7.0 user and all 1.6.1 users converge on a single latest.

No code changes vs 1.7.0; What's New keeps the 1.7.0 Move-mode + Homebrew pages (shown to 1.6.1 upgraders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)