### PR TITLE
fix(ios/appstore): make the OpenSSL privacy manifest unmissable (ITMS-91061)

### DIFF
--- a/swiftui/project.yml
+++ b/swiftui/project.yml
@@ -305,14 +305,19 @@ targets:
               # support the minimum OS Version"). Pin it to the app's deployment
               # target; every embedded binary supports that.
               plutil -replace MinimumOSVersion -string "${IPHONEOS_DEPLOYMENT_TARGET:-16.0}" "$CODESIGNING_FOLDER_PATH/$FRAMEWORK_FOLDER/Info.plist"
-              # _ssl and _hashlib statically link OpenSSL/BoringSSL, which Apple's
-              # "commonly used third-party SDK" list requires to carry a privacy
-              # manifest (ITMS-91061). Drop one into those two frameworks; it gets
-              # signed with the framework in the codesign pass below.
-              case "$FULL_MODULE_NAME" in
-                _ssl|_hashlib) cp "$OSSL_PRIVACY" "$CODESIGNING_FOLDER_PATH/$FRAMEWORK_FOLDER/PrivacyInfo.xcprivacy" ;;
-              esac
             fi
+            # _ssl and _hashlib statically link OpenSSL/BoringSSL, which Apple's
+            # "commonly used third-party SDK" list requires to carry a privacy
+            # manifest (ITMS-91061). Drop one into those two frameworks; it gets
+            # signed with the framework in the codesign pass below.
+            # Deliberately OUTSIDE the `! -d` guard above: that guard only fires
+            # when the framework folder is created, so on an incremental build
+            # over build products predating this fix the manifest would never be
+            # copied and the app would ship without it. Copying every time is
+            # idempotent and cheap.
+            case "$FULL_MODULE_NAME" in
+              _ssl|_hashlib) cp "$OSSL_PRIVACY" "$CODESIGNING_FOLDER_PATH/$FRAMEWORK_FOLDER/PrivacyInfo.xcprivacy" ;;
+            esac
             mv "$FULL_EXT" "$CODESIGNING_FOLDER_PATH/$FRAMEWORK_FOLDER/$FULL_MODULE_NAME"
             echo "$FRAMEWORK_FOLDER/$FULL_MODULE_NAME" > "${FULL_EXT%.so}.fwork"
             echo "${RELATIVE_EXT%.so}.fwork" > "$CODESIGNING_FOLDER_PATH/$FRAMEWORK_FOLDER/$FULL_MODULE_NAME.origin"
@@ -344,6 +349,20 @@ targets:
           find "$CODESIGNING_FOLDER_PATH/python/lib/$PYTHON_VER/lib-dynload" -name "*.so" | while read FULL_EXT; do
             install_dylib "python/lib/$PYTHON_VER/lib-dynload/" "$FULL_EXT"
           done
+
+          # Fail the build rather than ship a binary App Review will reject.
+          # iOS 1.8.1 (build 24) was cut from the v1.8.0 tag, which predates the
+          # privacy-manifest fix by 15 minutes — the manifests were silently
+          # absent and Apple returned ITMS-91061, leaving the version stuck in
+          # "Invalid Binary". A missing manifest must break the build loudly.
+          for OSSL_MOD in _ssl _hashlib; do
+            OSSL_FW="$CODESIGNING_FOLDER_PATH/Frameworks/$OSSL_MOD.framework"
+            if [ -d "$OSSL_FW" ] && [ ! -f "$OSSL_FW/PrivacyInfo.xcprivacy" ]; then
+              echo "error: $OSSL_MOD.framework is missing PrivacyInfo.xcprivacy — App Review rejects this with ITMS-91061 (OpenSSL/BoringSSL is a 'commonly used third-party SDK'). Expected source: $OSSL_PRIVACY" >&2
+              exit 1
+            fi
+          done
+
           if [ -n "$EXPANDED_CODE_SIGN_IDENTITY" ]; then
             find "$CODESIGNING_FOLDER_PATH/Frameworks" -name "*.framework" -exec /usr/bin/codesign --force --sign "$EXPANDED_CODE_SIGN_IDENTITY" ${OTHER_CODE_SIGN_FLAGS:-} -o runtime --timestamp=none --preserve-metadata=identifier,entitlements,flags "{}" \; || true
           fi


### PR DESCRIPTION
## Why iOS 1.8.1 is stuck in "Invalid Binary"

App Store Connect shows **iOS 1.8.1 — Invalid Binary**. The cause, from Apple's Aug 4 mail (6 min after submission):

> **ITMS-91061: Missing privacy manifest** — Your app includes `Frameworks/_hashlib.framework/_hashlib`, which includes BoringSSL / openssl_grpc, an SDK that was identified in the documentation as a commonly used third-party SDK… (same again for `_ssl`)

The fix for this already existed — commit `8876efc45`, which drops an OpenSSL privacy manifest into those two frameworks. It landed **15 minutes after the `v1.8.0` tag was cut**:

| | |
|---|---|
| Jul 17 12:16 | `v1.8.0` tag (merge of #214) |
| Jul 17 12:31 | `8876efc45` — the ITMS-91061 fix (#216) |
| Jul 17 12:42 | build 23 uploaded **with** the fix → iOS 1.8.0 approved ✅ |
| Aug 3/4 | 1.8.1 cut **from the `v1.8.0` tag** → tree lacks `8876efc45` → build 24 ships without the manifests → ITMS-91061 ❌ |

`git merge-base --is-ancestor 8876efc45 v1.8.1` → **false**. Confirmed directly against the archive that produced build 24 (`raymol-appstore-1.8.1/swiftui/build_archive/RayMol-iOS.xcarchive`): neither `_ssl.framework` nor `_hashlib.framework` contains `PrivacyInfo.xcprivacy`.

## What this PR changes

The fix is on `master`, so a clean build from `master` is already correct. This makes it impossible to lose again:

1. **Copy the manifest outside the `! -d "$FRAMEWORK_FOLDER"` guard.** That guard only fires when the framework folder is *created*, so an incremental build over build products predating the fix would never copy it. The copy is idempotent.
2. **Assert it.** If `_ssl`/`_hashlib.framework` exists without `PrivacyInfo.xcprivacy`, the build fails with the ITMS code instead of producing a binary App Review rejects.

## Verification

- Scanned every embedded framework in the build-24 app for OpenSSL/BoringSSL markers — `_ssl` and `_hashlib` are the **only** two, so the manifest's coverage is complete.
- All 5 `scripts/tests/run_*_test.sh` pipeline suites pass.
- `scripts/ios_deps_fingerprint.sh` is unchanged (`a0663ba183cc`) — no iOS deps artifact rebuild needed.
- `project.yml` still has exactly one `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` (the `apply_ci_versions.sh` precondition).

## Shipping

iOS is two releases behind (1.8.0 live; macOS is on 1.9.1). Rather than resurrect 1.8.1, iOS **1.9.1** is being built from this tree and uploaded — that is the first iOS binary to carry both the manifest fix and the 1.9.x work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)