### PR TITLE
Fix #219: skip transparency probes for non-molecular objects

### DIFF
--- a/modules/pymol/appkit_inspector.py
+++ b/modules/pymol/appkit_inspector.py
@@ -171,6 +171,13 @@ def transp_summary(obj):
     no atom-level override exists (it never returns None here), so comparing the
     effective range to the object-level value is what detects a genuine override.
     """
+    # Measurement, CGO, map, and other non-molecular objects are not atom
+    # selections. Passing their names to iterate emits a Selector-Error before
+    # Python can catch the exception, which floods the native app's feedback log
+    # on every object-panel poll. They cannot carry per-atom overrides anyway.
+    if cmd.get_type(obj) != 'object:molecule':
+        return {}
+
     objlv = {s: _num(s, obj) for s in TRANSP_SETTINGS}
     mn = {s: None for s in TRANSP_SETTINGS}
     mx = {s: None for s in TRANSP_SETTINGS}

--- a/testing/tests/test_appkit_objpanel_poll.py
+++ b/testing/tests/test_appkit_objpanel_poll.py
@@ -23,8 +23,9 @@ import io
 import json
 import os
 import tempfile
+from unittest.mock import patch
 
-from pymol import cmd, testing
+from pymol import cgo, cmd, testing
 from pymol import appkit_inspector as ai
 
 # layer0/PyMOLGlobals.h: OrthoLineLength — the per-line feedback cap that the
@@ -72,6 +73,21 @@ class TestObjPanelPoll(testing.PyMOLTestCase):
                 cmd.select(sel, '%s and (%s)' % (obj, expr), quiet=1)
                 sels.append(sel)
         return objs, sels
+
+    def _mixed_object_session(self):
+        """Create one molecule plus the non-molecular object kinds from #219."""
+        cmd.delete('all')
+        cmd.fragment('gly', 'mol')
+        atoms = ['mol and index %d' % i for i in range(1, 5)]
+        cmd.distance('dist01', *atoms[:2])
+        cmd.angle('ang01', *atoms[:3])
+        cmd.dihedral('dih01', *atoms[:4])
+        cmd.load_cgo([cgo.STOP], 'cgo01')
+        non_molecules = ['dist01', 'ang01', 'dih01', 'cgo01']
+        self.assertEqual(cmd.get_type('mol'), 'object:molecule')
+        for name in non_molecules:
+            self.assertNotEqual(cmd.get_type(name), 'object:molecule')
+        return non_molecules
 
     def _poll(self):
         """Run poll_panel(), returning (printed_lines, payload_from_temp_file)."""
@@ -171,3 +187,20 @@ class TestObjPanelPoll(testing.PyMOLTestCase):
         large, _ = self._poll()
 
         self.assertEqual(small, large)
+
+    def testTransparencyInspectionSkipsNonMolecularObjects(self):
+        non_molecules = self._mixed_object_session()
+
+        # poll_panel() drives collapsed-row badges; _build() is the independent
+        # expanded-card path. Across both paths only the molecule may be treated
+        # as an atom selection by the transparency inspector.
+        with patch.object(ai.cmd, 'iterate', wraps=ai.cmd.iterate) as iterate:
+            _, payload = self._poll()
+            detail = ai._build(non_molecules)['detail']
+
+        inspected = [call.args[0] for call in iterate.call_args_list]
+        self.assertEqual(inspected, ['mol'])
+        for name in non_molecules:
+            self.assertIn(name, payload['has_transp'])
+            self.assertFalse(payload['has_transp'][name])
+            self.assertEqual(detail[name], [])


### PR DESCRIPTION
## Summary

- Skip per-atom transparency inspection for measurement, CGO, and other non-molecular objects.
- Apply the guard centrally so it covers both periodic object-panel polling and expanded object cards.
- Preserve `has_transp` entries as `false` for non-molecular objects.
- Add focused regression coverage for molecule, distance, angle, dihedral, and CGO objects.

## Problem

The object panel probes every public object for per-atom transparency. `transp_summary()` passed each object name to `cmd.iterate()`, which treats the name as an atom selection. Measurement and other non-molecular object names are not valid atom selections, so the selector wrote an error to the feedback log before the Python exception handler could suppress it. Because the panel polls repeatedly, this flooded the console.

## Solution

Return an empty transparency summary when `cmd.get_type(obj)` is not `object:molecule`. Non-molecular objects cannot carry per-atom transparency overrides, and placing the guard in `transp_summary()` protects both the collapsed-row polling path and the independently reachable expanded-card path.

The regression test builds a mixed session and verifies that only the molecular object reaches `cmd.iterate()`. It also checks that non-molecular objects retain false transparency flags and empty expanded-card details.

## Testing

- PASS: `git diff --check`
- PASS: changed-file secret-pattern scan
- NOT RUN: focused PyMOL object-panel tests; no reviewed compatible isolated runner was available.
- NOT RUN: broader PyMOL test suite.
- NOT RUN: macOS and iOS Xcode builds.
- NOT RUN: native smoke verification across repeated poll intervals and expanded object cards.

Runtime behavior therefore still needs verification in a reviewed isolated macOS environment.

Fixes #219
