### PR TITLE
iOS: wire up trackpad/pencil hover pre-selection preview (#165)

### DIFF
--- a/swiftui/PyMOLViewer/Shared/MetalViewport.swift
+++ b/swiftui/PyMOLViewer/Shared/MetalViewport.swift
@@ -248,13 +248,15 @@ struct MetalViewport: UIViewRepresentable {
         view.addGestureRecognizer(rotation)
         view.addGestureRecognizer(longPress)
 
-        // TODO(#165, iPad hover follow-up): add a UIHoverGestureRecognizer here
-        // (target: coordinator) so a trackpad/Apple-Pencil-hover on iPadOS drives
-        // the same hover pre-selection preview as macOS mouseMoved. Its .changed
-        // handler would compute NDC exactly like handleTap and call
-        // engine.hoverPreview(...); .ended would call engine.clearHoverPreview().
-        // Deferred: touch has no persistent cursor, so this only helps the
-        // pointer/pencil-hover case and needs its own gate against tap/drag.
+        // iPad hover pre-selection preview (issue #165): a UIHoverGestureRecognizer
+        // fires ONLY for an indirect pointer hover — trackpad (Magic Keyboard),
+        // mouse, or Apple Pencil hover — with no button/touch held, mirroring the
+        // macOS NSTrackingArea/mouseMoved path. It drives the same
+        // engine.hoverPreview(...) → hover_preview_at → `_preselect` machinery.
+        // Touch input never triggers it (no persistent cursor), so it needs no
+        // gate against tap/drag.
+        let hover = UIHoverGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleHover(_:)))
+        view.addGestureRecognizer(hover)
 
         return view
     }
@@ -385,6 +387,10 @@ extension MetalViewport {
         // Move mode: the gizmo handle a one-finger pan is manipulating (nil =
         // none → the pan orbits the camera).
         private var panMoveHandle: GizmoHandle?
+        // Hover pre-selection preview (issue #165): last hover location fed to a
+        // preview, used to skip re-picking when the pointer barely moved. .zero
+        // is treated as "no prior move" (any first move re-picks).
+        private var lastHoverLoc: CGPoint = .zero
         #endif
 
         // MARK: - MTKViewDelegate
@@ -1033,6 +1039,37 @@ extension MetalViewport {
                 engine.measurePick(ndcX: ndcX, ndcY: ndcY, aspect: aspect)
             } else {
                 engine.pick(ndcX: ndcX, ndcY: ndcY, aspect: aspect)
+            }
+        }
+
+        // Trackpad / mouse / Apple-Pencil hover (issue #165) → hover pre-selection
+        // preview, the iPad twin of macOS handleMouseMoved. Fires only for an
+        // indirect-pointer hover with nothing held. Computes NDC EXACTLY like
+        // handleTap (top-left origin, Y flipped) so the preview aligns with what a
+        // tap would select. A sub-pixel move gate skips the re-pick when the
+        // pointer barely moved; the engine additionally debounces the Python pick.
+        // .ended/.cancelled (pointer lifted / left the view) clears the preview.
+        @objc func handleHover(_ gesture: UIHoverGestureRecognizer) {
+            guard let engine = engine, let view = mtkView else { return }
+            switch gesture.state {
+            case .began, .changed:
+                guard engine.measureMode == nil else { return }
+                let p = gesture.location(in: view)
+                if lastHoverLoc != .zero,
+                   hypot(p.x - lastHoverLoc.x, p.y - lastHoverLoc.y) < 2 {
+                    return
+                }
+                lastHoverLoc = p
+                let w = view.bounds.width, h = view.bounds.height
+                guard w > 0, h > 0 else { return }
+                let ndcX = Float(p.x / w) * 2 - 1
+                let ndcY = 1 - Float(p.y / h) * 2
+                engine.hoverPreview(ndcX, ndcY, Float(w / h))
+            case .ended, .cancelled:
+                lastHoverLoc = .zero
+                engine.clearHoverPreview()
+            default:
+                break
             }
         }
 

--- a/swiftui/PyMOLViewer/Shared/MetalViewport.swift
+++ b/swiftui/PyMOLViewer/Shared/MetalViewport.swift
@@ -1042,24 +1042,41 @@ extension MetalViewport {
             }
         }
 
-        // Trackpad / mouse / Apple-Pencil hover (issue #165) → hover pre-selection
-        // preview, the iPad twin of macOS handleMouseMoved. Fires only for an
-        // indirect-pointer hover with nothing held. Computes NDC EXACTLY like
-        // handleTap (top-left origin, Y flipped) so the preview aligns with what a
-        // tap would select. A sub-pixel move gate skips the re-pick when the
-        // pointer barely moved; the engine additionally debounces the Python pick.
-        // .ended/.cancelled (pointer lifted / left the view) clears the preview.
+        // Trackpad / mouse / Apple-Pencil hover (issue #165) → the iPad twin of
+        // macOS handleMouseMoved. Fires only for an indirect-pointer hover with
+        // nothing held. A sub-pixel move gate skips the re-pick when the pointer
+        // barely moved; the engine additionally debounces the Python pick.
+        //   • Move mode: highlight the gizmo handle under the pointer (what a drag
+        //     would grab) instead of pre-selecting an atom, and reflect Shift
+        //     (Magic Keyboard) as adjust-frame mode — mirroring macOS. The gizmo's
+        //     cached 2D projection goes stale on any view change since the last
+        //     gesture-end, so refresh the hit-test geometry for the CURRENT view
+        //     before testing (same as handleMovePan).
+        //   • Viewing mode: pre-select the atom under the pointer, computing NDC
+        //     EXACTLY like handleTap (top-left origin, Y flipped) so it aligns with
+        //     what a tap would select. Suppressed while measuring.
+        // .ended/.cancelled (pointer lifted / left the view) clears whatever the
+        // hover left behind — atom preview, hovered handle, and Shift-adjust.
         @objc func handleHover(_ gesture: UIHoverGestureRecognizer) {
             guard let engine = engine, let view = mtkView else { return }
             switch gesture.state {
             case .began, .changed:
-                guard engine.measureMode == nil else { return }
                 let p = gesture.location(in: view)
                 if lastHoverLoc != .zero,
                    hypot(p.x - lastHoverLoc.x, p.y - lastHoverLoc.y) < 2 {
                     return
                 }
                 lastHoverLoc = p
+                if engine.interactionMode == .move {
+                    engine.moveShiftHeld = gesture.modifierFlags.contains(.shift)
+                    guard let (nx, ny, aspect) = gizmoNDC(in: view, at: p) else { return }
+                    engine.refreshGizmo(aspect: aspect)
+                    let hit = engine.gizmo?.hitTest(ndc: CGPoint(x: CGFloat(nx), y: CGFloat(ny)),
+                                                    aspect: CGFloat(aspect))
+                    if engine.hoveredHandle != hit { engine.hoveredHandle = hit }
+                    return
+                }
+                guard engine.measureMode == nil else { return }
                 let w = view.bounds.width, h = view.bounds.height
                 guard w > 0, h > 0 else { return }
                 let ndcX = Float(p.x / w) * 2 - 1
@@ -1068,6 +1085,8 @@ extension MetalViewport {
             case .ended, .cancelled:
                 lastHoverLoc = .zero
                 engine.clearHoverPreview()
+                if engine.hoveredHandle != nil { engine.hoveredHandle = nil }
+                if engine.moveShiftHeld { engine.moveShiftHeld = false }
             default:
                 break
             }


### PR DESCRIPTION
The hover pre-selection preview (highlight the residue a click would select) was only wired up on macOS via NSTrackingArea/mouseMoved. On iPadOS the viewport registered only touch gesture recognizers, so a Magic Keyboard trackpad / mouse / Apple Pencil hover produced no events and nothing highlighted.

Add a `UIHoverGestureRecognizer` that drives the same `engine.hoverPreview(...)` → `hover_preview_at` → `_preselect` machinery the macOS path already uses. It fires only for an indirect pointer with nothing held, so it needs no gate against tap/drag. NDC is computed exactly like `handleTap` (top-left origin, Y flipped); `.ended`/`.cancelled` clears the preview. A sub-pixel move gate plus the engine's existing throttle keep the Python pick cheap.

## Move-mode parity

In Move mode the macOS hover path suppresses atom pre-selection and instead highlights the gizmo handle under the pointer — what a drag would grab — and reflects Shift as adjust-frame mode. `handleHover` now mirrors that: in Move mode it refreshes the gizmo hit-test for the current view, publishes `engine.hoveredHandle` for the handle under the pointer, and reflects Shift (Magic Keyboard) via `moveShiftHeld`, returning without an atom pick; `.ended`/`.cancelled` also clears the hovered handle. It reuses the same `gizmoNDC` / `engine.gizmo.hitTest` / `refreshGizmo` APIs as `handleMovePan`, and `hoveredHandle` is a shared `@Published` rendered by the shared `ContentView` gizmo overlay, so the highlight appears on iPad exactly as on macOS.

## Verification

- **Viewing-mode hover — confirmed on-device**: physical iPad Air (4th gen), iPadOS 26.2.1, with a Magic Keyboard — trackpad/pointer hover pre-selects the residue under it.
- **Device build** (Release / arm64 iphoneos) compiles cleanly and installs/launches.
- **Move-mode parity** mirrors the proven macOS `handleMouseMoved` path and ships in the same on-device build for a final hover pass.

_The branch was rebased onto current master (it had gone stale/conflicting). The hover behavior needs a real indirect pointer — it is not reproducible via touch or on the simulator._
