### PR TITLE
fix(ios): unblock the Xcode Cloud beta archive and stop betas burning version numbers

### DIFF
--- a/scripts/apply_ci_versions.sh
+++ b/scripts/apply_ci_versions.sh
@@ -11,12 +11,20 @@
 # fails to apply, every build after the first uploads a duplicate pair and is
 # rejected — so the substitution is verified below and a no-op is fatal.
 #
-# Usage: apply_ci_versions.sh <project.yml> <marketing-version> <build-number>
+# The optional 4th argument is the human-readable beta label from
+# scripts/beta_label.sh (e.g. "1.9.1-beta27"). It is stamped into
+# RAYMOL_BETA_LABEL, which a postBuildScript copies to the built Info.plist's
+# RayMolBetaLabel key for the app's Settings pane to display. Omit it and the
+# committed empty value stands, which is what marks a build as NOT a beta —
+# so release builds must keep omitting it.
+#
+# Usage: apply_ci_versions.sh <project.yml> <marketing-version> <build-number> [beta-label]
 set -euo pipefail
 
-YML="${1:?usage: apply_ci_versions.sh <project.yml> <marketing-version> <build-number>}"
+YML="${1:?usage: apply_ci_versions.sh <project.yml> <marketing-version> <build-number> [beta-label]}"
 MKT="${2:-}"
 BUILD="${3:-}"
+LABEL="${4:-}"
 
 [ -f "$YML" ] || { echo "ERROR: not found: $YML" >&2; exit 1; }
 [[ "$MKT" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
@@ -56,4 +64,31 @@ grep -qE "^[[:space:]]*MARKETING_VERSION: \"$MKT\"$" "$YML" || {
 grep -qE "^[[:space:]]*CURRENT_PROJECT_VERSION: $BUILD$" "$YML" || {
   echo "ERROR: CURRENT_PROJECT_VERSION edit did not apply to $YML" >&2; exit 1; }
 
-echo "project.yml -> $MKT ($BUILD)"
+# The beta label is optional, but a MALFORMED one is not tolerated: it is what a
+# tester reads off the Settings pane to report a bug against, so "1.9.1-beta" or
+# a stray newline is worse than no label at all.
+if [ -n "$LABEL" ]; then
+  [[ "$LABEL" =~ ^[0-9]+\.[0-9]+\.[0-9]+-beta[0-9]+$ ]] || {
+    echo "ERROR: beta label must be X.Y.Z-betaN, got '$LABEL'" >&2
+    echo "       Build it with scripts/beta_label.sh, not by hand." >&2
+    exit 1; }
+  # Same exactly-once discipline as the two version keys above: we rewrite the
+  # committed placeholder and never append, so an absent line is a hard failure
+  # rather than a beta that silently ships with no label.
+  LBL_COUNT="$(grep -cE '^[[:space:]]*RAYMOL_BETA_LABEL:' "$YML" || true)"
+  case "$LBL_COUNT" in
+    0) echo "ERROR: no RAYMOL_BETA_LABEL line in $YML — add the placeholder to project.yml" >&2; exit 1 ;;
+    1) ;;
+    *) echo "ERROR: $LBL_COUNT RAYMOL_BETA_LABEL lines in $YML — ambiguous; refusing to rewrite all" >&2; exit 1 ;;
+  esac
+
+  /usr/bin/sed -i '' -E \
+    -e "s/^([[:space:]]*)RAYMOL_BETA_LABEL:.*/\1RAYMOL_BETA_LABEL: \"$LABEL\"/" \
+    "$YML"
+
+  grep -qE "^[[:space:]]*RAYMOL_BETA_LABEL: \"$LABEL\"$" "$YML" || {
+    echo "ERROR: RAYMOL_BETA_LABEL edit did not apply to $YML" >&2; exit 1; }
+  echo "project.yml -> $MKT ($BUILD), label $LABEL"
+else
+  echo "project.yml -> $MKT ($BUILD)"
+fi

--- a/scripts/beta_label.sh
+++ b/scripts/beta_label.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# beta_label.sh — emit the human-readable label for an automated beta build:
+#     beta_label.sh 1.9.1 27  ->  1.9.1-beta27
+#
+# WHY THIS IS NOT THE MARKETING VERSION. App Store Connect requires
+# CFBundleShortVersionString to be a period-separated list of at most three
+# non-negative integers, so "1.9.1-beta27" is rejected at upload — a beta cannot
+# carry it as its version. Apple therefore only ever sees "1.9.1 (27)". This
+# label is the same information in the form a human reads, and it goes only where
+# WE control the text: RAYMOL_BETA_LABEL -> the built Info.plist's
+# RayMolBetaLabel key -> the app's Settings pane. It is display text, never an
+# identity Apple validates or sorts on.
+#
+# WHY THE BUILD NUMBER IS THE BETA ORDINAL. Xcode Cloud's CI_BUILD_NUMBER is a
+# monotonic integer across the whole app, so the counter does not restart at 1
+# for each version line — 1.9.1-beta27 can be followed by 1.10.0-beta34. That is
+# deliberate: a per-version ordinal would need persistent state (the build number
+# at which the line started) and would make two different builds share a label if
+# that state were ever wrong. Monotonic-and-slightly-odd beats ambiguous.
+#
+# Usage: beta_label.sh <marketing-version> <build-number>
+set -euo pipefail
+
+MKT="${1:-}"
+BUILD="${2:-}"
+
+# Validate both halves to the SAME rules their consumers enforce, so a bad label
+# fails here rather than showing a tester a version that does not exist.
+# apply_ci_versions.sh applies the identical two patterns to the real settings.
+[[ "$MKT" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+  echo "ERROR: marketing version must be X.Y.Z, got '$MKT'" >&2; exit 1; }
+[[ "$BUILD" =~ ^[0-9]+$ ]] || {
+  echo "ERROR: build number must be a non-negative integer, got '$BUILD'" >&2; exit 1; }
+
+echo "${MKT}-beta${BUILD}"

--- a/scripts/nightly_version.sh
+++ b/scripts/nightly_version.sh
@@ -1,22 +1,38 @@
 #!/bin/bash
 # nightly_version.sh — emit the marketing version for automated beta
-# (TestFlight) builds: the next MINOR after whatever swiftui/project.yml
-# currently declares.
-#     project.yml MARKETING_VERSION 1.8.0  ->  1.9.0
+# (TestFlight) builds: whatever swiftui/project.yml currently declares, VERBATIM.
+#     project.yml MARKETING_VERSION 1.9.1  ->  1.9.1
 #
-# DO NOT derive this from git tags. This repo carries the inherited PyMOL
-# version line, so `git tag | sort -V | tail -1` yields v3.2.0 while RayMol's
-# own releases top out at v1.8.0. A tag-based scheme would stamp betas 3.3.0 and
+# WHY THIS DOES NOT BUMP. It used to emit the next MINOR (1.9.1 -> 1.10.0) so a
+# beta always sorted above the last release. That pre-claims a version number
+# App Store Connect will not let you take back: by 2026-08-10 the iOS app had a
+# TestFlight prerelease 1.10.0 sitting above a live App Store 1.8.0, for a
+# release nobody had decided on yet. When the real next version turned out to be
+# a patch, 1.10.0 was stranded and every beta was labelled with a version that
+# would never ship. Betas now ride the CURRENT version and are distinguished by
+# the build number, which is exactly what the (CFBundleShortVersionString,
+# CFBundleVersion) uniqueness rule is for:
+#     1.9.1 (27), 1.9.1 (28), 1.9.1 (29) ...
+# so no version is burned until a release actually claims it.
+#
+# The human-readable "1.9.1-beta27" that testers see is built by
+# scripts/beta_label.sh from this version plus the build number, and cannot live
+# here: App Store Connect requires CFBundleShortVersionString to be at most
+# three numeric components, so a "-beta27" suffix in the marketing version is
+# rejected at upload. See run_nightly_version_test.sh, which asserts exactly
+# that this script refuses a non-numeric version.
+#
+# DO NOT derive this from git tags. This repo carries the inherited PyMOL version
+# line, so `git tag | sort -V | tail -1` yields v3.2.0 while RayMol's own
+# releases top out at 1.9.1. A tag-based scheme would stamp betas 3.3.0 and
 # permanently burn that version in App Store Connect — versions cannot be
 # deleted there.
 #
-# The line advances by itself: publish_release.sh already asserts the packaged
-# version matches project.yml, so cutting 1.9.0 sets that field to 1.9.0 and
-# betas move to 1.10.0.
-#
-# COROLLARY / CONVENTION: bump MARKETING_VERSION *to* the release version when
-# cutting a release, never in advance — pre-bumping makes betas leapfrog the
-# version actually being prepared.
+# COROLLARY / CONVENTION, unchanged and now load-bearing in a second way: bump
+# MARKETING_VERSION *to* the release version when cutting a release, never in
+# advance. publish_release.sh already asserts the packaged version matches
+# project.yml. Pre-bumping it no longer makes betas leapfrog — it makes them
+# claim a version that has not shipped.
 #
 # Usage: nightly_version.sh [path/to/project.yml]
 # The optional argument exists for unit tests; production callers pass nothing.
@@ -38,9 +54,4 @@ CUR="$(sed -nE 's/^[[:space:]]*MARKETING_VERSION:[[:space:]]*"?([0-9]+\.[0-9]+\.
   echo "       in App Store Connect." >&2
   exit 1; }
 
-MAJOR="${CUR%%.*}"
-REST="${CUR#*.}"
-MINOR="${REST%%.*}"
-
-# $(( )) forces integer arithmetic, so 1.9.x -> 1.10.0 rather than a string bug.
-echo "${MAJOR}.$((MINOR + 1)).0"
+echo "$CUR"

--- a/scripts/tests/run_apply_ci_versions_test.sh
+++ b/scripts/tests/run_apply_ci_versions_test.sh
@@ -16,6 +16,7 @@ fixture () {
     echo "        PRODUCT_NAME: RayMol"
     echo "        MARKETING_VERSION: \"1.8.0\""
     echo "        CURRENT_PROJECT_VERSION: 23"
+    echo "        RAYMOL_BETA_LABEL: \"\""
     echo "        GENERATE_INFOPLIST_FILE: YES"
   } > "$f"
   echo "$f"
@@ -122,6 +123,74 @@ DUP_CPV="$TMP/dup_cpv.yml"
 if bash "$SCRIPT" "$DUP_CPV" "1.9.0" "47" >/dev/null 2>&1; then
   echo "  FAIL: succeeded with duplicate CURRENT_PROJECT_VERSION lines"; FAILED=1
 else echo "  ok: fails when CURRENT_PROJECT_VERSION appears more than once"; fi
+
+# ---------------------------------------------------------------------------
+# Beta label (optional 4th argument)
+# ---------------------------------------------------------------------------
+# The label is what a TestFlight tester reads off the Settings pane to report a
+# bug against, since betas share their marketing version with the release they
+# were cut from. A wrong or missing label is therefore a real defect, not cosmetic.
+
+L="$(fixture)"
+if bash "$SCRIPT" "$L" "1.9.0" "47" "1.9.0-beta47" >/dev/null 2>&1; then
+  echo "  ok: valid beta label accepted"
+else echo "  FAIL: valid beta label rejected"; FAILED=1; fi
+
+if grep -qE '^        RAYMOL_BETA_LABEL: "1\.9\.0-beta47"$' "$L"; then
+  echo "  ok: RAYMOL_BETA_LABEL rewritten with indentation preserved"
+else echo "  FAIL: RAYMOL_BETA_LABEL not rewritten"; FAILED=1; fi
+
+[ "$(grep -c 'RAYMOL_BETA_LABEL:' "$L")" = 1 ] \
+  && echo "  ok: single RAYMOL_BETA_LABEL line" \
+  || { echo "  FAIL: duplicate RAYMOL_BETA_LABEL lines"; FAILED=1; }
+
+# OMITTING the label must leave the committed empty value alone. That empty value
+# is what marks a build as NOT a beta, so a release build that accidentally
+# inherited a label would tell every user they are running a beta.
+O="$(fixture)"
+bash "$SCRIPT" "$O" "1.9.0" "47" >/dev/null 2>&1
+if grep -qE '^        RAYMOL_BETA_LABEL: ""$' "$O"; then
+  echo "  ok: omitted label leaves the placeholder empty"
+else echo "  FAIL: omitted label did not leave RAYMOL_BETA_LABEL empty"; FAILED=1; fi
+
+# Malformed labels. "1.9.0-beta" (no ordinal) and a bare version are the two a
+# human would plausibly hand-write; both are ambiguous between builds.
+for bad in "1.9.0-beta" "1.9.0" "beta47" "1.9-beta47" "1.9.0-beta47-extra" "1.9.0 beta47"; do
+  if bash "$SCRIPT" "$(fixture)" "1.9.0" "47" "$bad" >/dev/null 2>&1; then
+    echo "  FAIL: accepted bad beta label '$bad'"; FAILED=1
+  else echo "  ok: rejects beta label '$bad'"; fi
+done
+
+# A label with nowhere to go must fail loudly rather than be dropped: the build
+# would otherwise ship as a beta with no way for a tester to identify it.
+NO_LBL="$TMP/no_lbl.yml"
+printf 'settings:\n  base:\n        MARKETING_VERSION: "1.8.0"\n        CURRENT_PROJECT_VERSION: 23\n' > "$NO_LBL"
+if bash "$SCRIPT" "$NO_LBL" "1.9.0" "47" "1.9.0-beta47" >/dev/null 2>&1; then
+  echo "  FAIL: succeeded with RAYMOL_BETA_LABEL absent"; FAILED=1
+else echo "  ok: fails when RAYMOL_BETA_LABEL is absent and a label was given"; fi
+
+# ...but with NO label the absent line is fine — that is the pre-existing
+# three-argument contract, which release tooling still uses.
+NO_LBL2="$TMP/no_lbl2.yml"
+printf 'settings:\n  base:\n        MARKETING_VERSION: "1.8.0"\n        CURRENT_PROJECT_VERSION: 23\n' > "$NO_LBL2"
+if bash "$SCRIPT" "$NO_LBL2" "1.9.0" "47" >/dev/null 2>&1; then
+  echo "  ok: 3-argument form still works without a RAYMOL_BETA_LABEL line"
+else echo "  FAIL: 3-argument form broke when RAYMOL_BETA_LABEL is absent"; FAILED=1; fi
+
+DUP_LBL="$TMP/dup_lbl.yml"
+{
+  echo "settings:"
+  echo "  base:"
+  echo "        MARKETING_VERSION: \"1.8.0\""
+  echo "        CURRENT_PROJECT_VERSION: 23"
+  echo "        RAYMOL_BETA_LABEL: \"\""
+  echo "  targets:"
+  echo "    RayMol:"
+  echo "        RAYMOL_BETA_LABEL: \"\""
+} > "$DUP_LBL"
+if bash "$SCRIPT" "$DUP_LBL" "1.9.0" "47" "1.9.0-beta47" >/dev/null 2>&1; then
+  echo "  FAIL: succeeded with duplicate RAYMOL_BETA_LABEL lines"; FAILED=1
+else echo "  ok: fails when RAYMOL_BETA_LABEL appears more than once"; fi
 
 rm -rf "$TMP"
 [ "$FAILED" = 0 ] && echo "PASS" || { echo "FAILURES"; exit 1; }

--- a/scripts/tests/run_beta_label_test.sh
+++ b/scripts/tests/run_beta_label_test.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Unit tests for scripts/beta_label.sh.
+#
+# The label is display text, not an identity Apple validates — but it is the ONLY
+# thing that tells a TestFlight tester which build they are on, because betas
+# share their marketing version with the release they were cut from. A label that
+# is wrong, ambiguous, or silently empty makes every bug report from that build
+# unattributable, so the failure cases below matter as much as the happy path.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="$ROOT/scripts/beta_label.sh"
+FAILED=0
+
+expect_ok () {  # $1=label $2=version $3=build $4=expected
+  local got; got="$(bash "$SCRIPT" "$2" "$3" 2>/dev/null)"
+  if [ "$got" = "$4" ]; then echo "  ok: $1"
+  else echo "  FAIL: $1 — expected '$4', got '$got'"; FAILED=1; fi
+}
+
+expect_fail () {  # $1=label $2=version $3=build
+  if bash "$SCRIPT" "$2" "$3" >/dev/null 2>&1; then
+    echo "  FAIL: $1 — should have exited non-zero"; FAILED=1
+  else echo "  ok: $1"; fi
+}
+
+echo "== beta_label =="
+
+expect_ok "1.9.1 + 27"          "1.9.1"  "27"  "1.9.1-beta27"
+expect_ok "double-digit minor"  "1.10.0" "34"  "1.10.0-beta34"
+expect_ok "build 0"             "1.9.1"  "0"   "1.9.1-beta0"
+expect_ok "large build number"  "2.0.0"  "1234" "2.0.0-beta1234"
+
+# A malformed version must not reach a tester's screen. These are exactly the
+# forms App Store Connect itself rejects for CFBundleShortVersionString, kept in
+# lockstep with apply_ci_versions.sh's validation.
+expect_fail "two-component version"   "1.9"        "27"
+expect_fail "four-component version"  "1.9.0.1"    "27"
+expect_fail "v-prefixed version"      "v1.9.1"     "27"
+expect_fail "already-suffixed version" "1.9.1-beta" "27"
+expect_fail "empty version"           ""           "27"
+
+# Xcode Cloud build numbers are always non-negative integers; anything else means
+# the caller passed the wrong variable.
+expect_fail "non-numeric build"  "1.9.1" "abc"
+expect_fail "negative build"     "1.9.1" "-1"
+expect_fail "decimal build"      "1.9.1" "27.1"
+expect_fail "empty build"        "1.9.1" ""
+
+# No arguments at all must fail rather than emit a bare "-beta".
+expect_fail "no arguments" "" ""
+
+# Round-trip: the output must satisfy the pattern apply_ci_versions.sh enforces,
+# or the two scripts disagree and the pipeline dies at the stamping step.
+OUT="$(bash "$SCRIPT" "1.9.1" "27" 2>/dev/null)"
+if [[ "$OUT" =~ ^[0-9]+\.[0-9]+\.[0-9]+-beta[0-9]+$ ]]; then
+  echo "  ok: output satisfies apply_ci_versions.sh's label pattern"
+else
+  echo "  FAIL: '$OUT' would be rejected by apply_ci_versions.sh"; FAILED=1
+fi
+
+# The label must NOT be a valid marketing version — if it ever were, someone
+# could pass it to apply_ci_versions.sh as the version and upload would fail.
+if [[ "$OUT" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "  FAIL: '$OUT' looks like a marketing version"; FAILED=1
+else
+  echo "  ok: label is distinguishable from a marketing version"
+fi
+
+[ "$FAILED" = 0 ] && echo "PASS" || { echo "FAILURES"; exit 1; }

--- a/scripts/tests/run_ci_post_clone_plugin_trust_test.sh
+++ b/scripts/tests/run_ci_post_clone_plugin_trust_test.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# Unit tests for the package-plugin trust step of swiftui/ci_scripts/ci_post_clone.sh.
+#
+# WHY THIS SUITE EXISTS. mlx-swift ships a `CudaBuild` build-tool plugin. Xcode
+# will not run an untrusted package plugin, and Xcode Cloud has no dialog to
+# trust it at, so its Archive - iOS action fails outright with
+#     Plugin "CudaBuild" from package "mlx-swift" must be enabled before it can be used
+# Every iOS Beta build from #22 to #23 died exactly there. The cure is two
+# `defaults write` calls in ci_post_clone.sh, because Xcode Cloud runs its own
+# xcodebuild and we cannot pass it -skipPackagePluginValidation.
+#
+# The failure mode this suite guards is narrow and nasty: one of the two keys is
+# spelled with Apple's own typo — IDESkipPackagePluginFingerprintValidat*at*ion.
+# "Correcting" it produces a key nothing reads, `defaults write` still exits 0,
+# and the break resurfaces 20 minutes later inside a build whose flags we do not
+# control. Nothing else in the repo can catch that, and ci_post_clone.sh itself
+# cannot run outside Xcode Cloud (it `set -u`s on CI_PRIMARY_REPOSITORY_PATH),
+# so the assertions below are made against its source text plus — when an Xcode
+# is installed — the key names Xcode itself contains.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+HOOK="$ROOT/swiftui/ci_scripts/ci_post_clone.sh"
+FAILED=0
+
+# The exact strings Xcode recognises. GOOD_PLUGIN carries Apple's doubled "at".
+GOOD_PLUGIN="IDESkipPackagePluginFingerprintValidatation"
+GOOD_MACRO="IDESkipMacroFingerprintValidation"
+# The plausible "fix" someone will eventually apply to GOOD_PLUGIN. It is inert.
+TYPO_FIX="IDESkipPackagePluginFingerprintValidation"
+
+echo "== ci_post_clone plugin trust =="
+
+if [ ! -f "$HOOK" ]; then
+  echo "  FAIL: hook not found: $HOOK"
+  echo "FAILURES"; exit 1
+fi
+
+# 1. Both keys are actually written, to the domain xcodebuild reads.
+for KEY in "$GOOD_PLUGIN" "$GOOD_MACRO"; do
+  if grep -qE "^defaults write com\.apple\.dt\.Xcode $KEY -bool YES$" "$HOOK"; then
+    echo "  ok: writes $KEY"
+  else
+    echo "  FAIL: no 'defaults write com.apple.dt.Xcode $KEY -bool YES' line in ci_post_clone.sh"
+    FAILED=1
+  fi
+done
+
+# 2. The corrected spelling must never appear. grep for it as a whole word so
+#    the doubled-"at" form above cannot satisfy this check by accident.
+if grep -qE "(^|[^a-zA-Z])$TYPO_FIX([^a-zA-Z]|$)" "$HOOK"; then
+  echo "  FAIL: found the 'corrected' spelling $TYPO_FIX — Xcode does not read that key."
+  echo "        Apple's own string is $GOOD_PLUGIN (doubled 'at'). Restore it."
+  FAILED=1
+else
+  echo "  ok: no inert 'corrected' spelling"
+fi
+
+# 3. The writes are verified by a read-back. A `defaults write` that silently
+#    no-ops must not reach the archive action unnoticed — same discipline as the
+#    xcconfig and project.yml patches elsewhere in the hook.
+if grep -qE 'defaults read com\.apple\.dt\.Xcode' "$HOOK"; then
+  for KEY in "$GOOD_PLUGIN" "$GOOD_MACRO"; do
+    # The key must be in the verification loop's own key list, not merely
+    # mentioned somewhere in the file — a prose reference verifies nothing.
+    if grep -qE "^for KEY in .*$KEY" "$HOOK"; then
+      echo "  ok: $KEY write is read back"
+    else
+      echo "  FAIL: $KEY is not in the read-back verification loop's key list"
+      FAILED=1
+    fi
+  done
+else
+  echo "  FAIL: no 'defaults read com.apple.dt.Xcode' read-back at all —"
+  echo "        a silent no-op write would reach the archive action unnoticed"
+  FAILED=1
+fi
+
+# 4. Cross-check the key names against the installed Xcode. This is what makes
+#    the suite more than a restatement of the source: if a future Xcode renames
+#    or de-typos either key, this fails and tells us to write BOTH spellings
+#    rather than silently regressing the pipeline.
+DEVDIR="$(xcode-select -p 2>/dev/null || true)"
+CANDIDATES=(
+  "$DEVDIR/../Frameworks/IDEFoundation.framework/Versions/A/IDEFoundation"
+  "$DEVDIR/../SharedFrameworks/SwiftPM.framework/Versions/A/SwiftPM"
+  "$DEVDIR/../SharedFrameworks/IDESwiftPackageCore.framework/Versions/A/IDESwiftPackageCore"
+)
+FOUND_BIN=0
+for KEY in "$GOOD_PLUGIN" "$GOOD_MACRO"; do
+  HIT=0
+  for BIN in "${CANDIDATES[@]}"; do
+    [ -f "$BIN" ] || continue
+    FOUND_BIN=1
+    # Count rather than `grep -q`: -q exits on the first match, which SIGPIPEs
+    # `strings` (141), and `set -o pipefail` above then reports the whole
+    # pipeline as failed even though the string WAS found. -c drains the stream.
+    N="$(strings -a "$BIN" 2>/dev/null | grep -cxF "$KEY" || true)"
+    if [ "${N:-0}" -gt 0 ]; then HIT=1; break; fi
+  done
+  if [ "$FOUND_BIN" = 0 ]; then continue; fi
+  if [ "$HIT" = 1 ]; then
+    echo "  ok: Xcode contains $KEY"
+  else
+    echo "  FAIL: the installed Xcode does not contain the string $KEY."
+    echo "        Apple may have renamed it; find the current name with"
+    echo "        strings -a <IDEFoundation> | grep '^IDESkip' and write BOTH."
+    FAILED=1
+  fi
+done
+if [ "$FOUND_BIN" = 0 ]; then
+  # Announce loudly rather than pass quietly — an unrun assertion is not a pass.
+  echo "  SKIP: no Xcode framework binary found under '$DEVDIR/..'; key names"
+  echo "        not cross-checked against Xcode on this machine."
+fi
+
+[ "$FAILED" = 0 ] && echo "PASS" || { echo "FAILURES"; exit 1; }

--- a/scripts/tests/run_nightly_version_test.sh
+++ b/scripts/tests/run_nightly_version_test.sh
@@ -35,15 +35,28 @@ expect_fail () {  # $1=label $2=version-literal (may be empty)
 
 echo "== nightly_version =="
 
-# Core behaviour: bump the MINOR, zero the PATCH.
-expect_ok "1.8.0 -> 1.9.0"   '"1.8.0"'  "1.9.0"
-expect_ok "1.9.9 -> 1.10.0"  '"1.9.9"'  "1.10.0"
-expect_ok "0.1.0 -> 0.2.0"   '"0.1.0"'  "0.2.0"
-expect_ok "2.0.3 -> 2.1.0"   '"2.0.3"'  "2.1.0"
-# Double-digit minors must not be mangled by string comparison.
-expect_ok "1.10.0 -> 1.11.0" '"1.10.0"' "1.11.0"
+# Core behaviour: emit project.yml's version VERBATIM — no bump.
+#
+# This is the assertion that matters, and it is the inverse of what this suite
+# asserted before 2026-08-10. Bumping to the next minor pre-claimed a version in
+# App Store Connect that could never be released or reclaimed (the iOS app ended
+# up with a TestFlight 1.10.0 above a live 1.8.0). Betas are now told apart by
+# build number, so a bump reintroduced here is a regression, not a refinement.
+expect_ok "1.8.0 stays 1.8.0"   '"1.8.0"'  "1.8.0"
+expect_ok "1.9.1 stays 1.9.1"   '"1.9.1"'  "1.9.1"
+expect_ok "1.9.9 stays 1.9.9"   '"1.9.9"'  "1.9.9"
+expect_ok "0.1.0 stays 0.1.0"   '"0.1.0"'  "0.1.0"
+# Double-digit minors must survive verbatim (no numeric round-trip mangling).
+expect_ok "1.10.0 stays 1.10.0" '"1.10.0"' "1.10.0"
 # Unquoted YAML scalar is still valid YAML and must parse.
-expect_ok "unquoted 1.8.0"   '1.8.0'    "1.9.0"
+expect_ok "unquoted 1.8.0"      '1.8.0'    "1.8.0"
+
+# Explicitly pin the anti-regression: the output must NEVER exceed the input.
+for v in "1.8.0" "1.9.1" "1.10.0" "2.0.3"; do
+  got="$(bash "$SCRIPT" "$(fixture "\"$v\"")" 2>/dev/null)"
+  if [ "$got" = "$v" ]; then echo "  ok: $v not bumped"
+  else echo "  FAIL: $v was rewritten to '$got' — betas must not claim a new version"; FAILED=1; fi
+done
 
 # Hard failures — guessing a version is unrecoverable in App Store Connect.
 expect_fail "missing MARKETING_VERSION" ""
@@ -57,16 +70,21 @@ if bash "$SCRIPT" "$TMP/does-not-exist.yml" >/dev/null 2>&1; then
 else echo "  ok: missing file exits non-zero"; fi
 
 # Smoke-test the real repo file: with no argument the script must default to
-# swiftui/project.yml, exit 0, and emit a valid release-version string.
-# We do NOT assert a literal value here (e.g. "1.9.0") because that would
-# make CI fail on every release once project.yml is bumped — the arithmetic
-# is already exhaustively proven by the fixture cases above.  Deriving the
-# expectation from the script itself (expected="$(bash "$SCRIPT")") would be
-# circular and would pass even if the script were completely broken.
-# Asserting the structural contract — exit 0 + X.Y.0 form — is release-proof.
-if REAL="$(bash "$SCRIPT" 2>/dev/null)" && [[ "$REAL" =~ ^[0-9]+\.[0-9]+\.0$ ]]; then
-  echo "  ok: real repo → $REAL"
-else echo "  FAIL: real repo gave '$REAL' (expected X.Y.0 and exit 0)"; FAILED=1; fi
+# swiftui/project.yml and exit 0.
+#
+# This now asserts the value directly, which the old bump-based version could
+# not: the answer is "whatever project.yml declares" rather than arithmetic on
+# it, and that equality IS the contract. Reading the expectation out of the file
+# with an independent sed (not by calling the script) keeps it non-circular, and
+# it stays correct across every future release bump.
+REAL_YML="$ROOT/swiftui/project.yml"
+DECLARED="$(sed -nE 's/^[[:space:]]*MARKETING_VERSION:[[:space:]]*"?([0-9]+\.[0-9]+\.[0-9]+)"?[[:space:]]*$/\1/p' \
+             "$REAL_YML" | head -1)"
+if REAL="$(bash "$SCRIPT" 2>/dev/null)" && [ -n "$DECLARED" ] && [ "$REAL" = "$DECLARED" ]; then
+  echo "  ok: real repo → $REAL (matches project.yml verbatim)"
+else
+  echo "  FAIL: real repo gave '$REAL', project.yml declares '$DECLARED'"; FAILED=1
+fi
 
 rm -rf "$TMP"
 [ "$FAILED" = 0 ] && echo "PASS" || { echo "FAILURES"; exit 1; }

--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -9,10 +9,12 @@
 /* Begin PBXBuildFile section */
 		020822B7AD61092433C2F78E /* whatsnew-170-move.png in Resources */ = {isa = PBXBuildFile; fileRef = 4C570F9CAC877E201F237016 /* whatsnew-170-move.png */; };
 		042F08F899EE19B73EFEC143 /* CommandPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50D264C420888CBF7FDE633 /* CommandPanel.swift */; };
+		057F3C59DACA26AAC603702E /* AppBuildInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AE160C6EB58F631604002E6 /* AppBuildInfoTests.swift */; };
 		0C0E67D9436CC6DF29DE983C /* DesignEditingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05E6ECE945556A6D1FAE98F9 /* DesignEditingTests.swift */; };
 		0F6C6BD0DB9B077E51D1EFAF /* WhatsNewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5377EE69A856479317FD61 /* WhatsNewModel.swift */; };
 		0FFCBEB460CD541E932326AB /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3E805AC2D63B01AB7EE29C /* Theme.swift */; };
 		104B27F848D308735A6D6DD2 /* MetalViewport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E9F8D36908E3216D1C8F893 /* MetalViewport.swift */; };
+		124F6E6764C7D94831B8AC7E /* AppVersionFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3F3410F7C0D3C85783B985F /* AppVersionFooter.swift */; };
 		13B48E7F8C2A51ADAF48F4C3 /* SequencePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474D18A43D0D9A6BDD69EEFD /* SequencePanel.swift */; };
 		13E8687216067D92666E3078 /* openssl-PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = CB0108E0FA1F204BE0E41F0D /* openssl-PrivacyInfo.xcprivacy */; };
 		142D8657C5BC7DCD8648D407 /* DesignCompactPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D7FF883D3762DC6E40908F /* DesignCompactPanel.swift */; };
@@ -39,6 +41,7 @@
 		42BC62ABCFB3CDB9C2CE3518 /* DesignColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B045EA1D04163863BD9DA94 /* DesignColorTests.swift */; };
 		42D3395698D37E4BF7055EEA /* MCPBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A18D8A6B0FB56FCD3C31211 /* MCPBridge.swift */; };
 		42F2467DC338FA8435632918 /* WhatsNew.json in Resources */ = {isa = PBXBuildFile; fileRef = 689CDE512811C244D4BA931B /* WhatsNew.json */; };
+		45817B402639546111EFD5B7 /* AppVersionFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3F3410F7C0D3C85783B985F /* AppVersionFooter.swift */; };
 		4679E36960C9AE8AAE3B1F7D /* ObjectPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A73267D4D7B506E647B7A995 /* ObjectPanel.swift */; };
 		484D9DFA048A6444660199CB /* MPNNKit in Frameworks */ = {isa = PBXBuildFile; productRef = 791C3459ADD4745BE10E27AA /* MPNNKit */; };
 		4852173B3AB34D6B4FF76415 /* MCPDesktopInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786939619F7871E32E2BB123 /* MCPDesktopInstaller.swift */; };
@@ -96,11 +99,13 @@
 		97F0B5805CD3B11723C7B43B /* whatsnew-152-timeline.png in Resources */ = {isa = PBXBuildFile; fileRef = 55094A33AFF9AEF5561CFD96 /* whatsnew-152-timeline.png */; };
 		983BCF8F1E0F251E82C1CF0E /* DesignController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4FB7F151982A2927D612F0 /* DesignController.swift */; };
 		9FE703EF6FD7C97884C299DF /* RayMol.icon in Resources */ = {isa = PBXBuildFile; fileRef = BB5ABD1A8C45E5BC97AB0B80 /* RayMol.icon */; };
+		AA00B9355E30A51B8F4C207B /* AppBuildInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525F338CAB2EE18987CD1701 /* AppBuildInfo.swift */; };
 		AA36D034CEC68207CFC82340 /* WhatsNewModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4D170B35BCCF683A6B3D655 /* WhatsNewModal.swift */; };
 		ACBE8F70B980BCCE6730141A /* MovieBuilderSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ED5BFF3FEE9D6621BB40AE5 /* MovieBuilderSheet.swift */; };
 		B2697EF48D85EF14D4A19163 /* RayMol.icon in Resources */ = {isa = PBXBuildFile; fileRef = BB5ABD1A8C45E5BC97AB0B80 /* RayMol.icon */; };
 		B33C0620EDD48195A59B7DD8 /* MCPBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A18D8A6B0FB56FCD3C31211 /* MCPBridge.swift */; };
 		B39D2F9676F6394CD354209A /* whatsnew-190-redesign.png in Resources */ = {isa = PBXBuildFile; fileRef = 137F4EFE6CA3B90DE4765559 /* whatsnew-190-redesign.png */; };
+		B532BA92CE9FB3A65DD02D37 /* AppBuildInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525F338CAB2EE18987CD1701 /* AppBuildInfo.swift */; };
 		B5CC8EFFCE99E9813AEC1422 /* DesignRegionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2CE99D9A3C57ACBBDBF3B5 /* DesignRegionTests.swift */; };
 		B6FBF55DD1FA97A86C678618 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 98AC6A7391B7E7A564A30A61 /* Sparkle */; };
 		B84285B5FAD1A429B1FCEDBF /* 1ubq.cif in Resources */ = {isa = PBXBuildFile; fileRef = 1A55383922D69D691CA1BAB1 /* 1ubq.cif */; };
@@ -193,6 +198,7 @@
 		4A2C1E1633D1E93E9914BEC3 /* OpenFilesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenFilesTests.swift; sourceTree = "<group>"; };
 		4C570F9CAC877E201F237016 /* whatsnew-170-move.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "whatsnew-170-move.png"; sourceTree = "<group>"; };
 		4D6A959CC1590FC60333582B /* DesignEditInferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignEditInferenceTests.swift; sourceTree = "<group>"; };
+		525F338CAB2EE18987CD1701 /* AppBuildInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBuildInfo.swift; sourceTree = "<group>"; };
 		55094A33AFF9AEF5561CFD96 /* whatsnew-152-timeline.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "whatsnew-152-timeline.png"; sourceTree = "<group>"; };
 		55F4F52D951CF1F96606F41C /* SmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmokeTests.swift; sourceTree = "<group>"; };
 		56BE219EF1CF1EB2B05E44AD /* MPNNGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPNNGate.swift; sourceTree = "<group>"; };
@@ -202,6 +208,7 @@
 		5E9F8D36908E3216D1C8F893 /* MetalViewport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalViewport.swift; sourceTree = "<group>"; };
 		689CDE512811C244D4BA931B /* WhatsNew.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = WhatsNew.json; sourceTree = "<group>"; };
 		6A0950CBB18F3934DDA02CBE /* whatsnew-190-scenes.mp4 */ = {isa = PBXFileReference; path = "whatsnew-190-scenes.mp4"; sourceTree = "<group>"; };
+		6AE160C6EB58F631604002E6 /* AppBuildInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBuildInfoTests.swift; sourceTree = "<group>"; };
 		6E2FC2AD1A8FEE912986DF9D /* whatsnew-161-hover.mp4 */ = {isa = PBXFileReference; path = "whatsnew-161-hover.mp4"; sourceTree = "<group>"; };
 		6ECDA98647B184340BC7934F /* DesignIOSPortTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignIOSPortTests.swift; sourceTree = "<group>"; };
 		75F059BB95517CE91BD3E26E /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -225,6 +232,7 @@
 		B820FE9080BF73526A54CD66 /* TimelinePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelinePanel.swift; sourceTree = "<group>"; };
 		B9EC978B16F58D988575E206 /* MCPDrivingBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPDrivingBanner.swift; sourceTree = "<group>"; };
 		BB5ABD1A8C45E5BC97AB0B80 /* RayMol.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = RayMol.icon; sourceTree = "<group>"; };
+		C3F3410F7C0D3C85783B985F /* AppVersionFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionFooter.swift; sourceTree = "<group>"; };
 		C562306A5AD1EEDDBA931B98 /* TransportBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportBar.swift; sourceTree = "<group>"; };
 		C5F2DF248B756BF6CA3CBE92 /* DesignColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignColor.swift; sourceTree = "<group>"; };
 		C78CBBCC3AFAD0E62BBAA884 /* PyMOLViewer.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = PyMOLViewer.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -249,7 +257,7 @@
 		F7E41DCBB427678A8F018B0E /* DesignControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignControllerTests.swift; sourceTree = "<group>"; };
 		FB1304C662D9011F7C4505FC /* MCPStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPStatusView.swift; sourceTree = "<group>"; };
 		FF4FB7F151982A2927D612F0 /* DesignController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignController.swift; sourceTree = "<group>"; };
-		"TEMP_C91CA554-3146-4D90-8B65-349117B4020E" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
+		"TEMP_538CF3AC-3EAE-45D1-9968-D016092C39D4" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -363,6 +371,8 @@
 		64BF1D08B3C4F59EA8DE2FE1 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				525F338CAB2EE18987CD1701 /* AppBuildInfo.swift */,
+				C3F3410F7C0D3C85783B985F /* AppVersionFooter.swift */,
 				75F059BB95517CE91BD3E26E /* ContentView.swift */,
 				4300265954DF2B8309EDAA6C /* DesignAvailability.swift */,
 				C5F2DF248B756BF6CA3CBE92 /* DesignColor.swift */,
@@ -395,6 +405,7 @@
 		7CDEA29979CAC7C794816FCF /* PyMOLViewerTests */ = {
 			isa = PBXGroup;
 			children = (
+				6AE160C6EB58F631604002E6 /* AppBuildInfoTests.swift */,
 				2345D7E2703CF29D4A2AA277 /* DesignAvailabilityTests.swift */,
 				1B045EA1D04163863BD9DA94 /* DesignColorTests.swift */,
 				F7E41DCBB427678A8F018B0E /* DesignControllerTests.swift */,
@@ -437,10 +448,10 @@
 			path = Bridge;
 			sourceTree = "<group>";
 		};
-		"TEMP_3EF596E2-09DB-414E-83E1-5043487CDDEA" /* swiftui */ = {
+		"TEMP_40BB0994-A55D-4A53-B88A-8A2FF99FC7B4" /* swiftui */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_C91CA554-3146-4D90-8B65-349117B4020E" /* PyMOLBridge.xcconfig */,
+				"TEMP_538CF3AC-3EAE-45D1-9968-D016092C39D4" /* PyMOLBridge.xcconfig */,
 			);
 			path = swiftui;
 			sourceTree = "<group>";
@@ -456,6 +467,7 @@
 				D61D47B2F441B27E03C9023B /* Resources */,
 				4E6246238783B0F1F0B91508 /* Frameworks */,
 				E9A5181B8D4750082E0C0F2C /* Brand: set CFBundleName = RayMol */,
+				7227265B2801BD14276EC727 /* Beta: set RayMolBetaLabel from RAYMOL_BETA_LABEL */,
 				B07CD62C5BBE02F19894A460 /* Sparkle: inject auto-update Info.plist keys (macOS, non-MAS) */,
 				7AD50FCE7EA1A86486FE1AA6 /* Brand: register molecular document types */,
 				D6E180B4CFF12A0215D1E81F /* iOS: Embed Python.framework */,
@@ -489,6 +501,7 @@
 				61D7B61F4D5ACB99F6B7EA8D /* Resources */,
 				FB23646F44642041FD58D674 /* Frameworks */,
 				2A8B25C9FABB5F43C64A3B4F /* Brand: set CFBundleName = RayMol */,
+				2A47BF2FE69ED02355B5F8B5 /* Beta: set RayMolBetaLabel from RAYMOL_BETA_LABEL */,
 				2AC63EBF7745B988799768CA /* Sparkle: inject auto-update Info.plist keys (macOS, non-MAS) */,
 				20F6E2447B7743E74607108B /* Brand: register molecular document types */,
 				674165941FEA5412EAD0F21B /* iOS: Embed Python.framework */,
@@ -683,6 +696,26 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\nPLIST=\"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\n[ -f \"$PLIST\" ] || { echo \"no Info.plist at $PLIST\"; exit 0; }\n/usr/bin/plutil -replace CFBundleDocumentTypes -json '[\n  {\"CFBundleTypeName\":\"PyMOL Session\",\"CFBundleTypeRole\":\"Editor\",\"LSHandlerRank\":\"Owner\",\"LSItemContentTypes\":[\"org.pymol.pse\"]},\n  {\"CFBundleTypeName\":\"Molecular Structure\",\"CFBundleTypeRole\":\"Viewer\",\"LSHandlerRank\":\"Default\",\"LSItemContentTypes\":[\"org.pymol.structure\"]},\n  {\"CFBundleTypeName\":\"Small Molecule\",\"CFBundleTypeRole\":\"Viewer\",\"LSHandlerRank\":\"Default\",\"LSItemContentTypes\":[\"org.pymol.small-molecule\"]},\n  {\"CFBundleTypeName\":\"Electron Density / Map\",\"CFBundleTypeRole\":\"Viewer\",\"LSHandlerRank\":\"Default\",\"LSItemContentTypes\":[\"org.pymol.map\"]}\n]' \"$PLIST\"\n/usr/bin/plutil -replace UTImportedTypeDeclarations -json '[\n  {\"UTTypeIdentifier\":\"org.pymol.pse\",\"UTTypeDescription\":\"PyMOL Session\",\"UTTypeConformsTo\":[\"public.data\"],\"UTTypeTagSpecification\":{\"public.filename-extension\":[\"pse\"]}},\n  {\"UTTypeIdentifier\":\"org.pymol.structure\",\"UTTypeDescription\":\"Molecular Structure\",\"UTTypeConformsTo\":[\"public.data\",\"public.text\"],\"UTTypeTagSpecification\":{\"public.filename-extension\":[\"pdb\",\"ent\",\"cif\",\"mmcif\",\"mcif\",\"mmtf\"]}},\n  {\"UTTypeIdentifier\":\"org.pymol.small-molecule\",\"UTTypeDescription\":\"Small Molecule\",\"UTTypeConformsTo\":[\"public.data\",\"public.text\"],\"UTTypeTagSpecification\":{\"public.filename-extension\":[\"sdf\",\"mol\",\"mol2\",\"xyz\",\"mae\"]}},\n  {\"UTTypeIdentifier\":\"org.pymol.map\",\"UTTypeDescription\":\"Electron Density / Map\",\"UTTypeConformsTo\":[\"public.data\"],\"UTTypeTagSpecification\":{\"public.filename-extension\":[\"ccp4\",\"mtz\",\"dx\",\"xplor\",\"map\",\"mrc\"]}}\n]' \"$PLIST\"\n# A document-based app declaring CFBundleDocumentTypes must also state\n# whether it opens files in place (App Store warning 90737). RayMol opens\n# documents in place (Files / drag-drop), so declare it.\n/usr/bin/plutil -replace LSSupportsOpeningDocumentsInPlace -bool YES \"$PLIST\"\necho \"CFBundleDocumentTypes + UTImportedTypeDeclarations -> $PLIST\"\n";
 		};
+		2A47BF2FE69ED02355B5F8B5 /* Beta: set RayMolBetaLabel from RAYMOL_BETA_LABEL */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
+			);
+			name = "Beta: set RayMolBetaLabel from RAYMOL_BETA_LABEL";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -e\nLABEL=\"${RAYMOL_BETA_LABEL:-}\"\n# Empty is the normal case: every local, DMG and App Store build. Leave\n# the key ABSENT rather than writing \"\" so the app can treat presence of\n# the key as \"this is a beta\" without also testing for emptiness.\n[ -n \"$LABEL\" ] || { echo \"RayMolBetaLabel skipped (not a beta build)\"; exit 0; }\nPLIST=\"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\n[ -f \"$PLIST\" ] || { echo \"no Info.plist at $PLIST\"; exit 0; }\n/usr/bin/plutil -replace RayMolBetaLabel -string \"$LABEL\" \"$PLIST\"\necho \"RayMolBetaLabel -> $LABEL ($PLIST)\"\n";
+		};
 		2A8B25C9FABB5F43C64A3B4F /* Brand: set CFBundleName = RayMol */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -779,6 +812,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "case \"$PLATFORM_NAME\" in iphone*) ;; *) echo \"skip (non-iOS)\"; exit 0 ;; esac\nset -e\nif [ \"$EFFECTIVE_PLATFORM_NAME\" = \"-iphonesimulator\" ]; then SLICE=ios-arm64_x86_64-simulator; else SLICE=ios-arm64; fi\nSRC=\"$SRCROOT/../deps_ios/Python.xcframework/$SLICE/Python.framework\"\nmkdir -p \"$CODESIGNING_FOLDER_PATH/Frameworks\"\nditto \"$SRC\" \"$CODESIGNING_FOLDER_PATH/Frameworks/Python.framework\"\n";
+		};
+		7227265B2801BD14276EC727 /* Beta: set RayMolBetaLabel from RAYMOL_BETA_LABEL */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
+			);
+			name = "Beta: set RayMolBetaLabel from RAYMOL_BETA_LABEL";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -e\nLABEL=\"${RAYMOL_BETA_LABEL:-}\"\n# Empty is the normal case: every local, DMG and App Store build. Leave\n# the key ABSENT rather than writing \"\" so the app can treat presence of\n# the key as \"this is a beta\" without also testing for emptiness.\n[ -n \"$LABEL\" ] || { echo \"RayMolBetaLabel skipped (not a beta build)\"; exit 0; }\nPLIST=\"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\n[ -f \"$PLIST\" ] || { echo \"no Info.plist at $PLIST\"; exit 0; }\n/usr/bin/plutil -replace RayMolBetaLabel -string \"$LABEL\" \"$PLIST\"\necho \"RayMolBetaLabel -> $LABEL ($PLIST)\"\n";
 		};
 		7AD50FCE7EA1A86486FE1AA6 /* Brand: register molecular document types */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1086,6 +1139,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				057F3C59DACA26AAC603702E /* AppBuildInfoTests.swift in Sources */,
 				B88942D786AB0D1CDC354C1F /* DesignAvailabilityTests.swift in Sources */,
 				42BC62ABCFB3CDB9C2CE3518 /* DesignColorTests.swift in Sources */,
 				FCB5A40892C6D7239E49791A /* DesignControllerTests.swift in Sources */,
@@ -1111,6 +1165,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B532BA92CE9FB3A65DD02D37 /* AppBuildInfo.swift in Sources */,
+				124F6E6764C7D94831B8AC7E /* AppVersionFooter.swift in Sources */,
 				DC8A9C1AA5EB1946175041FA /* CommandPanel.swift in Sources */,
 				4128B469229CEE6A6A4E4B68 /* ContentView.swift in Sources */,
 				78893185798035F798A26A9B /* DesignAvailability.swift in Sources */,
@@ -1156,6 +1212,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AA00B9355E30A51B8F4C207B /* AppBuildInfo.swift in Sources */,
+				45817B402639546111EFD5B7 /* AppVersionFooter.swift in Sources */,
 				042F08F899EE19B73EFEC143 /* CommandPanel.swift in Sources */,
 				3F96563B0EA8F919B068A421 /* ContentView.swift in Sources */,
 				4E1CFC49EFB50160C3D388B2 /* DesignAvailability.swift in Sources */,
@@ -1237,6 +1295,7 @@
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
+				RAYMOL_BETA_LABEL = "";
 				SDKROOT = iphoneos;
 				"SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=iphoneos*]" = "$(inherited) RAYMOL_MPNN";
 				"SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=iphonesimulator*]" = "$(inherited) RAYMOL_MPNN";
@@ -1270,6 +1329,7 @@
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
+				RAYMOL_BETA_LABEL = "";
 				SDKROOT = macosx;
 				"SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=iphoneos*]" = "$(inherited) RAYMOL_MPNN";
 				"SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=iphonesimulator*]" = "$(inherited) RAYMOL_MPNN";
@@ -1306,6 +1366,7 @@
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
+				RAYMOL_BETA_LABEL = "";
 				SDKROOT = macosx;
 				"SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=iphoneos*]" = "$(inherited) RAYMOL_MPNN";
 				"SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=iphonesimulator*]" = "$(inherited) RAYMOL_MPNN";
@@ -1362,6 +1423,7 @@
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = io.raymol.RayMol;
 				PRODUCT_NAME = RayMol;
+				RAYMOL_BETA_LABEL = "";
 				SDKROOT = iphoneos;
 				"SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=iphoneos*]" = "$(inherited) RAYMOL_MPNN";
 				"SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=iphonesimulator*]" = "$(inherited) RAYMOL_MPNN";
@@ -1373,7 +1435,7 @@
 		};
 		76B7E9DB75E073D1E60928FA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_C91CA554-3146-4D90-8B65-349117B4020E" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_538CF3AC-3EAE-45D1-9968-D016092C39D4" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1480,7 +1542,7 @@
 		};
 		D8F44FDFF036013D2F03BA83 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_C91CA554-3146-4D90-8B65-349117B4020E" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_538CF3AC-3EAE-45D1-9968-D016092C39D4" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/swiftui/PyMOLViewer/Shared/AppBuildInfo.swift
+++ b/swiftui/PyMOLViewer/Shared/AppBuildInfo.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// The app's own version identity, as a user should read it.
+///
+/// Why this exists rather than reading `CFBundleShortVersionString` at each call
+/// site: a TestFlight beta and the release it was cut from share that string.
+/// Betas ride the CURRENT marketing version and are told apart only by the build
+/// number, because App Store Connect requires `CFBundleShortVersionString` to be
+/// at most three numeric components and rejects a "-beta27" suffix at upload
+/// (see scripts/nightly_version.sh for the full rationale). So "which build am I
+/// actually running?" cannot be answered by the version alone, and a tester
+/// filing a bug needs the answer.
+///
+/// The beta half comes from `RayMolBetaLabel`, which exists in the Info.plist
+/// ONLY for builds produced by Xcode Cloud: swiftui/ci_scripts/ci_post_clone.sh
+/// stamps `RAYMOL_BETA_LABEL` and a postBuildScript copies it in. Its presence is
+/// therefore the signal "this is a beta" — local, DMG and App Store builds have
+/// no such key and display a plain version.
+enum AppBuildInfo {
+
+    /// `CFBundleShortVersionString`, e.g. "1.9.1". Empty if somehow absent.
+    static var version: String { string(for: "CFBundleShortVersionString") }
+
+    /// `CFBundleVersion`, e.g. "27". Empty if somehow absent.
+    static var build: String { string(for: "CFBundleVersion") }
+
+    /// `RayMolBetaLabel`, e.g. "1.9.1-beta27" — `nil` for any non-beta build.
+    static var betaLabel: String? { Self.normalizedLabel(string(for: "RayMolBetaLabel")) }
+
+    /// What to show the user, e.g. "1.9.1-beta27" or "1.9.1 (27)".
+    static var displayVersion: String {
+        Self.displayVersion(version: version, build: build, betaLabel: betaLabel)
+    }
+
+    /// True when this build came off the beta pipeline.
+    static var isBeta: Bool { betaLabel != nil }
+
+    // MARK: - Pure logic (unit-tested; no Bundle access)
+
+    /// Treat a missing key and a present-but-blank one identically. The
+    /// postBuildScript is written to omit the key rather than write "", but a
+    /// hand-edited plist or a future change to that script must not produce a
+    /// build that claims to be "beta" with nothing after the dash.
+    static func normalizedLabel(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// The label wins when present — it already contains the version, so showing
+    /// both would read "1.9.1 (27) 1.9.1-beta27". Falls back to the App Store's
+    /// own "version (build)" convention, and degrades to whichever half exists if
+    /// the Info.plist is incomplete rather than rendering stray parentheses.
+    static func displayVersion(version: String, build: String, betaLabel: String?) -> String {
+        if let label = normalizedLabel(betaLabel) { return label }
+        switch (version.isEmpty, build.isEmpty) {
+        case (false, false): return "\(version) (\(build))"
+        case (false, true):  return version
+        case (true, false):  return "(\(build))"
+        case (true, true):   return ""
+        }
+    }
+
+    // MARK: - Bundle access
+
+    private static func string(for key: String) -> String {
+        (Bundle.main.object(forInfoDictionaryKey: key) as? String) ?? ""
+    }
+}

--- a/swiftui/PyMOLViewer/Shared/AppVersionFooter.swift
+++ b/swiftui/PyMOLViewer/Shared/AppVersionFooter.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+/// Small footer identifying the running build, shown at the bottom of the
+/// Display/Settings pane on both platforms.
+///
+/// It earns its place on iOS specifically: TestFlight betas carry the same
+/// `CFBundleShortVersionString` as the release they were cut from (App Store
+/// Connect will not accept a "-betaN" suffix there), so without this a tester
+/// reporting a bug has no way to say which beta they are on. See `AppBuildInfo`.
+struct AppVersionFooter: View {
+    /// e.g. "1.9.1-beta27" on a beta, "1.9.1 (27)" everywhere else.
+    private var label: String { AppBuildInfo.displayVersion }
+
+    var body: some View {
+        // Empty only if the Info.plist lost both version keys — render nothing
+        // rather than a bare "RayMol" that looks like a truncated string.
+        if !label.isEmpty {
+            Text(verbatim: "RayMol \(label)")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                // Testers paste this into bug reports; make it selectable rather
+                // than something they have to transcribe from a screenshot.
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity)
+                .padding(.top, 2)
+                .accessibilityIdentifier("app-version-footer")
+        }
+    }
+}

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -2797,6 +2797,12 @@ struct ContentView: View {
                         .controlSize(.large)
                         #endif
                         SceneCard()
+                        // Version footer. The only place a TestFlight tester can
+                        // see WHICH beta they are on: betas share their marketing
+                        // version with the release they were cut from (App Store
+                        // Connect rejects a "-betaN" suffix in the version), so
+                        // "1.9.1" alone is ambiguous and "1.9.1-beta27" is not.
+                        AppVersionFooter()
                     }
                     .padding(12)
                 }

--- a/swiftui/PyMOLViewerTests/AppBuildInfoTests.swift
+++ b/swiftui/PyMOLViewerTests/AppBuildInfoTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+@testable import RayMol
+
+/// Covers the pure half of `AppBuildInfo` — the part that decides what a user
+/// sees when asked "which build is this?".
+///
+/// This matters because a TestFlight beta and the release it was cut from share
+/// a `CFBundleShortVersionString`: App Store Connect requires at most three
+/// numeric components, so betas ride the current version and are separated only
+/// by build number. `RayMolBetaLabel` is the sole disambiguator, and getting its
+/// presence/absence logic wrong either hides which beta a tester is on or tells
+/// a paying App Store user they are running a beta.
+final class AppBuildInfoTests: XCTestCase {
+
+    // MARK: - normalizedLabel
+
+    // Absent key. Every local, DMG and App Store build takes this path.
+    func testNilLabelIsNotABeta() {
+        XCTAssertNil(AppBuildInfo.normalizedLabel(nil))
+    }
+
+    // Present-but-blank must be treated as absent. The postBuildScript is written
+    // to omit the key entirely, but project.yml carries RAYMOL_BETA_LABEL: "" and
+    // one changed `[ -n "$LABEL" ]` guard away this becomes an empty string in the
+    // plist — which must NOT read as "beta".
+    func testBlankLabelIsNotABeta() {
+        XCTAssertNil(AppBuildInfo.normalizedLabel(""))
+        XCTAssertNil(AppBuildInfo.normalizedLabel("   "))
+        XCTAssertNil(AppBuildInfo.normalizedLabel("\n"))
+        XCTAssertNil(AppBuildInfo.normalizedLabel(" \t \n "))
+    }
+
+    func testLabelIsTrimmedNotMangled() {
+        XCTAssertEqual(AppBuildInfo.normalizedLabel("1.9.1-beta27"), "1.9.1-beta27")
+        XCTAssertEqual(AppBuildInfo.normalizedLabel("  1.9.1-beta27\n"), "1.9.1-beta27")
+    }
+
+    // MARK: - displayVersion
+
+    // The beta label already contains the version, so it replaces the whole
+    // string rather than being appended — otherwise testers read
+    // "1.9.1 (27) 1.9.1-beta27".
+    func testBetaLabelWinsOverVersionAndBuild() {
+        XCTAssertEqual(
+            AppBuildInfo.displayVersion(version: "1.9.1", build: "27", betaLabel: "1.9.1-beta27"),
+            "1.9.1-beta27")
+    }
+
+    // The App Store's own convention for a non-beta build.
+    func testNonBetaUsesVersionAndBuild() {
+        XCTAssertEqual(
+            AppBuildInfo.displayVersion(version: "1.9.1", build: "27", betaLabel: nil),
+            "1.9.1 (27)")
+    }
+
+    // A blank label must fall through to the plain form, not produce "".
+    func testBlankLabelFallsThroughToVersion() {
+        XCTAssertEqual(
+            AppBuildInfo.displayVersion(version: "1.9.1", build: "27", betaLabel: ""),
+            "1.9.1 (27)")
+        XCTAssertEqual(
+            AppBuildInfo.displayVersion(version: "1.9.1", build: "27", betaLabel: "   "),
+            "1.9.1 (27)")
+    }
+
+    // Incomplete Info.plist: degrade to whichever half exists rather than
+    // rendering "1.9.1 ()" or " (27)" at the user.
+    func testMissingHalvesDegradeCleanly() {
+        XCTAssertEqual(
+            AppBuildInfo.displayVersion(version: "1.9.1", build: "", betaLabel: nil),
+            "1.9.1")
+        XCTAssertEqual(
+            AppBuildInfo.displayVersion(version: "", build: "27", betaLabel: nil),
+            "(27)")
+        XCTAssertEqual(
+            AppBuildInfo.displayVersion(version: "", build: "", betaLabel: nil),
+            "")
+    }
+
+    // A beta label must still win when the version keys are missing — it is the
+    // more specific fact, and it is complete on its own.
+    func testLabelWinsEvenWithEmptyVersionKeys() {
+        XCTAssertEqual(
+            AppBuildInfo.displayVersion(version: "", build: "", betaLabel: "1.9.1-beta27"),
+            "1.9.1-beta27")
+    }
+
+    // MARK: - The shipped bundle
+
+    // The app under test is a local build, which must never claim to be a beta.
+    // This is the assertion that would catch a non-empty RAYMOL_BETA_LABEL being
+    // committed to project.yml — the mistake that would mark every DMG and App
+    // Store build as a beta.
+    func testLocalBuildIsNotMarkedBeta() {
+        XCTAssertNil(AppBuildInfo.betaLabel,
+                     "This build carries RayMolBetaLabel=\(AppBuildInfo.betaLabel ?? "nil"). "
+                     + "RAYMOL_BETA_LABEL must be empty in the committed project.yml; only "
+                     + "ci_post_clone.sh may set it.")
+        XCTAssertFalse(AppBuildInfo.isBeta)
+    }
+
+    // Whatever the bundle says, the footer must have something to show.
+    func testBundleDisplayVersionIsNonEmpty() {
+        XCTAssertFalse(AppBuildInfo.displayVersion.isEmpty)
+    }
+}

--- a/swiftui/ci_scripts/ci_post_clone.sh
+++ b/swiftui/ci_scripts/ci_post_clone.sh
@@ -19,7 +19,44 @@ cd "$CI_PRIMARY_REPOSITORY_PATH"
 
 REPO="javierbq/RayMol"
 
-echo "== 1/6  Toolchain =="
+echo "== 1/7  Allow the mlx-swift build-tool plugin =="
+# mlx-swift's Cmlx target carries a `CudaBuild` .buildTool() plugin. Xcode
+# fingerprints package plugins and refuses to run one that has not been trusted;
+# in the IDE that trust is a dialog, and there is no dialog on Xcode Cloud. The
+# archive action just dies with
+#     Plugin "CudaBuild" from package "mlx-swift" must be enabled before it can be used
+# which is what broke every iOS Beta build from #22 (the #217 Phase 2d merge that
+# linked mlx-swift into the iOS target) onward.
+#
+# Locally and in swiftui/archive_appstore.sh the cure is
+# `-skipPackagePluginValidation -skipMacroValidation` on our own xcodebuild call.
+# That is NOT available here: Xcode Cloud runs its own `xcodebuild archive` for
+# the Archive - iOS action and gives us no way to add flags to it. The defaults
+# below are the same switches at the preference layer, so they apply to a
+# xcodebuild we never invoke. ci_post_clone.sh runs before that action, which is
+# the whole reason this belongs here and not in a build script.
+#
+# DO NOT "fix" the spelling of IDESkipPackagePluginFingerprintValidatation. The
+# doubled "at" is Apple's own typo — the string is verbatim what ships inside
+# Xcode's IDEFoundation and SwiftPM frameworks, and the corrected spelling reads
+# as an unset key, silently restoring the failure. scripts/tests/
+# run_ci_post_clone_plugin_trust_test.sh pins both names against exactly that.
+defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidatation -bool YES
+defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
+# Read the values back. `defaults write` to an unwritable domain still exits 0,
+# and a silent no-op here fails ~20 minutes later inside an xcodebuild whose
+# flags we do not control — the same discipline the xcconfig patch in step 2
+# follows, for the same reason.
+for KEY in IDESkipPackagePluginFingerprintValidatation IDESkipMacroFingerprintValidation; do
+  VAL="$(defaults read com.apple.dt.Xcode "$KEY" 2>/dev/null || echo MISSING)"
+  [ "$VAL" = "1" ] || {
+    echo "ERROR: $KEY did not stick (read back '$VAL')." >&2
+    echo "       Xcode Cloud's archive action will fail plugin validation." >&2
+    exit 1; }
+  echo "  $KEY=1"
+done
+
+echo "== 2/7  Toolchain =="
 # The COMPLETE set the iOS core build needs. Derived by reading
 # appkit/CMakeLists.txt's iOS branch rather than by guessing:
 #   cmake, xcodegen  - tools, neither preinstalled on Xcode Cloud
@@ -46,7 +83,7 @@ echo "  PYMOL_EXTERNAL_PREFIX=$PYMOL_EXTERNAL_PREFIX"
 #     (line 44). On Xcode Cloud the prefix is /usr/local, so that path is absent.
 # Build 4 failed with 'glm/vec3.hpp' file not found for exactly this reason.
 # Patch the ephemeral checkout in place — same treatment project.yml gets in
-# step 3.
+# step 4.
 sed -i '' "s|^PYMOL_EXTERNAL_PREFIX = .*|PYMOL_EXTERNAL_PREFIX = $PYMOL_EXTERNAL_PREFIX|" \
   swiftui/PyMOLBridge.xcconfig
 # `sed` exits 0 whether or not the pattern matched. Verify the substitution
@@ -62,7 +99,7 @@ test -f "$PYMOL_EXTERNAL_PREFIX/include/glm/vec3.hpp" \
   && echo "  glm/vec3.hpp present under the patched prefix" \
   || { echo "ERROR: glm/vec3.hpp missing under $PYMOL_EXTERNAL_PREFIX/include" >&2; exit 1; }
 
-echo "== 2/6  Fetch prebuilt deps_ios =="
+echo "== 3/7  Fetch prebuilt deps_ios =="
 FP="$(bash scripts/ios_deps_fingerprint.sh)"
 TARBALL="deps_ios-$FP.tar.gz"
 BASE="https://github.com/$REPO/releases/download/ios-deps-$FP"
@@ -70,7 +107,7 @@ echo "  fingerprint=$FP"
 # Build 2 skipped this step: appkit/CMakeLists.txt silently fell back to an
 # uninstalled $(brew --prefix)/opt/python@3.13/... and died in contrib/champ
 # with "'Python.h' file not found". deps_ios MUST be staged before the core
-# build in step 5.
+# build in step 6.
 #
 # Fail loudly when the artifact is absent. NEVER fall back to building deps
 # inline, and never accept a different fingerprint: today's core linked against
@@ -86,23 +123,30 @@ shasum -a 256 -c "$TARBALL.sha256"
 tar -xzf "$TARBALL"
 rm -f "$TARBALL" "$TARBALL.sha256"
 
-echo "== 3/6  Stamp marketing version + build number =="
+echo "== 4/7  Stamp marketing version + build number =="
+# nightly_version.sh emits project.yml's CURRENT version verbatim — betas ride
+# the released version and are told apart by CI_BUILD_NUMBER, so no unreleased
+# version number is claimed in App Store Connect (where it could never be
+# reclaimed). BETA_LABEL is the human-readable half of the same identity, for the
+# Settings pane; Apple only sees the numeric pair.
 MKT="$(bash scripts/nightly_version.sh)"
-# apply_ci_versions.sh must run before xcodegen (step 4): xcodegen propagates
-# MARKETING_VERSION and CURRENT_PROJECT_VERSION from project.yml into the
-# generated .pbxproj.
-bash scripts/apply_ci_versions.sh swiftui/project.yml "$MKT" "$CI_BUILD_NUMBER"
+BETA_LABEL="$(bash scripts/beta_label.sh "$MKT" "$CI_BUILD_NUMBER")"
+echo "  version=$MKT build=$CI_BUILD_NUMBER label=$BETA_LABEL"
+# apply_ci_versions.sh must run before xcodegen (step 5): xcodegen propagates
+# MARKETING_VERSION, CURRENT_PROJECT_VERSION and RAYMOL_BETA_LABEL from
+# project.yml into the generated .pbxproj.
+bash scripts/apply_ci_versions.sh swiftui/project.yml "$MKT" "$CI_BUILD_NUMBER" "$BETA_LABEL"
 
-echo "== 4/6  Regenerate the Xcode project =="
+echo "== 5/7  Regenerate the Xcode project =="
 # project.yml is the source of truth and the committed .pbxproj can lag it —
 # skipping this is how PR #124's app-icon setting was once silently reverted.
-# It is also what picks up the version stamp from step 3.
+# It is also what picks up the version stamp from step 4.
 ( cd swiftui && xcodegen generate )
 
-echo "== 5/6  Build libpymol_core.a (device) =="
+echo "== 6/7  Build libpymol_core.a (device) =="
 bash swiftui/build_ios.sh device
 
-echo "== 6/6  Assert build inputs before xcodebuild =="
+echo "== 7/7  Assert build inputs before xcodebuild =="
 bash scripts/assert_ios_build_inputs.sh "$CI_PRIMARY_REPOSITORY_PATH"
 
 echo "ci_post_clone OK — $MKT ($CI_BUILD_NUMBER), deps fingerprint $FP"

--- a/swiftui/project.yml
+++ b/swiftui/project.yml
@@ -119,6 +119,15 @@ targets:
         INFOPLIST_GENERATION_MODE: GeneratedFile
         MARKETING_VERSION: "1.9.1"
         CURRENT_PROJECT_VERSION: 26
+        # Human-readable beta label, e.g. "1.9.1-beta27". EMPTY on purpose in the
+        # committed file: empty means "this is not a beta", and the postBuildScript
+        # below then leaves RayMolBetaLabel out of the Info.plist entirely. Only
+        # ci_post_clone.sh fills it in, in the ephemeral Xcode Cloud checkout, via
+        # apply_ci_versions.sh's 4th argument. Never commit a non-empty value —
+        # every DMG and App Store build would then claim to be a beta.
+        # Apple only ever sees MARKETING_VERSION + CURRENT_PROJECT_VERSION;
+        # CFBundleShortVersionString may not carry a "-betaN" suffix.
+        RAYMOL_BETA_LABEL: ""
         GENERATE_INFOPLIST_FILE: YES
         # Generate a launch screen so iOS renders at the device's NATIVE
         # resolution. Without it the app is letterboxed at a legacy size on
@@ -184,6 +193,29 @@ targets:
           [ -f "$PLIST" ] || { echo "no Info.plist at $PLIST"; exit 0; }
           /usr/bin/plutil -replace CFBundleName -string "RayMol" "$PLIST"
           echo "CFBundleName -> RayMol ($PLIST)"
+      # Beta label for testers, e.g. "1.9.1-beta27" -> Info.plist RayMolBetaLabel,
+      # which AppBuildInfo reads and the Settings pane shows under the version.
+      # Apple's own CFBundleShortVersionString cannot carry the "-betaN" suffix
+      # (at most three numeric components), so this is the only place testers can
+      # see which beta they are on. Runs on BOTH platforms; a no-op unless
+      # ci_post_clone.sh stamped RAYMOL_BETA_LABEL for this build.
+      - name: "Beta: set RayMolBetaLabel from RAYMOL_BETA_LABEL"
+        basedOnDependencyAnalysis: false
+        # Same Info.plist input edge as above — without it this races plist
+        # generation and the key is silently dropped.
+        inputFiles:
+          - "$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)"
+        script: |
+          set -e
+          LABEL="${RAYMOL_BETA_LABEL:-}"
+          # Empty is the normal case: every local, DMG and App Store build. Leave
+          # the key ABSENT rather than writing "" so the app can treat presence of
+          # the key as "this is a beta" without also testing for emptiness.
+          [ -n "$LABEL" ] || { echo "RayMolBetaLabel skipped (not a beta build)"; exit 0; }
+          PLIST="${TARGET_BUILD_DIR}/${INFOPLIST_PATH}"
+          [ -f "$PLIST" ] || { echo "no Info.plist at $PLIST"; exit 0; }
+          /usr/bin/plutil -replace RayMolBetaLabel -string "$LABEL" "$PLIST"
+          echo "RayMolBetaLabel -> $LABEL ($PLIST)"
       # Sparkle auto-update keys. macOS only (Sparkle is not linked on iOS), and
       # skipped for the Mac App Store fallback (RAYMOL_MAS_RESTRICTED) since that
       # build updates through Apple. The public EdDSA key pairs with the private


### PR DESCRIPTION
Master's red X is Xcode Cloud, not Actions. Two separate defects in the iOS Beta pipeline.

## 1. Every beta build since #22 failed to archive

```
Plugin "CudaBuild" from package "mlx-swift" must be enabled before it can be used
```

mlx-swift's `Cmlx` target carries a build-tool plugin, and Xcode refuses to run an untrusted package plugin. In the IDE that trust is a dialog; on Xcode Cloud there is no dialog, and no way to pass `-skipPackagePluginValidation` to an `xcodebuild` we never invoke. `swiftui/archive_appstore.sh` already solved this locally with that flag — the same switches at the preference layer, written from `ci_post_clone.sh` (which runs *before* the archive action), fix it for Xcode Cloud.

Broken since build #22 — the #217 Phase 2d merge that linked mlx-swift into the iOS target. Build #21 (Aug 5) was the last green one.

**Verification.** Reproduced locally without the flags (`Validate plug-in "CudaBuild"` → `BUILD FAILED`), then confirmed the defaults clear it. The iOS slice then builds clean all the way to `BUILD SUCCEEDED`, so no second error was hiding behind the plugin one — worth checking, since Xcode Cloud has not compiled iOS Swift since Phase 2d landed.

> ⚠️ The doubled "at" in `IDESkipPackagePluginFingerprintValidatation` is **Apple's own typo**, verbatim from Xcode's `IDEFoundation`/`SwiftPM` binaries. "Correcting" it produces a key nothing reads, and `defaults write` still exits 0, so the break would silently return. `run_ci_post_clone_plugin_trust_test.sh` pins both spellings against the installed Xcode and fails loudly if Apple ever renames them.

## 2. Betas were burning version numbers

`nightly_version.sh` emitted the next **minor**, pre-claiming a version App Store Connect will not give back. Today the iOS app has a TestFlight prerelease **1.10.0** sitting above a live App Store **1.8.0** — for a release nobody had decided on.

Betas now ride the **current** version and are separated by build number:

| | before | after |
|---|---|---|
| release 1.9.1 | betas 1.10.0 (27), 1.10.0 (28) | betas 1.9.1 (27), 1.9.1 (28) |
| ASC versions burned | one **minor** per cycle | **none** |

### Why not literally `1.9.1-beta1`

App Store Connect requires `CFBundleShortVersionString` to be at most three numeric components and rejects a `-beta1` suffix at upload — `run_nightly_version_test.sh` already asserted this (it rejects `1.8.0-beta`). So Apple only ever sees `1.9.1 (27)`, and the human-readable label goes where we control the text:

```
beta_label.sh → RAYMOL_BETA_LABEL → Info.plist RayMolBetaLabel → Display/Settings pane footer
```

Presence of that key is what marks a build as a beta, so the committed `project.yml` keeps it **empty** and only `ci_post_clone.sh` fills it in. Without it a tester cannot tell which beta they are on, now that betas and the release share a version. The beta ordinal is `CI_BUILD_NUMBER` (monotonic app-wide), so a label reads `1.9.1-beta27` — deliberately not restarting per version line, since a per-version ordinal would need persistent state that, if wrong, makes two builds share a label.

## Verification

- All **7** `scripts/tests` suites pass (2 new). Both new suites mutation-tested: re-introducing the version bump fails 11 assertions; "correcting" Apple's typo fails the trust suite.
- **macOS and iOS targets both build** — `ContentView` is shared and no CI compiles iOS, so both were compiled by hand.
- **161 macOS unit tests pass**, including 10 new `AppBuildInfoTests`.
- **End-to-end**: a simulated CI run (`nightly_version` → `beta_label` → `apply_ci_versions` → `xcodegen` → build) produced `CFBundleShortVersionString=1.9.1`, `CFBundleVersion=27`, `RayMolBetaLabel=1.9.1-beta27`; an unstamped build omits the key entirely and logs `RayMolBetaLabel skipped (not a beta build)`.

## Note for the reviewer

The existing TestFlight prerelease **1.10.0** is not removable — App Store Connect keeps versions forever. This PR stops new ones accruing; 1.10.0 will simply be the version in use when you actually cut that release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)