### PR TITLE
Tests: cover the selection-driven OBJPANEL feedback overflow (#231)

### DIFF
--- a/testing/tests/test_appkit_objpanel_poll.py
+++ b/testing/tests/test_appkit_objpanel_poll.py
@@ -10,6 +10,12 @@ list) and the prefix-less continuation leaked into the console every poll tick.
 poll_panel() must therefore keep the payload OFF the feedback line: write the
 full JSON to a temp file and print only a short constant marker, exactly as
 poll() / OBJDETAIL:ready already does for the rep-detail payload.
+
+Object count is only one way to cross the cap. The session that forced the 1.8.1
+hotfix held just 12 objects but 48 long-named chain selections; the payload
+carries one `sel_counts` entry per selection, so selection count and name length
+inflate it just as fast (3578 bytes measured, 3.5x the cap). Both paths are
+covered below.
 """
 
 import contextlib
@@ -40,6 +46,32 @@ class TestObjPanelPoll(testing.PyMOLTestCase):
         self.assertEqual(cmd.count_states(base), nstates)
         cmd.split_states(base)
         return base
+
+    # Per-chain selection labels in the style of the hotfix session's binder
+    # designs, paired with a cheap expression that makes each count distinct.
+    DESIGN_CHAINS = (
+        ('IL18Ralpha', 'resi 1-2'),
+        ('IL18BPmimic', 'resi 3-4'),
+        ('binderChainB', 'resi 5-6'),
+        ('epitopeHotspot', 'name CA'),
+    )
+
+    def _design_session(self, nobj=12):
+        """Mirror the session that forced the 1.8.1 hotfix: a dozen binder-design
+        complexes — well under the object-count threshold, and no split_states —
+        each carrying several long-named chain selections (`s26_r3d28_il18_IL18Ralpha`
+        and friends), so the payload crosses the cap through selections instead."""
+        cmd.delete('all')
+        objs, sels = [], []
+        for i in range(nobj):
+            obj = 's%02d_r3d28_il18' % (15 + i)
+            cmd.fab('ACDEFG', obj)
+            objs.append(obj)
+            for chain, expr in self.DESIGN_CHAINS:
+                sel = '%s_%s' % (obj, chain)
+                cmd.select(sel, '%s and (%s)' % (obj, expr), quiet=1)
+                sels.append(sel)
+        return objs, sels
 
     def _poll(self):
         """Run poll_panel(), returning (printed_lines, payload_from_temp_file)."""
@@ -93,6 +125,40 @@ class TestObjPanelPoll(testing.PyMOLTestCase):
                          cmd.count_atoms('mysele'))
         self.assertIn('%s_0001' % base, payload['enabled'])
         self.assertNotIn('%s_0002' % base, payload['enabled'])
+
+    def testMarkerStaysUnderFeedbackCapWithManySelections(self):
+        # The 1.8.1 path: few objects, but `sel_counts` + `selections` carry 48
+        # ~25-char names. The marker must be immune to that too.
+        objs, sels = self._design_session()
+        self.assertLess(len(objs), 16,
+                        'object count alone must stay under the old threshold, '
+                        'so only the selection path can overflow here')
+        self.assertEqual(len(sels), 48, 'fixture must match the hotfix session')
+
+        lines, payload = self._poll()
+
+        # Exactly what the pre-#231 code would have put on the feedback line.
+        inline = 'OBJPANEL:' + json.dumps(payload)
+        self.assertGreater(len(inline), ORTHO_LINE_LENGTH,
+                           'selection-heavy payload must cross the cap, else '
+                           'this test proves nothing')
+
+        self.assertEqual(lines, ['OBJPANEL:ready'])
+        for ln in lines:
+            self.assertLess(len(ln), ORTHO_LINE_LENGTH)
+
+    def testPayloadIsCompleteForEveryChainSelection(self):
+        # Truncation used to drop the whole update; the file payload must carry
+        # every object AND every selection the panel needs to render.
+        objs, sels = self._design_session()
+
+        _, payload = self._poll()
+
+        self.assertEqual(sorted(payload['objects']), sorted(objs))
+        self.assertEqual(sorted(payload['selections']), sorted(sels))
+        for sel in sels:
+            self.assertEqual(payload['sel_counts'][sel], cmd.count_atoms(sel))
+            self.assertGreater(payload['sel_counts'][sel], 0)
 
     def testMarkerLengthDoesNotGrowWithObjectCount(self):
         # Constant-length marker is the property that makes the panel immune to


### PR DESCRIPTION
## Why

Every existing test in `testing/tests/test_appkit_objpanel_poll.py` crosses the old ~1KB `OrthoLineLength` cap by **object count** — `_split_ensemble()` creates 20 split-state objects.

The real-world session that forced the **1.8.1 hotfix** crossed it a different way: only **12 objects**, but **48 long-named chain selections** (e.g. `s26_r3d28_il18_IL18Ralpha`). The payload carries one `sel_counts` entry per selection, so selection count and name length inflate it just as fast as extra objects do — 3578 bytes measured in that session, 3.5x the cap. That path had no coverage.

## What

- `_design_session()` — a dozen cheap `cmd.fab` complexes, four ~25-char chain selections each, **no `split_states`**. Follows the existing `_split_ensemble()` / `_poll()` conventions.
- `testMarkerStaysUnderFeedbackCapWithManySelections` — `poll_panel()` prints exactly `['OBJPANEL:ready']`, every line under 1024. Guards that object count stays *below* the old threshold, so only the selection path can overflow.
- `testPayloadIsCompleteForEveryChainSelection` — the temp-file payload carries all 12 objects and all 48 selections, with `sel_counts[sel] == cmd.count_atoms(sel)`.

## Verification

The fix is already in place, so a new test that only ever passes would prove nothing. Both tests were run against deliberate reverts to confirm they can fail:

| Break applied to `poll_panel()` | Result |
|---|---|
| Reverted to pre-#231 inline `print('OBJPANEL:' + json.dumps(payload))` | Marker test **FAILED** — fixture emits one **4244-byte** line, **4.1x** the cap, from 12 objects with no `split_states` |
| Truncated payload selection list to `[:8]` | Completeness test **FAILED**, while the existing `testPayloadCarriesSelectionsAndEnabledState` **passed** (it creates only one selection, inside the truncation window) — the coverage gap this closes |

With production restored: **6/6** in this file, **89 passed / 0 failed** across all `test_appkit_*.py` + `test_metal_pick.py`. `git diff` on `modules/pymol/appkit_inspector.py` is empty.

```bash
.venv/bin/pymol -ckqy testing/testing.py --run testing/tests/test_appkit_objpanel_poll.py
```

> **Note for reviewers:** the venv's `pymol/*.py` layer is symlinked to whichever worktree was last built, so that command alone can silently exercise a different tree. Verify `pymol.appkit_inserted`… i.e. check `os.path.realpath(pymol.appkit_inspector.__file__)` resolves to the tree under review before trusting a run.

Test-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)