### PR TITLE
fix(panel): cache the object panel poll so large sessions stay interactive

### DIFF
--- a/modules/pymol/appkit_inspector.py
+++ b/modules/pymol/appkit_inspector.py
@@ -356,6 +356,61 @@ def poll(objs):
 _GROUP_FP = None
 _GROUP_PARENTS = {}
 
+# Caches backing poll_panel()'s three O(atoms) fields.
+#
+# poll_panel() runs on a 500 ms MAIN-THREAD timer (PyMOLEngine.pollObjects), so
+# anything proportional to atom count inside it is paid twice a second for as
+# long as the session is open. Uncached, on a 12-object / 79,568-atom /
+# 48-selection binder-design session, one poll measured 713 ms -- longer than
+# its own period. The main thread never came free, so the viewport rendered but
+# never saw a mouse drag: the session opened and could not be rotated.
+#
+# None of the three can change without a command running, so each is cached per
+# NAME and recomputed only for names that are new since the last poll; names
+# that have gone away are pruned. Adding an object to the session above costs
+# one atom scan instead of twelve.
+#
+# invalidate() drops all of it and is called from RayMol's command paths, which
+# is what catches an edit that moves no name at all -- `alter ... s.cartoon_
+# transparency = 0.5`, `unset transparency, (obj)`, or loading states into an
+# existing object. The residue: a change made by a script that bypasses those
+# paths AND adds/removes no object or selection is not reflected until the next
+# one that does. That is the same trade group_parents() makes below, for the
+# same reason.
+_TRANSP_CACHE = {}      # object name -> bool (has a per-atom transparency override)
+_NSTATE_CACHE = {}      # object name -> int  (state count)
+_SELCOUNT_CACHE = {}    # selection name -> int (atom count)
+_SELCOUNT_OBJS = None   # object tuple the cached selection counts were measured against
+
+
+def invalidate():
+    """Drop the poll caches so the next poll_panel() rebuilds from scratch.
+
+    Cheap and idempotent -- call it liberally from anywhere that runs a user
+    command. It only costs the next poll, not this one.
+    """
+    global _SELCOUNT_OBJS, _GROUP_FP
+    _TRANSP_CACHE.clear()
+    _NSTATE_CACHE.clear()
+    _SELCOUNT_CACHE.clear()
+    _SELCOUNT_OBJS = None
+    _GROUP_FP = None
+
+
+def _cached(cache, names, compute):
+    """{name: value} for `names`, calling `compute` only for cache misses.
+
+    Prunes departed names first so a deleted object can neither keep its entry
+    alive nor leak back into the payload.
+    """
+    live = set(names)
+    for stale in [k for k in cache if k not in live]:
+        del cache[stale]
+    for name in names:
+        if name not in cache:
+            cache[name] = compute(name)
+    return {name: cache[name] for name in names}
+
 
 def _group_fingerprint(objs, groups):
     """Cheap (~0.1 ms) signature of the object tree's SHAPE.
@@ -422,11 +477,22 @@ def poll_panel():
     prefix-less continuation leaked into the console on every poll tick. Keep the
     payload off the feedback line entirely and emit only `OBJPANEL:ready`."""
     import json, os, tempfile
+    global _SELCOUNT_OBJS
     try:
         objs = list(cmd.get_names('public_objects') or [])
         sels = list(cmd.get_names('public_selections') or [])
         enabled = set(cmd.get_names('public_objects', enabled_only=1) or [])
         enabled |= set(cmd.get_names('public_selections', enabled_only=1) or [])
+        # Enabled state is re-read every poll (a name walk, no atom access), so
+        # toggling an object's visibility -- the most common panel interaction --
+        # stays instant and does NOT invalidate the atom scans below.
+        #
+        # Deleting an object changes the count of every selection that referenced
+        # it, so the selection counts are only valid for the object set they were
+        # measured against.
+        if _SELCOUNT_OBJS != tuple(objs):
+            _SELCOUNT_CACHE.clear()
+            _SELCOUNT_OBJS = tuple(objs)
         # Group tree (#255). Kept in its own try so a failure here degrades to a
         # flat list rather than aborting the whole poll — the single except below
         # writes NO file, and Swift only routes lines prefixed 'OBJPANEL:', so an
@@ -440,9 +506,10 @@ def poll_panel():
             'objects': objs,
             'selections': sels,
             'enabled': list(enabled),
-            'sel_counts': {s: cmd.count_atoms(s) for s in sels},
-            'nstate': {o: cmd.count_states('?' + o) for o in objs},
-            'has_transp': {o: object_has_atom_transp(o) for o in objs},
+            'sel_counts': _cached(_SELCOUNT_CACHE, sels, cmd.count_atoms),
+            'nstate': _cached(_NSTATE_CACHE, objs,
+                              lambda o: cmd.count_states('?' + o)),
+            'has_transp': _cached(_TRANSP_CACHE, objs, object_has_atom_transp),
             'groups': groups,
             'parent': parents,
         }

--- a/modules/raymol_mcp/tools.py
+++ b/modules/raymol_mcp/tools.py
@@ -60,6 +60,21 @@ def _error(s):
 
 # --- Tool implementations -------------------------------------------------
 
+def _invalidate_panel_caches():
+    """Drop the object panel's poll caches after an MCP-driven mutation.
+
+    The Swift command funnel (PyMOLEngine.runCommandCore) does this for anything
+    the user types or clicks, but MCP tools reach the core directly and bypass
+    it, so a `set cartoon_transparency` or `alter` arriving over MCP would leave
+    the panel showing stale counts and a stale transparency badge.
+    """
+    try:
+        from pymol import appkit_inspector
+        appkit_inspector.invalidate()
+    except Exception:
+        pass      # the panel is a macOS-only nicety; never fail a tool call for it
+
+
 def _run_pymol_command(args):
     cmd_str = args.get("command", "")
     if not cmd_str:
@@ -69,6 +84,7 @@ def _run_pymol_command(args):
         from pymol import cmd
         cmd.do(cmd_str)
         cmd.sync()
+        _invalidate_panel_caches()
         return _text("ok")
 
     try:
@@ -90,6 +106,7 @@ def _run_python(args):
                 exec(code, ns)
             from pymol import cmd
             cmd.sync()
+            _invalidate_panel_caches()
             out = buf.getvalue()
             return _text(out if out else "ok")
         except Exception:

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -871,6 +871,7 @@ final class PyMOLEngine: ObservableObject {
     // never runCommand, so it can't re-enter the heavy-dispatch path.
     private func runCommandCore(_ command: String) {
         PyMOLBridge_RunCommand(command)
+        invalidatePanelCaches()
         handleSessionViewport(for: command)
         maybeWidenClipForSurface(for: command)
         // A per-object `set state, N, obj` (and the related all_states / unset
@@ -884,6 +885,23 @@ final class PyMOLEngine: ObservableObject {
             || l.hasPrefix("unset all_states") {
             requestViewportRedraw()
         }
+    }
+
+    // The object panel caches its three O(atoms) fields (per-atom transparency
+    // badge, selection counts, per-object state counts) between polls, because
+    // recomputing them on the 500ms main-thread timer cost 713ms/poll on a
+    // 12-object / 79.5k-atom / 48-selection session — the main thread never came
+    // free and the viewport could not be rotated.
+    //
+    // The cache keys off object/selection NAMES, which is blind to a command that
+    // changes what those fields measure without adding or removing a name:
+    // `alter … s.cartoon_transparency = 0.5`, `unset transparency, (obj)`, or
+    // loading extra states into an existing object. So every command drops the
+    // caches. Clearing three dicts is free, and the recompute lands on the next
+    // poll only if something really did change — never on the idle path, which is
+    // the one the user is trying to rotate through.
+    private func invalidatePanelCaches() {
+        runPython("from pymol import appkit_inspector as _ai\n_ai.invalidate()")
     }
 
     // Classify a command as a known long (>~2s) operation that deserves the

--- a/testing/tests/test_appkit_objpanel_poll.py
+++ b/testing/tests/test_appkit_objpanel_poll.py
@@ -24,6 +24,7 @@ import json
 import os
 import sys
 import tempfile
+import unittest.mock as mock
 
 from pymol import cmd, testing
 from pymol import appkit_inspector as ai
@@ -387,7 +388,199 @@ class TestGroupTreePayload(testing.PyMOLTestCase):
                          'group tree probe leaked a selector error: %r' % console)
 
 
+@contextlib.contextmanager
+def count_atom_work():
+    """Count the atom-touching cmd calls poll_panel makes, by name.
+
+    These three are the whole of the poll's cost: `iterate` drives the per-atom
+    transparency scan, `count_atoms` the per-selection counts and the rep probe,
+    `count_states` the per-object state counts. Each is O(atoms) in the C++
+    selector, so counting CALLS (rather than timing) gives a machine-independent
+    assertion that survives a fast CI box.
+    """
+    names = ('iterate', 'count_atoms', 'count_states')
+    counts = dict.fromkeys(names, 0)
+    patches = []
+
+    def wrap(name, real):
+        def wrapper(*args, **kwargs):
+            counts[name] += 1
+            return real(*args, **kwargs)
+        return wrapper
+
+    for name in names:
+        p = mock.patch.object(cmd, name, wrap(name, getattr(cmd, name)))
+        p.start()
+        patches.append(p)
+    try:
+        yield counts
+    finally:
+        for p in patches:
+            p.stop()
+
+
+class TestPollPanelSkipsUnchangedSessions(testing.PyMOLTestCase):
+    """Regression coverage for the 1.9.1 "opens but won't rotate" report.
+
+    poll_panel() runs on a 500 ms MAIN-THREAD timer (PyMOLEngine.pollObjects).
+    It rebuilt the whole payload every tick: a per-atom `cmd.iterate` for EVERY
+    object (has_transp), a `count_atoms` for every selection (sel_counts) and a
+    `count_states` per object. On the reported session — 12 objects, 79,568
+    atoms, 48 chain selections, the same shape as the 1.8.1 hotfix session above
+    — one poll measured 713 ms against a 500 ms budget, so the main thread never
+    came free and mouse drags were never serviced: the viewport rendered but
+    could not be rotated.
+
+    The panel's data only changes when the user acts, so a session that has not
+    changed since the last poll must cost NO atom work at all. Structural change
+    and explicit invalidation must still refresh it.
+    """
+
+    def _poll_counting(self):
+        with count_atom_work() as counts:
+            ai.poll_panel()
+        return counts
+
+    def testFirstPollOfASessionScansAtoms(self):
+        # Control for the test below: if the poll never scanned atoms even when
+        # cold, "no scan on the second poll" would prove nothing.
+        self._design_session()
+        ai.invalidate()
+
+        counts = self._poll_counting()
+
+        self.assertGreater(counts['iterate'], 0,
+                           'a cold poll must still run the per-atom scan')
+        self.assertGreater(counts['count_atoms'], 0,
+                           'a cold poll must still count the selections')
+
+    def testSecondPollOfUnchangedSessionScansNoAtoms(self):
+        # The bug: every tick redid all of it. Nothing changed between these two
+        # polls, so the second must be pure cache.
+        self._design_session()
+        ai.poll_panel()
+
+        counts = self._poll_counting()
+
+        self.assertEqual(counts, {'iterate': 0, 'count_atoms': 0,
+                                  'count_states': 0},
+                         'an unchanged session must cost no atom work')
+
+    def testRepeatedPollsStayFree(self):
+        # The panel polls ~2x/second for as long as the session is open, so the
+        # cache has to hold, not just skip one tick.
+        self._design_session()
+        ai.poll_panel()
+
+        with count_atom_work() as counts:
+            for _ in range(10):
+                ai.poll_panel()
+
+        self.assertEqual(counts['iterate'], 0)
+        self.assertEqual(counts['count_atoms'], 0)
+
+    def testEnablingAnObjectDoesNotRescanAtoms(self):
+        # Toggling visibility is the most common panel interaction and changes
+        # nothing the atom scan measures, so it must not trigger a rescan.
+        objs, _ = self._design_session()
+        ai.poll_panel()
+
+        cmd.disable(objs[0])
+        counts = self._poll_counting()
+
+        self.assertEqual(counts['iterate'], 0,
+                         'enable/disable must not invalidate the atom scan')
+
+    def testDisabledObjectStillReportsEnabledState(self):
+        # ...but the cheap part of the payload must still track the toggle.
+        objs, _ = self._design_session()
+        ai.poll_panel()
+
+        cmd.disable(objs[0])
+        _, payload = self._poll()
+
+        self.assertNotIn(objs[0], payload['enabled'])
+        self.assertIn(objs[1], payload['enabled'])
+
+    def testNewSelectionIsCountedWithoutRecountingTheOthers(self):
+        # A new selection must appear, and the 48 unchanged ones must not be
+        # recounted -- that per-selection recount was 174 ms of the 713 ms.
+        objs, sels = self._design_session()
+        ai.poll_panel()
+
+        cmd.select('brand_new', '%s and name CA' % objs[0], quiet=1)
+        with count_atom_work() as counts:
+            _, payload = self._poll()
+
+        self.assertEqual(payload['sel_counts']['brand_new'],
+                         cmd.count_atoms('brand_new'))
+        self.assertLessEqual(counts['count_atoms'], 2,
+                             'only the new selection needed counting, not all '
+                             '%d of them' % (len(sels) + 1))
+
+    def testNewObjectIsScannedWithoutRescanningTheOthers(self):
+        objs, _ = self._design_session()
+        ai.poll_panel()
+
+        cmd.fab('ACDEFG', 'late_arrival')
+        with count_atom_work() as counts:
+            _, payload = self._poll()
+
+        self.assertIn('late_arrival', payload['objects'])
+        self.assertIn('late_arrival', payload['has_transp'])
+        self.assertLessEqual(counts['iterate'], 1,
+                             'only the new object needed scanning, not all '
+                             '%d of them' % (len(objs) + 1))
+
+    def testDeletedObjectLeavesThePayload(self):
+        objs, _ = self._design_session()
+        ai.poll_panel()
+
+        cmd.delete(objs[0])
+        _, payload = self._poll()
+
+        self.assertNotIn(objs[0], payload['objects'])
+        self.assertNotIn(objs[0], payload['has_transp'])
+        self.assertNotIn(objs[0], payload['nstate'])
+
+    def testInvalidateRefreshesTheTransparencyBadge(self):
+        # A bare `alter` changes no name, so the cheap fingerprint cannot see it.
+        # Every RayMol command path calls invalidate() for exactly this reason;
+        # without it the badge would stay stale until the next structural edit.
+        cmd.delete('all')
+        cmd.fab('ACDEFG', 'mol')
+        cmd.show('cartoon', 'mol')
+        _, payload = self._poll()
+        self.assertFalse(payload['has_transp']['mol'],
+                         'fixture must start clean, else this proves nothing')
+
+        cmd.alter('mol and resi 1-2', 's.cartoon_transparency = 0.5')
+        ai.invalidate()
+        _, payload = self._poll()
+
+        self.assertTrue(payload['has_transp']['mol'],
+                        'invalidate() must force the per-atom scan to re-run')
+
+    def testCachedPollStillWritesTheFullPayload(self):
+        # The Swift side re-reads the temp file on every OBJPANEL:ready marker,
+        # so a cache HIT must still leave a complete, valid file behind -- only
+        # the recomputation is skipped, never the write.
+        objs, sels = self._design_session()
+        _, first = self._poll()
+
+        _, second = self._poll()
+
+        self.assertEqual(first, second)
+        self.assertEqual(sorted(second['objects']), sorted(objs))
+        self.assertEqual(sorted(second['selections']), sorted(sels))
+        for sel in sels:
+            self.assertEqual(second['sel_counts'][sel], cmd.count_atoms(sel))
+
+
 # _poll lives on TestObjPanelPoll; reuse it rather than duplicating the tempfile
 # dance, and pull in cgo for the CGO member above.
 TestGroupTreePayload._poll = TestObjPanelPoll._poll
+TestPollPanelSkipsUnchangedSessions._poll = TestObjPanelPoll._poll
+TestPollPanelSkipsUnchangedSessions._design_session = TestObjPanelPoll._design_session
+TestPollPanelSkipsUnchangedSessions.DESIGN_CHAINS = TestObjPanelPoll.DESIGN_CHAINS
 from pymol import cgo  # noqa: E402  (kept next to its only use for clarity)


### PR DESCRIPTION
## The report

A 12-object / 79,568-atom / 48-selection binder-design `.pse` **opened fine in RayMol 1.9.1 but could not be rotated or interacted with**. It opens and rotates normally in upstream PyMOL.

## Root cause

The object panel polls on a **500 ms main-thread timer** (`PyMOLEngine.pollObjects` → `appkit_inspector.poll_panel`). It rebuilt the entire payload every tick:

- `has_transp` → a **per-atom `cmd.iterate` for every object** (the per-atom transparency badge)
- `sel_counts` → a `count_atoms` per selection — each a full selector pass
- `nstate` → a `count_states` per object

All three are O(atoms), run twice a second, forever. Measured in the shipped app on the reported session:

```
poll_panel() FULL            713 ms      <- on a 500 ms timer
  has_transp (12 objs)       461 ms
  sel_counts (48 sels)       174 ms
  nstate (12 objs)            70 ms
```

The poll could not finish before the next one fired. `sample` showed **1849 of 3724 main-thread samples inside `pollObjects`**, the hot leaf being `PyErr_Format`/`PyUnicode_FromFormatV` — every `s.<setting>` lookup without an atom-level override raises *and formats* an `AttributeError`, once per atom. The viewport rendered fine; it just never got a mouse event.

Note `object_has_atom_transp` also ran the full atom scan *before* its rep gate, so the documented "cheap short-circuit" never applied, and it scanned disabled objects too (hiding objects didn't help: 381 ms → 393 ms).

## The fix

None of the three quantities can change without a command running, so each is cached **per name**, recomputing only names that are new since the last poll and pruning ones that have gone away. Adding one object costs one atom scan instead of twelve; toggling visibility costs none (enabled state is re-read every poll as a cheap name walk).

`invalidate()` drops the caches and is called from the command paths — the Swift funnel (`runCommandCore`) and the MCP tools, which bypass it — so an edit that moves no name at all (`alter … s.cartoon_transparency`, `unset transparency, (obj)`, loading states into an existing object) is still picked up. Residue is documented in the module, matching the trade `group_parents()` already makes.

The payload is still written on every poll, so the Swift contract is unchanged — only the recomputation is skipped.

## Verification

- **10 new tests** in `test_appkit_objpanel_poll.py`, asserting on *call counts* of the atom-touching `cmd` entry points rather than wall time, so they don't depend on machine speed. Full CI list: **272 passed, 0 failed**.
- **A/B in the shipped app on the reported session**, same process, cache bypassed at runtime vs enabled:

  | | main thread in `pollObjects` | idle CPU |
  |---|---|---|
  | bypassed (old behaviour) | 959/2890 = **33.2%** | 10.6–35.1% |
  | cached (this PR) | 17/2199 = **0.8%** | 1.3–3.3% |

- Panel correctness confirmed live in a VM against the real session: 12 objects / 48 selections, and a new selection appeared immediately (48 → 49), exercising the invalidation path end-to-end.

**Not verified:** an automated end-to-end mouse-drag rotation. Synthetic drag sessions don't reach the app on the host, and `tart input` has no drag verb, so neither environment can witness a rotation. The change targets main-thread occupancy, which is measured above; the rotation code itself is untouched. Worth a manual spin on the original session before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)