### PR TITLE
fix(ios): betas must ride the next patch, not the shipped version

### DIFF
--- a/docs/ios-beta-pipeline.md
+++ b/docs/ios-beta-pipeline.md
@@ -224,22 +224,54 @@ If it approaches them, expire the oldest builds in App Store Connect.
 
 ## Versions and build numbers
 
-- **Marketing version** is derived by `scripts/nightly_version.sh` as the next
-  minor after `swiftui/project.yml`'s `MARKETING_VERSION` (e.g., `1.8.0` →
-  betas are `1.9.0`).
+- **Marketing version** is the next **patch** after `swiftui/project.yml`'s
+  `MARKETING_VERSION`, from `scripts/nightly_version.sh` (`1.9.1` → betas are
+  `1.9.2`). It is **stable across betas** — every beta rides `1.9.2` until a
+  release claims it; only the build number moves.
 - **Build number** is Xcode Cloud's `CI_BUILD_NUMBER`.
+- **Tester-visible label** is `scripts/beta_label.sh`'s `1.9.2-beta29`, written
+  to the `RayMolBetaLabel` Info.plist key and shown in the app's Settings pane.
 - App Store Connect requires the `(version, build)` pair to be unique. iOS does
   not require build numbers to increase across versions; only macOS does.
 
-**Convention when cutting a release:** bump `MARKETING_VERSION` in
-`swiftui/project.yml` **to** the released version — never in advance.
-Pre-bumping makes betas leapfrog the version being prepared.
+### Why betas cannot ride the current version
 
-`scripts/tests/run_nightly_version_test.sh`'s real-repo check asserts only a
-format (`^[0-9]+\.[0-9]+\.0$`), deliberately not a literal value, so it
-survives releases without needing an update. But failing to bump
-`MARKETING_VERSION` at release time means betas will carry a version number
-higher than the release until you do.
+A beta **must** sit on a version that has never been approved. Once a version
+ships, App Store Connect closes its pre-release train permanently. On
+2026-08-10, with iOS `1.9.1` live (`READY_FOR_SALE`), an upload under `1.9.1`
+was rejected with:
+
+```
+ITMS-90186: Invalid Pre-Release Train — the train version '1.9.1' is closed
+            for new build submissions
+ITMS-90062: CFBundleShortVersionString [1.9.1] must contain a higher version
+            than the previously approved version [1.9.1]
+```
+
+So "don't bump, claim nothing" is not the conservative option — it is a rejected
+upload. The **next patch** is the smallest claim Apple permits: one version
+ahead, and the one most likely to ship next anyway, so in the usual case nothing
+is stranded. (An earlier scheme bumped the next *minor* and did strand a
+TestFlight `1.10.0` above a live `1.8.0` for a release nobody had planned.)
+
+### Why the label is not the version
+
+`CFBundleShortVersionString` must be one to three period-separated integers, so
+`1.9.2-beta29` is rejected at upload. Apple only ever sees `1.9.2 (29)`. The
+readable label carries the same identity through the one channel we control —
+the Info.plist key — and is display text, never something Apple validates or
+sorts on.
+
+**Convention when cutting a release:** bump `MARKETING_VERSION` in
+`swiftui/project.yml` **to** the released version — never in advance. This
+script reads that field as "the last version that shipped", so the beta train
+advances by itself the moment a release lands. Pre-bumping makes betas skip a
+version.
+
+`scripts/tests/run_nightly_version_test.sh`'s real-repo check derives its
+expectation from `project.yml` with an independent `sed` plus independent
+arithmetic — never by calling the script — so it stays non-circular and stays
+correct across every future release bump.
 
 Never derive the version from git tags: this repo carries the inherited PyMOL
 version line, so the newest tag by version sort is `v3.2.0` while RayMol's own

--- a/scripts/nightly_version.sh
+++ b/scripts/nightly_version.sh
@@ -1,19 +1,35 @@
 #!/bin/bash
 # nightly_version.sh — emit the marketing version for automated beta
-# (TestFlight) builds: whatever swiftui/project.yml currently declares, VERBATIM.
-#     project.yml MARKETING_VERSION 1.9.1  ->  1.9.1
+# (TestFlight) builds: the next PATCH after whatever swiftui/project.yml
+# currently declares.
+#     project.yml MARKETING_VERSION 1.9.1  ->  1.9.2
 #
-# WHY THIS DOES NOT BUMP. It used to emit the next MINOR (1.9.1 -> 1.10.0) so a
-# beta always sorted above the last release. That pre-claims a version number
-# App Store Connect will not let you take back: by 2026-08-10 the iOS app had a
-# TestFlight prerelease 1.10.0 sitting above a live App Store 1.8.0, for a
-# release nobody had decided on yet. When the real next version turned out to be
-# a patch, 1.10.0 was stranded and every beta was labelled with a version that
-# would never ship. Betas now ride the CURRENT version and are distinguished by
-# the build number, which is exactly what the (CFBundleShortVersionString,
+# WHY IT CANNOT RIDE THE CURRENT VERSION (learned 2026-08-10, the hard way).
+# This script previously emitted project.yml's version verbatim so that betas
+# would not claim an unreleased number at all. App Store Connect does not allow
+# it. Once a version is APPROVED, its "pre-release train" is closed forever and
+# no further build may be uploaded under it. iOS 1.9.1 went READY_FOR_SALE, and
+# the next beta upload was rejected outright:
+#     ITMS-90186: Invalid Pre-Release Train — the train version '1.9.1' is
+#                 closed for new build submissions
+#     ITMS-90062: CFBundleShortVersionString [1.9.1] must contain a higher
+#                 version than the previously approved version [1.9.1]
+# A beta therefore MUST sit on a version that has never been approved. That is
+# Apple's rule, not a preference of ours.
+#
+# WHY THE NEXT PATCH, AND NOT THE NEXT MINOR. Emitting the next MINOR
+# (1.9.1 -> 1.10.0) was the original scheme and it over-claimed: it stranded a
+# TestFlight 1.10.0 above a live 1.8.0 for a release nobody had decided on, and
+# when the real next version turned out to be a patch, every beta carried a
+# version that would never ship. The next PATCH is the smallest legal claim —
+# exactly one version ahead, and the one most likely to be released next anyway,
+# so in the common case nothing is stranded at all.
+#
+# THE MARKETING VERSION IS STABLE ACROSS BETAS. This does not bump per build.
+# Every beta rides the same 1.9.2 until a release actually claims it; only
+# CI_BUILD_NUMBER moves, which is precisely what the (CFBundleShortVersionString,
 # CFBundleVersion) uniqueness rule is for:
-#     1.9.1 (27), 1.9.1 (28), 1.9.1 (29) ...
-# so no version is burned until a release actually claims it.
+#     1.9.2 (27), 1.9.2 (28), 1.9.2 (29) ...
 #
 # The human-readable "1.9.1-beta27" that testers see is built by
 # scripts/beta_label.sh from this version plus the build number, and cannot live
@@ -28,11 +44,12 @@
 # permanently burn that version in App Store Connect — versions cannot be
 # deleted there.
 #
-# COROLLARY / CONVENTION, unchanged and now load-bearing in a second way: bump
-# MARKETING_VERSION *to* the release version when cutting a release, never in
-# advance. publish_release.sh already asserts the packaged version matches
-# project.yml. Pre-bumping it no longer makes betas leapfrog — it makes them
-# claim a version that has not shipped.
+# COROLLARY / CONVENTION, unchanged and load-bearing: bump MARKETING_VERSION
+# *to* the release version when cutting a release, never in advance.
+# publish_release.sh already asserts the packaged version matches project.yml.
+# This script reads project.yml as "the last version that shipped" and returns
+# the first one that has not — so the beta train advances by itself the moment a
+# release lands. Pre-bumping breaks that reading and makes betas skip a version.
 #
 # Usage: nightly_version.sh [path/to/project.yml]
 # The optional argument exists for unit tests; production callers pass nothing.
@@ -54,4 +71,10 @@ CUR="$(sed -nE 's/^[[:space:]]*MARKETING_VERSION:[[:space:]]*"?([0-9]+\.[0-9]+\.
   echo "       in App Store Connect." >&2
   exit 1; }
 
-echo "$CUR"
+MAJOR="${CUR%%.*}"
+REST="${CUR#*.}"
+MINOR="${REST%%.*}"
+PATCH="${REST#*.}"
+
+# $(( )) forces integer arithmetic, so 1.9.9 -> 1.9.10 rather than a string bug.
+echo "${MAJOR}.${MINOR}.$((PATCH + 1))"

--- a/scripts/tests/run_nightly_version_test.sh
+++ b/scripts/tests/run_nightly_version_test.sh
@@ -35,27 +35,43 @@ expect_fail () {  # $1=label $2=version-literal (may be empty)
 
 echo "== nightly_version =="
 
-# Core behaviour: emit project.yml's version VERBATIM — no bump.
+# Core behaviour: emit the next PATCH after project.yml's version.
 #
-# This is the assertion that matters, and it is the inverse of what this suite
-# asserted before 2026-08-10. Bumping to the next minor pre-claimed a version in
-# App Store Connect that could never be released or reclaimed (the iOS app ended
-# up with a TestFlight 1.10.0 above a live 1.8.0). Betas are now told apart by
-# build number, so a bump reintroduced here is a regression, not a refinement.
-expect_ok "1.8.0 stays 1.8.0"   '"1.8.0"'  "1.8.0"
-expect_ok "1.9.1 stays 1.9.1"   '"1.9.1"'  "1.9.1"
-expect_ok "1.9.9 stays 1.9.9"   '"1.9.9"'  "1.9.9"
-expect_ok "0.1.0 stays 0.1.0"   '"0.1.0"'  "0.1.0"
-# Double-digit minors must survive verbatim (no numeric round-trip mangling).
-expect_ok "1.10.0 stays 1.10.0" '"1.10.0"' "1.10.0"
+# READ THIS BEFORE "FIXING" IT BACK. This suite has now asserted three different
+# things, and the history matters because two of them were wrong:
+#   1. next MINOR (1.9.1 -> 1.10.0). Over-claimed: stranded a TestFlight 1.10.0
+#      above a live 1.8.0 for a release nobody had decided on.
+#   2. VERBATIM (1.9.1 -> 1.9.1), to claim nothing at all. Apple rejects this
+#      outright once the version ships — iOS 1.9.1 went READY_FOR_SALE and the
+#      next upload came back ITMS-90186 "the train version '1.9.1' is closed for
+#      new build submissions" plus ITMS-90062 "must contain a higher version
+#      than the previously approved version".
+#   3. next PATCH (1.9.1 -> 1.9.2), below. The smallest claim Apple permits.
+# So "do not bump" is not a safer choice here; it is a rejected upload. A beta
+# MUST sit on a version that has never been approved.
+expect_ok "1.8.0 -> 1.8.1"   '"1.8.0"'  "1.8.1"
+expect_ok "1.9.1 -> 1.9.2"   '"1.9.1"'  "1.9.2"
+expect_ok "0.1.0 -> 0.1.1"   '"0.1.0"'  "0.1.1"
+# Integer arithmetic, not string: the patch must roll 9 -> 10, never "1.9.91".
+expect_ok "1.9.9 -> 1.9.10"  '"1.9.9"'  "1.9.10"
+# Double-digit minors must survive untouched while only the patch moves.
+expect_ok "1.10.0 -> 1.10.1" '"1.10.0"' "1.10.1"
 # Unquoted YAML scalar is still valid YAML and must parse.
-expect_ok "unquoted 1.8.0"      '1.8.0'    "1.8.0"
+expect_ok "unquoted 1.8.0"   '1.8.0'    "1.8.1"
 
-# Explicitly pin the anti-regression: the output must NEVER exceed the input.
+# Pin both halves of the contract: the output must differ from the input (or the
+# upload is rejected), and it must exceed it by exactly ONE patch (or we are
+# over-claiming versions again, which is how scheme 1 stranded 1.10.0).
 for v in "1.8.0" "1.9.1" "1.10.0" "2.0.3"; do
   got="$(bash "$SCRIPT" "$(fixture "\"$v\"")" 2>/dev/null)"
-  if [ "$got" = "$v" ]; then echo "  ok: $v not bumped"
-  else echo "  FAIL: $v was rewritten to '$got' — betas must not claim a new version"; FAILED=1; fi
+  want="${v%.*}.$(( ${v##*.} + 1 ))"     # computed here, independently of the script
+  if [ "$got" = "$v" ]; then
+    echo "  FAIL: $v unchanged — an approved version's train is closed (ITMS-90186)"; FAILED=1
+  elif [ "$got" != "$want" ]; then
+    echo "  FAIL: $v -> '$got', expected exactly one patch up ('$want')"; FAILED=1
+  else
+    echo "  ok: $v -> $got (exactly one patch)"
+  fi
 done
 
 # Hard failures — guessing a version is unrecoverable in App Store Connect.
@@ -72,18 +88,18 @@ else echo "  ok: missing file exits non-zero"; fi
 # Smoke-test the real repo file: with no argument the script must default to
 # swiftui/project.yml and exit 0.
 #
-# This now asserts the value directly, which the old bump-based version could
-# not: the answer is "whatever project.yml declares" rather than arithmetic on
-# it, and that equality IS the contract. Reading the expectation out of the file
-# with an independent sed (not by calling the script) keeps it non-circular, and
-# it stays correct across every future release bump.
+# The expectation is read out of the file with an independent sed and bumped
+# with independent arithmetic — never by calling the script — so this stays
+# non-circular, and it stays correct across every future release bump rather
+# than pinning a literal that goes stale the next time a version ships.
 REAL_YML="$ROOT/swiftui/project.yml"
 DECLARED="$(sed -nE 's/^[[:space:]]*MARKETING_VERSION:[[:space:]]*"?([0-9]+\.[0-9]+\.[0-9]+)"?[[:space:]]*$/\1/p' \
              "$REAL_YML" | head -1)"
-if REAL="$(bash "$SCRIPT" 2>/dev/null)" && [ -n "$DECLARED" ] && [ "$REAL" = "$DECLARED" ]; then
-  echo "  ok: real repo → $REAL (matches project.yml verbatim)"
+WANT="${DECLARED%.*}.$(( ${DECLARED##*.} + 1 ))"
+if REAL="$(bash "$SCRIPT" 2>/dev/null)" && [ -n "$DECLARED" ] && [ "$REAL" = "$WANT" ]; then
+  echo "  ok: real repo → $REAL (one patch above project.yml's $DECLARED)"
 else
-  echo "  FAIL: real repo gave '$REAL', project.yml declares '$DECLARED'"; FAILED=1
+  echo "  FAIL: real repo gave '$REAL', expected '$WANT' (project.yml declares '$DECLARED')"; FAILED=1
 fi
 
 rm -rf "$TMP"

--- a/swiftui/ci_scripts/ci_post_clone.sh
+++ b/swiftui/ci_scripts/ci_post_clone.sh
@@ -124,11 +124,16 @@ tar -xzf "$TARBALL"
 rm -f "$TARBALL" "$TARBALL.sha256"
 
 echo "== 4/7  Stamp marketing version + build number =="
-# nightly_version.sh emits project.yml's CURRENT version verbatim — betas ride
-# the released version and are told apart by CI_BUILD_NUMBER, so no unreleased
-# version number is claimed in App Store Connect (where it could never be
-# reclaimed). BETA_LABEL is the human-readable half of the same identity, for the
-# Settings pane; Apple only sees the numeric pair.
+# nightly_version.sh emits the next PATCH after project.yml's version, so betas
+# ride a version that has never been approved. They must: App Store Connect
+# closes a version's pre-release train permanently once it ships, and uploading
+# under the live 1.9.1 came back ITMS-90186 "train version '1.9.1' is closed" and
+# ITMS-90062 "must contain a higher version than the previously approved".
+# The marketing version is still STABLE across betas — every one rides the same
+# 1.9.2 until a release claims it; only CI_BUILD_NUMBER moves. BETA_LABEL is the
+# human-readable half of the same identity ("1.9.2-beta29") for the Settings
+# pane; Apple only ever sees the numeric pair, which is why the label cannot be
+# the marketing version.
 MKT="$(bash scripts/nightly_version.sh)"
 BETA_LABEL="$(bash scripts/beta_label.sh "$MKT" "$CI_BUILD_NUMBER")"
 echo "  version=$MKT build=$CI_BUILD_NUMBER label=$BETA_LABEL"


### PR DESCRIPTION
Xcode Cloud beta build 29 was rejected by App Store Connect:

```
ITMS-90186: Invalid Pre-Release Train — the train version '1.9.1' is closed
            for new build submissions
ITMS-90062: CFBundleShortVersionString [1.9.1] must contain a higher version
            than the previously approved version [1.9.1]
```

## Cause

iOS `1.9.1` is `READY_FOR_SALE`, and App Store Connect closes a version's
pre-release train **permanently** once it is approved. `nightly_version.sh` was
emitting `project.yml`'s version verbatim so that betas would not claim an
unreleased number at all — but that is not the conservative option, it is a
guaranteed rejected upload. A beta must sit on a version that has never been
approved.

## Fix

`nightly_version.sh` now emits the next **patch** (`1.9.1` → `1.9.2`).

That is the smallest claim Apple permits: one version ahead, and the one most
likely to ship next anyway, so in the usual case nothing is stranded. It is
deliberately **not** the next minor — that was the original scheme and it
over-claimed, stranding a TestFlight `1.10.0` above a live `1.8.0` for a release
nobody had planned.

**The marketing version stays stable across betas.** Every beta rides `1.9.2`
until a release claims it; only `CI_BUILD_NUMBER` moves. This is not a per-build
bump.

| | |
|---|---|
| `project.yml` | `1.9.1` — the last version that shipped |
| Apple sees | `1.9.2` + `CI_BUILD_NUMBER` |
| Testers see | `1.9.2-beta30` |

`beta_label.sh` is **unchanged and was already correct**: testers get
`1.9.2-beta29` via the `RayMolBetaLabel` Info.plist key, because
`CFBundleShortVersionString` takes at most three integers and rejects a
`-beta29` suffix outright.

## Test suite

The anti-regression guard is inverted: it previously insisted the output must
never exceed the input, which is exactly what Apple forbids. It now pins both
halves — the output must differ from the input, and exceed it by exactly one
patch.

This suite has now asserted three different things, two of them wrong, so all
three schemes are recorded in-file to stop the verbatim one being reintroduced
as a "fix". The real-repo check derives its expectation from `project.yml` with
an independent `sed` plus independent arithmetic — never by calling the script —
so it stays non-circular and survives future releases.

## Docs

The runbook's versioning section was doubly stale: it still described the
original minor-bump scheme and had never been updated for the verbatim change
either. Rewritten, with the ITMS errors quoted and the reasoning for patch-over-
minor recorded.

## Verification

All six script suites pass (`ios_deps_fingerprint`, `nightly_version`,
`prune_ios_deps`, `apply_ci_versions`, `assert_ios_build_inputs`, `beta_label`).
Version matrix verified: `1.9.1→1.9.2`, `1.9.9→1.9.10` (integer arithmetic, not
string), `1.10.0→1.10.1`, `2.0.0→2.0.1`.

Not verified here: the next real Xcode Cloud archive. Merging this triggers one,
and that upload passing validation is the actual proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)