### PR TITLE
test(runner): warn when the installed pymol Python layer is stale

### DIFF
--- a/.github/workflows/raymol-embedded-tests.yml
+++ b/.github/workflows/raymol-embedded-tests.yml
@@ -55,4 +55,5 @@ jobs:
               testing/tests/test_appkit_sequence_panel.py \
               testing/tests/test_appkit_ray_overlay.py \
               testing/tests/test_metal_pick.py \
-              testing/tests/test_mouse_panel.py
+              testing/tests/test_mouse_panel.py \
+              testing/tests/test_stale_check.py

--- a/testing/stale_check.py
+++ b/testing/stale_check.py
@@ -1,0 +1,97 @@
+"""Detect a stale installed `pymol` Python layer vs. this source checkout.
+
+The test runner imports `pymol` from wherever it is *installed* (site-packages),
+never from this checkout's `modules/pymol`. `pip install .` copies those files,
+so a checkout that has moved on since the last install silently exercises OLD
+code. That produces failures which look like real bugs on master -- and, worse,
+can let a genuine regression pass. CI is immune (it installs from source on
+every run); long-lived local venvs are not.
+
+Reporting the drift is all this does; the runner only warns. Pure stdlib, and
+deliberately free of any `pymol` import so it can be unit-tested headless.
+"""
+
+import filecmp
+import os
+
+#: Names listed individually in the warning before it collapses to a count.
+_MAX_LISTED = 8
+
+
+def compare_python_layer(source_dir, installed_dir):
+    """Compare ``*.py`` in *source_dir* against *installed_dir*.
+
+    Returns ``(stale, missing)``, each a sorted list of basenames: *stale* is
+    present in both but differs in content, *missing* is absent from the
+    install. A file that resolves to the same path on disk (a symlinked or
+    editable install) is up to date. Files only the install has are ignored --
+    the checkout does not claim to own them. A vanished or unreadable
+    *source_dir* yields no findings, so a non-checkout run stays quiet.
+    """
+    stale = []
+    missing = []
+    try:
+        names = os.listdir(source_dir)
+    except OSError:
+        return [], []
+    for name in names:
+        if not name.endswith('.py'):
+            continue
+        source = os.path.join(source_dir, name)
+        installed = os.path.join(installed_dir, name)
+        if not os.path.exists(installed):
+            missing.append(name)
+            continue
+        try:
+            if os.path.realpath(source) == os.path.realpath(installed):
+                continue
+            if not filecmp.cmp(source, installed, shallow=False):
+                stale.append(name)
+        except OSError:
+            # Unreadable either side: report it rather than crash the run.
+            stale.append(name)
+    return sorted(stale), sorted(missing)
+
+
+def _summarize(names):
+    if len(names) <= _MAX_LISTED:
+        return ', '.join(names)
+    return '%s, ... (%d more)' % (', '.join(names[:_MAX_LISTED]),
+                                  len(names) - _MAX_LISTED)
+
+
+def format_warning(stale, missing, source_dir, installed_dir):
+    """Render a banner for the findings, or None when the layer is up to date."""
+    if not stale and not missing:
+        return None
+    counts = '%d stale, %d missing' % (len(stale), len(missing))
+    lines = [
+        '',
+        '=' * 78,
+        'WARNING: the installed pymol Python layer does not match this checkout',
+        '         (%s) -- these tests are NOT exercising your source.' % counts,
+        '',
+        '  checkout:  %s' % source_dir,
+        '  installed: %s' % installed_dir,
+    ]
+    if stale:
+        lines += ['', '  stale (installed copy differs):', '    %s' % _summarize(stale)]
+    if missing:
+        lines += ['', '  missing from install:', '    %s' % _summarize(missing)]
+    lines += [
+        '',
+        '  Failures below may be bogus -- and real regressions may be hidden.',
+        '  Refresh with `pip install .`, or symlink the Python layer:',
+        '',
+        '    SP="%s"' % installed_dir,
+        '    for f in "%s"/*.py; do ln -sfn "$f" "$SP/$(basename "$f")"; done' % source_dir,
+        '=' * 78,
+        '',
+    ]
+    return '\n'.join(lines)
+
+
+def check_installed_layer(source_dir, installed_dir):
+    """Convenience wrapper: returns the warning text, or None when clean."""
+    stale, missing = compare_python_layer(source_dir, installed_dir)
+    return format_warning(stale, missing, source_dir, installed_dir)

--- a/testing/testing.py
+++ b/testing/testing.py
@@ -121,6 +121,29 @@ else:
 
     pymol_test_dir = os.path.abspath(os.path.dirname(__file__))
 
+    def check_installed_layer():
+        '''
+        RayMol: warn when the *installed* pymol Python layer has drifted from
+        this checkout, because the runner imports pymol from site-packages and
+        would otherwise test old code without saying so. Returns the warning
+        text (already printed) or None. Never raises -- a diagnostic must not
+        be able to break the run it is diagnosing.
+        '''
+        try:
+            stale_check = import_from_file(
+                os.path.join(pymol_test_dir, 'stale_check.py'),
+                'raymol_stale_check')
+            warning = stale_check.check_installed_layer(
+                os.path.join(os.path.dirname(pymol_test_dir), 'modules', 'pymol'),
+                os.path.dirname(os.path.abspath(pymol.__file__)))
+        except Exception as e:
+            print('stale_check skipped: %s' % e, file=sys.stderr)
+            return None
+        if warning:
+            print(warning, file=sys.stderr)
+            sys.stderr.flush()
+        return warning
+
     deferred_unlink = []
     deferred_rmtree = []
 
@@ -648,6 +671,8 @@ USAGE
 
     run_testfiles file1 file2 ... [, verbosity [, out ]]
         '''
+        stale_warning = check_installed_layer()
+
         if filenames in ('all', ['all']):
             global run_all
             run_all = True
@@ -704,7 +729,18 @@ USAGE
             import subprocess
             subprocess.call(['rd', '/s', '/q', deferred_rmtree.pop()], shell=True)
 
-        return len(testresult.errors) + len(testresult.failures) + pytest_nfail
+        nfail = len(testresult.errors) + len(testresult.failures) + pytest_nfail
+
+        # Repeat the staleness verdict *after* the results, where it is read.
+        if stale_warning:
+            print('\nREMINDER: the installed pymol Python layer is stale (see the '
+                  'warning above)\n          -- %s here cannot be trusted either '
+                  'way. Refresh, then re-run.'
+                  % ('the %d failure(s)' % nfail if nfail else 'the passes'),
+                  file=sys.stderr)
+            sys.stderr.flush()
+
+        return nfail
 
     def cli():
         '''

--- a/testing/tests/test_stale_check.py
+++ b/testing/tests/test_stale_check.py
@@ -1,0 +1,133 @@
+"""Unit tests for testing/stale_check.py — headless, no PyMOL required.
+
+stale_check guards against the runner silently testing an OLD installed copy of
+the Python layer (see the module docstring). These tests pin the comparison
+semantics: content drift is stale, absence is missing, a symlinked/editable
+install is up to date, and files the source doesn't own are none of our
+business.
+"""
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+
+_STALE_CHECK = os.path.join(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))), "stale_check.py")
+_spec = importlib.util.spec_from_file_location("raymol_stale_check", _STALE_CHECK)
+sc = importlib.util.module_from_spec(_spec)
+sys.modules["raymol_stale_check"] = sc
+_spec.loader.exec_module(sc)
+
+
+def _write(dirname, name, text):
+    path = os.path.join(dirname, name)
+    with open(path, "w") as handle:
+        handle.write(text)
+    return path
+
+
+class ComparePythonLayerTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.src = os.path.join(self._tmp.name, "src")
+        self.dst = os.path.join(self._tmp.name, "dst")
+        os.makedirs(self.src)
+        os.makedirs(self.dst)
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_identical_layer_is_clean(self):
+        _write(self.src, "a.py", "x = 1\n")
+        _write(self.dst, "a.py", "x = 1\n")
+        self.assertEqual(sc.compare_python_layer(self.src, self.dst), ([], []))
+
+    def test_content_drift_is_stale(self):
+        _write(self.src, "a.py", "x = 2\n")   # checkout moved on
+        _write(self.dst, "a.py", "x = 1\n")   # installed copy is old
+        self.assertEqual(sc.compare_python_layer(self.src, self.dst),
+                         (["a.py"], []))
+
+    def test_same_size_different_bytes_is_stale(self):
+        # Guards against a shallow (size/mtime-only) comparison.
+        _write(self.src, "a.py", "x = 1\n")
+        _write(self.dst, "a.py", "x = 9\n")
+        self.assertEqual(sc.compare_python_layer(self.src, self.dst),
+                         (["a.py"], []))
+
+    def test_absent_from_install_is_missing(self):
+        _write(self.src, "new_module.py", "x = 1\n")
+        self.assertEqual(sc.compare_python_layer(self.src, self.dst),
+                         ([], ["new_module.py"]))
+
+    def test_symlinked_install_is_up_to_date(self):
+        # The documented dev fix: site-packages symlinked at the checkout.
+        src = _write(self.src, "a.py", "x = 1\n")
+        os.symlink(src, os.path.join(self.dst, "a.py"))
+        self.assertEqual(sc.compare_python_layer(self.src, self.dst), ([], []))
+
+    def test_extra_installed_file_is_ignored(self):
+        # Vanilla-PyMOL modules the fork doesn't ship are not our business.
+        _write(self.dst, "only_installed.py", "x = 1\n")
+        self.assertEqual(sc.compare_python_layer(self.src, self.dst), ([], []))
+
+    def test_non_python_files_ignored(self):
+        _write(self.src, "notes.txt", "hello\n")
+        self.assertEqual(sc.compare_python_layer(self.src, self.dst), ([], []))
+
+    def test_results_are_sorted_and_partitioned(self):
+        for name in ("b.py", "a.py"):
+            _write(self.src, name, "new\n")
+            _write(self.dst, name, "old\n")
+        for name in ("z.py", "c.py"):
+            _write(self.src, name, "new\n")
+        self.assertEqual(sc.compare_python_layer(self.src, self.dst),
+                         (["a.py", "b.py"], ["c.py", "z.py"]))
+
+    def test_missing_source_dir_is_clean(self):
+        # Not running from a source checkout (installed pymol only) — no noise.
+        self.assertEqual(
+            sc.compare_python_layer(os.path.join(self._tmp.name, "nope"),
+                                    self.dst), ([], []))
+
+    def test_unreadable_file_does_not_raise(self):
+        path = _write(self.src, "a.py", "x = 1\n")
+        _write(self.dst, "a.py", "x = 1\n")
+        os.chmod(path, 0o000)
+        self.addCleanup(os.chmod, path, 0o644)
+        if os.access(path, os.R_OK):
+            self.skipTest("running as root; cannot make a file unreadable")
+        # Must degrade to a report, never crash the whole test run.
+        stale, missing = sc.compare_python_layer(self.src, self.dst)
+        self.assertEqual(missing, [])
+
+
+class FormatWarningTest(unittest.TestCase):
+    def test_clean_layer_returns_none(self):
+        self.assertIsNone(sc.format_warning([], [], "/src", "/dst"))
+
+    def test_warning_names_files_and_dirs(self):
+        text = sc.format_warning(["appkit_theme_preview.py"], ["metal_move.py"],
+                                 "/repo/modules/pymol", "/sp/pymol")
+        self.assertIn("appkit_theme_preview.py", text)
+        self.assertIn("metal_move.py", text)
+        self.assertIn("/repo/modules/pymol", text)
+        self.assertIn("/sp/pymol", text)
+
+    def test_warning_states_counts_and_offers_a_fix(self):
+        text = sc.format_warning(["a.py", "b.py"], ["c.py"], "/src", "/dst")
+        self.assertIn("2 stale", text)
+        self.assertIn("1 missing", text)
+        # Must be actionable, not just alarming.
+        self.assertIn("ln -sfn", text)
+
+    def test_long_lists_are_truncated(self):
+        many = ["mod%02d.py" % i for i in range(40)]
+        text = sc.format_warning(many, [], "/src", "/dst")
+        self.assertIn("40 stale", text)
+        self.assertLess(len(text.splitlines()), 30)
+        self.assertIn("more", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

The test runner imports `pymol` from **site-packages**, never from the checkout's `modules/pymol`. `pip install .` *copies* those files, so a long-lived local venv silently exercises **old code** once the checkout moves on. CI is immune — it installs from source on every run — so this is invisible until it wastes someone's afternoon.

It already cost us a false bug report. `test_appkit_theme_preview.py::BeginTest::test_begin_without_snapshot_leaves_scene_untouched` was believed to be a pre-existing failure on master. **It is not** — it passes on master, and it has been in the CI list and green the whole time. A local venv held the pre-`17f86fc4a` copy of `appkit_theme_preview.py` (a 2026-06-18 snapshot, nine days older than the 2026-06-27 data-loss fix that added the `if _saved is None: return` guard), so the test was correctly flagging the *old* bug against 5 passing neighbours.

The scarier direction is the same mechanism in reverse: a stale copy hiding a **real** regression behind a green run.

## What

`testing/stale_check.py` diffs the checkout's `modules/pymol/*.py` against the installed package. `run_testfiles` prints a banner naming the drifted files and the command to fix it — once before the tests, and again **after** the results, where failures are actually read:

```
==============================================================================
WARNING: the installed pymol Python layer does not match this checkout
         (1 stale, 0 missing) -- these tests are NOT exercising your source.

  checkout:  /…/modules/pymol
  installed: /…/site-packages/pymol

  stale (installed copy differs):
    appkit_theme_preview.py

  Failures below may be bogus -- and real regressions may be hidden.
  Refresh with `pip install .`, or symlink the Python layer:
    …
==============================================================================
…
BeginTest::test_begin_without_snapshot_leaves_scene_untouched FAILED

REMINDER: the installed pymol Python layer is stale (see the warning above)
          -- the 1 failure(s) here cannot be trusted either way.
```

Design notes:

- **Warns, never fails.** A diagnostic must not be able to break the run it is diagnosing, and it can't fail CI, where the layer matches by construction.
- **Cannot crash the run** — every path is wrapped; an unreadable file is reported, not raised.
- **Symlinked (editable) installs count as up to date**, so the documented dev workaround stays quiet.
- **Files only the install has are ignored** — vanilla-PyMOL modules the fork doesn't ship aren't our business.
- Pure stdlib, no `pymol` import, so the comparison is unit-testable headless.

## Verification

- Reinstated the real June-18 copy: banner names `appkit_theme_preview.py`, the test fails exactly as it originally did, trailing reminder marks that failure untrustworthy.
- With a matching layer the check is **silent** and the full CI list is **111/111**, including 14 new `test_stale_check.py` cases (content drift, same-size-different-bytes, missing, symlinked, extra-installed, non-`.py`, absent source dir, unreadable file, truncation).
- Exercised the runner's non-pytest unittest path too (`tests/api/build.py`, 6 tests OK), since the change touches the shared return.
- `test_stale_check.py` added to the workflow list.

No production code is touched — `modules/pymol/appkit_theme_preview.py` and its test were both already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)