### PR TITLE
Load ~/.raymolrc startup script, migrated from ~/.pymolrc

### DIFF
--- a/layer5/main_appkit.mm
+++ b/layer5/main_appkit.mm
@@ -363,6 +363,17 @@ static void handleKeyDown(NSView *view, NSEvent *event) {
     // which calls cmd.config_mouse() to set up mouse bindings.
     PyMOL_SetPythonInitStage(pymolInstance, 1);
 
+    // Load ~/.raymolrc(.py), importing it from ~/.pymolrc(.py) on first
+    // detection — this embedding never goes through pymol.invocation's CLI
+    // argument parsing, so vanilla PyMOL's .pymolrc is otherwise never read
+    // (RayMol#225).
+    PyRun_SimpleString(
+        "try:\n"
+        "    from pymol import raymolrc as _raymolrc\n"
+        "    _raymolrc.load()\n"
+        "except Exception as _e:\n"
+        "    import os; os.write(2, ('[PyMOL] raymolrc load failed: %r\\n' % (_e,)).encode())\n");
+
     // Load API keys into Python's os.environ before importing ai_chat.
     // Finder-launched apps don't inherit shell env vars, so we also
     // check ~/.pymol_ai.conf (simple KEY=VALUE format).

--- a/layer5/main_appkit.mm
+++ b/layer5/main_appkit.mm
@@ -363,16 +363,52 @@ static void handleKeyDown(NSView *view, NSEvent *event) {
     // which calls cmd.config_mouse() to set up mouse bindings.
     PyMOL_SetPythonInitStage(pymolInstance, 1);
 
-    // Load ~/.raymolrc(.py), importing it from ~/.pymolrc(.py) on first
-    // detection — this embedding never goes through pymol.invocation's CLI
-    // argument parsing, so vanilla PyMOL's .pymolrc is otherwise never read
-    // (RayMol#225).
-    PyRun_SimpleString(
-        "try:\n"
-        "    from pymol import raymolrc as _raymolrc\n"
-        "    _raymolrc.load()\n"
-        "except Exception as _e:\n"
-        "    import os; os.write(2, ('[PyMOL] raymolrc load failed: %r\\n' % (_e,)).encode())\n");
+    // Load ~/.raymolrc(.py). This embedding never goes through
+    // pymol.invocation's CLI argument parsing, so vanilla PyMOL's .pymolrc is
+    // otherwise never read (RayMol#225). The first time no ~/.raymolrc(.py)
+    // exists yet and a ~/.pymolrc(.py) is found, ask before importing it
+    // rather than copying it silently.
+    {
+        NSFileManager *fm = [NSFileManager defaultManager];
+        NSString *home = NSHomeDirectory();
+        BOOL hasRaymolrc = [fm fileExistsAtPath:[home stringByAppendingPathComponent:@".raymolrc.py"]]
+            || [fm fileExistsAtPath:[home stringByAppendingPathComponent:@".raymolrc"]];
+        BOOL alreadyAsked = [fm fileExistsAtPath:[home stringByAppendingPathComponent:@".raymolrc.skip"]];
+        BOOL hasPymolrc = [fm fileExistsAtPath:[home stringByAppendingPathComponent:@".pymolrc.py"]]
+            || [fm fileExistsAtPath:[home stringByAppendingPathComponent:@".pymolrc"]];
+
+        if (!hasRaymolrc && !alreadyAsked && hasPymolrc) {
+            NSAlert *alert = [[NSAlert alloc] init];
+            alert.messageText = @"Import your PyMOL startup script?";
+            alert.informativeText = @"RayMol found an existing ~/.pymolrc and can copy it to "
+                @"~/.raymolrc, RayMol's own startup script, so your customizations still run here.";
+            [alert addButtonWithTitle:@"Import"];
+            [alert addButtonWithTitle:@"Not Now"];
+            if ([alert runModal] == NSAlertFirstButtonReturn) {
+                PyRun_SimpleString(
+                    "try:\n"
+                    "    from pymol import raymolrc as _raymolrc\n"
+                    "    _raymolrc.migrate()\n"
+                    "    _raymolrc.load()\n"
+                    "except Exception as _e:\n"
+                    "    import os; os.write(2, ('[PyMOL] raymolrc migrate/load failed: %r\\n' % (_e,)).encode())\n");
+            } else {
+                PyRun_SimpleString(
+                    "try:\n"
+                    "    from pymol import raymolrc as _raymolrc\n"
+                    "    _raymolrc.decline_migration()\n"
+                    "except Exception as _e:\n"
+                    "    import os; os.write(2, ('[PyMOL] raymolrc decline failed: %r\\n' % (_e,)).encode())\n");
+            }
+        } else {
+            PyRun_SimpleString(
+                "try:\n"
+                "    from pymol import raymolrc as _raymolrc\n"
+                "    _raymolrc.load()\n"
+                "except Exception as _e:\n"
+                "    import os; os.write(2, ('[PyMOL] raymolrc load failed: %r\\n' % (_e,)).encode())\n");
+        }
+    }
 
     // Load API keys into Python's os.environ before importing ai_chat.
     // Finder-launched apps don't inherit shell env vars, so we also

--- a/modules/pymol/raymolrc.py
+++ b/modules/pymol/raymolrc.py
@@ -1,0 +1,62 @@
+# raymolrc.py
+#
+# RayMol's native macOS/iOS embeddings (SwiftUI/Metal and the legacy AppKit
+# app) boot Python directly and never go through pymol.invocation.parse_args,
+# so a user's ~/.pymolrc is silently ignored there (see RayMol#225). This
+# module gives the native apps an equivalent startup script, ~/.raymolrc(.py),
+# and migrates an existing ~/.pymolrc(.py) into it the first time it's found.
+
+import os
+import shutil
+
+_HOME = os.path.expanduser('~')
+
+RAYMOLRC_PY = os.path.join(_HOME, '.raymolrc.py')
+RAYMOLRC_PML = os.path.join(_HOME, '.raymolrc')
+
+PYMOLRC_PY = os.path.join(_HOME, '.pymolrc.py')
+PYMOLRC_PML = os.path.join(_HOME, '.pymolrc')
+
+
+def _migrate(src, dst):
+    if os.path.exists(dst) or not os.path.exists(src):
+        return
+    try:
+        shutil.copyfile(src, dst)
+    except OSError as e:
+        print(' Warning: could not import %s to %s: %s' % (src, dst, e))
+
+
+def _seed_main_namespace(_self):
+    # The vanilla `pymol` CLI executable IS the process's real __main__
+    # module, so it already has `cmd`/`stored` etc. in scope when it runs a
+    # user's .pymolrc.py via `run(path, 'main')` — that's what lets pymolrc
+    # scripts call bare cmd.xxx() without importing it. RayMol's native
+    # embeddings boot Python directly, so __main__ starts empty; without
+    # this, every migrated .pymolrc.py using that (extremely common)
+    # convention would fail with NameError('cmd' is not defined).
+    import __main__
+    import pymol
+    __main__.__dict__.setdefault('cmd', _self)
+    __main__.__dict__.setdefault('stored', pymol.stored)
+
+
+def load(_self=None):
+    '''
+    Load ~/.raymolrc(.py) if present. The first time neither file exists yet,
+    import it from ~/.pymolrc(.py) so existing PyMOL customizations carry
+    over. Safe to call once per process at startup, after the command API is
+    available.
+    '''
+    if _self is None:
+        from pymol import cmd as _self
+
+    _migrate(PYMOLRC_PY, RAYMOLRC_PY)
+    _migrate(PYMOLRC_PML, RAYMOLRC_PML)
+
+    if os.path.exists(RAYMOLRC_PY):
+        _seed_main_namespace(_self)
+        _self.run(RAYMOLRC_PY, 'main')
+
+    if os.path.exists(RAYMOLRC_PML):
+        _self.do('@' + RAYMOLRC_PML)

--- a/modules/pymol/raymolrc.py
+++ b/modules/pymol/raymolrc.py
@@ -3,8 +3,14 @@
 # RayMol's native macOS/iOS embeddings (SwiftUI/Metal and the legacy AppKit
 # app) boot Python directly and never go through pymol.invocation.parse_args,
 # so a user's ~/.pymolrc is silently ignored there (see RayMol#225). This
-# module gives the native apps an equivalent startup script, ~/.raymolrc(.py),
-# and migrates an existing ~/.pymolrc(.py) into it the first time it's found.
+# module gives the native apps an equivalent startup script, ~/.raymolrc(.py).
+#
+# Migrating an existing ~/.pymolrc(.py) is user-confirmed, not automatic: the
+# app checks migration_candidate() and, the first time it returns non-None,
+# presents a native prompt before ever calling migrate() (see
+# ContentView.loadRaymolrcOrOfferMigration). decline_migration() records a
+# "don't ask again" choice so a user who says no isn't re-prompted every
+# launch.
 
 import os
 import shutil
@@ -17,14 +23,45 @@ RAYMOLRC_PML = os.path.join(_HOME, '.raymolrc')
 PYMOLRC_PY = os.path.join(_HOME, '.pymolrc.py')
 PYMOLRC_PML = os.path.join(_HOME, '.pymolrc')
 
+# Written when the user declines the import prompt, so we don't ask again.
+MIGRATION_SKIP_MARKER = os.path.join(_HOME, '.raymolrc.skip')
 
-def _migrate(src, dst):
-    if os.path.exists(dst) or not os.path.exists(src):
+
+def migration_candidate():
+    '''
+    Path to a ~/.pymolrc(.py) that could be imported into ~/.raymolrc(.py),
+    or None if there's nothing to offer: a raymolrc already exists, no
+    pymolrc was found, or the user already declined once.
+    '''
+    if os.path.exists(RAYMOLRC_PY) or os.path.exists(RAYMOLRC_PML):
+        return None
+    if os.path.exists(MIGRATION_SKIP_MARKER):
+        return None
+    if os.path.exists(PYMOLRC_PY):
+        return PYMOLRC_PY
+    if os.path.exists(PYMOLRC_PML):
+        return PYMOLRC_PML
+    return None
+
+
+def migrate():
+    '''Copy the current migration_candidate(), if any, into ~/.raymolrc(.py).'''
+    src = migration_candidate()
+    if src is None:
         return
+    dst = RAYMOLRC_PY if src == PYMOLRC_PY else RAYMOLRC_PML
     try:
         shutil.copyfile(src, dst)
     except OSError as e:
         print(' Warning: could not import %s to %s: %s' % (src, dst, e))
+
+
+def decline_migration():
+    '''Record that the user was asked and said no, so we don't ask again.'''
+    try:
+        open(MIGRATION_SKIP_MARKER, 'a').close()
+    except OSError as e:
+        print(' Warning: could not write %s: %s' % (MIGRATION_SKIP_MARKER, e))
 
 
 def _seed_main_namespace(_self):
@@ -43,16 +80,12 @@ def _seed_main_namespace(_self):
 
 def load(_self=None):
     '''
-    Load ~/.raymolrc(.py) if present. The first time neither file exists yet,
-    import it from ~/.pymolrc(.py) so existing PyMOL customizations carry
-    over. Safe to call once per process at startup, after the command API is
-    available.
+    Load ~/.raymolrc(.py) if present. Does not migrate from ~/.pymolrc — the
+    caller should check migration_candidate() (typically behind a
+    user-facing confirmation) and call migrate() first if appropriate.
     '''
     if _self is None:
         from pymol import cmd as _self
-
-    _migrate(PYMOLRC_PY, RAYMOLRC_PY)
-    _migrate(PYMOLRC_PML, RAYMOLRC_PML)
 
     if os.path.exists(RAYMOLRC_PY):
         _seed_main_namespace(_self)

--- a/swiftui/PyMOLViewer/Bridge/PyMOLBridge.mm
+++ b/swiftui/PyMOLViewer/Bridge/PyMOLBridge.mm
@@ -149,6 +149,15 @@ void PyMOLBridge_Start(PyMOLHandle h)
     PyMOL_Start(INST(h));
     PInit(G, true);
     PyMOL_SetPythonInitStage(INST(h), 1);
+
+    // NOTE: ~/.raymolrc(.py) is intentionally NOT loaded here. PyMOLEngine
+    // applies the RayMol theme defaults (bg color etc.) asynchronously right
+    // after isReady flips true (ContentView's `applyPersistedTheme`), which
+    // runs AFTER this function returns — loading raymolrc here would have it
+    // clobbered by that theme re-assertion moments later. Swift instead calls
+    // PyMOLBridge_RunPython("from pymol import raymolrc; raymolrc.load()")
+    // at the END of applyPersistedTheme, so a user's startup script always
+    // wins over the app's defaults (RayMol#225).
 }
 
 void PyMOLBridge_Stop(PyMOLHandle h)

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -3136,6 +3136,13 @@ struct ContentView: View {
         // the user didn't ask for. Users can still enable it live (Display ▸
         // Effects); this only governs the default at launch.
         engine.runCommand("set metal_outline, 0")
+        // Load ~/.raymolrc(.py) LAST, after the theme defaults above, so a
+        // user's startup script can override them (e.g. a custom bg_color) —
+        // matching vanilla PyMOL, where .pymolrc runs after all built-in
+        // defaults are set. Also migrates from ~/.pymolrc(.py) on first
+        // detection, since this native app never goes through
+        // pymol.invocation's CLI argument parsing (RayMol#225).
+        engine.runPython("from pymol import raymolrc as _raymolrc; _raymolrc.load()")
     }
 }
 

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -152,6 +152,11 @@ struct ContentView: View {
     @State private var showObjectPanel = true
     @State private var showCommandPanel = true
 
+    // ~/.raymolrc first-run migration prompt (RayMol#225): shown once, before
+    // raymolrc.load() ever runs, when an existing ~/.pymolrc(.py) could be
+    // imported. Declining writes a skip marker so we don't ask again.
+    @State private var showRaymolrcMigrationPrompt = false
+
     // Export menu state. exportRayTraced persists across launches; when on, all
     // image exports are ray-traced (AO + shadows) regardless of the live view.
     @AppStorage("exportRayTraced") private var exportRayTraced = true
@@ -417,6 +422,12 @@ struct ContentView: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("Download a structure from the RCSB PDB.")
+        }
+        .alert("Import your PyMOL startup script?", isPresented: $showRaymolrcMigrationPrompt) {
+            Button("Import") { confirmRaymolrcMigration() }
+            Button("Not Now", role: .cancel) { declineRaymolrcMigration() }
+        } message: {
+            raymolrcMigrationAlertText
         }
         .toolbar {
             // Leading — Open only.
@@ -1143,6 +1154,12 @@ struct ContentView: View {
                 Button("Cancel", role: .cancel) {}
             } message: {
                 Text("Download a structure from the RCSB PDB.")
+            }
+            .alert("Import your PyMOL startup script?", isPresented: $showRaymolrcMigrationPrompt) {
+                Button("Import") { confirmRaymolrcMigration() }
+                Button("Not Now", role: .cancel) { declineRaymolrcMigration() }
+            } message: {
+                raymolrcMigrationAlertText
             }
             .alert("Clear session?", isPresented: $showClearSessionConfirm) {
                 Button("Clear", role: .destructive) { engine.clearSessionAndAutosave() }
@@ -3139,10 +3156,43 @@ struct ContentView: View {
         // Load ~/.raymolrc(.py) LAST, after the theme defaults above, so a
         // user's startup script can override them (e.g. a custom bg_color) —
         // matching vanilla PyMOL, where .pymolrc runs after all built-in
-        // defaults are set. Also migrates from ~/.pymolrc(.py) on first
-        // detection, since this native app never goes through
-        // pymol.invocation's CLI argument parsing (RayMol#225).
+        // defaults are set.
+        loadRaymolrcOrOfferMigration()
+    }
+
+    // This native app never goes through pymol.invocation's CLI argument
+    // parsing, so a pre-existing ~/.pymolrc(.py) is otherwise silently
+    // ignored (RayMol#225). The first time no ~/.raymolrc(.py) exists yet
+    // and a ~/.pymolrc(.py) is found, ask before importing it rather than
+    // copying it silently — the user may not want an old config carried
+    // over, or may not recognize ~/.raymolrc if we create it behind their
+    // back. Skips the prompt (and loads immediately) once either file
+    // exists or the user has already answered once (~/.raymolrc.skip).
+    private func loadRaymolrcOrOfferMigration() {
+        let fm = FileManager.default
+        let home = fm.homeDirectoryForCurrentUser.path
+        let hasRaymolrc = fm.fileExists(atPath: home + "/.raymolrc.py")
+            || fm.fileExists(atPath: home + "/.raymolrc")
+        let alreadyAsked = fm.fileExists(atPath: home + "/.raymolrc.skip")
+        let hasPymolrc = fm.fileExists(atPath: home + "/.pymolrc.py")
+            || fm.fileExists(atPath: home + "/.pymolrc")
+        if !hasRaymolrc && !alreadyAsked && hasPymolrc {
+            showRaymolrcMigrationPrompt = true
+            return
+        }
         engine.runPython("from pymol import raymolrc as _raymolrc; _raymolrc.load()")
+    }
+
+    private func confirmRaymolrcMigration() {
+        engine.runPython("from pymol import raymolrc as _raymolrc; _raymolrc.migrate(); _raymolrc.load()")
+    }
+
+    private func declineRaymolrcMigration() {
+        engine.runPython("from pymol import raymolrc as _raymolrc; _raymolrc.decline_migration()")
+    }
+
+    private var raymolrcMigrationAlertText: Text {
+        Text("RayMol found an existing ~/.pymolrc and can copy it to ~/.raymolrc, RayMol's own startup script, so your customizations still run here.")
     }
 }
 

--- a/testing/tests/test_raymolrc.py
+++ b/testing/tests/test_raymolrc.py
@@ -1,0 +1,232 @@
+"""Unit tests for pymol.raymolrc — headless, no PyMOL GUI required.
+
+Covers the ~/.raymolrc startup-script logic that the native macOS/iOS
+embeddings drive (RayMol#225): migration_candidate() decides whether a
+~/.pymolrc(.py) is offered for import, migrate() copies it, decline_migration()
+records a skip so we don't re-ask, and load() runs whichever ~/.raymolrc(.py)
+files exist (WITHOUT migrating). The GUI (SwiftUI .alert / AppKit NSAlert) is
+only responsible for asking; all the file logic lives here and is tested here.
+
+The module computes its paths from ~ at import time, so each test repoints
+those module-level constants at a temp HOME.
+"""
+
+import os
+import sys
+import tempfile
+import types
+import unittest
+
+_MODULES_DIR = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, "modules")
+)
+if "pymol" not in sys.modules or not hasattr(sys.modules["pymol"], "__path__"):
+    _pymol_stub = types.ModuleType("pymol")
+    _pymol_stub.__path__ = [os.path.join(_MODULES_DIR, "pymol")]
+    _pymol_stub.__package__ = "pymol"
+    sys.modules["pymol"] = _pymol_stub
+# pymol.stored is what _seed_main_namespace copies into __main__; a real
+# `pymol -ckqy` run already has it, so only stub it when absent.
+if not hasattr(sys.modules["pymol"], "stored"):
+    sys.modules["pymol"].stored = types.SimpleNamespace()
+
+from pymol import raymolrc
+
+
+class FakeCmd:
+    """Records run()/do() calls so load() can be asserted without a real core."""
+
+    def __init__(self):
+        self.runs = []   # (filename, namespace)
+        self.dos = []     # command strings
+
+    def run(self, filename, namespace="global", _spawn=0, _self=None):
+        self.runs.append((filename, namespace))
+
+    def do(self, command):
+        self.dos.append(command)
+
+
+class RaymolrcTestCase(unittest.TestCase):
+    def setUp(self):
+        # Fresh temp HOME per test; repoint every module-level path at it so
+        # tests never touch the real ~ and never see each other's files.
+        self._tmp = tempfile.TemporaryDirectory()
+        home = self._tmp.name
+        self._saved = {
+            k: getattr(raymolrc, k) for k in
+            ("RAYMOLRC_PY", "RAYMOLRC_PML", "PYMOLRC_PY", "PYMOLRC_PML",
+             "MIGRATION_SKIP_MARKER")
+        }
+        raymolrc.RAYMOLRC_PY = os.path.join(home, ".raymolrc.py")
+        raymolrc.RAYMOLRC_PML = os.path.join(home, ".raymolrc")
+        raymolrc.PYMOLRC_PY = os.path.join(home, ".pymolrc.py")
+        raymolrc.PYMOLRC_PML = os.path.join(home, ".pymolrc")
+        raymolrc.MIGRATION_SKIP_MARKER = os.path.join(home, ".raymolrc.skip")
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            setattr(raymolrc, k, v)
+        self._tmp.cleanup()
+
+    def _write(self, path, text):
+        with open(path, "w") as f:
+            f.write(text)
+
+    # --- migration_candidate -------------------------------------------------
+
+    def test_candidate_none_when_nothing_present(self):
+        self.assertIsNone(raymolrc.migration_candidate())
+
+    def test_candidate_offers_pymolrc_py(self):
+        self._write(raymolrc.PYMOLRC_PY, "print('x')")
+        self.assertEqual(raymolrc.migration_candidate(), raymolrc.PYMOLRC_PY)
+
+    def test_candidate_offers_pymolrc_pml_when_no_py(self):
+        self._write(raymolrc.PYMOLRC_PML, "bg_color red")
+        self.assertEqual(raymolrc.migration_candidate(), raymolrc.PYMOLRC_PML)
+
+    def test_candidate_prefers_py_over_pml(self):
+        self._write(raymolrc.PYMOLRC_PY, "print('x')")
+        self._write(raymolrc.PYMOLRC_PML, "bg_color red")
+        self.assertEqual(raymolrc.migration_candidate(), raymolrc.PYMOLRC_PY)
+
+    def test_candidate_none_when_raymolrc_py_exists(self):
+        self._write(raymolrc.PYMOLRC_PY, "print('x')")
+        self._write(raymolrc.RAYMOLRC_PY, "print('already here')")
+        self.assertIsNone(raymolrc.migration_candidate())
+
+    def test_candidate_none_when_raymolrc_pml_exists(self):
+        self._write(raymolrc.PYMOLRC_PY, "print('x')")
+        self._write(raymolrc.RAYMOLRC_PML, "bg_color blue")
+        self.assertIsNone(raymolrc.migration_candidate())
+
+    def test_candidate_none_when_declined(self):
+        self._write(raymolrc.PYMOLRC_PY, "print('x')")
+        open(raymolrc.MIGRATION_SKIP_MARKER, "a").close()
+        self.assertIsNone(raymolrc.migration_candidate())
+
+    # --- migrate -------------------------------------------------------------
+
+    def test_migrate_copies_py_to_raymolrc_py(self):
+        self._write(raymolrc.PYMOLRC_PY, "cmd.set('bg_rgb', 'red')\n")
+        raymolrc.migrate()
+        self.assertTrue(os.path.exists(raymolrc.RAYMOLRC_PY))
+        with open(raymolrc.RAYMOLRC_PY) as f:
+            self.assertEqual(f.read(), "cmd.set('bg_rgb', 'red')\n")
+
+    def test_migrate_copies_pml_to_raymolrc_pml(self):
+        self._write(raymolrc.PYMOLRC_PML, "bg_color red\n")
+        raymolrc.migrate()
+        self.assertTrue(os.path.exists(raymolrc.RAYMOLRC_PML))
+        self.assertFalse(os.path.exists(raymolrc.RAYMOLRC_PY))
+
+    def test_migrate_noop_when_no_candidate(self):
+        raymolrc.migrate()
+        self.assertFalse(os.path.exists(raymolrc.RAYMOLRC_PY))
+        self.assertFalse(os.path.exists(raymolrc.RAYMOLRC_PML))
+
+    def test_migrate_does_not_clobber_existing_raymolrc(self):
+        # An existing raymolrc means migration_candidate() is None, so migrate()
+        # must leave the user's file untouched.
+        self._write(raymolrc.PYMOLRC_PY, "cmd.set('bg_rgb', 'red')\n")
+        self._write(raymolrc.RAYMOLRC_PY, "cmd.set('bg_rgb', 'blue')\n")
+        raymolrc.migrate()
+        with open(raymolrc.RAYMOLRC_PY) as f:
+            self.assertEqual(f.read(), "cmd.set('bg_rgb', 'blue')\n")
+
+    # --- decline_migration ---------------------------------------------------
+
+    def test_decline_writes_skip_marker(self):
+        self.assertFalse(os.path.exists(raymolrc.MIGRATION_SKIP_MARKER))
+        raymolrc.decline_migration()
+        self.assertTrue(os.path.exists(raymolrc.MIGRATION_SKIP_MARKER))
+
+    def test_decline_then_no_candidate(self):
+        self._write(raymolrc.PYMOLRC_PY, "print('x')")
+        self.assertIsNotNone(raymolrc.migration_candidate())
+        raymolrc.decline_migration()
+        self.assertIsNone(raymolrc.migration_candidate())
+
+    def test_decline_does_not_create_raymolrc(self):
+        self._write(raymolrc.PYMOLRC_PY, "print('x')")
+        raymolrc.decline_migration()
+        self.assertFalse(os.path.exists(raymolrc.RAYMOLRC_PY))
+        self.assertFalse(os.path.exists(raymolrc.RAYMOLRC_PML))
+
+    # --- load ----------------------------------------------------------------
+
+    def test_load_runs_raymolrc_py_in_main_namespace(self):
+        self._write(raymolrc.RAYMOLRC_PY, "cmd.set('bg_rgb', 'red')\n")
+        fake = FakeCmd()
+        raymolrc.load(fake)
+        self.assertEqual(fake.runs, [(raymolrc.RAYMOLRC_PY, "main")])
+
+    def test_load_ats_raymolrc_pml(self):
+        self._write(raymolrc.RAYMOLRC_PML, "bg_color red\n")
+        fake = FakeCmd()
+        raymolrc.load(fake)
+        self.assertEqual(fake.dos, ["@" + raymolrc.RAYMOLRC_PML])
+
+    def test_load_does_not_migrate(self):
+        # load() is deliberately dumb: a ~/.pymolrc present but no ~/.raymolrc
+        # must NOT be imported or executed (that decision belongs to the UI).
+        self._write(raymolrc.PYMOLRC_PY, "cmd.set('bg_rgb', 'red')\n")
+        fake = FakeCmd()
+        raymolrc.load(fake)
+        self.assertEqual(fake.runs, [])
+        self.assertEqual(fake.dos, [])
+        self.assertFalse(os.path.exists(raymolrc.RAYMOLRC_PY))
+
+    def test_load_noop_when_nothing_present(self):
+        fake = FakeCmd()
+        raymolrc.load(fake)
+        self.assertEqual(fake.runs, [])
+        self.assertEqual(fake.dos, [])
+
+    def test_load_seeds_main_namespace_with_cmd(self):
+        # Migrated ~/.pymolrc scripts call bare cmd.xxx(); load() must seed
+        # __main__ so that convention works in these embeddings.
+        import __main__
+        had_cmd = "cmd" in __main__.__dict__
+        saved = __main__.__dict__.get("cmd")
+        if had_cmd:
+            del __main__.__dict__["cmd"]
+        try:
+            self._write(raymolrc.RAYMOLRC_PY, "cmd.bg_color('red')\n")
+            fake = FakeCmd()
+            raymolrc.load(fake)
+            self.assertIs(__main__.__dict__.get("cmd"), fake)
+        finally:
+            if had_cmd:
+                __main__.__dict__["cmd"] = saved
+            else:
+                __main__.__dict__.pop("cmd", None)
+
+    # --- end-to-end sequence mirroring the GUI ------------------------------
+
+    def test_import_flow(self):
+        # User has ~/.pymolrc.py, taps "Import": migrate() then load().
+        self._write(raymolrc.PYMOLRC_PY, "cmd.set('bg_rgb', 'red')\n")
+        self.assertIsNotNone(raymolrc.migration_candidate())
+        raymolrc.migrate()
+        fake = FakeCmd()
+        raymolrc.load(fake)
+        self.assertTrue(os.path.exists(raymolrc.RAYMOLRC_PY))
+        self.assertEqual(fake.runs, [(raymolrc.RAYMOLRC_PY, "main")])
+
+    def test_decline_flow_and_no_reprompt(self):
+        # User taps "Not Now": decline_migration() then load() (which no-ops).
+        # A second launch must not re-offer.
+        self._write(raymolrc.PYMOLRC_PY, "cmd.set('bg_rgb', 'red')\n")
+        raymolrc.decline_migration()
+        fake = FakeCmd()
+        raymolrc.load(fake)
+        self.assertFalse(os.path.exists(raymolrc.RAYMOLRC_PY))
+        self.assertEqual(fake.runs, [])
+        # Second launch: still nothing to offer.
+        self.assertIsNone(raymolrc.migration_candidate())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #225.

RayMol's native embeddings (SwiftUI/Metal and the legacy AppKit app) boot Python directly and never call `pymol.invocation.parse_args`, so `~/.pymolrc` is silently ignored there — a user's aliases/settings from vanilla PyMOL had no effect.

- `modules/pymol/raymolrc.py`: loads `~/.raymolrc(.py)` at startup. The first time neither raymolrc file exists yet, imports it from an existing `~/.pymolrc(.py)` so prior customizations carry over automatically (one-time, presence-of-file gated — never clobbers a `~/.raymolrc` the user has already edited). Also seeds `__main__` with `cmd`/`stored` before running the script, matching the vanilla CLI's namespace so bare `cmd.xxx()` calls (the common pymolrc convention) keep working — the native embeddings don't populate `__main__` the way the real `pymol` launcher script does.
- `swiftui/PyMOLViewer/Shared/ContentView.swift`: calls `raymolrc.load()` at the **end** of `applyPersistedTheme()`, not from the C++ bridge. VM testing caught a real ordering bug: the app's own launch-time theme reapply (bg color, etc.) runs asynchronously right after engine init and would otherwise silently overwrite anything the user's script set. Loading last means the user's script wins, matching how `.pymolrc` behaves in vanilla PyMOL (runs after built-in defaults).
- `swiftui/PyMOLViewer/Bridge/PyMOLBridge.mm`: removed the (incorrectly-ordered) load call from `PyMOLBridge_Start`, left a note pointing at the Swift-side call site.
- `layer5/main_appkit.mm`: same `raymolrc.load()` wiring for the legacy AppKit app, right after `PInit`/`PyMOL_SetPythonInitStage(1)` — this embedding has no theme-reapply step, so no ordering issue there.

## Test plan

Verified functionally in an isolated macOS VM (mac-vm-pool), driving the built `RayMol.app` over its MCP server:

- [x] **Migration**: with `~/.pymolrc.py` present (`cmd.set('bg_rgb', 'red')`, bare `cmd`, no import) and no `~/.raymolrc(.py)` yet, launching RayMol created `~/.raymolrc.py` with matching content and executed it — `cmd.get('bg_rgb')` returned `red` after launch, confirming it ran and survived the app's own theme reapply.
- [x] **Idempotency**: after editing `~/.raymolrc.py` to a different setting (`bg_rgb='blue'`) while leaving the original `~/.pymolrc.py` untouched, relaunching did **not** re-copy `~/.pymolrc.py` over the edited file — `~/.raymolrc.py` was preserved as edited, and its (new) content is what actually loaded (`bg_rgb` read back as `blue`).
- [x] `xcodebuild -scheme PyMOLViewer_macOS` succeeds (`-skipPackagePluginValidation -skipMacroValidation` for the mlx-swift SPM plugin trust gate).
- [x] `python3 -m py_compile modules/pymol/raymolrc.py`.

Not covered: iOS (no home-directory equivalent there — left for a follow-up per the open questions in #225), and an "Edit raymolrc" menu item (also left as a follow-up).