### PR TITLE
Fix iOS build: gate ~/.raymolrc migration prompt to macOS

### DIFF
--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -155,7 +155,11 @@ struct ContentView: View {
     // ~/.raymolrc first-run migration prompt (RayMol#225): shown once, before
     // raymolrc.load() ever runs, when an existing ~/.pymolrc(.py) could be
     // imported. Declining writes a skip marker so we don't ask again.
+    // macOS-only: a startup rc file is a desktop concept, and iOS has no
+    // user-visible home directory to put one in (see loadRaymolrcOrOfferMigration).
+    #if os(macOS)
     @State private var showRaymolrcMigrationPrompt = false
+    #endif
 
     // Export menu state. exportRayTraced persists across launches; when on, all
     // image exports are ray-traced (AO + shadows) regardless of the live view.
@@ -1171,12 +1175,6 @@ struct ContentView: View {
                 Button("Cancel", role: .cancel) {}
             } message: {
                 Text("Download a structure from the RCSB PDB.")
-            }
-            .alert("Import your PyMOL startup script?", isPresented: $showRaymolrcMigrationPrompt) {
-                Button("Import") { confirmRaymolrcMigration() }
-                Button("Not Now", role: .cancel) { declineRaymolrcMigration() }
-            } message: {
-                raymolrcMigrationAlertText
             }
             .alert("Clear session?", isPresented: $showClearSessionConfirm) {
                 Button("Clear", role: .destructive) { engine.clearSessionAndAutosave() }
@@ -3173,8 +3171,11 @@ struct ContentView: View {
         // Load ~/.raymolrc(.py) LAST, after the theme defaults above, so a
         // user's startup script can override them (e.g. a custom bg_color) —
         // matching vanilla PyMOL, where .pymolrc runs after all built-in
-        // defaults are set.
+        // defaults are set. macOS-only (RayMol#225 left iOS as an open
+        // question): there is no user-visible ~ on iOS to author an rc file in.
+        #if os(macOS)
         loadRaymolrcOrOfferMigration()
+        #endif
     }
 
     // This native app never goes through pymol.invocation's CLI argument
@@ -3185,6 +3186,14 @@ struct ContentView: View {
     // over, or may not recognize ~/.raymolrc if we create it behind their
     // back. Skips the prompt (and loads immediately) once either file
     // exists or the user has already answered once (~/.raymolrc.skip).
+    //
+    // macOS-only, for two reasons: homeDirectoryForCurrentUser is unavailable
+    // on iOS, and more fundamentally a dotfile in ~ is a desktop concept —
+    // iOS's ~ is the app container, which the user can neither see nor write
+    // to, so an iOS build could only ever no-op here. RayMol#225 explicitly
+    // left "whether iOS needs an equivalent (likely app-container-relative)"
+    // as an open question; it is deliberately still open.
+    #if os(macOS)
     private func loadRaymolrcOrOfferMigration() {
         let fm = FileManager.default
         let home = fm.homeDirectoryForCurrentUser.path
@@ -3211,6 +3220,7 @@ struct ContentView: View {
     private var raymolrcMigrationAlertText: Text {
         Text("RayMol found an existing ~/.pymolrc and can copy it to ~/.raymolrc, RayMol's own startup script, so your customizations still run here.")
     }
+    #endif
 }
 
 #if RAYMOL_MPNN


### PR DESCRIPTION
## Problem

`PyMOLViewer_iOS` has not compiled since **2026-07-24**:

```
swiftui/PyMOLViewer/Shared/ContentView.swift: error: 'homeDirectoryForCurrentUser' is unavailable in iOS
```

`ab30c08c9` ("Load ~/.raymolrc startup script, with opt-in ~/.pymolrc import (#226)") added `loadRaymolrcOrOfferMigration()` to the **shared** region of `ContentView.swift`. It calls `FileManager.homeDirectoryForCurrentUser`, which is macOS-only. This is the recurring `ContentView` shared/iOS-boundary trap, in the macOS-API-in-shared-code direction.

Pre-existing break, unrelated to any in-flight work.

## Fix

Gate the whole feature behind `#if os(macOS)` — the `@State` flag, the alert, the call site in `applyPersistedTheme()`, and all four members — matching the existing `macOpenToolbar` idiom already in this file (`ContentView.swift:2638`).

Also drops the duplicate `.alert` that #226 placed *inside* the `#if os(iOS)` block, which could never have fired.

**macOS behaviour is unchanged** — every line macOS compiled before, it still compiles.

### Why gate rather than port to iOS

Confirmed against #226's intent. Issue #225 explicitly lists iOS as an **open question**, not a requirement:

> "whether iOS needs an equivalent (no home directory in the same sense — likely app-container-relative)"

The implementation never answered it. Gating keeps it open; porting would silently answer it. And nothing is lost functionally: a startup dotfile in `~` is a desktop concept, and iOS's `~` is the app container, which the user can neither see nor write to — so `raymolrc.load()` on iOS could only ever no-op.

### Why *not* `NSHomeDirectory()`

Under App Sandbox (the Mac App Store build, `RAYMOL_MAS_RESTRICTED`) `NSHomeDirectory()` returns the sandbox **container** while `homeDirectoryForCurrentUser` returns the real home. A blind swap would silently move where macOS looks for `~/.raymolrc`, `~/.pymolrc` and `~/.raymolrc.skip`, breaking the #226 feature for sandboxed builds. Not touched.

## Verification

| Check | Before | After |
|---|---|---|
| `xcodebuild build -scheme PyMOLViewer_iOS -destination 'generic/platform=iOS Simulator'` | `** BUILD FAILED **` (3 failures) | `** BUILD SUCCEEDED **`, exit 0 |
| `xcodebuild test -scheme UnitTests_macOS -destination 'platform=macOS'` | — | `** TEST SUCCEEDED **`, 65 tests / 3 skipped / **0 failures** |

Red→green confirmed on the identical command. Also verified statically: every `#if`/`#endif` in the file balances, all 19 `raymolrc` code lines now sit inside `os(macOS)`, `raymolrc` appears nowhere in the iOS build log (fully compiled out), and a nesting-aware scan of `ContentView.swift` finds **zero** remaining macOS-only APIs outside an `os(macOS)` guard. No Python changed, so #226's 21 headless `test_raymolrc.py` tests are untouched.

## Follow-up (not in this PR)

No CI workflow compiles the iOS target — `grep -ln 'PyMOLViewer_iOS\|iOS Simulator' .github/workflows/*` returns nothing — which is why this sat broken for two days. Worth a compile-only iOS job, or failing that a cheap lint for macOS-only APIs in shared Swift outside `#if os(macOS)`. Filed separately; the `deps_ios` prerequisite makes it non-trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)