### PR TITLE
fix(macos): load co-crystal HETATM groups (#201) + show multi-SDF compound names (#203)

### DIFF
--- a/modules/pymol/appkit_inspector.py
+++ b/modules/pymol/appkit_inspector.py
@@ -262,8 +262,20 @@ def _build(objs):
     # frame's state when not pinned) and whether all states are overlaid.
     objmeta = {}
     for o in objs:
-        objmeta[o] = {'state': int(round(_num('state', o))),
-                      'all': int(round(_num('all_states', o)))}
+        entry = {'state': int(round(_num('state', o))),
+                 'all': int(round(_num('all_states', o)))}
+        # Per-state titles (e.g. compound names from a multi-record SDF, which
+        # PyMOL stores as each state's title). Included only when at least one
+        # state carries a non-empty title, so ordinary single structures add
+        # nothing to the payload (issue #203).
+        try:
+            _ns = cmd.count_states(o)
+            _titles = [cmd.get_title(o, _s) or '' for _s in range(1, _ns + 1)]
+            if any(_titles):
+                entry['titles'] = _titles
+        except Exception:
+            pass
+        objmeta[o] = entry
     # Saved scenes (ordered) + the current one, for the Scenes strip.
     try:
         scenes = list(cmd.get_scene_list() or [])

--- a/modules/pymol/appkit_sequence.py
+++ b/modules/pymol/appkit_sequence.py
@@ -51,6 +51,25 @@ def _object_rows(names):
                         space={'r': r})
         except Exception:
             pass
+        # HETATM groups (co-crystal ligands, ions, waters) have no guide atom,
+        # so the query above skips them entirely. Append one entry per
+        # non-polymer residue (deduped, in atom order) tagged 'het' so they show
+        # and are selectable in the sequence viewer like PyMOL — the Swift panel
+        # spreads a het entry's 3-letter resn across columns (issue #201).
+        try:
+            het = []
+            cmd.iterate('(%s) and not polymer and not hydro' % o,
+                        'het.append([chain, resi, resn, str(color)])',
+                        space={'het': het})
+            seen = set()
+            for e in het:
+                key = (e[0], e[1], e[2])
+                if key in seen:
+                    continue
+                seen.add(key)
+                r.append([e[0], e[1], e[2], e[3], 'het'])
+        except Exception:
+            pass
         if not r:
             continue
         name = 'example' if o == '__theme_preview' else o

--- a/modules/pymol/raymol_theme.py
+++ b/modules/pymol/raymol_theme.py
@@ -99,6 +99,19 @@ def cnc(selection="(all)"):
                   "(%s) and elem %s" % (selection, elem))
 
 
+def _show_het(obj):
+    """Reveal non-polymer HETATM groups that a cartoon-only view would leave
+    invisible: co-crystal ligands, ions, and waters. Cartoon only draws the
+    polymer, so without this a loaded ligand (e.g. SY7 in 5HBH) is present but
+    unseen. Mirrors PyMOL's default presentation — ligands as sticks, ions as
+    (small) spheres, waters as nonbonded crosses (issue #201)."""
+    cmd.show("sticks", "(%s) and organic" % obj)
+    cmd.show("nonbonded", "(%s) and solvent" % obj)
+    ions = "(%s) and inorganic" % obj
+    cmd.show("spheres", ions)
+    cmd.set("sphere_scale", 0.3, ions)
+
+
 def apply_default_style(obj):
     """Apply the active default representation + cartoon settings to `obj`."""
     style = _default_style
@@ -106,6 +119,7 @@ def apply_default_style(obj):
     cmd.set("cartoon_fancy_helices", 1 if _fancy_helices else 0, obj)
     if style == "cartoon":
         cmd.hide("everything", obj); cmd.show("cartoon", obj)
+        _show_het(obj)
     elif style == "sticks":
         cmd.hide("everything", obj); cmd.show("sticks", obj)
     elif style == "spheres":
@@ -117,6 +131,7 @@ def apply_default_style(obj):
         cmd.show("surface", obj)
     elif style == "pretty":
         cmd.hide("everything", obj); cmd.show("cartoon", obj)
+        _show_het(obj)
 
 
 def apply_to(obj):

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -64,6 +64,16 @@ struct SceneState: Equatable {
 struct ObjStateMeta: Equatable {
     var state: Int = 1        // effective current state (resolves the frame)
     var overlayAll: Bool = false   // all_states overlay for this object
+    // Per-state titles (e.g. compound names from a multi-record SDF). Empty
+    // unless at least one state carries a title. Indexed by state-1 (issue #203).
+    var titles: [String] = []
+
+    /// Title for a 1-based state, or nil when none/blank.
+    func title(forState state: Int) -> String? {
+        guard state >= 1, state <= titles.count else { return nil }
+        let t = titles[state - 1]
+        return t.isEmpty ? nil : t
+    }
 }
 
 // MARK: - Representation inspector: control metadata
@@ -1955,6 +1965,23 @@ private struct ObjectCard: View {
                     .font(.system(size: 10, design: .monospaced))
                     .foregroundColor(PanelTheme.textColor)
                     .frame(width: 42, alignment: .trailing)
+            }
+            // Compound name for this state, when present (e.g. a multi-record
+            // SDF's per-record title), so docking-pose / library sets can be
+            // navigated by name while scrubbing states (issue #203).
+            if let name = meta?.title(forState: cur) {
+                HStack(spacing: 6) {
+                    Text("Name")
+                        .font(.system(size: 10)).foregroundColor(PanelTheme.textColor)
+                        .frame(width: 78, alignment: .leading)
+                    Text(name)
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(TimelineTheme.accent)
+                        .lineLimit(1).truncationMode(.middle)
+                        .textSelection(.enabled)
+                        .help(name)
+                    Spacer(minLength: 0)
+                }
             }
             // Play/pause + per-object fps — animates THIS object's models (via a
             // Swift timer + `set state`), independent of the movie and other objects.

--- a/swiftui/PyMOLViewer/Panels/SequencePanel.swift
+++ b/swiftui/PyMOLViewer/Panels/SequencePanel.swift
@@ -437,6 +437,26 @@ extension PyMOLEngine {
                     red: rgb.count > 0 ? rgb[0] : 0.8,
                     green: rgb.count > 1 ? rgb[1] : 0.8,
                     blue: rgb.count > 2 ? rgb[2] : 0.8)
+                // HETATM groups (ligands, ions, waters) are tagged 'het' by
+                // appkit_sequence. They have no 1-letter code, so spread the
+                // 3-letter resn (SY7, EDO, HOH…) across adjacent columns like
+                // PyMOL — every cell shares one selKey (obj/chain/resi), so a
+                // click on any character selects the whole group (issue #201).
+                if t.count >= 5 && t[4] == "het" {
+                    let letters = resn.isEmpty ? ["?"] : resn.map { String($0) }
+                    for (j, ch) in letters.enumerated() {
+                        residues.append(SequenceResidue(
+                            id: "\(o.name)/\(chain)/\(resi)/\(i)/\(j)",
+                            objectName: o.name,
+                            chain: chain,
+                            oneLetter: ch,
+                            resi: resi,
+                            resn: resn,
+                            color: color
+                        ))
+                    }
+                    continue
+                }
                 residues.append(SequenceResidue(
                     id: "\(o.name)/\(chain)/\(resi)/\(i)",
                     objectName: o.name,

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -2391,7 +2391,8 @@ final class PyMOLEngine: ObservableObject {
                 guard let m = mAny as? [String: Any] else { continue }
                 meta[obj] = ObjStateMeta(
                     state: (m["state"] as? NSNumber)?.intValue ?? 1,
-                    overlayAll: ((m["all"] as? NSNumber)?.intValue ?? 0) != 0)
+                    overlayAll: ((m["all"] as? NSNumber)?.intValue ?? 0) != 0,
+                    titles: (m["titles"] as? [Any])?.map { $0 as? String ?? "" } ?? [])
             }
         }
 


### PR DESCRIPTION
## Summary
Fixes two issues from the virtual-screening workflow (reported by Tony L.):

- **#201** — Co-crystal ligands, waters, and other HETATM groups were loaded but invisible in the viewport (default cartoon style draws only polymer) and absent from the sequence viewer (row builder used only `guide` atoms).
- **#203** — Multi-compound SDF libraries/docking-pose sets gave no visible compound names when stepping through states.

Both fixes are **Python + Swift only** — no C++ core change.

## #201 — HETATM groups
- `raymol_theme.apply_default_style`: for cartoon/pretty, also show `organic` as sticks, `solvent` as nonbonded, `inorganic` as small spheres.
- `appkit_sequence._object_rows`: append one tagged `het` entry per non-polymer residue (deduped).
- `SequencePanel.swift`: render a het entry's 3-letter resn across columns like PyMOL; all cells share one sel-key so a click selects the whole group.

_Note: the issue calls the ligand `SY7`; 5HBH's actual resn is `5Y7`. The fix is resn-agnostic (`organic`/`solvent`/`inorganic`), so it's unaffected._

## #203 — SDF compound names
The C MOL reader already stores each record's title in the per-state `CoordSet.Name` (`cmd.get_title(obj, state)`); a multi-record SDF loads as one object with N states. Purely a surfacing fix:
- `appkit_inspector.poll`: emit per-state `titles` in `objmeta` (only when a title exists).
- `PyMOLEngine.swift`: parse into `ObjStateMeta`.
- `ObjectPanel.swift`: State row shows a **Name** line for the current state.

## Testing
Built and functionally verified in a disposable macOS VM (RayMol MCP + tart):
- **5HBH**: 46 ligand atoms (5Y7/EDO/FMT) render as sticks, 21 waters as crosses; het groups appear + are selectable in the sequence viewer.
- **3-record test SDF**: stepping states shows `aspirin_pose_1` → `caffeine_pose_2` → `ZINC04211breslin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)