### PR TITLE
fix(release): make_dmg.sh must skip mlx package-plugin validation

### DIFF
--- a/swiftui/make_dmg.sh
+++ b/swiftui/make_dmg.sh
@@ -120,9 +120,17 @@ fi
 rm -rf "$RELEASE_DD/Build"
 XCLOG="$LOGDIR/xcodebuild-release.log"
 echo "  (full xcodebuild output → $XCLOG)"
+# -skipPackagePluginValidation / -skipMacroValidation: MPNNKit (Design mode, new
+# in 1.9.0) pulls in mlx-swift, which ships a "CudaBuild" package plug-in. Xcode
+# refuses to run an unvalidated plug-in in a non-interactive build, so without
+# these the Release build dies at "Validate plug-in CudaBuild in package
+# mlx-swift" — which is exactly how the first 1.9.0 DMG attempt failed. Every
+# Design-mode dev/test command already passes both; this is the release path
+# catching up.
 if ! xcodebuild -project "$SWIFTUI/PyMOLViewer.xcodeproj" -scheme PyMOLViewer_macOS \
   -configuration Release -destination 'platform=macOS,arch=arm64' \
   -derivedDataPath "$RELEASE_DD" \
+  -skipPackagePluginValidation -skipMacroValidation \
   CODE_SIGNING_ALLOWED=NO clean build >"$XCLOG" 2>&1; then
   echo "ERROR: Release build failed. Last 60 lines of $XCLOG:"; tail -60 "$XCLOG"; exit 1
 fi


### PR DESCRIPTION
Blocks the 1.9.0 DMG. Caught while cutting the release.

## Failure

```
Validate plug-in "CudaBuild" in package "mlx-swift"
** BUILD FAILED **
```

MPNNKit (Design mode, #217) pulls in **mlx-swift**, which ships a `CudaBuild` package plug-in. Xcode won't run an unvalidated package plug-in in a non-interactive build, so `make_dmg.sh`'s Release `xcodebuild` dies on it.

This isn't a regression in 1.9.0 — it's latent. The release path has been missing the flag since mlx entered the dependency graph; **1.9.0 is just the first release cut since then**. Every Design-mode dev/test command in `docs/superpowers/plans/` already passes `-skipPackagePluginValidation` (most also `-skipMacroValidation`); only `make_dmg.sh` never got them.

## Fix

Add `-skipPackagePluginValidation -skipMacroValidation` to the Release `xcodebuild` in `make_dmg.sh`, with a comment explaining why so it isn't "cleaned up" later.

## Blast radius

Build tooling only — no app source, so the shipped bits are unchanged. The failure lands ~2 minutes in, well before signing and notarization, so a hit costs nothing but a restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)