### PR TITLE
Fix #235: Escape exits Move / Design / Measure mode

### DIFF
--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		55F78301BAF8CD914D86069D /* MCPConnectSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE692F1547C53D28B5F9A9AD /* MCPConnectSheet.swift */; };
 		56CC6A9A8A95D5B1B8D92688 /* PyMOLEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33D6A753E4525628B96C259C /* PyMOLEngine.swift */; };
 		575E4E4792DE4C46A70ECE01 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 10CCAA289EA2934B267C337A /* PrivacyInfo.xcprivacy */; };
+		57E2333020DE9DC8910BDC3E /* InteractionModeExitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43E4051E6410834AAAA4047 /* InteractionModeExitTests.swift */; };
 		5992346BC7D06026A673BA71 /* ObjectPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A73267D4D7B506E647B7A995 /* ObjectPanel.swift */; };
 		5A20A6D21AA3CFAE2394BAB4 /* dylib-Info-template.plist in Resources */ = {isa = PBXBuildFile; fileRef = 57E9E81F5C4757D03AAF7ABD /* dylib-Info-template.plist */; };
 		5C923361D76329D2A466FFA9 /* PyMOLApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D965CB609C447033E5DB0046 /* PyMOLApp.swift */; };
@@ -201,11 +202,12 @@
 		EEC5AE545F97DF175BFE0462 /* DesignScoreCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignScoreCache.swift; sourceTree = "<group>"; };
 		F16058D96E2773BE9A24C323 /* RayMol.svg */ = {isa = PBXFileReference; path = RayMol.svg; sourceTree = "<group>"; };
 		F2078076B68D28457409F7A5 /* RayMol.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RayMol.entitlements; sourceTree = "<group>"; };
+		F43E4051E6410834AAAA4047 /* InteractionModeExitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractionModeExitTests.swift; sourceTree = "<group>"; };
 		F607D204A410CA38B84223BE /* RayMolUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RayMolUpdater.swift; sourceTree = "<group>"; };
 		F7E41DCBB427678A8F018B0E /* DesignControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignControllerTests.swift; sourceTree = "<group>"; };
 		FB1304C662D9011F7C4505FC /* MCPStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPStatusView.swift; sourceTree = "<group>"; };
 		FF4FB7F151982A2927D612F0 /* DesignController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignController.swift; sourceTree = "<group>"; };
-		"TEMP_217C32D4-BD6D-4615-9DDE-B3D806CCB362" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
+		"TEMP_88D83469-F094-4791-A60D-BE1EB7F93027" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -341,6 +343,7 @@
 				9A2CE99D9A3C57ACBBDBF3B5 /* DesignRegionTests.swift */,
 				48EDC39F7E7F250CFC4F7D0D /* DesignResiduesTests.swift */,
 				D0BCB2A867C3554FB56A7299 /* DesignScoreCacheTests.swift */,
+				F43E4051E6410834AAAA4047 /* InteractionModeExitTests.swift */,
 				4A2C1E1633D1E93E9914BEC3 /* OpenFilesTests.swift */,
 				55F4F52D951CF1F96606F41C /* SmokeTests.swift */,
 			);
@@ -367,10 +370,10 @@
 			path = Bridge;
 			sourceTree = "<group>";
 		};
-		"TEMP_896FE4C1-5F49-4F35-917D-F94BF0375504" /* swiftui */ = {
+		"TEMP_4618A80D-7859-4B7D-9935-CEB61B2DC5DD" /* swiftui */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_217C32D4-BD6D-4615-9DDE-B3D806CCB362" /* PyMOLBridge.xcconfig */,
+				"TEMP_88D83469-F094-4791-A60D-BE1EB7F93027" /* PyMOLBridge.xcconfig */,
 			);
 			path = swiftui;
 			sourceTree = "<group>";
@@ -1012,6 +1015,7 @@
 				B5CC8EFFCE99E9813AEC1422 /* DesignRegionTests.swift in Sources */,
 				52B5620BEF26DEB8E3A700C1 /* DesignResiduesTests.swift in Sources */,
 				6EAC8947F66B8D7AD29BF3B8 /* DesignScoreCacheTests.swift in Sources */,
+				57E2333020DE9DC8910BDC3E /* InteractionModeExitTests.swift in Sources */,
 				C89E138879C40C8FB6C0478A /* OpenFilesTests.swift in Sources */,
 				5CAB662574D238626A8F4D68 /* SmokeTests.swift in Sources */,
 			);
@@ -1265,7 +1269,7 @@
 		};
 		76B7E9DB75E073D1E60928FA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_217C32D4-BD6D-4615-9DDE-B3D806CCB362" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_88D83469-F094-4791-A60D-BE1EB7F93027" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1372,7 +1376,7 @@
 		};
 		D8F44FDFF036013D2F03BA83 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_217C32D4-BD6D-4615-9DDE-B3D806CCB362" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_88D83469-F094-4791-A60D-BE1EB7F93027" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -543,18 +543,21 @@ struct ContentView: View {
             }
     }
 
-    // Esc → two-stage clear selection (issues #163 + #166). A local key-down
-    // monitor (not .onKeyPress, which is macOS 14+; deployment target is macOS
-    // 13) so the whole main window catches Esc even when the viewport isn't the
-    // SwiftUI focus. We must NOT swallow Esc that belongs to something else:
+    // Esc → back out one level. A local key-down monitor rather than .onKeyPress
+    // because the whole main window must catch Esc even when the viewport isn't
+    // the SwiftUI focus — MetalViewport deliberately declines first-responder
+    // status (issue #73) so the command line stays hot for typing.
+    //
+    // The ladder, in order (issues #163 + #166, then #235):
     //   (a) a sheet / panel / popover is up (their window is key, not the main
-    //       RayMol window) — Esc should dismiss it, or
-    //   (b) the first responder is a text/field editor (the command line is
-    //       being edited) — Esc there cancels the field edit.
-    // In those cases we return the event unhandled so the system routes it
-    // normally. Otherwise we run the shared clear-selection helper and consume
-    // the event (return nil). Non-Esc keys always pass through untouched.
-    // NOTE: iOS external-keyboard Esc is a deliberate follow-up (not wired here).
+    //       RayMol window) — Esc belongs to it, pass through so it dismisses;
+    //   (b) an exclusive interaction mode (Move / Design / Measure) is active —
+    //       leave it, then consume;
+    //   (c) otherwise — two-stage clear selection, then consume.
+    // Non-Esc keys always pass through untouched.
+    // NOTE: iOS external-keyboard Esc is a deliberate follow-up (not wired here);
+    // the routing itself lives on PyMOLEngine and is platform-neutral, so wiring
+    // iOS later is just a key source, not a second policy.
     private func installEscKeyMonitor() {
         guard escKeyMonitor == nil else { return }
         escKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
@@ -569,9 +572,16 @@ struct ContentView: View {
                 if keyWindow.isSheet || keyWindow is NSPanel { return event }
             }
             // NOTE: intentionally does NOT defer to a focused text field — Esc
-            // clears the selection regardless of keyboard focus (incl. while the
-            // command-line box is focused), per product decision. Only true
-            // modal/sheet/panel windows above still get Esc for dismissal.
+            // acts regardless of keyboard focus (incl. while the command-line box
+            // is focused), per product decision. Only true modal/sheet/panel
+            // windows above still get Esc for dismissal.
+            //
+            // (b) Leaving an interaction mode outranks clearing the selection —
+            // #166 anticipated exactly this ("exiting a mode should take priority
+            // before the selection stages kick in"). Routed through the engine so
+            // Esc reuses each mode's own exit path rather than duplicating it.
+            if engine.exitActiveInteractionMode() { return nil }
+            // (c) No mode was active → the selection stages.
             engine.escapeClearSelection()
             return nil  // consume — don't beep or propagate
         }

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -1953,6 +1953,32 @@ final class PyMOLEngine: ObservableObject {
         designMode = on
     }
 
+    // MARK: - Exclusive interaction modes (Move / Design / Measure)
+
+    /// Leave whichever exclusive interaction mode is active, each through that
+    /// mode's OWN existing exit path — so the Esc key (see
+    /// ContentView.installEscKeyMonitor) and the overlays' ✕ buttons converge on
+    /// identical behavior. In particular Design goes through `setDesignMode(false)`,
+    /// whose `.onChange` observer in ContentView runs the visual-state restore and
+    /// edit-session teardown; Esc must never grow a second, divergent path. (#235)
+    ///
+    /// The three modes are mutually exclusive, so in practice at most one branch
+    /// runs. They are checked independently rather than with early returns so a
+    /// desynchronized state still unwinds completely instead of leaving one mode
+    /// stranded.
+    ///
+    /// - Returns: whether any mode was actually exited. Callers use this to fall
+    ///   through to their next behavior (Esc clears the selection) when Escape
+    ///   found no mode to leave.
+    @discardableResult
+    func exitActiveInteractionMode() -> Bool {
+        var exited = false
+        if designMode { setDesignMode(false); exited = true }
+        if interactionMode == .move { setInteractionMode(.viewing); exited = true }
+        if measureMode != nil { setMeasureMode(nil); exited = true }
+        return exited
+    }
+
 #if RAYMOL_MPNN
     // Cached MPNNModel: loaded once on first use (throws → returns nil + logs).
     private var _mpnnModel: MPNNModel?

--- a/swiftui/PyMOLViewerTests/InteractionModeExitTests.swift
+++ b/swiftui/PyMOLViewerTests/InteractionModeExitTests.swift
@@ -1,0 +1,124 @@
+import XCTest
+@testable import RayMol
+
+/// Coverage for the shared "Esc backs out of the active mode" routing (#235).
+///
+/// The Esc key itself is an `NSEvent` local monitor in `ContentView`, which a
+/// unit test cannot press. What IS testable — and what actually carries the
+/// behavior — is `PyMOLEngine.exitActiveInteractionMode()`: the single routine
+/// both Esc and the overlays' ✕ buttons funnel through. These tests pin down
+/// its contract: exits the active mode via that mode's own path, reports
+/// whether it did anything (so Esc knows whether to fall through to clearing
+/// the selection), and stays a no-op when no mode is active.
+@MainActor
+final class InteractionModeExitTests: XCTestCase {
+    private var engine: PyMOLEngine { PyMOLEngine.shared }
+
+    // PyMOLEngine is a singleton shared with the other test classes, so start
+    // and finish every case from a known-clean viewing state.
+    override func setUp() {
+        super.setUp()
+        resetToViewing()
+    }
+
+    override func tearDown() {
+        resetToViewing()
+        super.tearDown()
+    }
+
+    private func resetToViewing() {
+        engine.setDesignMode(false)
+        engine.setMeasureMode(nil)
+        engine.setInteractionMode(.viewing)
+    }
+
+    // MARK: - Exits each mode
+
+    func testExitsMoveMode() {
+        engine.setInteractionMode(.move)
+        XCTAssertEqual(engine.interactionMode, .move)
+
+        XCTAssertTrue(engine.exitActiveInteractionMode(), "should report that it exited a mode")
+        XCTAssertEqual(engine.interactionMode, .viewing)
+    }
+
+    func testExitsDesignMode() {
+        engine.setDesignMode(true)
+        XCTAssertTrue(engine.designMode)
+
+        XCTAssertTrue(engine.exitActiveInteractionMode())
+        XCTAssertFalse(engine.designMode)
+    }
+
+    func testExitsMeasureMode() {
+        engine.setMeasureMode(.distance)
+        XCTAssertEqual(engine.measureMode, .distance)
+
+        XCTAssertTrue(engine.exitActiveInteractionMode())
+        XCTAssertNil(engine.measureMode)
+    }
+
+    func testExitsEachMeasureKind() {
+        for kind in [MeasureKind.distance, .angle, .dihedral] {
+            engine.setMeasureMode(kind)
+            XCTAssertEqual(engine.measureMode, kind)
+            XCTAssertTrue(engine.exitActiveInteractionMode(), "\(kind) should be exitable")
+            XCTAssertNil(engine.measureMode, "\(kind) should have been cleared")
+        }
+    }
+
+    // MARK: - No-op when nothing is active
+
+    func testNoOpWhenNoModeIsActive() {
+        XCTAssertFalse(engine.exitActiveInteractionMode(),
+                       "with no mode active it must report false so Esc falls through to clearing the selection")
+        XCTAssertEqual(engine.interactionMode, .viewing)
+        XCTAssertFalse(engine.designMode)
+        XCTAssertNil(engine.measureMode)
+    }
+
+    func testSecondExitIsANoOp() {
+        engine.setInteractionMode(.move)
+        XCTAssertTrue(engine.exitActiveInteractionMode())
+        // A second Esc has no mode left to leave and must hand off to the
+        // selection stages rather than silently consuming the key.
+        XCTAssertFalse(engine.exitActiveInteractionMode())
+    }
+
+    // MARK: - Goes through the mode's real exit path
+
+    func testExitingMoveTearsDownGizmoState() {
+        engine.setInteractionMode(.move)
+        engine.activeMoveObject = "1ubq"
+        engine.armedAxis = .x
+        engine.adjustFrameToggle = true
+
+        XCTAssertTrue(engine.exitActiveInteractionMode())
+
+        // Proves Esc routed through setInteractionMode(.viewing) rather than
+        // just flipping the mode flag: the whole gizmo satellite state is gone.
+        XCTAssertEqual(engine.interactionMode, .viewing)
+        XCTAssertNil(engine.activeMoveObject)
+        XCTAssertNil(engine.armedAxis)
+        XCTAssertNil(engine.gizmo)
+        XCTAssertFalse(engine.adjustFrameToggle)
+        XCTAssertFalse(engine.moveShiftHeld)
+    }
+
+    // MARK: - Defensive
+
+    func testUnwindsEveryModeIfStateIsDesynchronized() {
+        // The three modes are mutually exclusive, so this state should be
+        // unreachable — force it directly (bypassing the setters' exclusion) to
+        // pin the contract that a single exit still leaves nothing stranded.
+        engine.interactionMode = .move
+        engine.designMode = true
+        engine.measureMode = .angle
+
+        XCTAssertTrue(engine.exitActiveInteractionMode())
+
+        XCTAssertEqual(engine.interactionMode, .viewing)
+        XCTAssertFalse(engine.designMode)
+        XCTAssertNil(engine.measureMode)
+    }
+}


### PR DESCRIPTION
Closes #235.

## What

The three exclusive interaction modes — **Move**, **Design**, **Measure** — could only be left by clicking their toggle or ✕. Entering one by keyboard (⌃M / ⌃D) and then having to hunt for a mouse target to get out was the friction.

Esc was **already** wired up on macOS as the two-stage clear-selection from #163 + #166. Rather than add a second key path, this extends that existing monitor into a precedence ladder:

| order | condition | behavior |
|---|---|---|
| (a) | a sheet / panel / popover is key | pass Esc through so it dismisses |
| (b) | an interaction mode is active | leave it, consume |
| (c) | otherwise | two-stage clear selection, consume |

(b) before (c) is what #166 itself called for: *"exiting a mode should take priority before the selection stages kick in."*

## How

New `PyMOLEngine.exitActiveInteractionMode()` routes each mode through its **own existing exit path** — notably Design goes via `setDesignMode(false)`, whose `.onChange` observer runs the visual-state restore and edit-session teardown, so Esc and the ✕ physically cannot diverge. It returns whether it exited anything, which is what lets Esc fall through to the selection stages when no mode was active.

The three are checked independently rather than with early returns, so a desynchronized state unwinds completely instead of leaving one mode stranded.

## One deliberate deviation from the acceptance criteria

The issue asks that Esc not fire while the console / a text field has focus. **This PR does not do that**, on the user's call.

The existing handler carries an explicit product decision from #163/#166 — Esc acts regardless of keyboard focus, *including* while the command line is focused. Honoring the new bullet for mode-exit only would split Esc into two contradictory focus policies (while typing, Esc would clear your selection but refuse to leave Move mode); honoring it for both would regress shipped behavior. Keeping one rule won.

Modal / sheet / panel windows still get Esc first, exactly as before — that half of the criterion is verified below.

iOS external-keyboard Esc remains a follow-up. The routing is platform-neutral and lives on the engine, so wiring iOS later is a key source, not a second policy.

## Verification

**Unit** — 8 new tests in `PyMOLViewerTests/InteractionModeExitTests.swift` (exits each mode, exits each `MeasureKind`, no-op when idle, second Esc is a no-op, exiting Move tears down the whole gizmo satellite state, desynchronized state unwinds fully). Suite: **65 pass, 0 failures**. macOS and iOS targets both compile.

**Functional** — driven in a disposable macOS VM (fresh clone, Debug build, real `Escape` keystrokes):

- Move: `Move Objects` → enter → `Stop Moving Objects` → **Esc** → `Move Objects` ✅
- Design: `Enter Design Mode` → enter → `Exit Design Mode` → **Esc** → `Enter Design Mode` ✅
- Measure: ruler overlay (`Tap 2 atoms`) appears → **Esc** → overlay gone ✅
- **Esc** ×2 with no mode active → no-op, app healthy ✅
- Move active + Fetch-from-PDB modal open → **Esc** dismisses the *modal* and leaves Move active; a second **Esc** then exits Move ✅
- No mode active → **Esc** #1 deselects, **Esc** #2 deletes `(sele)` — #163/#166 intact ✅

## Found in passing (both out of scope, filed separately)

- `setDesignMode(true)` clears Move/Measure with bare assignments instead of the sibling setters, so entering Design from Move never runs `metal_move.cleanup()` and strands the `_move_gizmo` CGO (which is `_`-prefixed and so undeletable from the object panel).
- **The iOS target does not compile on master** — `ContentView.swift` `loadRaymolrcOrOfferMigration()` (added in ab30c08c9 / #226) sits in the shared band but calls `homeDirectoryForCurrentUser`, which is macOS-only. Reproduced on a pristine checkout of `0e6ba4a79`; the iOS build above passes only with that one line locally patched. Worth an iOS compile job in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)