### PR TITLE
Point Slack badge to the community channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # RayMol
 
-[![Join Slack](https://img.shields.io/badge/Slack-Join_Community-4A154B?logo=slack&logoColor=white)](https://raymol-slack-invite-production.up.railway.app)
+[![Join Slack](https://img.shields.io/badge/Slack-Join_Community-4A154B?logo=slack&logoColor=white)](https://raymol.slack.com/archives/C0BE58D4E7P)
 
 **RayMol** is a native **macOS · iPad · iPhone** reimagining of the
 [PyMOL](https://pymol.org) molecular visualization system — a SwiftUI front end


### PR DESCRIPTION
## Summary

Updates the README Community / Join Slack badge to point directly at the RayMol Slack channel:

**https://raymol.slack.com/archives/C0BE58D4E7P**

### Changes

- **README.md**: Slack badge now links to the channel instead of the old Railway invite.
- **Website (raymol.io)**: The same three links need updating in the landing-page source (header “Community” tab, hero “Join Community →” button, and footer “Join Slack”). Those files are not part of this repository and will need a separate update.

### Why

Gives existing workspace members a direct path into the active community channel rather than an intermediate invite page.

### Notes

- The channel deep-link works best for people already in the workspace. If open invites are still desired, the Railway invite can remain available separately.
- No functional or code changes beyond the README URL.

### Validation

- Confirmed the old Railway invite no longer appears in the tracked repository source.
- `git diff --check` passed.

