### PR TITLE
Fix #231: object panel froze + log spam past ~16 objects (OBJPANEL feedback-line overflow)

### DIFF
--- a/.github/workflows/raymol-embedded-tests.yml
+++ b/.github/workflows/raymol-embedded-tests.yml
@@ -48,6 +48,7 @@ jobs:
               testing/tests/test_appkit_measure.py \
               testing/tests/test_appkit_sequence.py \
               testing/tests/test_appkit_object_panel.py \
+              testing/tests/test_appkit_objpanel_poll.py \
               testing/tests/test_appkit_settings.py \
               testing/tests/test_appkit_theme_preview.py \
               testing/tests/test_appkit_command_panel.py \

--- a/modules/pymol/appkit_inspector.py
+++ b/modules/pymol/appkit_inspector.py
@@ -308,6 +308,39 @@ def poll(objs):
         print('OBJDETAIL_ERR:' + str(e))
 
 
+def poll_panel():
+    """Write the object-list JSON to a temp file and print a short marker.
+
+    Same rationale as poll(), for the object side-panel's list (#231). The payload
+    grows ~62 bytes per object (name + per-object nstate/has_transp), so printing
+    it inline as `OBJPANEL:<json>` overflowed PyMOL's ~1KB feedback-line cap at
+    ~16 objects — e.g. after `split_states` on a 20-model NMR ensemble. The core
+    then split the line: the truncated first fragment still carried the OBJPANEL:
+    prefix but failed JSON decode (so the panel froze on the stale list), and the
+    prefix-less continuation leaked into the console on every poll tick. Keep the
+    payload off the feedback line entirely and emit only `OBJPANEL:ready`."""
+    import json, os, tempfile
+    try:
+        objs = list(cmd.get_names('public_objects') or [])
+        sels = list(cmd.get_names('public_selections') or [])
+        enabled = set(cmd.get_names('public_objects', enabled_only=1) or [])
+        enabled |= set(cmd.get_names('public_selections', enabled_only=1) or [])
+        payload = {
+            'objects': objs,
+            'selections': sels,
+            'enabled': list(enabled),
+            'sel_counts': {s: cmd.count_atoms(s) for s in sels},
+            'nstate': {o: cmd.count_states('?' + o) for o in objs},
+            'has_transp': {o: object_has_atom_transp(o) for o in objs},
+        }
+        p = os.path.join(tempfile.gettempdir(), 'pymol_objpanel.json')
+        with open(p, 'w') as _f:
+            _f.write(json.dumps(payload))
+        print('OBJPANEL:ready')
+    except Exception as e:
+        print('OBJPANEL_ERR:' + str(e))
+
+
 def widen_clip_for_surface(buffer=12.0):
     """When a probe-extended rep (surface / mesh / dots) is shown, widen the
     clipping slab so the rep's ~solvent_radius shell (~3 A beyond the atoms) isn't

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -931,17 +931,13 @@ struct ObjectPanel: View {
 
     // Pick-granularity menu (mouse_selection_mode): what a viewport tap selects.
     private func refreshObjects() {
+        // Same file-based payload as the ~500ms poll (see parseObjectPanelFeedback):
+        // poll_panel writes the list to a temp file and prints only the marker, so
+        // a large object list can't overflow the feedback-line cap (#231).
         engine.runCommand(
             "python\n"
-            + "import json\n"
-            + "from pymol import cmd\n"
-            + "objs = list(cmd.get_names('public_objects') or [])\n"
-            + "sels = list(cmd.get_names('public_selections') or [])\n"
-            + "enabled = set(cmd.get_names('public_objects', enabled_only=1) or [])\n"
-            + "enabled |= set(cmd.get_names('public_selections', enabled_only=1) or [])\n"
-            + "sel_counts = {s: cmd.count_atoms(s) for s in sels}\n"
-            + "print('OBJPANEL:' + json.dumps({'objects': objs, 'selections': sels, "
-            + "'enabled': list(enabled), 'sel_counts': sel_counts}))\n"
+            + "from pymol import appkit_inspector as _ai\n"
+            + "_ai.poll_panel()\n"
             + "python end"
         )
     }
@@ -3393,13 +3389,17 @@ extension ObjectEntry {
 // MARK: - PyMOLEngine extensions for object polling
 
 extension PyMOLEngine {
-    /// Parse the OBJPANEL JSON output from feedback and update the objects array.
-    /// Called by the existing pollFeedback timer. Feedback lines starting with
-    /// "OBJPANEL:" carry the JSON payload from our Python query.
+    /// Parse the object-list JSON (written by appkit_inspector.poll_panel to a
+    /// temp file; the feedback line is just the "OBJPANEL:ready" trigger) and
+    /// update the objects array. Called by the existing pollFeedback timer.
+    /// File-based to avoid the ~1KB feedback-line cap splitting the payload —
+    /// inline, the list truncated at ~16 objects (so the panel froze on the stale
+    /// list after e.g. `split_states`) and the continuation leaked to the log (#231).
     func parseObjectPanelFeedback(_ line: String) {
         guard line.hasPrefix("OBJPANEL:") else { return }
-        let jsonStr = String(line.dropFirst("OBJPANEL:".count))
-        guard let data = jsonStr.data(using: .utf8) else { return }
+        let path = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("pymol_objpanel.json")
+        guard let data = FileManager.default.contents(atPath: path) else { return }
 
         struct PanelPayload: Decodable {
             let objects: [String]

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -1282,20 +1282,7 @@ final class PyMOLEngine: ObservableObject {
     /// the panels reflect the restored scene without lag).
     func refreshAfterRestore() {
         guard isReady else { return }
-        runPython(
-            "import json\n"
-            + "from pymol import cmd as _cmd\n"
-            + "_objs = list(_cmd.get_names('public_objects') or [])\n"
-            + "_sels = list(_cmd.get_names('public_selections') or [])\n"
-            + "_en = set(_cmd.get_names('public_objects', enabled_only=1) or [])\n"
-            + "_en |= set(_cmd.get_names('public_selections', enabled_only=1) or [])\n"
-            + "_sc = {s: _cmd.count_atoms(s) for s in _sels}\n"
-            + "_ns = {o: _cmd.count_states('?' + o) for o in _objs}\n"
-            + "from pymol import appkit_inspector as _ai\n"
-            + "_ht = {o: _ai.object_has_atom_transp(o) for o in _objs}\n"
-            + "print('OBJPANEL:' + json.dumps({'objects': _objs, 'selections': _sels, "
-            + "'enabled': list(_en), 'sel_counts': _sc, 'nstate': _ns, 'has_transp': _ht}))"
-        )
+        runPython("from pymol import appkit_inspector as _ai\n_ai.poll_panel()")
         refreshExpandedDetail()
         if sequenceVisible { fetchSequences() }
     }
@@ -2738,22 +2725,11 @@ final class PyMOLEngine: ObservableObject {
 
         // Run via runPython (raw PyRun), NOT runCommand/cmd.do — cmd.do echoes
         // the whole command block into the feedback log every poll, which floods
-        // the log and starves the UI. The print('OBJPANEL:') still reaches the
-        // feedback buffer (parsed by pollFeedback); only the echo is avoided.
-        runPython(
-            "import json\n"
-            + "from pymol import cmd as _cmd\n"
-            + "_objs = list(_cmd.get_names('public_objects') or [])\n"
-            + "_sels = list(_cmd.get_names('public_selections') or [])\n"
-            + "_en = set(_cmd.get_names('public_objects', enabled_only=1) or [])\n"
-            + "_en |= set(_cmd.get_names('public_selections', enabled_only=1) or [])\n"
-            + "_sc = {s: _cmd.count_atoms(s) for s in _sels}\n"
-            + "_ns = {o: _cmd.count_states('?' + o) for o in _objs}\n"
-            + "from pymol import appkit_inspector as _ai\n"
-            + "_ht = {o: _ai.object_has_atom_transp(o) for o in _objs}\n"
-            + "print('OBJPANEL:' + json.dumps({'objects': _objs, 'selections': _sels, "
-            + "'enabled': list(_en), 'sel_counts': _sc, 'nstate': _ns, 'has_transp': _ht}))"
-        )
+        // the log and starves the UI. The print('OBJPANEL:ready') still reaches
+        // the feedback buffer (parsed by pollFeedback); only the echo is avoided.
+        // poll_panel writes the list to a temp file and prints just that marker,
+        // so the payload can't overflow the ~1KB feedback-line cap (#231).
+        runPython("from pymol import appkit_inspector as _ai\n_ai.poll_panel()")
 
         pollDetails()
         // Discover/refresh the timeline length + frame (cheap). Fast updates

--- a/testing/tests/test_appkit_objpanel_poll.py
+++ b/testing/tests/test_appkit_objpanel_poll.py
@@ -1,0 +1,107 @@
+"""Tests for pymol.appkit_inspector.poll_panel — the object side-panel payload.
+
+Regression coverage for issue #231: the macOS object panel used to receive its
+object list INLINE on one `OBJPANEL:<json>` feedback line. PyMOL's feedback
+buffer caps a line at OrthoLineLength (1024 chars), so once a session held ~16
+objects (e.g. after `split_states` on a 20-model NMR ensemble) the core split the
+line: the truncated first fragment failed JSON decode (panel froze on the stale
+list) and the prefix-less continuation leaked into the console every poll tick.
+
+poll_panel() must therefore keep the payload OFF the feedback line: write the
+full JSON to a temp file and print only a short constant marker, exactly as
+poll() / OBJDETAIL:ready already does for the rep-detail payload.
+"""
+
+import contextlib
+import io
+import json
+import os
+import tempfile
+
+from pymol import cmd, testing
+from pymol import appkit_inspector as ai
+
+# layer0/PyMOLGlobals.h: OrthoLineLength — the per-line feedback cap that the
+# old inline payload overflowed.
+ORTHO_LINE_LENGTH = 1024
+
+PANEL_JSON = os.path.join(tempfile.gettempdir(), 'pymol_objpanel.json')
+
+
+class TestObjPanelPoll(testing.PyMOLTestCase):
+
+    def _split_ensemble(self, base='ens', nstates=20):
+        """Mirror `fetch 2kn1; split_states 2kn1`: an N-state object split into N
+        single-state objects, so the object count crosses the overflow threshold."""
+        cmd.delete('all')
+        cmd.fab('ACDEFG', base)
+        for i in range(2, nstates + 1):
+            cmd.create(base, base, 1, i)
+        self.assertEqual(cmd.count_states(base), nstates)
+        cmd.split_states(base)
+        return base
+
+    def _poll(self):
+        """Run poll_panel(), returning (printed_lines, payload_from_temp_file)."""
+        if os.path.exists(PANEL_JSON):
+            os.remove(PANEL_JSON)
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            ai.poll_panel()
+        lines = [ln for ln in buf.getvalue().splitlines() if ln.strip()]
+        with open(PANEL_JSON) as f:
+            return lines, json.load(f)
+
+    def testMarkerStaysUnderFeedbackCapWithManyObjects(self):
+        # The bug: the emitted line grew ~62 bytes per object and blew past 1024
+        # at 16 objects. The marker must be short and constant instead.
+        base = self._split_ensemble()
+        objs = list(cmd.get_names('public_objects'))
+        self.assertGreater(len(objs), 16, 'need to cross the old overflow threshold')
+
+        lines, _ = self._poll()
+
+        self.assertEqual(lines, ['OBJPANEL:ready'])
+        for ln in lines:
+            self.assertLess(len(ln), ORTHO_LINE_LENGTH)
+
+    def testPayloadIsCompleteForEverySplitObject(self):
+        # The truncated first fragment used to drop the whole update; the file
+        # payload must carry every object the panel needs to render.
+        base = self._split_ensemble()
+        objs = list(cmd.get_names('public_objects'))
+
+        _, payload = self._poll()
+
+        self.assertEqual(sorted(payload['objects']), sorted(objs))
+        self.assertEqual(payload['nstate'][base], 20)
+        for i in range(1, 21):
+            name = '%s_%04d' % (base, i)
+            self.assertIn(name, payload['objects'])
+            self.assertEqual(payload['nstate'][name], 1)
+            self.assertIn(name, payload['has_transp'])
+
+    def testPayloadCarriesSelectionsAndEnabledState(self):
+        base = self._split_ensemble(nstates=2)
+        cmd.select('mysele', '%s_0001 and name CA' % base)
+        cmd.disable('%s_0002' % base)
+
+        _, payload = self._poll()
+
+        self.assertIn('mysele', payload['selections'])
+        self.assertEqual(payload['sel_counts']['mysele'],
+                         cmd.count_atoms('mysele'))
+        self.assertIn('%s_0001' % base, payload['enabled'])
+        self.assertNotIn('%s_0002' % base, payload['enabled'])
+
+    def testMarkerLengthDoesNotGrowWithObjectCount(self):
+        # Constant-length marker is the property that makes the panel immune to
+        # the cap regardless of how many objects the session holds.
+        cmd.delete('all')
+        cmd.fab('ACDEFG', 'one')
+        small, _ = self._poll()
+
+        self._split_ensemble(base='many', nstates=20)
+        large, _ = self._poll()
+
+        self.assertEqual(small, large)


### PR DESCRIPTION
Fixes #231.

## The bug

`fetch 2kn1; split_states 2kn1` created all 20 objects in the viewport but **none appeared in the macOS object side-panel**, and the console filled with repeating raw-JSON fragments (`..., "2kn1_0020": false}}`), a new line every ~500 ms.

`split_states` itself was never at fault — it returns `ok` and creates every object. The real trigger is object **count**, not `split_states`: **any session reaching ≥16 objects** hit this.

## Root cause

The panel has no object-creation event; it is refreshed only by the ~500 ms `pollObjects()` timer, which printed the whole list **inline** as one `OBJPANEL:<json>` feedback line. PyMOL's feedback buffer caps a line at `OrthoLineLength` (1024, `layer0/PyMOLGlobals.h:43`), and the payload costs ~62 bytes/object (name + per-object `nstate`/`has_transp`):

```
15 objects ->  1010 chars  ok
16 objects ->  1072 chars  OVER 1024   <== panel stops updating here
21 objects ->  1382 chars  OVER        (fetch 2kn1 + split_states)
```

`OrthoAddOutput`'s fail-safe (`layer1/Ortho.cpp:1122-1129`) then split the line:

1. The **truncated first fragment** still carried the `OBJPANEL:` prefix but was invalid JSON, so `parseObjectPanelFeedback`'s `try? JSONDecoder().decode(...) else { return }` silently bailed → panel kept the **stale** list.
2. The **prefix-less continuation** fell through to the catch-all log path and was re-appended **every poll tick** → the log spam.

## The fix

Keep the payload off the feedback line, reusing the pattern `appkit_inspector.poll()` already uses for the rep-detail payload — whose own comment describes this exact ~1KB overflow. New `appkit_inspector.poll_panel()` writes the object list to a temp file and prints only `OBJPANEL:ready`; `parseObjectPanelFeedback` reads the file.

All **three** inline emitters now route through it, so no path can overflow:
- `PyMOLEngine.pollObjects()` (the ~500 ms poll)
- `PyMOLEngine.refreshAfterRestore()`
- `ObjectPanel.refreshObjects()` (on-appear one-shot)

Net effect: emitted line **1382 → 14 chars**, constant regardless of object count.

## Verification

Reproduced and verified in a clean, disposable macOS VM (15.7.7 arm64):

| | before | after |
|---|---|---|
| split objects listed in panel | 0 (stale) | **20** (`OBJECTS 21`) |
| leaked JSON lines in log | repeating every tick | **0** |
| emitted feedback line | 1382 chars | **14 chars** |

The panel went from `No objects loaded` to `OBJECTS 21` — `2kn1` with its `20`-state badge plus `2kn1_0001`..`2kn1_0020` — confirmed in both the screenshot and the accessibility tree.

Both the **macOS and iOS** targets build (the changed code is in shared files).

## Tests

New `testing/tests/test_appkit_objpanel_poll.py` (4 tests), wired into the embedded-test CI workflow:

- marker stays under the 1024 cap with >16 objects
- marker length is constant regardless of object count
- payload round-trips every split object (`nstate`, `has_transp`)
- payload carries selections + enabled state

Written test-first: all 4 failed against `master` (no `poll_panel`), pass after the fix. The rest of the RayMol Python suite is unchanged (85 passing; `test_appkit_theme_preview::test_begin_without_snapshot_leaves_scene_untouched` fails identically on `master` — pre-existing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)