### PR TITLE
Render object groups as a tree in the Objects panel (#255), and let a group describe its reps (#256)

### DIFF
--- a/modules/pymol/appkit_inspector.py
+++ b/modules/pymol/appkit_inspector.py
@@ -160,20 +160,30 @@ def _color_setting_rgb(setting, fallback=(0.0, 0.0, 0.0)):
     return [float(t[0]), float(t[1]), float(t[2])]
 
 
-def is_molecule(obj):
-    """True when `obj` is a molecular object — i.e. something an atom selection is
-    allowed to name.
+# Object types the C++ selector accepts as an atom selection. A GROUP belongs
+# here even though it is not itself a molecule: it resolves to its members'
+# atoms, so `iterate`/`count_atoms` on a group name succeed and describe the
+# union of the members (issue #256). Measurements, CGOs and maps do not.
+SELECTABLE_TYPES = ('object:molecule', 'object:group')
 
-    Measurement objects (`dist01`/`ang01`/`dih01`), CGOs, maps and groups are not.
-    Handing one to `cmd.iterate` / `cmd.count_atoms` makes the C++ selector reject
-    it and write `Selector-Error: Invalid selection name "<obj>"` straight to the
-    feedback log. A Python-level try/except cannot suppress that: the selector has
-    already emitted the line by the time it raises. Since the object panel polls
+
+def takes_atom_selection(obj):
+    """True when `obj` may be handed to `cmd.iterate` / `cmd.count_atoms`.
+
+    Measurement objects (`dist01`/`ang01`/`dih01`), CGOs and maps may not.
+    Handing one to the selector makes it reject the name and write
+    `Selector-Error: Invalid selection name "<obj>"` straight to the feedback log.
+    A Python-level try/except cannot suppress that: the selector has already
+    emitted the line by the time it raises. Since the object panel polls
     ~2x/second, an unguarded probe floods the console for as long as the object
     exists — issue #219.
+
+    Groups were originally caught by this guard too, which silently blanked their
+    rep list and per-atom transparency badge even though probing them is both safe
+    and meaningful — issue #256.
     """
     try:
-        return cmd.get_type(obj) == 'object:molecule'
+        return cmd.get_type(obj) in SELECTABLE_TYPES
     except Exception:
         return False
 
@@ -189,10 +199,11 @@ def transp_summary(obj):
     no atom-level override exists (it never returns None here), so comparing the
     effective range to the object-level value is what detects a genuine override.
 
-    Non-molecular objects are rejected up front (see is_molecule): they cannot
-    carry per-atom transparency anyway, so probing them is both wrong and noisy.
+    Objects the selector won't take are rejected up front (see
+    takes_atom_selection): they cannot carry per-atom transparency anyway, so
+    probing them is both wrong and noisy.
     """
-    if not is_molecule(obj):
+    if not takes_atom_selection(obj):
         return {}
     objlv = {s: _num(s, obj) for s in TRANSP_SETTINGS}
     mn = {s: None for s in TRANSP_SETTINGS}
@@ -242,11 +253,12 @@ def _build(objs):
     detail = {}
     for o in objs:
         reps = []
-        # Non-molecular objects (measurements, CGOs, maps, groups) have no reps to
-        # describe, and every probe below — transp_summary's iterate and the
-        # per-rep count_atoms — would make the selector log an error per poll tick
-        # (issue #219). Emit an empty rep list instead of interrogating them.
-        if not is_molecule(o):
+        # Measurements, CGOs and maps have no reps to describe, and every probe
+        # below — transp_summary's iterate and the per-rep count_atoms — would make
+        # the selector log an error per poll tick (issue #219). Emit an empty rep
+        # list instead of interrogating them. Groups DO describe their members'
+        # reps and are deliberately not excluded here (issue #256).
+        if not takes_atom_selection(o):
             detail[o] = reps
             continue
         # Effective per-atom transparency range per setting, computed once per
@@ -338,6 +350,65 @@ def poll(objs):
         print('OBJDETAIL_ERR:' + str(e))
 
 
+# Cache backing group_parents(): the cheap shape fingerprint of the last build,
+# and the {child: parent} map it produced.
+_GROUP_FP = None
+_GROUP_PARENTS = {}
+
+
+def _group_fingerprint(objs, groups):
+    """Cheap (~0.1 ms) signature of the object tree's SHAPE.
+
+    Every call here is a name walk with no serialization: `get_object_list`
+    resolves a group to its molecular leaves. Any create, delete, rename,
+    group/ungroup, or re-parent that involves a molecule changes this tuple.
+    """
+    return (tuple(objs), tuple(groups),
+            tuple((g, tuple(cmd.get_object_list(g) or [])) for g in groups))
+
+
+def group_parents(objs, groups):
+    """{child: parent} for every object that lives inside a group.
+
+    The only COMPLETE source is the session's per-object record — entry[6] is the
+    parent name. Nothing cheaper covers the whole tree: `get_object_list` reports a
+    group's MOLECULAR leaves only, so a measurement, CGO or map inside a group is
+    invisible to it (and to every other selection-based API), and no API at all
+    reports group-in-group nesting.
+
+    But `get_session` serializes every object — measured at ~8 ms and ~2.5 MB for a
+    single 10k-atom molecule, scaling with atom count — which is far too expensive
+    to run at the ~2x/second poll cadence. So it runs only when the cheap
+    fingerprint above changes, and the result is cached.
+
+    The residue: a re-parent that does NOT move the fingerprint (moving a
+    non-molecular object between groups, or re-nesting a group whose molecular
+    leaves are unchanged) is not picked up until the next structural edit. Both are
+    rare and self-heal. Replacing this whole function with a C++ accessor over
+    SpecRec.group_name would make it exact and free — see #255.
+    """
+    global _GROUP_FP, _GROUP_PARENTS
+    if not groups:
+        _GROUP_FP, _GROUP_PARENTS = None, {}
+        return {}
+    try:
+        fp = _group_fingerprint(objs, groups)
+    except Exception:
+        return dict(_GROUP_PARENTS)
+    if fp == _GROUP_FP:
+        return dict(_GROUP_PARENTS)
+    parents = {}
+    try:
+        for ent in (cmd.get_session(partial=1).get('names') or []):
+            # entry = [name, ..., parent_group_name]; '' means top level.
+            if ent and len(ent) > 6 and ent[6]:
+                parents[ent[0]] = ent[6]
+    except Exception:
+        return dict(_GROUP_PARENTS)      # keep the last good map on failure
+    _GROUP_FP, _GROUP_PARENTS = fp, parents
+    return dict(parents)
+
+
 def poll_panel():
     """Write the object-list JSON to a temp file and print a short marker.
 
@@ -355,6 +426,15 @@ def poll_panel():
         sels = list(cmd.get_names('public_selections') or [])
         enabled = set(cmd.get_names('public_objects', enabled_only=1) or [])
         enabled |= set(cmd.get_names('public_selections', enabled_only=1) or [])
+        # Group tree (#255). Kept in its own try so a failure here degrades to a
+        # flat list rather than aborting the whole poll — the single except below
+        # writes NO file, and Swift only routes lines prefixed 'OBJPANEL:', so an
+        # OBJPANEL_ERR would silently freeze the panel on its stale list.
+        try:
+            groups = list(cmd.get_names('public_group_objects') or [])
+            parents = group_parents(objs, groups)
+        except Exception:
+            groups, parents = [], {}
         payload = {
             'objects': objs,
             'selections': sels,
@@ -362,6 +442,8 @@ def poll_panel():
             'sel_counts': {s: cmd.count_atoms(s) for s in sels},
             'nstate': {o: cmd.count_states('?' + o) for o in objs},
             'has_transp': {o: object_has_atom_transp(o) for o in objs},
+            'groups': groups,
+            'parent': parents,
         }
         p = os.path.join(tempfile.gettempdir(), 'pymol_objpanel.json')
         with open(p, 'w') as _f:

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -2141,13 +2141,15 @@ private struct ObjectCard: View {
                 // Sharing one glyph read as a single behaviour that sometimes
                 // produced a subtree and sometimes a settings card. The group's own
                 // rep card is reached from the A menu ("Inspect Group…").
-                // Deliberately NOT the .square variants: the tri-state checkbox
-                // immediately to the right is already minus.square.fill.
+                // CIRCLE variants, not square and not bare: the tri-state checkbox
+                // immediately to the right is minus.square.fill, and an expanded
+                // group would otherwise put a bare "-" right beside a boxed "[-]".
+                // The enclosing shape is what separates them at a glance.
                 Button(action: { entry.isGroup ? (onToggleGroup?() ?? ()) : toggleExpand() }) {
                     Image(systemName: entry.isGroup
-                          ? (isOpen ? "minus" : "plus")
+                          ? (isOpen ? "minus.circle" : "plus.circle")
                           : (expanded ? "chevron.down" : "chevron.right"))
-                        .font(.system(size: 9, weight: entry.isGroup ? .bold : .regular))
+                        .font(.system(size: entry.isGroup ? 10 : 9))
                         .foregroundColor(PanelTheme.headerColor)
                         .frame(width: 13)
                 }

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -29,6 +29,14 @@ private let kRowH: CGFloat = 34
 private let kGutterW: CGFloat = 26
 #endif
 
+// Per-level indent for nested group members (#255), and the depth at which
+// indenting stops. Same width as the disclosure column every row already leads
+// with, so a member's chevron lines up under its parent's name. Capped because
+// the panel is ~300pt on macOS and narrower on a compact iPhone — past three
+// levels the name column would be crushed, so deeper nesting stops moving right.
+private let kIndentW: CGFloat = 13
+private let kMaxIndentDepth: Int = 3
+
 // MARK: - Representation inspector: polled state models
 // (Inlined here rather than a separate file so they're in both app targets
 // without editing the Xcode project's explicit file references.)
@@ -366,6 +374,11 @@ struct ObjectEntry: Identifiable, Equatable {
     // discoverability badge, since the object-level transparency slider then
     // doesn't reflect what's rendered. See appkit_inspector.object_has_atom_transp.
     var hasAtomTransp: Bool = false
+    // Group tree (#255). `isGroup` marks an `object:group`; `parent` is the name
+    // of the group this row lives in (nil = top level). Both default so the
+    // existing memberwise initializers keep compiling.
+    var isGroup: Bool = false
+    var parent: String? = nil
 
     var displayName: String {
         if isSelection, let count = atomCount {
@@ -373,6 +386,104 @@ struct ObjectEntry: Identifiable, Equatable {
         }
         return name
     }
+}
+
+// MARK: - Group tree (#255)
+
+/// One drawn row of the flattened object tree.
+private struct TreeRow: Identifiable {
+    let entry: ObjectEntry
+    let depth: Int
+    var id: String { entry.id }
+}
+
+/// Three-way visibility state. A group summarises its descendants, so it can be
+/// partially on in a way a single object never is.
+private enum CheckState { case on, off, mixed }
+
+/// Flatten the object list into the rows the panel draws, parents before children.
+///
+/// `engine.objects` mirrors PyMOL's own ordering and must NOT be reordered in
+/// place — `parseObjectPanelFeedback`'s equality guard and `setObjectEnabled`'s
+/// index lookup both assume it does. So nesting is derived here, at render time.
+///
+/// Children of a *collapsed* group are omitted entirely, which is what makes the
+/// disclosure a real collapse rather than a styling choice. Two robustness rules:
+/// an entry whose parent is not in the list is drawn at top level, and anything
+/// left unreachable (a cycle from a corrupt parent map) is drawn at top level too
+/// — an object must never silently disappear from the panel.
+private func flattenObjectTree(_ objects: [ObjectEntry],
+                               openGroups: Set<String>) -> [TreeRow] {
+    let known = Set(objects.map { $0.name })
+    let byParent = Dictionary(grouping: objects.filter {
+        if let p = $0.parent { return known.contains(p) } else { return false }
+    }, by: { $0.parent! })
+
+    let roots = objects.filter { $0.parent == nil || !known.contains($0.parent!) }
+
+    // Reachability ignores open/closed, so a collapsed child is not mistaken for
+    // an orphan and re-emitted at top level.
+    var reachable = Set<String>()
+    func mark(_ name: String) {
+        guard !reachable.contains(name) else { return }
+        reachable.insert(name)
+        for c in byParent[name] ?? [] { mark(c.name) }
+    }
+    for r in roots { mark(r.name) }
+
+    var rows: [TreeRow] = []
+    func emit(_ entry: ObjectEntry, _ depth: Int) {
+        rows.append(TreeRow(entry: entry, depth: depth))
+        guard entry.isGroup, openGroups.contains(entry.name) else { return }
+        for child in byParent[entry.name] ?? [] { emit(child, depth + 1) }
+    }
+    for r in roots { emit(r, 0) }
+    for entry in objects where !reachable.contains(entry.name) { emit(entry, 0) }
+    return rows
+}
+
+/// True when every ancestor of `entry` is enabled.
+///
+/// A member keeps reporting `enabled` while it is hidden by a disabled parent —
+/// `disable grp` leaves `get_names('public_objects', enabled_only=1)` returning
+/// the members — so a row must not take `isEnabled` at face value or it will show
+/// a checked box for something invisible.
+private func ancestorsEnabled(_ entry: ObjectEntry, byName: [String: ObjectEntry]) -> Bool {
+    var seen = Set<String>()
+    var next = entry.parent
+    while let name = next, !seen.contains(name), let anc = byName[name] {
+        if !anc.isEnabled { return false }
+        seen.insert(name)
+        next = anc.parent
+    }
+    return true
+}
+
+/// Checkbox state for a row; groups fold in their whole subtree.
+private func checkState(for entry: ObjectEntry,
+                        byParent: [String: [ObjectEntry]]) -> CheckState {
+    guard entry.isGroup else { return entry.isEnabled ? .on : .off }
+    if !entry.isEnabled { return .off }
+    var anyOn = false, anyOff = false
+    var seen = Set<String>()
+    var stack = byParent[entry.name] ?? []
+    while let c = stack.popLast() {
+        guard !seen.contains(c.name) else { continue }
+        seen.insert(c.name)
+        if c.isEnabled { anyOn = true } else { anyOff = true }
+        stack.append(contentsOf: byParent[c.name] ?? [])
+    }
+    return (anyOn && anyOff) ? .mixed : (anyOff ? .off : .on)
+}
+
+/// The shared visibility checkbox. Factored out because the same control is drawn
+/// by the object row, the selection row and the pinned "all" row.
+@ViewBuilder
+private func checkboxImage(_ state: CheckState) -> some View {
+    Image(systemName: state == .on ? "checkmark.square.fill"
+                    : state == .mixed ? "minus.square.fill" : "square")
+        .font(.system(size: 12))
+        .foregroundColor(state == .off ? PanelTheme.disabledColor : PanelTheme.textColor)
 }
 
 // MARK: - Menu Option Definitions
@@ -454,6 +565,10 @@ private indirect enum ActionMenuItem {
     // align entries.
     case alignToMolecule(label: String)
     case alignToSelection(label: String)
+    /// Dynamic submenu listing existing groups plus "New Group…" (#255). Built at
+    /// render time from engine.objects, like the align cases, because the set of
+    /// groups changes with every poll.
+    case moveToGroup(label: String)
 }
 
 private let baseActionMenuItems: [ActionMenuItem] = [
@@ -565,6 +680,8 @@ private let baseActionMenuItems: [ActionMenuItem] = [
         .action(label: "mol. weight (with H)",    key: "compute_mass_implicit"),
     ]),
     .separator,
+    .moveToGroup(label: "Move to Group"),
+    .separator,
     .action(label: "Rename",     key: "rename"),
     .action(label: "Duplicate",  key: "copy"),
     .action(label: "Delete",     key: "delete"),
@@ -579,7 +696,34 @@ private let baseActionMenuItems: [ActionMenuItem] = [
 /// unwanted chain, trim to a binding site) — distinct from "Delete", which only
 /// removes the selection marker and leaves every atom in place. Objects don't
 /// get it (they keep Delete + Remove Waters), matching desktop PyMOL.
-private func actionMenuItems(isSelection: Bool) -> [ActionMenuItem] {
+/// Action menu for a GROUP row (#255).
+///
+/// Deliberately much shorter than `baseActionMenuItems`: most of that menu is
+/// atom-level (Preset, Find, Compute, dss) and would be wrong or slow applied to
+/// a whole subtree. What remains is camera framing, the visibility verbs, and
+/// group lifecycle.
+///
+/// The two destructive entries are kept apart on purpose. "Ungroup" dissolves the
+/// group and leaves every object at top level; "Delete Group + Contents" removes
+/// the members too, because `delete <group>` in PyMOL takes the whole subtree with
+/// it. Labelling them identically would make an irreversible action look routine.
+private let groupActionMenuItems: [ActionMenuItem] = [
+    .action(label: "Zoom", key: "zoom"),
+    .action(label: "Orient", key: "orient"),
+    .action(label: "Center", key: "center"),
+    .separator,
+    .action(label: "Inspect Group…", key: "group_inspect"),
+    .separator,
+    .action(label: "Enable All Members", key: "group_enable_members"),
+    .action(label: "Disable All Members", key: "group_disable_members"),
+    .separator,
+    .action(label: "Rename…", key: "rename"),
+    .action(label: "Ungroup (keep objects)", key: "group_ungroup"),
+    .action(label: "Delete Group + Contents", key: "group_delete"),
+]
+
+private func actionMenuItems(isSelection: Bool, isGroup: Bool = false) -> [ActionMenuItem] {
+    if isGroup { return groupActionMenuItems }
     guard isSelection else { return baseActionMenuItems }
     var items = baseActionMenuItems
     // Place "Remove Atoms" in the cleanup section right after "Remove Waters" —
@@ -688,6 +832,24 @@ private func runActionCommand(_ key: String, name: String, engine: PyMOLEngine) 
         return
     case "copy":               cmd = "copy \(n)_copy, \(n)"
     case "delete":             cmd = "delete \(n)"
+    // Group lifecycle (#255). `action=excise` dissolves the group and leaves its
+    // members at top level; plain `delete <group>` removes the members too, which
+    // is why the two are separate menu entries with explicit labels.
+    case "group_ungroup":      cmd = "group \(n), , action=excise"
+    case "group_delete":       cmd = "delete \(n)"
+    case "group_enable_members":  cmd = "enable \(n)"
+    case "group_disable_members": cmd = "disable \(n)"
+    case "group_inspect":
+        // A group's rep card is the union of its members' reps (see #256). The
+        // chevron on a group row is spoken for by child expansion, so this is how
+        // the card is opened.
+        engine.expandedDetail = n
+        return
+    case "group_new":
+        // Create a group holding just this object; PyMOL creates the group on
+        // first reference, so no separate create step is needed.
+        engine.pendingGroupFor = n
+        return
     // Strip the selection's atoms out of their parent object(s), then drop the
     // now-empty selection (PyMOL's selection-menu "remove atoms"). Shown only on
     // selection rows — see actionMenuItems(isSelection:).
@@ -791,9 +953,19 @@ struct ObjectPanel: View {
     #endif
     @State private var showSelectionBuilder = false
     @State private var renameText = ""
+    @State private var groupNameText = ""
     // Independent collapse state for the three top-level sections (Scene starts
     // collapsed, matching the previous default).
     @State private var openSections: Set<String> = ["objects", "selections"]
+    // Which group rows are expanded. Deliberately NOT engine.expandedDetail: that
+    // is a single-slot accordion for the rep inspector whose didSet re-polls and
+    // which ContentView reads to resize the panel, so reusing it would make
+    // opening a group collapse the inspector and resize the pane. Held here rather
+    // than as @State on the row because rows live in a LazyVStack, which discards
+    // offscreen state. PyMOL's own open/closed flag (SpecRec OpenOrClosed) has no
+    // Python accessor, so this is the source of truth and we push it down with
+    // `group ..., action=open|close` — see the note in toggleGroupOpen.
+    @State private var openGroups: Set<String> = []
 
     var body: some View {
         panelBody
@@ -813,6 +985,28 @@ struct ObjectPanel: View {
             } message: { Text("Enter a new name for this object.") }
             .onChange(of: engine.pendingRename) { newValue in
                 if let n = newValue { renameText = n }   // prefill with current name
+            }
+            // "New Group…" (#255) — same request-channel shape as the rename alert.
+            .alert("New group for “\(engine.pendingGroupFor ?? "")”",
+                   isPresented: Binding(get: { engine.pendingGroupFor != nil },
+                                        set: { if !$0 { engine.pendingGroupFor = nil } })) {
+                TextField("Group name", text: $groupNameText)
+                Button("Create") {
+                    if let member = engine.pendingGroupFor {
+                        let g = groupNameText.trimmingCharacters(in: .whitespaces)
+                        if !g.isEmpty && g != member {
+                            // PyMOL creates the group on first reference, so this
+                            // both creates it and moves the object in.
+                            engine.runCommand("group \(g), \(member)")
+                            openGroups.insert(g)   // show the result immediately
+                        }
+                    }
+                    engine.pendingGroupFor = nil
+                }
+                Button("Cancel", role: .cancel) { engine.pendingGroupFor = nil }
+            } message: { Text("Enter a name for the new group.") }
+            .onChange(of: engine.pendingGroupFor) { newValue in
+                if newValue != nil { groupNameText = "" }
             }
     }
 
@@ -843,8 +1037,29 @@ struct ObjectPanel: View {
                             emptyHint("No objects loaded")
                         } else {
                             AllControlsRow()
-                            ForEach(Array(objects.enumerated()), id: \.element.id) { index, obj in
-                                ObjectCard(entry: obj, isAlt: index % 2 == 1)
+                            // Nested rows come from a flattened tree walk, and the
+                            // alternating stripe is indexed over THAT order — striping
+                            // the unflattened array desynchronises as groups collapse.
+                            let rows = flattenObjectTree(objects, openGroups: openGroups)
+                            let byName = Dictionary(objects.map { ($0.name, $0) },
+                                                    uniquingKeysWith: { a, _ in a })
+                            let byParent = Dictionary(grouping: objects.filter { $0.parent != nil },
+                                                      by: { $0.parent! })
+                            ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
+                                ObjectCard(
+                                    entry: row.entry,
+                                    isAlt: index % 2 == 1,
+                                    depth: row.depth,
+                                    check: checkState(for: row.entry, byParent: byParent),
+                                    dimmed: !ancestorsEnabled(row.entry, byName: byName),
+                                    isOpen: openGroups.contains(row.entry.name),
+                                    onToggleGroup: { toggleGroupOpen(row.entry.name) }
+                                )
+                                if row.entry.isGroup, openGroups.contains(row.entry.name),
+                                   (byParent[row.entry.name] ?? []).isEmpty {
+                                    emptyHint("Empty group")
+                                        .padding(.leading, kIndentW * CGFloat(min(row.depth + 1, kMaxIndentDepth)))
+                                }
                             }
                         }
                     }
@@ -914,6 +1129,16 @@ struct ObjectPanel: View {
         .padding(.horizontal, 8)
         .frame(height: 22)
         .background(PanelTheme.background)
+    }
+
+    /// Expand/collapse a group row, mirroring the state into PyMOL so the two
+    /// agree — `action=open|close` is what a `.pse` records, so a session saved
+    /// from here reopens with the same groups expanded.
+    private func toggleGroupOpen(_ name: String) {
+        let opening = !openGroups.contains(name)
+        if opening { openGroups.insert(name) } else { openGroups.remove(name) }
+        let escaped = name.replacingOccurrences(of: "'", with: "")
+        engine.runCommand("group \(escaped), , action=\(opening ? "open" : "close")")
     }
 
     private func emptyHint(_ text: String) -> some View {
@@ -1038,7 +1263,7 @@ private struct ObjectRowView: View {
             Spacer(minLength: 4)
 
             // Action buttons: A S H L C
-            ActionMenuButton(name: entry.name, isSelection: entry.isSelection)
+            ActionMenuButton(name: entry.name, isSelection: entry.isSelection, isGroup: entry.isGroup)
             ShowButton(name: entry.name)
             HideButton(name: entry.name)
             LabelMenuButton(name: entry.name)
@@ -1173,6 +1398,24 @@ private func actionMenuContent(_ items: [ActionMenuItem], name: String, engine: 
             Menu(label) {
                 AnyView(actionMenuContent(children, name: name, engine: engine))  // AnyView breaks recursive opaque-type inference
             }
+        case .moveToGroup(let label):
+            // Per-object grouping (#255). The panel has no multi-select — its only
+            // per-row state is visibility — so grouping is driven one object at a
+            // time from here rather than from a checked set.
+            Menu(label) {
+                let groups = engine.objects.filter { $0.isGroup && $0.name != name }
+                ForEach(groups) { g in
+                    Button(g.name) {
+                        engine.runCommand("group \(g.name), \(name), action=add")
+                    }
+                }
+                if !groups.isEmpty { Divider() }
+                Button("New Group…") { engine.pendingGroupFor = name }
+                if engine.objects.first(where: { $0.name == name })?.parent != nil {
+                    Divider()
+                    Button("Remove from Group") { engine.runCommand("ungroup \(name)") }
+                }
+            }
         case .alignToMolecule(let label):
             // Candidate targets: every OTHER loaded molecule object (mirrors
             // desktop PyMOL's align_to_object). Empty when nothing else is loaded.
@@ -1220,11 +1463,12 @@ private func runAlignCommand(mobile: String, target: String, engine: PyMOLEngine
 private struct ActionMenuButton: View {
     let name: String
     var isSelection: Bool = false
+    var isGroup: Bool = false
     @EnvironmentObject var engine: PyMOLEngine
 
     var body: some View {
         Menu {
-            actionMenuContent(actionMenuItems(isSelection: isSelection), name: name, engine: engine)
+            actionMenuContent(actionMenuItems(isSelection: isSelection, isGroup: isGroup), name: name, engine: engine)
         } label: {
             Text("A")
                 .frame(width: kActBtnW, height: kActBtnH)
@@ -1792,19 +2036,21 @@ private struct ObjectColorRow: View {
 
 private struct ObjectRowContent: View {
     let entry: ObjectEntry
+    // Tri-state for group rows (some descendants on). Defaults keep the plain
+    // object/selection behaviour for callers that don't compute it.
+    var check: CheckState? = nil
     @EnvironmentObject var engine: PyMOLEngine
 
     var body: some View {
         Button(action: { toggleEnabled() }) {
-            Image(systemName: entry.isEnabled ? "checkmark.square.fill" : "square")
-                .font(.system(size: 12))
-                .foregroundColor(entry.isEnabled ? PanelTheme.textColor : PanelTheme.disabledColor)
+            checkboxImage(check ?? (entry.isEnabled ? .on : .off))
         }
         .buttonStyle(.plain)
         .frame(width: kGutterW)
 
         Text(entry.displayName)
             .font(.system(size: 11))
+            .fontWeight(entry.isGroup ? .semibold : .regular)
             .foregroundColor(entry.isSelection ? PanelTheme.selectionTextColor : PanelTheme.textColor)
             .lineLimit(1)
             .truncationMode(.tail)
@@ -1851,6 +2097,13 @@ private struct ObjectRowContent: View {
 private struct ObjectCard: View {
     let entry: ObjectEntry
     let isAlt: Bool
+    // Group-tree presentation (#255). All defaulted so the preview/memberwise
+    // call sites that predate the tree keep compiling.
+    var depth: Int = 0
+    var check: CheckState = .on
+    var dimmed: Bool = false
+    var isOpen: Bool = false
+    var onToggleGroup: (() -> Void)? = nil
     @EnvironmentObject var engine: PyMOLEngine
     @State private var selectedRep: String?
     // Live state-slider value while dragging (nil = follow the object poll). Keeps
@@ -1875,19 +2128,44 @@ private struct ObjectCard: View {
     var body: some View {
         VStack(spacing: 0) {
             HStack(spacing: 2) {
-                Button(action: toggleExpand) {
-                    Image(systemName: expanded ? "chevron.down" : "chevron.right")
-                        .font(.system(size: 9))
+                // Indent nested members. Applied in THIS HStack, before the
+                // chevron — ObjectRowContent is a bare column tuple spliced into
+                // this stack, so wrapping it to indent would break its alignment
+                // with the selection and "all" rows.
+                if depth > 0 {
+                    Spacer().frame(width: kIndentW * CGFloat(min(depth, kMaxIndentDepth)))
+                }
+                // Groups get +/-, plain objects keep the chevron, because the two
+                // disclosures do genuinely DIFFERENT things: +/- expands the
+                // group's children, the chevron opens that object's rep inspector.
+                // Sharing one glyph read as a single behaviour that sometimes
+                // produced a subtree and sometimes a settings card. The group's own
+                // rep card is reached from the A menu ("Inspect Group…").
+                // Deliberately NOT the .square variants: the tri-state checkbox
+                // immediately to the right is already minus.square.fill.
+                Button(action: { entry.isGroup ? (onToggleGroup?() ?? ()) : toggleExpand() }) {
+                    Image(systemName: entry.isGroup
+                          ? (isOpen ? "minus" : "plus")
+                          : (expanded ? "chevron.down" : "chevron.right"))
+                        .font(.system(size: 9, weight: entry.isGroup ? .bold : .regular))
                         .foregroundColor(PanelTheme.headerColor)
                         .frame(width: 13)
                 }
                 .buttonStyle(.plain)
-                ObjectRowContent(entry: entry)
+                .accessibilityLabel(entry.isGroup
+                    ? "\(isOpen ? "Collapse" : "Expand") group \(entry.name)"
+                    : "\(expanded ? "Collapse" : "Expand") \(entry.name)")
+                ObjectRowContent(entry: entry, check: check)
             }
             .padding(.horizontal, 4)
             .padding(.vertical, 2)
             .frame(height: kRowH)
             .background(isAlt ? PanelTheme.rowAltBackground : PanelTheme.rowBackground)
+            // A member hidden by a disabled ancestor is dimmed: it still reports
+            // enabled, so without this the box reads as checked while nothing is
+            // on screen. Opacity rather than a new colour, because the A/S/H/L/C
+            // cells compute their own.
+            .opacity(dimmed ? 0.45 : 1.0)
             // Whole HEADER-row tap toggles enable. Applied to the header HStack
             // only (NOT the outer VStack) so the expanded rep-detail below stays
             // interactive. The disclosure chevron Button and the trailing
@@ -1896,7 +2174,7 @@ private struct ObjectCard: View {
             .contentShape(Rectangle())
             .onTapGesture { engine.setObjectEnabled(entry.name, !entry.isEnabled) }
             // Long-press (iOS) / right-click (macOS) opens the action menu.
-            .contextMenu { actionMenuContent(actionMenuItems(isSelection: entry.isSelection), name: entry.name, engine: engine) }
+            .contextMenu { actionMenuContent(actionMenuItems(isSelection: entry.isSelection, isGroup: entry.isGroup), name: entry.name, engine: engine) }
 
             if expanded {
                 VStack(spacing: 3) {
@@ -3401,6 +3679,12 @@ extension PyMOLEngine {
             let sel_counts: [String: Int]
             let nstate: [String: Int]?
             let has_transp: [String: Bool]?
+            // Group tree (#255). OPTIONAL on purpose: a non-optional field makes
+            // the whole decode fail against an older bundled appkit_inspector.py,
+            // which would freeze the panel on its last list rather than degrade
+            // to a flat one.
+            let groups: [String]?
+            let parent: [String: String]?
         }
 
         guard let payload = try? JSONDecoder().decode(PanelPayload.self, from: data) else {
@@ -3408,6 +3692,8 @@ extension PyMOLEngine {
         }
 
         let enabledSet = Set(payload.enabled)
+        let groupSet = Set(payload.groups ?? [])
+        let parentMap = payload.parent ?? [:]
         var entries: [ObjectEntry] = []
 
         for name in payload.objects {
@@ -3418,7 +3704,9 @@ extension PyMOLEngine {
                 isSelection: false,
                 atomCount: nil,
                 stateCount: max(payload.nstate?[name] ?? 1, 1),
-                hasAtomTransp: payload.has_transp?[name] ?? false
+                hasAtomTransp: payload.has_transp?[name] ?? false,
+                isGroup: groupSet.contains(name),
+                parent: parentMap[name]
             ))
         }
 

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -123,6 +123,9 @@ final class PyMOLEngine: ObservableObject {
     // name (PyMOL's `wizard renaming` has no UI on the Metal/SwiftUI app). The
     // ObjectPanel observes this and presents a name-entry alert.
     @Published var pendingRename: String? = nil
+    // Request channel for "New Group…" (#255): the object to put in a new group.
+    // ObjectPanel presents the name-entry alert, mirroring pendingRename.
+    @Published var pendingGroupFor: String? = nil
     // Pick-debug instrumentation (active when PYMOL_PICKDEBUG is set): the last
     // click point in viewport (top-down, SwiftUI) points, drawn as a crosshair so
     // a screenshot shows click-vs-selection alignment. Set by MetalViewport.
@@ -789,17 +792,35 @@ final class PyMOLEngine: ObservableObject {
     func setObjectEnabled(_ name: String, _ enabled: Bool) {
         // UI mutation must happen on the main thread (drives @Published).
         if Thread.isMainThread {
-            if let idx = objects.firstIndex(where: { $0.name == name }) {
-                objects[idx].isEnabled = enabled
-            }
+            applyEnabledOptimistically(name, enabled)
         } else {
-            DispatchQueue.main.async {
-                if let idx = self.objects.firstIndex(where: { $0.name == name }) {
-                    self.objects[idx].isEnabled = enabled
-                }
-            }
+            DispatchQueue.main.async { self.applyEnabledOptimistically(name, enabled) }
         }
         runCommand(enabled ? "enable \(name)" : "disable \(name)")
+    }
+
+    /// Flip `name` and, when it is a group, its whole subtree.
+    ///
+    /// PyMOL cascades enable/disable down a group already, but the panel would not
+    /// see that for up to a poll interval (~500ms), so a group tap would leave its
+    /// members' checkboxes visibly stale and any tri-state parent wrong. Mirroring
+    /// the cascade locally keeps the tree self-consistent until the poll confirms.
+    private func applyEnabledOptimistically(_ name: String, _ enabled: Bool) {
+        var targets: Set<String> = [name]
+        // Walk down by parent links; cheap (the list is tens of entries) and the
+        // seen-set makes a corrupt parent map terminate rather than spin.
+        var frontier: Set<String> = [name]
+        while !frontier.isEmpty {
+            let children = objects.filter { $0.parent.map { frontier.contains($0) } ?? false }
+                                  .map { $0.name }
+                                  .filter { !targets.contains($0) }
+            if children.isEmpty { break }
+            targets.formUnion(children)
+            frontier = Set(children)
+        }
+        for idx in objects.indices where targets.contains(objects[idx].name) {
+            objects[idx].isEnabled = enabled
+        }
     }
 
     func runCommand(_ command: String) {

--- a/testing/tests/test_appkit_objpanel_poll.py
+++ b/testing/tests/test_appkit_objpanel_poll.py
@@ -224,12 +224,27 @@ class TestNonMolecularObjectsAreNotProbed(testing.PyMOLTestCase):
         self.assertEqual(cmd.get_type('dist01'), 'object:measurement')
         return list(cmd.get_names('public_objects'))
 
-    def testIsMoleculeRejectsMeasurements(self):
+    def testTakesAtomSelectionRejectsMeasurements(self):
         self._measured_session()
-        self.assertTrue(ai.is_molecule('mol'))
-        self.assertFalse(ai.is_molecule('dist01'))
-        self.assertFalse(ai.is_molecule('ang01'))
-        self.assertFalse(ai.is_molecule('no_such_object'))
+        self.assertTrue(ai.takes_atom_selection('mol'))
+        self.assertFalse(ai.takes_atom_selection('dist01'))
+        self.assertFalse(ai.takes_atom_selection('ang01'))
+        self.assertFalse(ai.takes_atom_selection('no_such_object'))
+
+    def testTakesAtomSelectionAcceptsGroups(self):
+        # A group IS a valid atom selection — it resolves to its members' atoms —
+        # so the #219 guard must not reject it or the group's rep list and
+        # transparency badge go blank (issue #256).
+        self._measured_session()
+        cmd.group('grp', 'mol')
+        self.assertEqual(cmd.get_type('grp'), 'object:group')
+        self.assertTrue(ai.takes_atom_selection('grp'))
+        self.assertGreater(cmd.count_atoms('grp'), 0,
+                           'a group must expand to its members atoms, else this '
+                           'test would pass for the wrong reason')
+        cmd.show('cartoon', 'mol')
+        self.assertTrue(ai._build(['grp'])['detail']['grp'],
+                        'the group card must describe its members reps')
 
     def testPollPanelEmitsNoSelectorErrorForMeasurements(self):
         objs = self._measured_session()
@@ -280,3 +295,98 @@ class TestNonMolecularObjectsAreNotProbed(testing.PyMOLTestCase):
         detail = ai._build(['mol', 'dist01'])['detail']
         self.assertEqual(detail['dist01'], [])
         self.assertTrue(detail['mol'], 'the molecule must still describe its reps')
+
+
+class TestGroupTreePayload(testing.PyMOLTestCase):
+    """Coverage for the object-group tree in the panel payload (issue #255).
+
+    The panel renders groups as a tree, so poll_panel() has to report parentage.
+    The subtle part is that `cmd.get_object_list()` — the obvious source — reports
+    a group's MOLECULAR members only: a measurement, CGO or map inside a group is
+    invisible to it and to every other selection-based API, and nothing reports
+    group-in-group nesting at all. So these tests deliberately build a group whose
+    members span all four kinds plus a nested group.
+    """
+
+    def _mixed_group_session(self):
+        cmd.delete('all')
+        cmd.fragment('gly', 'molA')
+        cmd.fragment('ala', 'molB')
+        cmd.distance('dist01', 'molA and index 1', 'molA and index 2')
+        cmd.load_cgo([cgo.STOP], 'cgo01')
+        cmd.map_new('map01', 'gaussian', 1.0, 'molA')
+        cmd.group('grp', 'molA dist01 cgo01 map01')
+        cmd.group('outer', 'grp molB')
+
+    def testParentMapCoversNonMolecularMembers(self):
+        self._mixed_group_session()
+        _, payload = self._poll()
+        parent = payload['parent']
+        # The whole point: get_object_list() would report only molA here.
+        self.assertEqual(cmd.get_object_list('grp'), ['molA'],
+                         'if this changes, the expensive session lookup may no '
+                         'longer be needed')
+        for name in ('molA', 'dist01', 'cgo01', 'map01'):
+            self.assertEqual(parent.get(name), 'grp',
+                             '%s must be reported inside grp' % name)
+
+    def testParentMapCoversNesting(self):
+        self._mixed_group_session()
+        _, payload = self._poll()
+        self.assertEqual(payload['parent'].get('grp'), 'outer')
+        self.assertEqual(payload['parent'].get('molB'), 'outer')
+        self.assertNotIn('outer', payload['parent'],
+                         'a top-level group must have no parent entry')
+        self.assertEqual(sorted(payload['groups']), ['grp', 'outer'])
+
+    def testFlatSessionCarriesEmptyGroupTree(self):
+        cmd.delete('all')
+        cmd.fragment('gly', 'mol')
+        _, payload = self._poll()
+        self.assertEqual(payload['groups'], [])
+        self.assertEqual(payload['parent'], {})
+
+    def testEmptyGroupIsReported(self):
+        cmd.delete('all')
+        cmd.fragment('gly', 'mol')
+        cmd.group('empty_grp')
+        _, payload = self._poll()
+        self.assertIn('empty_grp', payload['groups'])
+        self.assertNotIn('empty_grp', payload['parent'])
+
+    def testParentMapTracksRegrouping(self):
+        # The parent map is cached behind a cheap fingerprint; ungrouping must
+        # invalidate it, or the panel would keep drawing a stale tree.
+        self._mixed_group_session()
+        _, before = self._poll()
+        self.assertEqual(before['parent'].get('molB'), 'outer')
+        cmd.ungroup('molB')
+        _, after = self._poll()
+        self.assertIsNone(after['parent'].get('molB'),
+                          'ungroup must invalidate the cached parent map')
+
+    def testGroupPollStaysOffTheFeedbackLine(self):
+        # #231 invariant: the payload must never ride the feedback line, however
+        # much the group tree adds to it.
+        self._mixed_group_session()
+        lines, _ = self._poll()
+        self.assertEqual(lines, ['OBJPANEL:ready'])
+        for ln in lines:
+            self.assertLess(len(ln), ORTHO_LINE_LENGTH)
+
+    def testGroupPollEmitsNoSelectorError(self):
+        # Groups sit alongside the measurement/CGO/map kinds from #219; building
+        # the tree must not hand any of them to the selector.
+        self._mixed_group_session()
+        with capture_console() as out:
+            for _ in range(5):
+                ai.poll_panel()
+        console = out.read()
+        self.assertNotIn(b'Invalid selection name', console,
+                         'group tree probe leaked a selector error: %r' % console)
+
+
+# _poll lives on TestObjPanelPoll; reuse it rather than duplicating the tempfile
+# dance, and pull in cgo for the CGO member above.
+TestGroupTreePayload._poll = TestObjPanelPoll._poll
+from pymol import cgo  # noqa: E402  (kept next to its only use for clarity)


### PR DESCRIPTION
Closes #255. Also fixes #256, which this depends on.

## What changed

The Objects panel listed a group and its members as sibling rows, so grouping made the list *longer* rather than tidier, and there was no way to group or ungroup from the UI at all. Groups now render as a real tree.

| | before | after |
|---|---|---|
| a group + 5 members | 6 flat rows | 1 root row, expandable |
| measurement/CGO/map in a group | sibling of its own parent | nested under it |
| group visibility | plain checkbox | tri-state, subtree-aware |
| grouping from the UI | not possible | Move to Group / New Group / Ungroup |

**Disclosure controls now say what they do.** Groups use `+`/`−` for child expansion; plain objects keep the `>` chevron for the rep inspector. They are genuinely different actions, and sharing one glyph read as a single behaviour that sometimes produced a subtree and sometimes a settings card. A group's own rep card moved to the A menu → "Inspect Group…".

**Visibility is subtree-aware.** A tri-state `minus.square.fill` marks a group whose descendants are partly enabled, and a member hidden by a disabled ancestor renders dimmed — PyMOL keeps reporting a member as `enabled` while its parent hides it, so the raw `enabled` list cannot drive member rows directly. `setObjectEnabled` mirrors PyMOL's cascade locally so a group tap doesn't leave its members visibly stale for a poll interval.

**Destructive actions are labelled apart.** "Ungroup (keep objects)" is `action=excise`; "Delete Group + Contents" is `delete <group>`, which takes every member with it. Same menu, deliberately different words.

## The tricky part: where parentage comes from

`cmd.get_object_list()` — the obvious source — reports a group's **molecular** members only:

```
group grp, molA dist01 cgo01 map01
cmd.get_object_list('grp')  ->  ['molA']
```

A measurement, CGO or map inside a group is invisible to it and to every other selection-based API, and nothing at all reports group-in-group nesting. Those objects would have rendered at top level as siblings of their own parent — broken exactly for the object kinds #219 was about.

The session record does carry it (`entry[6]` is the parent name), but it serializes every object — measured at **~8 ms and ~2.5 MB for a single 10k-atom molecule**, scaling with atom count — which is far too expensive at the ~2×/second panel poll. So it runs only when a cheap fingerprint of the tree's *shape* changes (`get_names` + `get_object_list`, ~0.1 ms), and the result is cached.

**Steady-state poll cost: 0.74 ms.** The residue, documented in the docstring: a re-parent that doesn't move the fingerprint — moving a non-molecular object between groups, or re-nesting a group whose molecular leaves are unchanged — isn't seen until the next structural edit. Both are rare and self-heal.

A small C++ accessor over `SpecRec.group_name` would make this exact *and* free, and would delete the whole caching layer. Worth a follow-up; deliberately not in this PR, which stays Swift + Python.

## Why #256 is in here

Decision 1 routes a group's rep card through "Inspect Group…", and that card was blank: `is_molecule()` excluded `object:group`, but a group **is** a valid atom selection — it resolves to its members' atoms. Widened and renamed to `takes_atom_selection()`; a group reports `['sticks','cartoon','nb_spheres']` again instead of `[]`. The #219 guard still rejects measurements, CGOs and maps, which genuinely do make the selector log an error per poll tick.

## Verification

- **262/262 embedded tests pass** (full CI list), including 8 new ones covering non-molecular members, nesting, empty groups, flat sessions, cache invalidation on `ungroup`, the #231 off-the-feedback-line invariant, and no selector-error leak.
- **macOS and iOS both `BUILD SUCCEEDED`.** iOS matters here — no CI compiles it, and panel edits have broken that target three times (#174, #226, #238).
- **Driven on the live iPad app**, tapping real disclosure controls, with a group holding a molecule + measurement + map plus a nested group:

```
outer        [–] mixed
  molB       [✓]
  grp        [–] mixed
    molA     [✓]
    dist01   [✓]   <- measurement
    map01    [ ]   <- map (disabled, so both parents read mixed)
```

`dist01` and `map01` are precisely the objects `get_object_list()` cannot see.

## Not covered

- **macOS VM run.** The host disk filled during this work; after clearing DerivedData there wasn't room for a golden-image clone. The macOS binary builds and the panel code is shared, but the macOS UI has not been exercised in a VM.
- **`.pse` collapse state.** PyMOL's own per-group open/closed flag (`OpenOrClosed`, `layer3/Executive.cpp`) has no Python accessor, so expansion state is owned by the panel and pushed down with `group ..., action=open|close`. A group closed when a session was saved therefore reopens expanded. Reading it back needs a small C++ getter — same follow-up as the parentage accessor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
