### PR TITLE
Fix #222: load every file from a multi-file macOS `open`

### DIFF
--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		BA6C9B288CFD5EB53D0E0057 /* RayMolMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9371B6FFB30D6166234C678B /* RayMolMain.swift */; };
 		BE397E89274A3180A2E649BF /* DesignColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F2DF248B756BF6CA3CBE92 /* DesignColor.swift */; };
 		C0BCE174EC5A1E6CBFBFA91F /* openssl-PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = CB0108E0FA1F204BE0E41F0D /* openssl-PrivacyInfo.xcprivacy */; };
+		C89E138879C40C8FB6C0478A /* OpenFilesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2C1E1633D1E93E9914BEC3 /* OpenFilesTests.swift */; };
 		CCA9FAAAD0E59CE43443B7DA /* PyMOLGestureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8EE6573045A81CF52A9CDF5 /* PyMOLGestureUITests.swift */; };
 		CE1CC588AA02F7FE11A0048B /* MPNNGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56BE219EF1CF1EB2B05E44AD /* MPNNGate.swift */; };
 		CE45D81735E70E8FFFD49875 /* ThemeStudioPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85B66833BF167209A47B9C15 /* ThemeStudioPanel.swift */; };
@@ -153,6 +154,7 @@
 		3F5377EE69A856479317FD61 /* WhatsNewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewModel.swift; sourceTree = "<group>"; };
 		474D18A43D0D9A6BDD69EEFD /* SequencePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequencePanel.swift; sourceTree = "<group>"; };
 		48EDC39F7E7F250CFC4F7D0D /* DesignResiduesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignResiduesTests.swift; sourceTree = "<group>"; };
+		4A2C1E1633D1E93E9914BEC3 /* OpenFilesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenFilesTests.swift; sourceTree = "<group>"; };
 		4C570F9CAC877E201F237016 /* whatsnew-170-move.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "whatsnew-170-move.png"; sourceTree = "<group>"; };
 		4D6A959CC1590FC60333582B /* DesignEditInferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignEditInferenceTests.swift; sourceTree = "<group>"; };
 		55094A33AFF9AEF5561CFD96 /* whatsnew-152-timeline.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "whatsnew-152-timeline.png"; sourceTree = "<group>"; };
@@ -201,7 +203,7 @@
 		F7E41DCBB427678A8F018B0E /* DesignControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignControllerTests.swift; sourceTree = "<group>"; };
 		FB1304C662D9011F7C4505FC /* MCPStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPStatusView.swift; sourceTree = "<group>"; };
 		FF4FB7F151982A2927D612F0 /* DesignController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignController.swift; sourceTree = "<group>"; };
-		"TEMP_FA6BC3E4-21DD-4F6F-BDA6-853A363CC0E6" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
+		"TEMP_AE9892B2-66F8-48CE-901D-B9565F973510" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -336,6 +338,7 @@
 				E47D8905CF71AF7BDF4BE074 /* DesignModeStateTests.swift */,
 				48EDC39F7E7F250CFC4F7D0D /* DesignResiduesTests.swift */,
 				D0BCB2A867C3554FB56A7299 /* DesignScoreCacheTests.swift */,
+				4A2C1E1633D1E93E9914BEC3 /* OpenFilesTests.swift */,
 				55F4F52D951CF1F96606F41C /* SmokeTests.swift */,
 			);
 			path = PyMOLViewerTests;
@@ -361,10 +364,10 @@
 			path = Bridge;
 			sourceTree = "<group>";
 		};
-		"TEMP_C8AEFFC6-2C3F-43BC-8A71-251C26E093CB" /* swiftui */ = {
+		"TEMP_52F49B6D-ABFA-40B1-9BE3-4162C39CCC25" /* swiftui */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_FA6BC3E4-21DD-4F6F-BDA6-853A363CC0E6" /* PyMOLBridge.xcconfig */,
+				"TEMP_AE9892B2-66F8-48CE-901D-B9565F973510" /* PyMOLBridge.xcconfig */,
 			);
 			path = swiftui;
 			sourceTree = "<group>";
@@ -1005,6 +1008,7 @@
 				2B6E59F50398ACB89A0BB029 /* DesignModeStateTests.swift in Sources */,
 				52B5620BEF26DEB8E3A700C1 /* DesignResiduesTests.swift in Sources */,
 				6EAC8947F66B8D7AD29BF3B8 /* DesignScoreCacheTests.swift in Sources */,
+				C89E138879C40C8FB6C0478A /* OpenFilesTests.swift in Sources */,
 				5CAB662574D238626A8F4D68 /* SmokeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1257,7 +1261,7 @@
 		};
 		76B7E9DB75E073D1E60928FA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_FA6BC3E4-21DD-4F6F-BDA6-853A363CC0E6" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_AE9892B2-66F8-48CE-901D-B9565F973510" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1364,7 +1368,7 @@
 		};
 		D8F44FDFF036013D2F03BA83 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_FA6BC3E4-21DD-4F6F-BDA6-853A363CC0E6" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_AE9892B2-66F8-48CE-901D-B9565F973510" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/swiftui/PyMOLViewer/Shared/PyMOLApp.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLApp.swift
@@ -19,6 +19,23 @@ final class OrientationLockDelegate: NSObject, UIApplicationDelegate {
 }
 #endif
 
+#if os(macOS)
+// macOS delivers files to open through NSApplicationDelegate.application(_:open:)
+// as the COMPLETE [URL] array — Terminal `open a.pdb b.pdb c.pdb`, Finder "Open
+// With" multi-select, and drag-drop onto the Dock icon all arrive this way.
+// SwiftUI's .onOpenURL surfaces only the FIRST of those URLs and silently drops
+// the rest, so a multi-file open loaded just one file (issue #222). Implementing
+// the delegate method and looping over the whole array is the reliable way to
+// receive every file; macOS therefore routes OS opens here instead of .onOpenURL.
+final class RayMolAppDelegate: NSObject, NSApplicationDelegate {
+    func application(_ application: NSApplication, open urls: [URL]) {
+        // Called on the main thread; hop to the main actor to reach loadOpenedFile
+        // (@MainActor), mirroring ContentView's drag-drop handler.
+        Task { @MainActor in handleOpenedURLs(urls, into: PyMOLEngine.shared) }
+    }
+}
+#endif
+
 struct PyMOLApp: App {
     @StateObject private var engine = PyMOLEngine.shared
     #if os(macOS) && !RAYMOL_MAS_RESTRICTED
@@ -28,6 +45,10 @@ struct PyMOLApp: App {
     #if os(iOS)
     @UIApplicationDelegateAdaptor(OrientationLockDelegate.self) private var appDelegate
     @Environment(\.scenePhase) private var scenePhase
+    #endif
+    #if os(macOS)
+    // Receives OS file-open events (application(_:open:)); see RayMolAppDelegate.
+    @NSApplicationDelegateAdaptor(RayMolAppDelegate.self) private var appDelegate
     #endif
 
     init() {
@@ -85,22 +106,26 @@ struct PyMOLApp: App {
                 // Accessibility. PYMOL_AUTOLANDSCAPE=left|right; absent = as-is.
                 .onAppear { Self.forceOrientationIfRequested() }
             #endif
-                // Open a file handed to RayMol by the OS (Finder double-click /
-                // "Open With", iOS Files / Share-sheet "Open in RayMol"). The
-                // registered document types (see project.yml) route these here.
-                // PyMOL infers the format from the extension; the object name is
-                // the sanitized filename stem. Engine init runs in ContentView's
-                // .onAppear, so on a cold launch the URL may arrive before the
-                // engine is ready — loadOpenedFile retries briefly until it is.
+                // Open a file handed to RayMol by the OS. iOS delivers a single URL
+                // per open (Files / Share-sheet "Open in RayMol") through
+                // .onOpenURL. macOS instead routes ALL opens (Finder double-click /
+                // "Open With" multi-select / Terminal `open a.pdb b.pdb` / Dock-icon
+                // drop) through RayMolAppDelegate.application(_:open:), because
+                // .onOpenURL surfaces only the FIRST url of a multi-file open and
+                // drops the rest (issue #222). The registered document types (see
+                // project.yml) route these here. PyMOL infers the format from the
+                // extension; the object name is the sanitized filename stem. Engine
+                // init runs in ContentView's .onAppear, so on a cold launch the URL
+                // may arrive before the engine is ready — loadOpenedFile retries.
+                #if os(iOS)
                 .onOpenURL { url in
-                    #if os(iOS)
                     // A launch-to-open-a-file takes precedence over the autosaved
                     // scene: flag it before the (possibly retried) load so the
                     // cold-launch restore doesn't merge the old session underneath.
                     engine.launchOpenRequested = true
-                    #endif
                     loadOpenedFile(url, into: engine)
                 }
+                #endif
             #if os(iOS)
                 // iOS purges backgrounded apps to reclaim memory; persist the
                 // session on the way out so the next cold launch can resume it.
@@ -313,4 +338,15 @@ func loadOpenedFile(_ url: URL, into engine: PyMOLEngine, attempt: Int = 0) {
     var name = String(raw.map { $0.isLetter || $0.isNumber ? $0 : "_" })
     if name.isEmpty { name = "mol" }
     engine.loadStructure(path: path, name: name)
+}
+
+// Load EVERY URL the OS handed us in one open (multi-file Terminal `open`, Finder
+// "Open With" multi-select, Dock-icon drop). Factored out of RayMolAppDelegate so
+// the "load them all, not just the first" contract (issue #222) is unit-testable
+// without booting the engine: tests pass a spy for `load` (which defaults to
+// loadOpenedFile) and assert every URL is forwarded, in order.
+@MainActor
+func handleOpenedURLs(_ urls: [URL], into engine: PyMOLEngine,
+                      load: @MainActor (URL, PyMOLEngine) -> Void = { loadOpenedFile($0, into: $1) }) {
+    for url in urls { load(url, engine) }
 }

--- a/swiftui/PyMOLViewerTests/OpenFilesTests.swift
+++ b/swiftui/PyMOLViewerTests/OpenFilesTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import RayMol
+
+// Regression tests for issue #222: `open a.pdb b.pdb c.pdb` from a Terminal (and
+// Finder "Open With" multi-select / Dock-icon drop) only loaded the first file.
+// macOS delivers all of them via NSApplicationDelegate.application(_:open:) as one
+// [URL] array; RayMolAppDelegate forwards that array through handleOpenedURLs.
+// These lock in that EVERY url is forwarded — a spy stands in for the real
+// loadOpenedFile so the engine/PyMOL core never has to boot.
+@MainActor
+final class OpenFilesTests: XCTestCase {
+
+    func testAllOpenedURLsAreForwardedInOrder() {
+        let urls = ["a.pdb", "b.pdb", "c.pdb"].map { URL(fileURLWithPath: "/tmp/\($0)") }
+        var seen: [String] = []
+        handleOpenedURLs(urls, into: PyMOLEngine.shared) { url, _ in
+            seen.append(url.lastPathComponent)
+        }
+        // The bug loaded only "a.pdb"; the fix must forward all three, in order.
+        XCTAssertEqual(seen, ["a.pdb", "b.pdb", "c.pdb"])
+    }
+
+    func testSingleOpenedURLStillForwarded() {
+        // A plain Finder double-click delivers a one-element array; it must still
+        // load (the delegate now handles single- and multi-file opens uniformly).
+        let urls = [URL(fileURLWithPath: "/tmp/only.pse")]
+        var seen: [String] = []
+        handleOpenedURLs(urls, into: PyMOLEngine.shared) { url, _ in
+            seen.append(url.lastPathComponent)
+        }
+        XCTAssertEqual(seen, ["only.pse"])
+    }
+
+    func testEmptyURLListIsNoOp() {
+        var called = false
+        handleOpenedURLs([], into: PyMOLEngine.shared) { _, _ in called = true }
+        XCTAssertFalse(called)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #222 — `open a.pdb b.pdb c.pdb` from a Terminal on macOS (and Finder "Open With" multi-select / drag-drop onto the Dock icon) only loaded the **first** file; the rest were silently dropped.

## Root cause (verified, not guessed)

macOS hands a multi-file open to the app as the **complete `[URL]` array** via `NSApplicationDelegate.application(_:open:)`. RayMol implemented only SwiftUI's `.onOpenURL`. I built a throwaway probe `.app` mirroring RayMol's single-`Window` structure and measured the delivery on cold **and** warm launch:

| App config | `.onOpenURL` receives | `application(_:open:)` receives |
|---|---|---|
| only `.onOpenURL` (**RayMol before**) | `urls[0]` | *no handler* → `urls[1…]` **dropped** |
| both | `urls[0]` | `urls[1…]` |
| only `application(_:open:)` (single `Window`) | — | **all urls** |

So RayMol loaded `urls[0]` and lost the rest.

## Fix

- Add a macOS `NSApplicationDelegateAdaptor(RayMolAppDelegate)` whose `application(_:open:)` loops `loadOpenedFile` over **every** URL.
- Scope `.onOpenURL` to **iOS** so macOS has a single, unambiguous delivery path (no double-load).
- Factor the per-URL loop into a testable `handleOpenedURLs` seam (its `load` closure is `@MainActor` so the default argument can call the `@MainActor` `loadOpenedFile`).

Viewport (window) drag-drop of multiple files already worked (`ContentView.handleViewportDrop` loops); only the Dock/Finder/`open` path through `application(_:open:)` was broken.

The issue comment's `open`-CLI *"…no scheme / No application knows how to open URL <third file>"* did **not** reproduce once RayMol is a registered `.pdb` handler — it's a transient LaunchServices / imported-UTI resolution artifact, separate from the app-side delivery bug fixed here.

## Testing (disposable macOS VM + host)

- Host `xcodebuild test -scheme UnitTests_macOS` → new `OpenFilesTests` **3/3 pass** (forwards all URLs / single URL / empty).
- In an isolated VM, driven over MCP — object count after each open:
  - `open -a RayMol a.pdb b.pdb c.pdb` (warm) → **3/3** ✅
  - `open a.pdb b.pdb c.pdb` (bare, warm) → **3/3** ✅
  - quit → `open a.pdb b.pdb c.pdb` (bare, **cold** — the exact issue scenario) → **3/3** ✅

## Scope / follow-ups

- Not changed: the in-app **Open…** panel (`NSOpenPanel`) is still `allowsMultipleSelection = false` — a separate entry point, deliberately left out of this focused fix. Easy follow-up if multi-select in that dialog is wanted.
- iOS unaffected by construction (its `.onOpenURL` path is unchanged; all macOS-only code is `#if os(macOS)`-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)