### PR TITLE
ci: run seven orphaned RayMol test files in the embedded suite

### DIFF
--- a/.github/workflows/raymol-embedded-tests.yml
+++ b/.github/workflows/raymol-embedded-tests.yml
@@ -62,6 +62,8 @@ jobs:
               testing/tests/test_inspector_transparency.py \
               testing/tests/test_raymolrc.py \
               testing/tests/test_mcp_events.py \
+              testing/tests/test_mcp_server.py \
+              testing/tests/test_mcp_tools.py \
               testing/tests/test_raymol_scene_anim.py \
               testing/tests/test_raymol_scene_ttt.py \
               testing/tests/raymol/design_color.py \

--- a/.github/workflows/raymol-embedded-tests.yml
+++ b/.github/workflows/raymol-embedded-tests.yml
@@ -60,8 +60,13 @@ jobs:
               testing/tests/test_stale_check.py \
               testing/tests/test_appkit_widen_clip.py \
               testing/tests/test_inspector_transparency.py \
+              testing/tests/test_raymolrc.py \
+              testing/tests/test_mcp_events.py \
+              testing/tests/test_raymol_scene_anim.py \
+              testing/tests/test_raymol_scene_ttt.py \
               testing/tests/raymol/design_color.py \
               testing/tests/raymol/design_editing.py \
               testing/tests/raymol/design_enumerate.py \
               testing/tests/raymol/design_region.py \
-              testing/tests/raymol/design_saverestore.py
+              testing/tests/raymol/design_saverestore.py \
+              testing/tests/raymol/scene_ttt.py

--- a/testing/tests/test_appkit_ray_overlay.py
+++ b/testing/tests/test_appkit_ray_overlay.py
@@ -6,6 +6,7 @@ show_ray_image() (no AppKit, png export failure, missing output file).
 AppKit/objc/Foundation stubbed permissively before import.
 """
 
+import importlib
 import os
 import sys
 import tempfile
@@ -52,7 +53,16 @@ if "pymol" not in sys.modules or not hasattr(sys.modules["pymol"], "__path__"):
     _pymol_stub.__package__ = "pymol"
     sys.modules["pymol"] = _pymol_stub
 
-from pymol import appkit_ray_overlay as ro
+# cmd.ray()/cmd.draw() lazily do `from pymol import appkit_ray_overlay`, so any
+# earlier test in this process that rendered has already imported this module
+# WITHOUT the stubs installed above. On a host with no pyobjc (every CI runner)
+# that bakes in _HAS_APPKIT=False, show_ray_image() then returns at its first
+# guard, and the tests below fail for a reason that has nothing to do with the
+# code under test. Drop any cached copy so the stubs govern this import.
+# Popping sys.modules alone is not enough: `from pymol import ...` would still
+# find the stale module as an attribute of the package.
+sys.modules.pop("pymol.appkit_ray_overlay", None)
+ro = importlib.import_module("pymol.appkit_ray_overlay")
 
 
 class FakeImageView:

--- a/testing/tests/test_mcp_server.py
+++ b/testing/tests/test_mcp_server.py
@@ -70,12 +70,24 @@ class TestHttpAuth(unittest.TestCase):
     def tearDown(self):
         server.stop()
 
-    def _post(self, body, token):
+    def _post(self, body, token, session=None):
         data = json.dumps(body).encode()
+        headers = {"Content-Type": "application/json",
+                   "Authorization": "Bearer %s" % token}
+        if session:
+            headers["Mcp-Session-Id"] = session
         req = rq.Request("http://127.0.0.1:%d/mcp" % self.port, data=data,
-                         headers={"Content-Type": "application/json",
-                                  "Authorization": "Bearer %s" % token})
+                         headers=headers)
         return rq.urlopen(req, timeout=5)
+
+    def _initialize(self):
+        """Complete a handshake and return the issued session id."""
+        resp = self._post({"jsonrpc": "2.0", "id": 1, "method": "initialize",
+                           "params": {"protocolVersion": "2025-06-18"}},
+                          "secret-token")
+        sid = resp.headers.get("Mcp-Session-Id")
+        resp.close()
+        return sid
 
     def test_missing_token_is_401(self):
         with self.assertRaises(rq.HTTPError) as ctx:
@@ -92,6 +104,24 @@ class TestHttpAuth(unittest.TestCase):
         resp.close()
         self.assertEqual(payload["result"]["serverInfo"]["name"], "raymol")
         self.assertEqual(server.status()["clients"], 1)
+
+    def test_request_refreshes_known_session_last_seen(self):
+        # do_POST's atomic check-and-touch used to live in a server._touch()
+        # helper; it is now inlined, so drive it through HTTP where it lives.
+        sid = self._initialize()
+        server._sessions[sid] = 0.0                 # age it well past the TTL
+        self._post({"jsonrpc": "2.0", "method": "notifications/initialized"},
+                   "secret-token", session=sid).close()
+        self.assertGreater(server._sessions[sid], 0.0)
+        self.assertEqual(server._prune_idle(now=server._sessions[sid] + 1.0), [])
+
+    def test_request_does_not_resurrect_unknown_session(self):
+        # The touch is deliberately check-THEN-set under one lock: an id the
+        # server never issued (or a sweep already pruned) must not be re-added,
+        # which would defeat idle expiry entirely.
+        self._post({"jsonrpc": "2.0", "method": "notifications/initialized"},
+                   "secret-token", session="never-issued").close()
+        self.assertNotIn("never-issued", server._sessions)
 
 
 class TestSessionExpiry(unittest.TestCase):
@@ -116,11 +146,13 @@ class TestSessionExpiry(unittest.TestCase):
         self.assertEqual(dead, [])
         self.assertEqual(set(server._sessions), {"a", "b"})
 
-    def test_touch_refreshes_last_seen(self):
-        server._sessions = {"a": 0.0}
-        server._touch("a")
-        dead = server._prune_idle(now=server._sessions["a"] + 1.0)
-        self.assertEqual(dead, [])
+    def test_prune_at_exactly_ttl_keeps_session(self):
+        # Boundary: expiry is `now - t > TTL`, so a session idle for exactly
+        # the TTL survives. Guards the off-by-one if that ever becomes >=.
+        now = 10000.0
+        server._sessions = {"edge": now - server.SESSION_TTL}
+        self.assertEqual(server._prune_idle(now=now), [])
+        self.assertIn("edge", server._sessions)
 
 
 if __name__ == "__main__":

--- a/testing/tests/test_mcp_tools.py
+++ b/testing/tests/test_mcp_tools.py
@@ -1,9 +1,27 @@
 import json
 import sys
+import threading
+import time
 import types
 import unittest
 
+import raymol_mcp.mainthread as mainthread
 import raymol_mcp.tools as tools
+
+
+def claim_main_thread(testcase):
+    """Make the calling thread pass for the app's main thread.
+
+    Tool bodies are marshalled through ``mainthread.run_on_main``, which blocks
+    for 30s waiting on an app main thread to drain the queue -- headless there
+    is none, so every tool call would time out. Draining once here records this
+    thread as the main thread, after which ``run_on_main`` takes its documented
+    re-entrancy path and runs the body inline. ``_main_ident`` is a process
+    global, so restore it or later tests inherit a bogus main thread.
+    """
+    testcase.addCleanup(setattr, mainthread, "_main_ident",
+                        mainthread._main_ident)
+    mainthread.drain_main_thread_queue()
 
 
 class _FakeCmd:
@@ -44,6 +62,7 @@ class TestGetSessionStateNonMolecule(unittest.TestCase):
     Claude-driving crash where an hb_* H-bond object aborted the whole call."""
 
     def setUp(self):
+        claim_main_thread(self)
         self._saved = sys.modules.get("pymol")
         fake = types.ModuleType("pymol")
         fake.cmd = _FakeCmd()
@@ -65,6 +84,76 @@ class TestGetSessionStateNonMolecule(unittest.TestCase):
         self.assertEqual(objs["hb_x"]["type"], "object:measurement")
         self.assertEqual(objs["hb_x"]["atoms"], 0)
         self.assertEqual(state["selections"], ["sele1"])
+
+
+class TestMainThreadMarshalling(unittest.TestCase):
+    """run_on_main() is the seam every tool body now goes through. It was
+    untested, which is how test_non_molecule_object_does_not_error silently
+    rotted into a 30s timeout when tools.py started marshalling through it."""
+
+    def setUp(self):
+        self.addCleanup(setattr, mainthread, "_main_ident",
+                        mainthread._main_ident)
+
+    def test_worker_thread_work_runs_on_the_draining_thread(self):
+        # The real topology: a handler thread enqueues, the main thread drains.
+        main_ident = threading.get_ident()
+        box = {}
+        started = threading.Event()
+
+        def worker():
+            started.set()
+            try:
+                box["ran_on"] = mainthread.run_on_main(threading.get_ident)
+            except BaseException as e:      # surface instead of hanging silently
+                box["exc"] = e
+
+        t = threading.Thread(target=worker)
+        t.start()
+        self.assertTrue(started.wait(5), "worker never started")
+        deadline = time.monotonic() + 5.0
+        while t.is_alive() and time.monotonic() < deadline:
+            mainthread.drain_main_thread_queue()
+            time.sleep(0.01)
+        t.join(timeout=5)
+        self.assertFalse(t.is_alive(), "run_on_main never returned")
+        self.assertNotIn("exc", box)
+        # The body ran on the draining thread, not the caller's.
+        self.assertEqual(box["ran_on"], main_ident)
+
+    def test_exception_propagates_to_the_caller(self):
+        box = {}
+
+        def boom():
+            raise ValueError("kaboom")
+
+        def worker():
+            try:
+                mainthread.run_on_main(boom)
+            except BaseException as e:
+                box["exc"] = e
+
+        t = threading.Thread(target=worker)
+        t.start()
+        deadline = time.monotonic() + 5.0
+        while t.is_alive() and time.monotonic() < deadline:
+            mainthread.drain_main_thread_queue()
+            time.sleep(0.01)
+        t.join(timeout=5)
+        self.assertIsInstance(box.get("exc"), ValueError)
+        self.assertEqual(str(box["exc"]), "kaboom")
+
+    def test_reentrant_call_on_main_thread_runs_inline(self):
+        # A queued fn calling back into run_on_main must not self-deadlock:
+        # the draining thread is the only consumer.
+        mainthread.drain_main_thread_queue()        # claim main-thread identity
+        self.assertEqual(mainthread.run_on_main(lambda: "inline"), "inline")
+
+    def test_timeout_when_nothing_drains(self):
+        # No drainer and we are not the main thread -> bounded failure, not a hang.
+        mainthread._main_ident = None
+        with self.assertRaises(TimeoutError):
+            mainthread.run_on_main(lambda: None, timeout=0.05)
 
 
 class TestMcpToolsRegistry(unittest.TestCase):

--- a/testing/tests/test_metal_pick.py
+++ b/testing/tests/test_metal_pick.py
@@ -148,6 +148,30 @@ class TestNDCToWorldMath(unittest.TestCase):
 class TestPickAtIntegration(unittest.TestCase):
     """Test pick_at() with a fully mocked cmd module."""
 
+    def setUp(self):
+        # Swapping pymol.cmd for a MagicMock is process-global: it outlives this
+        # file and breaks any later test that builds a real pymol2.PyMOL() (its
+        # Cmd ctor walks pymol.completing, which needs the genuine submodules).
+        # Snapshot every name we clobber and restore it, present or absent.
+        _pymol_mod = sys.modules["pymol"]
+        _sentinel = object()
+        _saved = [(_pymol_mod, "cmd", getattr(_pymol_mod, "cmd", _sentinel))]
+        _saved += [(sys.modules, k, sys.modules.get(k, _sentinel))
+                   for k in ("pymol.cmd", "pymol.metal_pick")]
+
+        def _restore():
+            for holder, key, val in _saved:
+                if holder is sys.modules:
+                    sys.modules.pop(key, None)
+                    if val is not _sentinel:
+                        sys.modules[key] = val
+                elif val is _sentinel:
+                    delattr(holder, key)
+                else:
+                    setattr(holder, key, val)
+
+        self.addCleanup(_restore)
+
     def test_pick_at_creates_selection(self):
         mock_cmd = MagicMock()
         mock_cmd.get_view.return_value = (


### PR DESCRIPTION
## Problem

`testing/tests/` contains test files that **no CI workflow references**, so they have never run. Regressions in the code they cover would go undetected. `grep -rn "test_raymolrc" .github/` returns nothing.

Audit of everything in `testing/tests/` against `raymol-embedded-tests.yml` — **seven files were orphaned, all seven now run**:

| File | Tests | Covers |
|---|---|---|
| `test_raymolrc.py` | 21 | `~/.raymolrc` startup logic (#225) |
| `test_mcp_events.py` | 4 | MCP stdout event encoding |
| `test_raymol_scene_anim.py` | 52 | per-scene render-setting animation |
| `test_raymol_scene_ttt.py` | 12 | per-object TTT capture (#204), headless |
| `raymol/scene_ttt.py` | 4 | per-object TTT capture, live core |
| `test_mcp_server.py` | 13 | JSON-RPC, HTTP auth, session expiry — *repaired, see below* |
| `test_mcp_tools.py` | 8 | tool registry, session state, marshalling — *repaired, see below* |

Note `testing/tests/raymol/` was only *partly* listed (the five `design_*.py`, but not `scene_ttt.py`) — a subdirectory appearing in the list does not mean it is covered.

## Repairing the two stale files

Both asserted against code that had moved on. Each is fixed at the seam the behaviour actually lives at now, rather than re-pointing the test at internals.

**`test_mcp_server.py`** — `test_touch_refreshes_last_seen` called `server._touch()`, a helper that no longer exists; the touch is now an inlined atomic check-and-touch in `do_POST`. Replaced with two tests driven over real HTTP, covering both branches the inline comment calls out:
- a **known** session's `last_seen` IS refreshed;
- an **unknown** id is NOT resurrected — which would defeat idle expiry entirely, and was never covered before.

`TestSessionExpiry` keeps its pure `_prune_idle` unit tests and gains the exact-TTL boundary case.

**`test_mcp_tools.py`** — `test_non_molecule_object_does_not_error` drives `_get_session_state()`, which now marshals its body through `run_on_main()`. Headless there is no app main thread to drain the queue, so it blocked the full 30s and raised `TimeoutError`. A `claim_main_thread()` helper drains once to record the test thread as the main thread, after which `run_on_main` takes its documented re-entrancy path and runs inline. `_main_ident` is a process global, so it is restored via `addCleanup`.

## New: `TestMainThreadMarshalling`

`run_on_main` is the seam **every** tool body now passes through, and it had no tests at all — which is precisely how the above rotted from "passing" to "30s timeout" without anyone noticing. Four deterministic tests: work runs on the draining thread (not the caller's), exceptions propagate back to the caller, a re-entrant call runs inline instead of self-deadlocking, and a missing drainer times out rather than hanging forever.

## Drive-by fix: a latent test-isolation leak

Adding `test_raymol_scene_ttt.py` surfaced a real bug in **`test_metal_pick.py`**. It replaced `pymol.cmd` and `sys.modules["pymol.cmd"]` with a `MagicMock` and never restored them. That leak is process-global, so every later `pymol2.PyMOL()` construction died in the `Cmd` ctor:

```
AttributeError: 'function' object has no attribute 'button_sc'
  pymol/completing.py:97 in get_auto_arg_list
```

Invisible only because nothing in the suite after it built a PyMOL instance. Bisected across all 15 previously-listed files to confirm it was the sole culprit. Now snapshotted and restored via `addCleanup` (handles the absent case, so it works whether or not the names pre-exist).

## Second drive-by fix: a lazy import poisoning the ray-overlay tests

Adding `raymol/scene_ttt.py` turned `test_appkit_ray_overlay.py` red in CI (it was green locally — see below):

```
ShowRayImageGuardsTest::test_returns_when_png_export_raises FAILED
```

`scene_ttt.py` calls `cmd.ray(120, 120)`. `viewing.py`'s `_ray()` (and `draw()`) then does a **lazy** `from pymol import appkit_ray_overlay`, importing the module under test *before* `test_appkit_ray_overlay.py` installs its AppKit/objc stubs. That module computes `_HAS_APPKIT` at import time, so on a host without pyobjc — every CI runner — it is baked to `False`. `show_ray_image()` then returns at its first guard, `cmd.png` is never called, and `assert_called_once()` fails for a reason unrelated to the code under test. The unittest-runner files run before the pytest ones, so `scene_ttt.py` always renders first.

Fixed at the fragility: the test drops any cached copy and re-imports under its own stubs. Popping `sys.modules` alone is insufficient — `from pymol import appkit_ray_overlay` would still resolve the stale module as a package attribute — hence `importlib.import_module`.

**Why local runs missed it:** pyobjc *is* installed on the dev Mac, so `_HAS_APPKIT` was `True` regardless of who imported first. Reproduced by emulating the runner with an `AppKit.py` that raises `ImportError` on `PYTHONPATH`; before the fix that reproduces the exact CI failure, and `ray_overlay` alone under the same conditions passes 9/9 — isolating import order, not the blocked AppKit, as the cause.

Audited the same vector fork-wide: only `appkit_ray_overlay` and `metal_pick` are lazily imported by core code, and `test_metal_pick.py` already purges `sys.modules` before re-importing, so it was never exposed.

## Verification

Ran the **exact command from the edited YAML** — extracted programmatically with `yaml.safe_load`, so the trailing-backslash continuations are verified as *parsed*, not eyeballed:

```
EXIT=0
PASSED=245  FAILED=0  ERRORS=0
Ran 25 tests in 0.169s -- OK
```

- Baseline before this PR was 135 pytest + 21 unittest; now **245 + 25**. The delta is exactly the tests added.
- No staleness warning — the run exercised this checkout's Python layer, not a stale install.
- Same green result with the **file order reversed**, confirming no order-dependent leakage from the process globals these tests touch.
- Green with pyobjc present, with AppKit blocked (emulating the runner), and in **reverse file order**.
- A control branch pushed at unmodified master HEAD (`4e8ab1c01`) went green, confirming master was fine and the ray-overlay regression was introduced here — then deleted.
- **Every new assertion was mutation-tested.** Disabling the inline touch, making the touch unconditional, flipping the prune boundary to `>=`, removing the marshalling, swallowing drain exceptions, and disabling the re-entrancy shortcut each fail *exactly* the intended test and no others — so none of the new tests are vacuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
