### PR TITLE
fix(macos): mouse-mode menu reflects the Metal backend's real behavior

### DIFF
--- a/swiftui/PyMOLViewer/Panels/MousePanel.swift
+++ b/swiftui/PyMOLViewer/Panels/MousePanel.swift
@@ -191,11 +191,23 @@ struct MousePanel: View {
     private let modifierColor = Color(red: 1.0, green: 0.3, blue: 0.3)
     private var labelColor: Color { ThemeManager.shared.active.panelText.color.opacity(0.6) }
 
-    // The keys shown in the mode picker. macOS appends the synthetic "Trackpad"
-    // entry; iOS shows the real PyMOL modes only.
+    // The keys shown in the mode picker.
+    //
+    // macOS offers only the two modes that are fully, cleanly implemented in the
+    // Metal viewport: 3-Button Viewing (rotate/zoom/clip via drags) and the
+    // synthetic Trackpad gesture mode. Every other classic mode is hidden here —
+    // on this backend a mode only reprograms the drag rows (clicks are hardcoded),
+    // and their distinguishing behavior is either unreachable (the middle-button
+    // column — no middle button on most Macs) or lacks its visual. Notably
+    // Maestro's signature bare-left box-select DOES select atoms but draws no
+    // rubber-band marquee: the Metal path (SceneRenderMetal) forces
+    // internal_gui/feedback off and never renders the Ortho overlay CGO that
+    // OrthoDrawLoop emits, so the drag has no on-screen feedback. Offering those
+    // modes would imply behavior the app doesn't visibly deliver. iOS still shows
+    // the full set — it has its own gesture handling and wasn't audited the same way.
     private var displayRing: [String] {
         #if os(macOS)
-        return modeRing + [kTrackpadKey]
+        return ["three_button_viewing", kTrackpadKey]
         #else
         return modeRing
         #endif
@@ -373,11 +385,16 @@ struct MousePanel: View {
 
             // Click rows
             #if os(macOS)
-            gridRow(modifier: "Sngl", modColor: labelColor,
-                    l: codeFor(mode[19]), m: codeFor(mode[20]), r: codeFor(mode[21]),
-                    cellColor: actionColor, font: gridFont)
-            gridRow(modifier: "Dbl ", modColor: labelColor,
-                    l: codeFor(mode[16]), m: codeFor(mode[17]), r: codeFor(mode[18]),
+            // macOS clicks BYPASS the per-mode button matrix: the Metal viewport
+            // intercepts bare left/right clicks itself (handleMouseUp /
+            // handleRightMouseUp in MetalViewport) and never routes them through
+            // `mouse <mode>`. A left-click always toggles the pick into 'sele'
+            // (honoring the Selecting row below); a right-click always opens the
+            // viewport context menu. Double-clicks aren't handled at all. So the
+            // per-mode Sngl/Dbl values are fiction here — collapse to one fixed,
+            // accurate Click row. (Middle is `--`: no middle button on most Macs.)
+            gridRow(modifier: "Clik", modColor: labelColor,
+                    l: "Sele", m: " -- ", r: "Menu",
                     cellColor: actionColor, font: gridFont)
             #else
             // iPadOS: show touch equivalents


### PR DESCRIPTION
## Summary

The macOS mouse-mode panel advertised the full PyMOL 3-button matrix (5 classic modes, per-mode single/double-click rows), but the native Metal viewport honors almost none of it. This aligns the menu with what the app actually does.

### What the audit found (macOS / Metal backend)

- **Clicks bypass the per-mode matrix.** The viewport intercepts bare left/right clicks itself — a left-click always toggles a `metal_pick` selection into `sele`; a right-click always opens the native SwiftUI context menu — and never routes them through `mouse <mode>`. The per-mode `Sngl` values were fiction.
- **Double-clicks aren't handled at all** (no `clickCount` path), so the `Dbl` row never fired.
- **Only drag rows are core-driven**, and the classic modes' distinguishing cells live largely in the **middle-button column** (no middle button on most Macs).
- **Maestro's box-select selects atoms but draws no marquee.** `SceneRenderMetal` forces `internal_gui`/`internal_feedback` off and never calls `OrthoDoDraw`/`OrthoRenderCGO`, so the Ortho overlay CGO that `OrthoDrawLoop` emits (the rubber-band) is never rendered. The drag has no on-screen feedback.

### Changes (all `#if os(macOS)`; iOS untouched — its gestures weren't audited)

- Reduce the picker to the two cleanly-implemented modes: **3-Button Viewing** + **Trackpad**.
- Collapse the fictional per-mode `Sngl`/`Dbl` rows into one fixed, accurate **`Click` row** (`Sele / -- / Menu`).

### Verification

Built on the host and driven in a disposable macOS VM (macOS 15.7): both remaining modes render correctly, and the `Click` row matches the actual click behavior. Maestro's box-select/marquee gap was settled by code trace (couldn't drive a viewport drag in the VM — no HID injection).

### Follow-up (not in this PR)

The missing selection marquee is a broader Metal-backend gap affecting **any** box-select path, not just Maestro. Worth a separate issue to render the Ortho loop CGO (or a SwiftUI overlay) during a box drag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
