### PR TITLE
Fix #195 (camera reset on dots/surface) and #219 (measurement console spam)

### DIFF
--- a/.github/workflows/raymol-embedded-tests.yml
+++ b/.github/workflows/raymol-embedded-tests.yml
@@ -57,4 +57,6 @@ jobs:
               testing/tests/test_appkit_ray_overlay.py \
               testing/tests/test_metal_pick.py \
               testing/tests/test_mouse_panel.py \
-              testing/tests/test_stale_check.py
+              testing/tests/test_stale_check.py \
+              testing/tests/test_appkit_widen_clip.py \
+              testing/tests/test_inspector_transparency.py

--- a/modules/pymol/appkit_inspector.py
+++ b/modules/pymol/appkit_inspector.py
@@ -160,6 +160,24 @@ def _color_setting_rgb(setting, fallback=(0.0, 0.0, 0.0)):
     return [float(t[0]), float(t[1]), float(t[2])]
 
 
+def is_molecule(obj):
+    """True when `obj` is a molecular object — i.e. something an atom selection is
+    allowed to name.
+
+    Measurement objects (`dist01`/`ang01`/`dih01`), CGOs, maps and groups are not.
+    Handing one to `cmd.iterate` / `cmd.count_atoms` makes the C++ selector reject
+    it and write `Selector-Error: Invalid selection name "<obj>"` straight to the
+    feedback log. A Python-level try/except cannot suppress that: the selector has
+    already emitted the line by the time it raises. Since the object panel polls
+    ~2x/second, an unguarded probe floods the console for as long as the object
+    exists — issue #219.
+    """
+    try:
+        return cmd.get_type(obj) == 'object:molecule'
+    except Exception:
+        return False
+
+
 def transp_summary(obj):
     """One pass over `obj`'s atoms → {setting: (min, max, over)} for the atom-level
     transparency settings, where min/max are the EFFECTIVE per-atom transparency
@@ -170,7 +188,12 @@ def transp_summary(obj):
     Reading `s.<setting>` in iterate always resolves to the object-level value when
     no atom-level override exists (it never returns None here), so comparing the
     effective range to the object-level value is what detects a genuine override.
+
+    Non-molecular objects are rejected up front (see is_molecule): they cannot
+    carry per-atom transparency anyway, so probing them is both wrong and noisy.
     """
+    if not is_molecule(obj):
+        return {}
     objlv = {s: _num(s, obj) for s in TRANSP_SETTINGS}
     mn = {s: None for s in TRANSP_SETTINGS}
     mx = {s: None for s in TRANSP_SETTINGS}
@@ -219,6 +242,13 @@ def _build(objs):
     detail = {}
     for o in objs:
         reps = []
+        # Non-molecular objects (measurements, CGOs, maps, groups) have no reps to
+        # describe, and every probe below — transp_summary's iterate and the
+        # per-rep count_atoms — would make the selector log an error per poll tick
+        # (issue #219). Emit an empty rep list instead of interrogating them.
+        if not is_molecule(o):
+            detail[o] = reps
+            continue
         # Effective per-atom transparency range per setting, computed once per
         # object; attached to the rep whose transparency setting is overridden so
         # the expanded card can show "per-atom: min–max" and a Clear action.

--- a/modules/pymol/appkit_inspector.py
+++ b/modules/pymol/appkit_inspector.py
@@ -347,22 +347,18 @@ def widen_clip_for_surface(buffer=12.0):
     front-clipped by the atom-fit slab that orient/reset/load set (which would
     slice the surface front and expose the interior).
 
-    Re-fit tight to the visible content first (zoom buffer 0 — idempotent, keeps
-    the molecule the same size), THEN push the near/far planes out by `buffer`.
-    The zoom reset makes repeated calls non-accumulating; the direct plane move
-    (not a camera dolly) clears the shell without shrinking the molecule, and
-    moving BOTH planes keeps the slab centered so depth precision stays good.
-    No-op when no such rep is shown."""
+    Use `clip atoms, buffer, visible`: it sets the near/far planes from the
+    visible atoms' extent about their CURRENT camera positions plus `buffer`,
+    touching only the clip planes -- never the camera position, rotation, or
+    center of rotation. That preserves the user's current view (previously a
+    `zoom visible` here recentered/rezoomed the camera every time dots/surface
+    was shown -- issue #195). It is absolute (recomputed from atom extents each
+    call), so repeated calls don't accumulate. No-op when no such rep is shown."""
     try:
         if (cmd.count_atoms('rep surface') + cmd.count_atoms('rep mesh')
                 + cmd.count_atoms('rep dots')) > 0:
-            cmd.zoom('visible', 0.0, complete=1)   # reset slab to tight visible fit
-            # `clip near, +d` moves the near plane TOWARD the viewer (front -= d);
-            # `clip far, -d` moves the far plane AWAY (back += d). Together they
-            # WIDEN the slab so the ~solvent_radius surface shell at both faces is
-            # inside it. (The opposite signs would narrow the slab and clip the
-            # surface — and the interior — away.)
-            cmd.clip('near', float(buffer))
-            cmd.clip('far', -float(buffer))
+            # Widen the slab to enclose the visible atoms +/- buffer WITHOUT
+            # moving the camera: clip atoms only calls SceneClipSet(front, back).
+            cmd.clip('atoms', float(buffer), 'visible')
     except Exception:
         pass

--- a/testing/tests/test_appkit_objpanel_poll.py
+++ b/testing/tests/test_appkit_objpanel_poll.py
@@ -22,10 +22,34 @@ import contextlib
 import io
 import json
 import os
+import sys
 import tempfile
 
 from pymol import cmd, testing
 from pymol import appkit_inspector as ai
+
+
+@contextlib.contextmanager
+def capture_console():
+    """Capture the REAL console stream (fd 1), not just sys.stdout.
+
+    Needed for issue #219: the `Selector-Error: Invalid selection name "dist01".`
+    line is written by the C++ selector through PyMOL's feedback system directly
+    to fd 1. contextlib.redirect_stdout only rebinds the Python-level sys.stdout
+    object, so it never sees that line — a test built on it would pass against the
+    unfixed code.
+    """
+    sys.stdout.flush()
+    saved = os.dup(1)
+    tmp = tempfile.TemporaryFile(mode='w+b')
+    try:
+        os.dup2(tmp.fileno(), 1)
+        yield tmp
+        sys.stdout.flush()
+    finally:
+        os.dup2(saved, 1)
+        os.close(saved)
+        tmp.seek(0)
 
 # layer0/PyMOLGlobals.h: OrthoLineLength — the per-line feedback cap that the
 # old inline payload overflowed.
@@ -171,3 +195,88 @@ class TestObjPanelPoll(testing.PyMOLTestCase):
         large, _ = self._poll()
 
         self.assertEqual(small, large)
+
+
+class TestNonMolecularObjectsAreNotProbed(testing.PyMOLTestCase):
+    """Regression coverage for issue #219.
+
+    Creating a measurement made the console repeat
+
+        Selector-Error: Invalid selection name "dist01".
+        dist01<--
+
+    at 2.00 lines/second, indefinitely (measured on the pre-fix build). The panel
+    poll probed EVERY public object for a per-atom transparency override without
+    filtering by type, so `cmd.iterate` was handed a measurement object and the
+    C++ selector rejected it. The Python try/except around the iterate swallowed
+    the exception but not the already-written feedback line — so it could only be
+    fixed by not making the call.
+    """
+
+    SELECTOR_ERROR = b'Invalid selection name'
+
+    def _measured_session(self):
+        cmd.delete('all')
+        cmd.fab('ACDEFG', 'mol')
+        cmd.distance('dist01', 'mol and i. 1 and n. CA', 'mol and i. 3 and n. CA')
+        cmd.angle('ang01', 'mol and i. 1 and n. CA', 'mol and i. 2 and n. CA',
+                  'mol and i. 3 and n. CA')
+        self.assertEqual(cmd.get_type('dist01'), 'object:measurement')
+        return list(cmd.get_names('public_objects'))
+
+    def testIsMoleculeRejectsMeasurements(self):
+        self._measured_session()
+        self.assertTrue(ai.is_molecule('mol'))
+        self.assertFalse(ai.is_molecule('dist01'))
+        self.assertFalse(ai.is_molecule('ang01'))
+        self.assertFalse(ai.is_molecule('no_such_object'))
+
+    def testPollPanelEmitsNoSelectorErrorForMeasurements(self):
+        objs = self._measured_session()
+        self.assertIn('dist01', objs,
+                      'the measurement must be in public_objects, else the poll '
+                      'never probes it and this test proves nothing')
+
+        with capture_console() as out:
+            for _ in range(5):        # the real panel polls ~2x/second
+                ai.poll_panel()
+        console = out.read()
+
+        self.assertNotIn(self.SELECTOR_ERROR, console,
+                         'poll_panel must not hand a non-molecular object to the '
+                         'selector (issue #219); console was: %r' % console)
+
+    def testExpandedCardBuildEmitsNoSelectorErrorForMeasurements(self):
+        # The rep-detail path reaches transp_summary independently of poll_panel,
+        # and spams identically when a measurement's card is expanded.
+        objs = self._measured_session()
+
+        with capture_console() as out:
+            for _ in range(5):
+                ai.poll(objs)
+        console = out.read()
+
+        self.assertNotIn(self.SELECTOR_ERROR, console,
+                         'poll()/_build must not probe non-molecular objects '
+                         '(issue #219); console was: %r' % console)
+
+    def testPanelStillReportsMeasurementsAndRealTransparency(self):
+        # The fix must silence the probe without dropping the objects from the
+        # panel or breaking per-atom transparency detection on real molecules.
+        self._measured_session()
+        cmd.show('cartoon', 'mol')
+        cmd.alter('mol and resi 1-2', 's.cartoon_transparency = 0.5')
+
+        ai.poll_panel()
+        with open(PANEL_JSON) as f:
+            payload = json.load(f)
+
+        for name in ('mol', 'dist01', 'ang01'):
+            self.assertIn(name, payload['objects'])
+            self.assertIn(name, payload['has_transp'])
+        self.assertFalse(payload['has_transp']['dist01'])
+        self.assertFalse(payload['has_transp']['ang01'])
+        # A measurement contributes an empty rep list rather than being probed.
+        detail = ai._build(['mol', 'dist01'])['detail']
+        self.assertEqual(detail['dist01'], [])
+        self.assertTrue(detail['mol'], 'the molecule must still describe its reps')

--- a/testing/tests/test_appkit_widen_clip.py
+++ b/testing/tests/test_appkit_widen_clip.py
@@ -1,0 +1,128 @@
+"""Tests for pymol.appkit_inspector.widen_clip_for_surface — the clip-slab widen
+the macOS/iOS app runs whenever a probe-extended rep is shown.
+
+Regression coverage for issue #195: showing dots (or surface, or mesh) reset the
+camera. PyMOLEngine.runCommandCore calls maybeWidenClipForSurface for any command
+containing `show dots` / `show surface` / `show mesh` (plus orient/reset/load/
+fetch), and widen_clip_for_surface opened with `cmd.zoom('visible', 0.0,
+complete=1)` to re-fit the slab tight before pushing the planes out. That zoom is
+a camera dolly, so every `show dots` yanked the user's view.
+
+The fix keeps the same intent — a slab wide enough for the ~solvent_radius shell —
+via `clip atoms, buffer, visible`, which only calls SceneClipSet(front, back).
+
+Measured on the pre-fix build (1UBQ, arm64 macOS): camera z went -165.147 ->
+-147.282, an 17.86 A dolly, with rotation and center untouched. So the assertions
+below split the view vector: [9:15] (camera position + center of rotation) must
+not move, while [15:17] (near/far) is expected and required to change.
+"""
+
+from pymol import cmd, testing
+from pymol import appkit_inspector as ai
+
+# cmd.get_view() layout — layer1/Scene.cpp / modules/pymol/viewing.py.
+ROT = slice(0, 9)        # rotation matrix
+CAMERA = slice(9, 15)    # camera position (9:12) + origin of rotation (12:15)
+CLIP = slice(15, 17)     # near / far
+
+TOL = 1e-4
+
+
+class TestWidenClipForSurface(testing.PyMOLTestCase):
+
+    def _scene(self, rep='dots'):
+        """A deliberate, non-default camera so any recenter/rezoom is obvious."""
+        cmd.delete('all')
+        cmd.fab('ACDEFGHIKL', 'mol')
+        cmd.hide('everything')
+        cmd.orient('mol')
+        cmd.turn('y', 35)
+        cmd.turn('x', 20)
+        cmd.zoom('mol', 8)
+        cmd.show(rep, 'mol')
+        self.assertGreater(cmd.count_atoms('rep %s' % rep), 0,
+                           'fixture must actually flag the %s rep, else '
+                           'widen_clip_for_surface no-ops and proves nothing' % rep)
+        return list(cmd.get_view())
+
+    def _assertViewPart(self, part, after, before, equal, msg):
+        for i, (a, b) in enumerate(zip(after[part], before[part])):
+            if equal:
+                self.assertAlmostEqual(a, b, delta=TOL,
+                                       msg='%s (component %d)' % (msg, i))
+        if not equal:
+            self.assertFalse(
+                all(abs(a - b) <= TOL for a, b in zip(after[part], before[part])),
+                msg)
+
+    @testing.foreach('dots', 'surface', 'mesh')
+    def testWidenPreservesCamera(self, rep):
+        # THE bug: this is the call the Swift layer makes on every `show <rep>`.
+        before = self._scene(rep)
+
+        ai.widen_clip_for_surface()
+        after = list(cmd.get_view())
+
+        self._assertViewPart(CAMERA, after, before, True,
+                             'widen_clip_for_surface must not move the camera '
+                             'position or the center of rotation (issue #195)')
+        self._assertViewPart(ROT, after, before, True,
+                             'widen_clip_for_surface must not rotate the view')
+
+    def testWidenStillAdjustsTheClipSlab(self):
+        # Guard against "fixing" #195 by turning the function into a no-op.
+        before = self._scene()
+
+        ai.widen_clip_for_surface()
+        after = list(cmd.get_view())
+
+        self._assertViewPart(CLIP, after, before, False,
+                             'widen_clip_for_surface must still move the near/far '
+                             'planes — that is the whole point of the function')
+
+    def testPlainShowDoesNotMoveTheCameraEither(self):
+        # Control: proves the camera move seen pre-fix came from the widen call
+        # and not from cmd.show itself.
+        cmd.delete('all')
+        cmd.fab('ACDEFGHIKL', 'mol')
+        cmd.hide('everything')
+        cmd.orient('mol')
+        cmd.zoom('mol', 8)
+        before = list(cmd.get_view())
+
+        cmd.show('dots', 'mol')
+
+        self._assertViewPart(CAMERA, list(cmd.get_view()), before, True,
+                             'cmd.show alone must never move the camera')
+
+    def testRepeatedCallsDoNotAccumulate(self):
+        # The old implementation justified its zoom as making repeated calls
+        # idempotent. The replacement is absolute (recomputed from atom extents),
+        # so it must be idempotent too — the poll can call this often.
+        self._scene()
+
+        ai.widen_clip_for_surface()
+        once = list(cmd.get_view())
+        for _ in range(4):
+            ai.widen_clip_for_surface()
+        many = list(cmd.get_view())
+
+        for i, (a, b) in enumerate(zip(many, once)):
+            self.assertAlmostEqual(a, b, delta=TOL,
+                                   msg='repeated widen drifted at index %d' % i)
+
+    def testNoOpWithoutAProbeExtendedRep(self):
+        cmd.delete('all')
+        cmd.fab('ACDEFGHIKL', 'mol')
+        cmd.hide('everything')
+        cmd.show('sticks', 'mol')
+        cmd.orient('mol')
+        cmd.zoom('mol', 8)
+        before = list(cmd.get_view())
+
+        ai.widen_clip_for_surface()
+
+        for i, (a, b) in enumerate(zip(list(cmd.get_view()), before)):
+            self.assertAlmostEqual(a, b, delta=TOL,
+                                   msg='must be a no-op with no dots/surface/mesh '
+                                       'rep shown (index %d)' % i)


### PR DESCRIPTION
Two tier-0 bugs, both in `modules/pymol/appkit_inspector.py`, both validated as still-live on `master` (`fa68bd68e`) in a disposable macOS VM before being fixed. Independent changes in separate commits, so either can be reverted alone.

## Fixes #195 — showing dots/surface/mesh reset the camera

`widen_clip_for_surface()` opened with `cmd.zoom('visible', 0.0, complete=1)` to re-fit the slab tight before pushing the clip planes out. That zoom is a **camera dolly**, and `PyMOLEngine.runCommandCore` calls `maybeWidenClipForSurface` for any command containing `show dots` / `show surface` / `show mesh`, so every one of those yanked the user's view.

Replaced with a single `clip atoms, buffer, visible`, which only calls `SceneClipSet(front, back)`. It is absolute rather than relative, so repeated calls still don't accumulate — the original justification for the zoom.

**This re-lands `da87d9938`**, written for #199 and stranded when that batch PR was abandoned. Its three siblings (#192, #193, #194) were re-landed at the time; this one was missed and stayed open for three weeks.

Isolating each operation against one baseline, in the VM:

| operation | Δ camera z |
|---|---|
| `clip near, +12` | +0.0000 |
| `clip far, -12` | +0.0000 |
| `clip atoms, 12, visible` | **+0.0000** |
| `zoom visible, 0` | **+17.8648** ← the entire bug |
| old widen (zoom + clip + clip) | **+17.8648** |

Pre-fix end-to-end (1UBQ, through the real Swift command path): camera z −165.147 → −147.282. Post-fix: **±0.0000**, with the slab still moving (130.20/200.09 → 138.20/194.01).

## Fixes #219 — a measurement spammed the console forever

Creating a Distance/Angle/Dihedral produced, indefinitely:

```
 Selector-Error: Invalid selection name "dist01".
dist01<--
```

The panel poll probed **every** public object for a per-atom transparency override with no type filter, so `cmd.iterate` was handed a measurement object and the selector rejected it. The `try/except` swallowed the Python exception but not the feedback line — the selector writes it *before* raising — so the only cure is not making the call.

Adds `is_molecule()` and gates both probe paths:
- `transp_summary()` returns `{}` up front — covers `poll_panel()` via `object_has_atom_transp()`.
- `_build()` emits an empty rep list and skips the object — its per-rep `count_atoms('(<obj>) & rep <r>')` calls spam identically once a measurement's card is expanded (the second path #219 flagged).

Measured in the VM, app otherwise idle: **74 → 114 errors over 20 s = 2.00/sec**, exactly the ~500 ms poll cadence. Post-fix: **0 over the same window, while the panel logged 99 `OBJPANEL:ready` ticks** — the poll still runs at full rate, so the error is silenced rather than the poll disabled.

## Tests

`testing/tests/test_appkit_widen_clip.py` (new, 7 tests) and 4 added to `test_appkit_objpanel_poll.py`.

Two things worth calling out, because both would otherwise produce vacuous tests:

- **The camera tests split the view vector.** `get_view()[9:15]` (camera position + center of rotation) must not move; `[15:17]` (near/far) *must*. So the fix cannot be "passed" by turning the function into a no-op — there is an explicit test for that.
- **The #219 tests capture fd 1, not `sys.stdout`.** The selector writes through PyMOL's feedback system straight to the real console stream, so a test built on `contextlib.redirect_stdout` passes against the unfixed code. There's a `capture_console()` helper for this.

Every new assertion was checked against the **unfixed** module: the 3 camera assertions and both selector-error assertions fail there and pass here. The remaining new tests are invariants/controls that hold both ways by design (`cmd.show` alone never moves the camera; the slab still moves; measurements still appear in the payload; real per-atom transparency is still detected).

```
135 passed, 0 failed, 0 errors
```
— the full `raymol-embedded-tests.yml` list plus both suites, run locally under embedded pymol.

## Also

Adds `test_appkit_widen_clip.py` **and** the pre-existing `test_inspector_transparency.py` to the CI job. The latter was never in the list despite being the primary coverage for `transp_summary()`, which this PR changes. Per #239, a regression guard outside CI isn't one.

## Verification notes

Validated against a Debug build of `master` running in a disposable macOS VM (15.7.7, arm64), driven over the in-app MCP server. Three traps that nearly produced wrong conclusions, recorded in case they bite someone else:

- MCP `run_pymol_command` does a bare `cmd.do()` and **bypasses** `PyMOLEngine.runCommandCore`, so driving `show dots` over MCP false-negatives #195 entirely. `PYMOL_AUTOCMD` goes through `runCommand` and is the faithful path.
- Under `launchctl asuser` the app runs as **root**, so a plain `pkill` silently fails and leaves the old process serving MCP — which produced one completely bogus "the fix doesn't work" result.
- `inspect.getsource()` reads the file from **disk**, not the loaded module, so it happily shows patched source while old bytecode runs. `func.__code__.co_names` is the honest check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
