### PR TITLE
fix(mas): hoist mlx-swift plugin-skip flags so the macOS App Store archive works

### DIFF
--- a/swiftui/archive_appstore.sh
+++ b/swiftui/archive_appstore.sh
@@ -8,7 +8,15 @@ cd "$(dirname "$0")"
 
 DEST="${1:-macOS}"
 EXTRA_SETTINGS=()
-EXTRA_FLAGS=()
+# mlx-swift's Cmlx target carries a CudaBuild buildTool plugin that stalls a
+# headless archive without these flags (plugin validation tries to spawn a
+# network request; macro validation also fails in a non-interactive shell).
+# BOTH platforms need them: Design mode enables RAYMOL_MPNN — and therefore the
+# MPNNKit/mlx-swift dependency — for macosx* as well as iphoneos* (project.yml).
+# This was iOS-only until 1.9.0 shipped Design mode on macOS, which silently
+# broke the Mac App Store archive ("Validate plug-in CudaBuild ... ARCHIVE
+# FAILED") — the DMG/Sparkle path never archives, so nothing caught it.
+EXTRA_FLAGS=(-skipPackagePluginValidation -skipMacroValidation)
 
 if [ "$DEST" = "macOS" ]; then
   # Mac App Store build: Sparkle has no place here — self-update is disallowed on
@@ -36,10 +44,6 @@ elif [ "$DEST" = "iOS" ]; then
   xcodegen generate
   SCHEME=PyMOLViewer_iOS
   DESTSPEC='generic/platform=iOS'
-  # mlx-swift's Cmlx target carries a CudaBuild buildTool plugin that stalls a
-  # headless archive without these flags (plugin validation tries to spawn a
-  # network request; macro validation also fails in a non-interactive shell).
-  EXTRA_FLAGS=(-skipPackagePluginValidation -skipMacroValidation)
 else
   echo "usage: $0 [macOS|iOS]" >&2; exit 2
 fi


### PR DESCRIPTION
The Mac App Store archive has been broken since 1.9.0 shipped Design mode. Found while submitting 1.9.1:

```
Validate plug-in "CudaBuild" in package "mlx-swift"
** ARCHIVE FAILED **
```

`mlx-swift`'s `Cmlx` target carries a `CudaBuild` buildTool plugin that stalls a headless archive. `-skipPackagePluginValidation` / `-skipMacroValidation` were set **only in the iOS branch** of `archive_appstore.sh` — but Design mode enables `RAYMOL_MPNN`, and therefore the MPNNKit/mlx-swift dependency, for `macosx*` as well as `iphoneos*`. macOS inherited the dependency without the flags.

Nothing caught it because the DMG/Sparkle release path only *builds*; it never *archives*. So **1.9.0 could not have been submitted to the App Store even if someone had tried** — consistent with 1.8.1 still being the live App Store version.

The flags are now set once before the platform branch, so both get them, with the reason recorded in a comment so a future reader doesn't re-scope them to one platform.

Verified: with this change `./archive_appstore.sh macOS` completes (`** EXPORT SUCCEEDED **`), and the resulting package passes `altool --validate-app` and uploaded to ASC as 1.9.1 build 26 (Apple Distribution signed, sandboxed, Sparkle + `raymol_mcp` stripped). The iOS branch is unchanged in behavior — it keeps the same two flags it always had.