### PR TITLE
Prototype a mobile-first mutagenesis wizard UI

### DIFF
--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -12,6 +12,11 @@
 		0C0E67D9436CC6DF29DE983C /* DesignEditingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05E6ECE945556A6D1FAE98F9 /* DesignEditingTests.swift */; };
 		0F6C6BD0DB9B077E51D1EFAF /* WhatsNewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5377EE69A856479317FD61 /* WhatsNewModel.swift */; };
 		0FFCBEB460CD541E932326AB /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3E805AC2D63B01AB7EE29C /* Theme.swift */; };
+		A13600000000000000000011 /* MutagenesisWizardContract.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13600000000000000000001 /* MutagenesisWizardContract.swift */; };
+		A13600000000000000000012 /* MutagenesisWizardContract.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13600000000000000000001 /* MutagenesisWizardContract.swift */; };
+		A13600000000000000000013 /* MutagenesisWizardPrototype.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13600000000000000000002 /* MutagenesisWizardPrototype.swift */; };
+		A13600000000000000000014 /* MutagenesisWizardPrototype.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13600000000000000000002 /* MutagenesisWizardPrototype.swift */; };
+		A13600000000000000000015 /* MutagenesisWizardContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13600000000000000000003 /* MutagenesisWizardContractTests.swift */; };
 		104B27F848D308735A6D6DD2 /* MetalViewport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E9F8D36908E3216D1C8F893 /* MetalViewport.swift */; };
 		13B48E7F8C2A51ADAF48F4C3 /* SequencePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474D18A43D0D9A6BDD69EEFD /* SequencePanel.swift */; };
 		13E8687216067D92666E3078 /* openssl-PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = CB0108E0FA1F204BE0E41F0D /* openssl-PrivacyInfo.xcprivacy */; };
@@ -190,6 +195,9 @@
 		99E8403E056CB6DA5DD9A3CA /* PyMOLViewerUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = PyMOLViewerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A2CE99D9A3C57ACBBDBF3B5 /* DesignRegionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignRegionTests.swift; sourceTree = "<group>"; };
 		A4D170B35BCCF683A6B3D655 /* WhatsNewModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewModal.swift; sourceTree = "<group>"; };
+		A13600000000000000000001 /* MutagenesisWizardContract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutagenesisWizardContract.swift; sourceTree = "<group>"; };
+		A13600000000000000000002 /* MutagenesisWizardPrototype.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutagenesisWizardPrototype.swift; sourceTree = "<group>"; };
+		A13600000000000000000003 /* MutagenesisWizardContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutagenesisWizardContractTests.swift; sourceTree = "<group>"; };
 		A63406B360384F3C62E511E1 /* RayMolPython.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RayMolPython.entitlements; sourceTree = "<group>"; };
 		A73267D4D7B506E647B7A995 /* ObjectPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectPanel.swift; sourceTree = "<group>"; };
 		AA4C108E3D04FD75288859DA /* GizmoOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GizmoOverlay.swift; sourceTree = "<group>"; };
@@ -251,6 +259,7 @@
 				B9EC978B16F58D988575E206 /* MCPDrivingBanner.swift */,
 				FB1304C662D9011F7C4505FC /* MCPStatusView.swift */,
 				221117550FAD97CF81924E05 /* MousePanel.swift */,
+				A13600000000000000000002 /* MutagenesisWizardPrototype.swift */,
 				0ED5BFF3FEE9D6621BB40AE5 /* MovieBuilderSheet.swift */,
 				8FE79EC8844C681A41A1E54A /* MovieExportSheet.swift */,
 				A73267D4D7B506E647B7A995 /* ObjectPanel.swift */,
@@ -334,6 +343,7 @@
 				14F3D56C490BC7C6166DD79F /* MCPServerManager.swift */,
 				5E9F8D36908E3216D1C8F893 /* MetalViewport.swift */,
 				56BE219EF1CF1EB2B05E44AD /* MPNNGate.swift */,
+				A13600000000000000000001 /* MutagenesisWizardContract.swift */,
 				D965CB609C447033E5DB0046 /* PyMOLApp.swift */,
 				33D6A753E4525628B96C259C /* PyMOLEngine.swift */,
 				9371B6FFB30D6166234C678B /* RayMolMain.swift */,
@@ -360,6 +370,7 @@
 				48EDC39F7E7F250CFC4F7D0D /* DesignResiduesTests.swift */,
 				D0BCB2A867C3554FB56A7299 /* DesignScoreCacheTests.swift */,
 				F43E4051E6410834AAAA4047 /* InteractionModeExitTests.swift */,
+				A13600000000000000000003 /* MutagenesisWizardContractTests.swift */,
 				4A2C1E1633D1E93E9914BEC3 /* OpenFilesTests.swift */,
 				55F4F52D951CF1F96606F41C /* SmokeTests.swift */,
 			);
@@ -1040,6 +1051,7 @@
 				52B5620BEF26DEB8E3A700C1 /* DesignResiduesTests.swift in Sources */,
 				6EAC8947F66B8D7AD29BF3B8 /* DesignScoreCacheTests.swift in Sources */,
 				57E2333020DE9DC8910BDC3E /* InteractionModeExitTests.swift in Sources */,
+				A13600000000000000000015 /* MutagenesisWizardContractTests.swift in Sources */,
 				C89E138879C40C8FB6C0478A /* OpenFilesTests.swift in Sources */,
 				5CAB662574D238626A8F4D68 /* SmokeTests.swift in Sources */,
 			);
@@ -1062,6 +1074,8 @@
 				77947569BB49AFA9845B7283 /* MCPDrivingBanner.swift in Sources */,
 				64DDBC57197D8C3A9AB0B68D /* MCPServerManager.swift in Sources */,
 				90F5E063444FBF4FF3770118 /* MCPStatusView.swift in Sources */,
+				A13600000000000000000011 /* MutagenesisWizardContract.swift in Sources */,
+				A13600000000000000000013 /* MutagenesisWizardPrototype.swift in Sources */,
 				CE1CC588AA02F7FE11A0048B /* MPNNGate.swift in Sources */,
 				104B27F848D308735A6D6DD2 /* MetalViewport.swift in Sources */,
 				5313FFF152E5D3F23159919B /* MousePanel.swift in Sources */,
@@ -1102,6 +1116,8 @@
 				F4B0ED522742FC38BFD36368 /* MCPDrivingBanner.swift in Sources */,
 				3ECB633FC33E73F4767D3AF5 /* MCPServerManager.swift in Sources */,
 				DE0E67FF8DD0D44121F1B386 /* MCPStatusView.swift in Sources */,
+				A13600000000000000000012 /* MutagenesisWizardContract.swift in Sources */,
+				A13600000000000000000014 /* MutagenesisWizardPrototype.swift in Sources */,
 				1624BC38CDD73398C68FC135 /* MPNNGate.swift in Sources */,
 				979AB10150CC62EE5E7962F9 /* MetalViewport.swift in Sources */,
 				F619DEB3EA3D691634AE8268 /* MousePanel.swift in Sources */,

--- a/swiftui/PyMOLViewer/Panels/MutagenesisWizardPrototype.md
+++ b/swiftui/PyMOLViewer/Panels/MutagenesisWizardPrototype.md
@@ -1,0 +1,32 @@
+# Mutagenesis wizard prototype
+
+This first milestone defines the mobile-first interaction model without choosing
+an app presentation location or sending commands to PyMOL. Maintainer review of
+the prototype should decide whether it belongs in a sheet, inspector, or
+dedicated compact-width screen before live integration begins.
+
+## Responsive layout
+
+- Below 560 points, controls stack vertically: residue mode, selected residue,
+  rotamer list, then the persistent Clear, Done, and Apply action bar.
+- At 560 points and wider, residue mode and selected-residue context occupy a
+  220-point leading column while the rotamer list uses the remaining width.
+- Both layouts use the same state and action contract and do not depend on
+  PyMOL's `internal_gui`.
+
+## State contract
+
+- `inactive`: no wizard controls or commands are available.
+- `awaitingResidue`: mode selection and lifecycle actions are available while
+  the panel asks the user to pick a residue.
+- `loading`: the selected residue is visible; mode, rotamer, and Apply actions
+  are disabled while Clear and Done remain available.
+- `ready`: rotamers are listed; Apply becomes available only after a valid
+  rotamer is selected. Changing residue mode clears a stale rotamer selection.
+- `failed`: the error is visible; Apply remains disabled and Clear/Done provide
+  recovery paths.
+
+`MutagenesisWizardAction` describes mode and rotamer selection plus Apply,
+Clear, and Done. The prototype controller forwards enabled actions to an
+injected sink for tests, but this milestone intentionally provides no live sink,
+bridge calls, or structure mutation.

--- a/swiftui/PyMOLViewer/Panels/MutagenesisWizardPrototype.swift
+++ b/swiftui/PyMOLViewer/Panels/MutagenesisWizardPrototype.swift
@@ -1,0 +1,245 @@
+// MutagenesisWizardPrototype.swift — non-destructive, mock-backed interaction
+// prototype for issue #136. This view is intentionally not wired into
+// ContentView until maintainers approve its presentation location.
+
+import SwiftUI
+
+struct MutagenesisWizardPrototype: View {
+    @ObservedObject var controller: MutagenesisWizardPrototypeController
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+
+            if controller.state.isActive {
+                GeometryReader { proxy in
+                    ScrollView {
+                        // Compact width stacks the mode and rotamers for a phone-sized
+                        // surface. Regular width keeps mode/status in a fixed leading
+                        // column and gives the rotamer list the remaining space.
+                        if MutagenesisWizardLayoutClass.resolve(
+                            availableWidth: Double(proxy.size.width)
+                        ) == .compact {
+                            VStack(alignment: .leading, spacing: 18) {
+                                modeSection
+                                detailSection
+                            }
+                            .padding(16)
+                        } else {
+                            HStack(alignment: .top, spacing: 24) {
+                                modeSection.frame(width: 220, alignment: .topLeading)
+                                Divider()
+                                detailSection.frame(maxWidth: .infinity, alignment: .topLeading)
+                            }
+                            .padding(20)
+                        }
+                    }
+                }
+                Divider()
+                actionBar
+            } else {
+                inactiveContent
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .background(Color.gray.opacity(0.06))
+        .accessibilityIdentifier("mutagenesis-wizard-prototype")
+    }
+
+    private var header: some View {
+        HStack(spacing: 9) {
+            Image(systemName: "wand.and.stars")
+                .foregroundStyle(.tint)
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Mutagenesis")
+                    .font(.headline)
+                Text("Select a residue mode and preview a rotamer")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    private var modeSection: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            sectionLabel("Residue mode")
+            Picker("Residue mode", selection: selectedModeBinding) {
+                ForEach(controller.state.residueModes) { mode in
+                    Text(mode.label).tag(mode.id)
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .disabled(!controller.state.commandAvailability.canSelectMode)
+            .accessibilityIdentifier("mutagenesis-residue-mode")
+
+            if let residue = controller.state.residue {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Selected residue")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(residue.displayName)
+                        .font(.body.weight(.semibold))
+                    Text(residue.objectName)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.top, 8)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private var detailSection: some View {
+        switch controller.state.phase {
+        case .inactive:
+            EmptyView()
+        case .awaitingResidue:
+            statusCard(
+                title: "Pick a residue",
+                message: "Select a residue in the molecular viewport to load its rotamers.",
+                systemImage: "scope"
+            )
+        case .loading(let residue):
+            HStack(spacing: 12) {
+                ProgressView()
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Loading rotamers…").font(.body.weight(.semibold))
+                    Text(residue.displayName).font(.caption).foregroundStyle(.secondary)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(16)
+            .background(RoundedRectangle(cornerRadius: 12).fill(Color.gray.opacity(0.1)))
+        case .ready(_, let rotamers):
+            VStack(alignment: .leading, spacing: 10) {
+                sectionLabel("Rotamers")
+                if rotamers.isEmpty {
+                    statusCard(
+                        title: "No rotamers available",
+                        message: "Choose another residue mode or clear the residue selection.",
+                        systemImage: "exclamationmark.circle"
+                    )
+                } else {
+                    ForEach(rotamers) { rotamer in
+                        rotamerRow(rotamer)
+                    }
+                }
+            }
+        case .failed(let message):
+            statusCard(
+                title: "Unable to load rotamers",
+                message: message,
+                systemImage: "exclamationmark.triangle"
+            )
+        }
+    }
+
+    private func rotamerRow(_ rotamer: MutagenesisRotamer) -> some View {
+        let selected = controller.state.selectedRotamerID == rotamer.id
+        return Button {
+            controller.send(.selectRotamer(rotamer.id))
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: selected ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(selected ? Color.accentColor : Color.secondary)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(rotamer.name).font(.body.weight(.medium))
+                    Text("\(rotamer.probability, format: .percent.precision(.fractionLength(0))) probability")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Text("Clash \(rotamer.clashScore, format: .number.precision(.fractionLength(1)))")
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+            .padding(12)
+            .contentShape(Rectangle())
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(selected ? Color.accentColor.opacity(0.12) : Color.gray.opacity(0.08))
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(!controller.state.commandAvailability.canSelectRotamer)
+        .accessibilityIdentifier("mutagenesis-\(rotamer.id)")
+    }
+
+    private var actionBar: some View {
+        let availability = controller.state.commandAvailability
+        return HStack(spacing: 10) {
+            Button("Clear") { controller.send(.clear) }
+                .disabled(!availability.canClear)
+                .accessibilityIdentifier("mutagenesis-clear")
+            Button("Done") { controller.send(.done) }
+                .disabled(!availability.canDone)
+                .accessibilityIdentifier("mutagenesis-done")
+            Spacer()
+            Button("Apply") { controller.send(.apply) }
+                .buttonStyle(.borderedProminent)
+                .disabled(!availability.canApply)
+                .accessibilityIdentifier("mutagenesis-apply")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    private var inactiveContent: some View {
+        statusCard(
+            title: "No active Mutagenesis wizard",
+            message: "Start Mutagenesis to display residue modes, rotamers, and actions here.",
+            systemImage: "wand.and.stars.inverse"
+        )
+        .padding(20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+
+    private var selectedModeBinding: Binding<String> {
+        Binding(
+            get: { controller.state.selectedModeID ?? "" },
+            set: { controller.send(.selectMode($0)) }
+        )
+    }
+
+    private func sectionLabel(_ title: String) -> some View {
+        Text(title.uppercased())
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.secondary)
+    }
+
+    private func statusCard(title: String, message: String, systemImage: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: systemImage)
+                .font(.title3)
+                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title).font(.body.weight(.semibold))
+                Text(message).font(.callout).foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .background(RoundedRectangle(cornerRadius: 12).fill(Color.gray.opacity(0.1)))
+    }
+}
+
+#Preview("Compact") {
+    MutagenesisWizardPrototype(
+        controller: MutagenesisWizardPrototypeController(state: .prototype)
+    )
+    .frame(width: 360, height: 620)
+}
+
+#Preview("Regular") {
+    MutagenesisWizardPrototype(
+        controller: MutagenesisWizardPrototypeController(state: .prototype)
+    )
+    .frame(width: 720, height: 440)
+}

--- a/swiftui/PyMOLViewer/Shared/MutagenesisWizardContract.swift
+++ b/swiftui/PyMOLViewer/Shared/MutagenesisWizardContract.swift
@@ -1,0 +1,200 @@
+// MutagenesisWizardContract.swift — platform-neutral state/action contract for
+// the native Mutagenesis wizard prototype.
+//
+// This milestone deliberately contains no PyMOL bridge calls. A later milestone
+// can adapt live wizard data to this contract after the presentation and
+// interaction model have maintainer approval.
+
+import Foundation
+import Combine
+
+struct MutagenesisResidueMode: Identifiable, Equatable {
+    let id: String
+    let label: String
+}
+
+struct MutagenesisResidue: Equatable {
+    let objectName: String
+    let chain: String
+    let name: String
+    let number: String
+
+    var displayName: String {
+        let chainPrefix = chain.isEmpty ? "" : "\(chain)/"
+        return "\(name) \(chainPrefix)\(number)"
+    }
+}
+
+struct MutagenesisRotamer: Identifiable, Equatable {
+    let id: String
+    let name: String
+    let probability: Double
+    let clashScore: Double
+}
+
+/// Lifecycle states exposed by a future PyMOL adapter.
+///
+/// `awaitingResidue` is an active wizard with no picked residue. `loading`
+/// separates an asynchronous refresh from a populated result, while `failed`
+/// keeps recovery controls available without inventing live command behavior.
+enum MutagenesisWizardPhase: Equatable {
+    case inactive
+    case awaitingResidue
+    case loading(residue: MutagenesisResidue)
+    case ready(residue: MutagenesisResidue, rotamers: [MutagenesisRotamer])
+    case failed(message: String)
+}
+
+enum MutagenesisWizardAction: Equatable {
+    case selectMode(String)
+    case selectRotamer(String)
+    case apply
+    case clear
+    case done
+}
+
+struct MutagenesisWizardCommandAvailability: Equatable {
+    let canSelectMode: Bool
+    let canSelectRotamer: Bool
+    let canApply: Bool
+    let canClear: Bool
+    let canDone: Bool
+}
+
+/// Presentation policy shared by every Apple platform. A phone-sized or narrow
+/// split-view surface stacks the controls; wider inspectors use two columns.
+enum MutagenesisWizardLayoutClass: Equatable {
+    case compact
+    case regular
+
+    static func resolve(availableWidth: Double) -> Self {
+        availableWidth < 560 ? .compact : .regular
+    }
+}
+
+struct MutagenesisWizardState: Equatable {
+    var phase: MutagenesisWizardPhase
+    var residueModes: [MutagenesisResidueMode]
+    var selectedModeID: String?
+    var selectedRotamerID: String?
+
+    var isActive: Bool {
+        if case .inactive = phase { return false }
+        return true
+    }
+
+    var residue: MutagenesisResidue? {
+        switch phase {
+        case .loading(let residue), .ready(let residue, _): return residue
+        case .inactive, .awaitingResidue, .failed: return nil
+        }
+    }
+
+    var rotamers: [MutagenesisRotamer] {
+        if case .ready(_, let rotamers) = phase { return rotamers }
+        return []
+    }
+
+    var errorMessage: String? {
+        if case .failed(let message) = phase { return message }
+        return nil
+    }
+
+    var commandAvailability: MutagenesisWizardCommandAvailability {
+        let ready: Bool
+        if case .ready = phase { ready = true } else { ready = false }
+        let hasValidRotamer = rotamers.contains { $0.id == selectedRotamerID }
+        return MutagenesisWizardCommandAvailability(
+            canSelectMode: isActive && !isLoading,
+            canSelectRotamer: ready && !rotamers.isEmpty,
+            canApply: ready && hasValidRotamer,
+            canClear: isActive,
+            canDone: isActive
+        )
+    }
+
+    private var isLoading: Bool {
+        if case .loading = phase { return true }
+        return false
+    }
+
+    /// Applies only prototype-local selection/lifecycle changes. The action is
+    /// still forwarded to the injected sink, but no structural mutation or
+    /// PyMOL command is performed in this milestone.
+    mutating func applyPrototypeAction(_ action: MutagenesisWizardAction) {
+        switch action {
+        case .selectMode(let id):
+            guard commandAvailability.canSelectMode,
+                  residueModes.contains(where: { $0.id == id }) else { return }
+            selectedModeID = id
+            selectedRotamerID = nil
+        case .selectRotamer(let id):
+            guard commandAvailability.canSelectRotamer,
+                  rotamers.contains(where: { $0.id == id }) else { return }
+            selectedRotamerID = id
+        case .apply:
+            break
+        case .clear:
+            guard commandAvailability.canClear else { return }
+            phase = .awaitingResidue
+            selectedRotamerID = nil
+        case .done:
+            guard commandAvailability.canDone else { return }
+            phase = .inactive
+            selectedRotamerID = nil
+        }
+    }
+}
+
+final class MutagenesisWizardPrototypeController: ObservableObject {
+    @Published private(set) var state: MutagenesisWizardState
+    private let actionSink: (MutagenesisWizardAction) -> Void
+
+    init(
+        state: MutagenesisWizardState,
+        actionSink: @escaping (MutagenesisWizardAction) -> Void = { _ in }
+    ) {
+        self.state = state
+        self.actionSink = actionSink
+    }
+
+    func send(_ action: MutagenesisWizardAction) {
+        let before = state
+        state.applyPrototypeAction(action)
+
+        // Invalid or unavailable selections are not forwarded as commands.
+        if case .selectMode = action, state == before { return }
+        if case .selectRotamer = action, state == before { return }
+        if action == .apply && !before.commandAvailability.canApply { return }
+        if action == .clear && !before.commandAvailability.canClear { return }
+        if action == .done && !before.commandAvailability.canDone { return }
+        actionSink(action)
+    }
+}
+
+extension MutagenesisWizardState {
+    /// Mock data used only by the SwiftUI prototype and Xcode previews.
+    static let prototype = MutagenesisWizardState(
+        phase: .ready(
+            residue: MutagenesisResidue(
+                objectName: "6f8p",
+                chain: "A",
+                name: "ARG",
+                number: "159"
+            ),
+            rotamers: [
+                MutagenesisRotamer(id: "rotamer-1", name: "Rotamer 1", probability: 0.42, clashScore: 0.8),
+                MutagenesisRotamer(id: "rotamer-2", name: "Rotamer 2", probability: 0.31, clashScore: 1.4),
+                MutagenesisRotamer(id: "rotamer-3", name: "Rotamer 3", probability: 0.17, clashScore: 2.1)
+            ]
+        ),
+        residueModes: [
+            MutagenesisResidueMode(id: "current", label: "No mutation"),
+            MutagenesisResidueMode(id: "ALA", label: "Alanine (ALA)"),
+            MutagenesisResidueMode(id: "GLY", label: "Glycine (GLY)"),
+            MutagenesisResidueMode(id: "LYS", label: "Lysine (LYS)")
+        ],
+        selectedModeID: "ALA",
+        selectedRotamerID: "rotamer-1"
+    )
+}

--- a/swiftui/PyMOLViewerTests/MutagenesisWizardContractTests.swift
+++ b/swiftui/PyMOLViewerTests/MutagenesisWizardContractTests.swift
@@ -1,0 +1,166 @@
+import XCTest
+@testable import RayMol
+
+final class MutagenesisWizardContractTests: XCTestCase {
+    private let residue = MutagenesisResidue(
+        objectName: "6f8p",
+        chain: "A",
+        name: "ARG",
+        number: "159"
+    )
+    private let modes = [
+        MutagenesisResidueMode(id: "current", label: "No mutation"),
+        MutagenesisResidueMode(id: "ALA", label: "Alanine")
+    ]
+    private let rotamers = [
+        MutagenesisRotamer(id: "r1", name: "Rotamer 1", probability: 0.6, clashScore: 0.8),
+        MutagenesisRotamer(id: "r2", name: "Rotamer 2", probability: 0.4, clashScore: 1.2)
+    ]
+
+    private func state(
+        phase: MutagenesisWizardPhase,
+        selectedModeID: String? = "ALA",
+        selectedRotamerID: String? = nil
+    ) -> MutagenesisWizardState {
+        MutagenesisWizardState(
+            phase: phase,
+            residueModes: modes,
+            selectedModeID: selectedModeID,
+            selectedRotamerID: selectedRotamerID
+        )
+    }
+
+    func testInactiveStateHidesWizardDataAndDisablesCommands() {
+        let state = state(phase: .inactive)
+
+        XCTAssertFalse(state.isActive)
+        XCTAssertNil(state.residue)
+        XCTAssertTrue(state.rotamers.isEmpty)
+        XCTAssertEqual(
+            state.commandAvailability,
+            MutagenesisWizardCommandAvailability(
+                canSelectMode: false,
+                canSelectRotamer: false,
+                canApply: false,
+                canClear: false,
+                canDone: false
+            )
+        )
+    }
+
+    func testAwaitingResidueKeepsModeAndLifecycleActionsAvailable() {
+        let state = state(phase: .awaitingResidue)
+
+        XCTAssertTrue(state.isActive)
+        XCTAssertTrue(state.commandAvailability.canSelectMode)
+        XCTAssertFalse(state.commandAvailability.canSelectRotamer)
+        XCTAssertFalse(state.commandAvailability.canApply)
+        XCTAssertTrue(state.commandAvailability.canClear)
+        XCTAssertTrue(state.commandAvailability.canDone)
+    }
+
+    func testLoadingDisablesSelectionAndApplyButCanBeClearedOrClosed() {
+        let state = state(phase: .loading(residue: residue))
+
+        XCTAssertEqual(state.residue, residue)
+        XCTAssertFalse(state.commandAvailability.canSelectMode)
+        XCTAssertFalse(state.commandAvailability.canSelectRotamer)
+        XCTAssertFalse(state.commandAvailability.canApply)
+        XCTAssertTrue(state.commandAvailability.canClear)
+        XCTAssertTrue(state.commandAvailability.canDone)
+    }
+
+    func testReadyStateRequiresAValidRotamerBeforeApply() {
+        var state = state(phase: .ready(residue: residue, rotamers: rotamers))
+
+        XCTAssertEqual(state.rotamers, rotamers)
+        XCTAssertTrue(state.commandAvailability.canSelectRotamer)
+        XCTAssertFalse(state.commandAvailability.canApply)
+
+        state.applyPrototypeAction(.selectRotamer("r2"))
+
+        XCTAssertEqual(state.selectedRotamerID, "r2")
+        XCTAssertTrue(state.commandAvailability.canApply)
+    }
+
+    func testChangingModeClearsStaleRotamerSelection() {
+        var state = state(
+            phase: .ready(residue: residue, rotamers: rotamers),
+            selectedModeID: "ALA",
+            selectedRotamerID: "r1"
+        )
+
+        state.applyPrototypeAction(.selectMode("current"))
+
+        XCTAssertEqual(state.selectedModeID, "current")
+        XCTAssertNil(state.selectedRotamerID)
+        XCTAssertFalse(state.commandAvailability.canApply)
+    }
+
+    func testInvalidSelectionsAreIgnoredAndNotDispatched() {
+        var actions: [MutagenesisWizardAction] = []
+        let controller = MutagenesisWizardPrototypeController(
+            state: state(phase: .ready(residue: residue, rotamers: rotamers)),
+            actionSink: { actions.append($0) }
+        )
+
+        controller.send(.selectMode("NOT_A_MODE"))
+        controller.send(.selectRotamer("NOT_A_ROTAMER"))
+
+        XCTAssertEqual(controller.state.selectedModeID, "ALA")
+        XCTAssertNil(controller.state.selectedRotamerID)
+        XCTAssertTrue(actions.isEmpty)
+    }
+
+    func testActionSinkReceivesSelectionAndEnabledCommandsWithoutLiveMutation() {
+        var actions: [MutagenesisWizardAction] = []
+        let original = state(phase: .ready(residue: residue, rotamers: rotamers))
+        let controller = MutagenesisWizardPrototypeController(
+            state: original,
+            actionSink: { actions.append($0) }
+        )
+
+        controller.send(.selectRotamer("r1"))
+        controller.send(.apply)
+
+        XCTAssertEqual(actions, [.selectRotamer("r1"), .apply])
+        XCTAssertEqual(controller.state.phase, original.phase)
+        XCTAssertEqual(controller.state.selectedRotamerID, "r1")
+    }
+
+    func testClearAndDoneModelTheLocalLifecycle() {
+        var actions: [MutagenesisWizardAction] = []
+        let controller = MutagenesisWizardPrototypeController(
+            state: state(
+                phase: .ready(residue: residue, rotamers: rotamers),
+                selectedRotamerID: "r1"
+            ),
+            actionSink: { actions.append($0) }
+        )
+
+        controller.send(.clear)
+        XCTAssertEqual(controller.state.phase, .awaitingResidue)
+        XCTAssertNil(controller.state.selectedRotamerID)
+
+        controller.send(.done)
+        XCTAssertEqual(controller.state.phase, .inactive)
+        XCTAssertEqual(actions, [.clear, .done])
+    }
+
+    func testErrorStateExposesRecoveryWithoutApply() {
+        let state = state(phase: .failed(message: "Rotamer library unavailable"))
+
+        XCTAssertEqual(state.errorMessage, "Rotamer library unavailable")
+        XCTAssertFalse(state.commandAvailability.canSelectRotamer)
+        XCTAssertFalse(state.commandAvailability.canApply)
+        XCTAssertTrue(state.commandAvailability.canClear)
+        XCTAssertTrue(state.commandAvailability.canDone)
+    }
+
+    func testLayoutPolicyStacksNarrowSurfacesAndSplitsWideSurfaces() {
+        XCTAssertEqual(MutagenesisWizardLayoutClass.resolve(availableWidth: 359), .compact)
+        XCTAssertEqual(MutagenesisWizardLayoutClass.resolve(availableWidth: 559), .compact)
+        XCTAssertEqual(MutagenesisWizardLayoutClass.resolve(availableWidth: 560), .regular)
+        XCTAssertEqual(MutagenesisWizardLayoutClass.resolve(availableWidth: 900), .regular)
+    }
+}


### PR DESCRIPTION
## Summary

This review-oriented first milestone:

- defines a platform-neutral contract for Mutagenesis wizard state, actions, command availability, and responsive layout
- adds a mock-backed SwiftUI prototype for compact and regular widths
- models residue-mode selection, rotamers, and Apply, Clear, and Done controls without invoking PyMOL
- documents the proposed interaction model and adds focused XCTest coverage
- registers the new application and test sources in the Xcode project

## Problem

RayMol's PyMOL backend supports the Mutagenesis wizard, but users cannot operate it through the native interface.

## Root cause

`PyMOLBridge.mm` disables PyMOL's `internal_gui`, while the SwiftUI application does not provide an equivalent Mutagenesis surface. The wizard therefore remains accessible only through Python commands.

## Approach

The new contract represents inactive, awaiting-residue, loading, ready, and error states and derives which commands are available in each state. Changing residue mode clears stale rotamer selection, and Apply is enabled only for a valid selected rotamer.

The prototype stacks controls below 560 points and uses a two-column layout at wider sizes. Its controller forwards enabled actions to an injected sink for testability, but intentionally performs no live bridge calls or structural mutations.

## Testing

- `git diff --check` passed.
- The configured Docker source-contract check was attempted through `scripts/safe_project.py`, but could not start because the Colima Docker socket was unavailable.
- `xcodebuild -project swiftui/PyMOLViewer.xcodeproj -scheme UnitTests_macOS -configuration Debug -destination 'platform=macOS' test` was not run because no reviewed isolated macOS runner was available and the configured Python Docker image cannot provide Xcode.

Swift compilation and the added XCTest suite therefore remain unverified.

## Risks and follow-up

- The prototype is deliberately not connected to `ContentView`, so it does not yet make the wizard available in the application.
- The final presentation location and interaction model still need maintainer approval.
- Live PyMOL state observation, command dispatch, navigation integration, and cross-platform UI validation are deferred.
- An isolated macOS runner is required to build the SwiftUI targets and execute the tests.

Relates to #136.
