### PR TITLE
release: RayMol 1.9.1 (build 26)

### DIFF
--- a/docs/release-notes/v1.9.1.md
+++ b/docs/release-notes/v1.9.1.md
@@ -1,0 +1,37 @@
+## RayMol 1.9.1
+
+A fix release, led by one long-standing gap: **keyboard shortcuts now work**.
+
+### Keyboard shortcuts
+
+- **`set_key` remapping works again.** Bindings in your startup script — or typed
+  at the command line — now actually fire. If you have carried a `~/.pymolrc`
+  full of `cmd.set_key` bindings from desktop PyMOL for years, copy it to
+  `~/.raymolrc.py` and it will do what it always did. Function keys, arrows,
+  Page Up/Down, Home/End, and `⌃`/`⌥` combinations are all delivered.
+- **PyMOL's own built-in shortcuts are live too.** All 125 of them, for the
+  first time in RayMol: `←`/`→` step movie frames, `Page Up`/`Page Down` change
+  scenes, `Home` zooms to fit.
+- **Typing still wins.** While you are editing a command, the command line keeps
+  the arrows, Home/End and the usual `⌃A`/`⌃E`/`⌃H` text-editing keys — they
+  only trigger PyMOL bindings once the prompt is empty. Page Up/Down and the
+  function keys always work, so a binding is never out of reach.
+- **Your bindings beat the app's.** If your script binds a key RayMol also uses
+  as a menu shortcut (`⌃M`, `⌃D`), yours wins and RayMol tells you so at
+  startup. The menu item still works by click.
+
+Two notes. **`⌥`-key bindings only fire when the command line does not have
+focus** — click the viewport first. On macOS, Option is the character-composition
+key (`⌥L` types `@` on a German layout), so RayMol cannot safely treat it as a
+shortcut while you are typing. And keyboard shortcuts are macOS-only for now.
+
+### Fixes
+
+- **Fixed: the camera jumped when showing dots, surface or mesh.** Turning on
+  one of these representations could re-frame the scene; your view is now
+  preserved.
+- **Fixed: console spam from the object panel.** The panel probed non-molecular
+  objects — maps, groups, CGOs — and filled the log with warnings.
+- **The sequence toggles are labeled "Seq"**, which is what they actually do.
+
+Built on the open-source PyMOL engine. Updates install automatically via the in-app updater (**Check for Updates…** in the app menu).

--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -249,7 +249,7 @@
 		F7E41DCBB427678A8F018B0E /* DesignControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignControllerTests.swift; sourceTree = "<group>"; };
 		FB1304C662D9011F7C4505FC /* MCPStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPStatusView.swift; sourceTree = "<group>"; };
 		FF4FB7F151982A2927D612F0 /* DesignController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignController.swift; sourceTree = "<group>"; };
-		"TEMP_7E38C272-94B4-41B9-A004-CB298BAA46BD" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
+		"TEMP_C91CA554-3146-4D90-8B65-349117B4020E" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -437,10 +437,10 @@
 			path = Bridge;
 			sourceTree = "<group>";
 		};
-		"TEMP_E4E0BE92-597B-4721-8A72-70A947CF66F8" /* swiftui */ = {
+		"TEMP_3EF596E2-09DB-414E-83E1-5043487CDDEA" /* swiftui */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_7E38C272-94B4-41B9-A004-CB298BAA46BD" /* PyMOLBridge.xcconfig */,
+				"TEMP_C91CA554-3146-4D90-8B65-349117B4020E" /* PyMOLBridge.xcconfig */,
 			);
 			path = swiftui;
 			sourceTree = "<group>";
@@ -1219,7 +1219,7 @@
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = RayMol;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -1233,7 +1233,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -1252,7 +1252,7 @@
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = RayMol;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -1266,7 +1266,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -1286,7 +1286,7 @@
 				CODE_SIGN_ENTITLEMENTS = PyMOLViewer/RayMol.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				DEVELOPMENT_TEAM = VT99UQUQ89;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1302,7 +1302,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -1342,7 +1342,7 @@
 				CODE_SIGN_ENTITLEMENTS = PyMOLViewer/RayMol.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				DEVELOPMENT_TEAM = VT99UQUQ89;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1358,7 +1358,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
@@ -1373,7 +1373,7 @@
 		};
 		76B7E9DB75E073D1E60928FA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_7E38C272-94B4-41B9-A004-CB298BAA46BD" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_C91CA554-3146-4D90-8B65-349117B4020E" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1480,7 +1480,7 @@
 		};
 		D8F44FDFF036013D2F03BA83 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_7E38C272-94B4-41B9-A004-CB298BAA46BD" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_C91CA554-3146-4D90-8B65-349117B4020E" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/swiftui/project.yml
+++ b/swiftui/project.yml
@@ -117,8 +117,8 @@ targets:
         # AppIcon.appiconset fallback. Applies to both macOS + iOS.
         ASSETCATALOG_COMPILER_APPICON_NAME: RayMol
         INFOPLIST_GENERATION_MODE: GeneratedFile
-        MARKETING_VERSION: "1.9.0"
-        CURRENT_PROJECT_VERSION: 25
+        MARKETING_VERSION: "1.9.1"
+        CURRENT_PROJECT_VERSION: 26
         GENERATE_INFOPLIST_FILE: YES
         # Generate a launch screen so iOS renders at the device's NATIVE
         # resolution. Without it the app is letterboxed at a legacy size on


### PR DESCRIPTION
Version bump and release notes for 1.9.1.

- `MARKETING_VERSION` 1.9.0 → 1.9.1, `CURRENT_PROJECT_VERSION` 25 → 26 (last published build is 25, so Sparkle will offer it).
- Adds `docs/release-notes/v1.9.1.md`.

Patch release, so no new What's New splash page.

Headline is #258 (`cmd.set_key` keyboard bindings now dispatch on macOS, merged in #262), plus three macOS fixes already on master: camera preserved when showing dots/surface/mesh (#195), object-panel console spam (#219), and the "Seq" toggle label.

RC built from this branch and verified at 1.9.1 / build 26.