### PR TITLE
feat(predict): auto-load results into a pending placeholder object

### DIFF
--- a/modules/pymol/appkit_inspector.py
+++ b/modules/pymol/appkit_inspector.py
@@ -410,6 +410,28 @@ def group_parents(objs, groups):
     return dict(parents)
 
 
+def _pending_map():
+    """name -> hover detail for prediction placeholders still waiting on a job.
+
+    Never raises: a failure here would freeze the whole object panel on a stale list,
+    because the caller's single `except` writes no file at all.
+    """
+    try:
+        from pymol import predicting
+        names = predicting.pending_objects()
+        if not names:
+            return {}
+        out = {}
+        for name in names:
+            try:
+                out[name] = predicting.pending_detail(name) or 'pending'
+            except Exception:
+                out[name] = 'pending'
+        return out
+    except Exception:
+        return {}
+
+
 def poll_panel():
     """Write the object-list JSON to a temp file and print a short marker.
 
@@ -445,6 +467,15 @@ def poll_panel():
             'has_transp': {o: object_has_atom_transp(o) for o in objs},
             'groups': groups,
             'parent': parents,
+            # Structure prediction (#224): objects that are empty placeholders waiting on
+            # a running job. The panel disables their enable-toggle (there is nothing to
+            # show) and puts the detail string in a hover tooltip.
+            #
+            # Cheap by construction: `pending` is normally empty, and only pending names
+            # read a status file. This poll runs on the MAIN thread every 500 ms and was
+            # already a measured hot spot (PR #270), so it must stay O(pending), never
+            # O(objects).
+            'pending': _pending_map(),
         }
         # Multiple RayMol windows may run as separate processes. A process-local
         # filename prevents an empty instance from replacing another instance's

--- a/modules/pymol/appkit_inspector.py
+++ b/modules/pymol/appkit_inspector.py
@@ -181,7 +181,17 @@ def takes_atom_selection(obj):
     Groups were originally caught by this guard too, which silently blanked their
     rep list and per-atom transparency badge even though probing them is both safe
     and meaningful — issue #256.
+
+    A name that no longer EXISTS is the same trap by another route, and the one a
+    user actually hits: `cmd.get_type` runs the name through the selector, so it
+    emits the Selector-Error line before raising, and the `except` below catches an
+    exception that has already been logged. Deleting an inspected object -- or
+    `reinitialize`, which deletes everything while the panel still holds the name --
+    then floods the console once per poll tick. Check existence FIRST, via
+    `get_names`, which does not touch the selector.
     """
+    if obj not in cmd.get_names('all'):
+        return False
     try:
         return cmd.get_type(obj) in SELECTABLE_TYPES
     except Exception:
@@ -251,7 +261,18 @@ def object_has_atom_transp(obj):
 
 def _build(objs):
     detail = {}
+    # One lookup for the whole tick. takes_atom_selection() also guards, but calling
+    # get_names per object would make a hot main-thread poll quadratic.
+    try:
+        known = set(cmd.get_names('all') or [])
+    except Exception:
+        known = None
     for o in objs:
+        if known is not None and o not in known:
+            # Stale name from the panel: object deleted, or reinitialize ran. Emitting
+            # nothing is right -- probing it would log a Selector-Error per tick.
+            detail[o] = []
+            continue
         reps = []
         # Measurements, CGOs and maps have no reps to describe, and every probe
         # below — transp_summary's iterate and the per-rep count_atoms — would make
@@ -304,6 +325,12 @@ def _build(objs):
     # frame's state when not pinned) and whether all states are overlaid.
     objmeta = {}
     for o in objs:
+        # Same stale-name guard as the rep loop above. This second pass probes
+        # count_states/get_title, and count_states runs the name through the
+        # SELECTOR -- so a deleted or reinitialized object logs a Selector-Error
+        # here once per poll tick even though the rep loop already skipped it.
+        if known is not None and o not in known:
+            continue
         entry = {'state': int(round(_num('state', o))),
                  'all': int(round(_num('all_states', o)))}
         # Per-state titles (e.g. compound names from a multi-record SDF, which

--- a/modules/pymol/cmd.py
+++ b/modules/pymol/cmd.py
@@ -53,6 +53,13 @@ def _deferred_init_pymol_internals(_pymol):
     if wizarding.session_save_wizard not in _pymol._session_save_tasks:
         _pymol._session_save_tasks.append(wizarding.session_save_wizard)
 
+    # Structure prediction (#224): keeps pending placeholders out of a saved .pse.
+    # Imported here, not at module scope: predicting does `from pymol import cmd`, so a
+    # top-level import would be circular. This runs after module init, so it is safe.
+    from . import predicting
+    if predicting.session_save not in _pymol._session_save_tasks:
+        _pymol._session_save_tasks.append(predicting.session_save)
+
     # RayMol: per-scene render-settings snapshot (DOF/lighting/metal_* look).
     # Imported here (deferred) to avoid a circular import at cmd.py load time.
     # Wrapped so a fork-module problem can never break core PyMOL startup.

--- a/modules/pymol/completing.py
+++ b/modules/pymol/completing.py
@@ -71,6 +71,28 @@ def wizard_sc():
             for name in os.listdir(p) if name.endswith('.py')]
     return Shortcut(names_glob)
 
+def _predictor_shortcut():
+    """Registered structure predictors, for `predict`/`predict_weights` completion.
+
+    Never raises. A completer that throws takes Tab down for EVERY command, not just
+    this one, so an unavailable registry degrades to "no suggestions".
+    """
+    try:
+        from pymol.predictors import registry
+        return Shortcut(registry.available())
+    except Exception:
+        return Shortcut([])
+
+
+def _predict_job_shortcut():
+    """Job ids submitted this session, for predict_status/_cancel/_result. Never raises."""
+    try:
+        from pymol import predicting
+        return Shortcut(predicting.job_ids())
+    except Exception:
+        return Shortcut([])
+
+
 def get_auto_arg_list(self_cmd=cmd):
     self_cmd = self_cmd._weakrefproxy
 
@@ -81,11 +103,18 @@ def get_auto_arg_list(self_cmd=cmd):
             Shortcut(self_cmd.get_names_of_type('object:ramp')),
             'ramp', '' ]
     aa_scene_e = [lambda: Shortcut(cmd.get_scene_list()), 'scene', '']
+    aa_predictor_c = [_predictor_shortcut, 'predictor', ', ']
+    aa_predict_job_c = [_predict_job_shortcut, 'job id', ', ']
 
     return [
 # 1st
         {
         'align'          : aa_sel_c,
+        'predict'        : aa_predictor_c,
+        'predict_weights': aa_predictor_c,
+        'predict_status' : aa_predict_job_c,
+        'predict_cancel' : aa_predict_job_c,
+        'predict_result' : aa_predict_job_c,
         'alignto'        : aa_obj_c,
         'alter'          : aa_sel_e,
         'alphatoall'     : aa_sel_c,

--- a/modules/pymol/predicting.py
+++ b/modules/pymol/predicting.py
@@ -42,6 +42,10 @@ def weight_cache():
 # at state 1 rather than appending after a phantom empty state, so re-running the same
 # sequence yields models 1..N in one object with no gaps.
 
+#: Upper bound for a randomly chosen seed. Below 2**53 so the value survives a JSON
+#: round-trip through a Double on the Swift side; still 4 billion distinct samples.
+RANDOM_SEED_BOUND = 2 ** 32
+
 #: Hex digits of the sequence digest used in a derived object name. Eight, not six:
 #: six is 24 bits, and two DIFFERENT sequences colliding would silently merge into one
 #: object, which is worse than a visible name clash. Widen, never narrow.
@@ -127,7 +131,7 @@ def clear_pending(_self=cmd):
         discard_pending(name, _self=_self)
 
 
-def deliver_result(path, name, _self=cmd):
+def deliver_result(path, name, seed=None, _self=cmd):
     """Load a finished prediction into its placeholder and retire the pending mark.
 
     One entry point rather than two calls from the host, so the load and the bookkeeping
@@ -140,6 +144,14 @@ def deliver_result(path, name, _self=cmd):
     """
     try:
         _self.load(path, name, zoom=0)
+        # Record which seed produced THIS model, in its state title, so a multi-model
+        # object says what each model is. It survives into a saved .pse, which is what
+        # makes a randomly seeded run reproducible after the fact.
+        if seed is not None:
+            try:
+                _self.set_title(name, _self.count_states(name), 'seed=%d' % int(seed))
+            except Exception:
+                pass
         # Assign secondary structure explicitly. `auto_dss` does NOT fire when loading
         # into a PRE-EXISTING object, which is exactly what the placeholder makes this --
         # measured: this path leaves ss='' on every residue, while the same file loaded
@@ -193,7 +205,7 @@ def session_save(session, _self=cmd):
 
 
 def predict(predictor, sequence, name='', recycling_steps=3, diffusion_steps=200,
-            seed=0, diffusion_samples=None, quiet=1, _self=cmd):
+            seed=None, diffusion_samples=None, quiet=1, _self=cmd):
     """
 DESCRIPTION
 
@@ -255,6 +267,22 @@ SEE ALSO
     predictor_obj.check_available()
 
     spec = predictor_obj.parse_spec(sequence, name=name or (predictor + '_pred'))
+
+    # A fresh seed per run unless one is given, so repeat predictions of the same sequence
+    # are genuinely different models rather than bit-identical duplicates -- measured, two
+    # runs at the fixed seed 0 gave RMSD 0.0000 and appending the second was pointless.
+    #
+    # The seed used is RECORDED -- printed, carried on the job's options, and written into
+    # the per-state title -- because a random seed you cannot recover makes every result
+    # unreproducible. `seed=N` reproduces one exactly.
+    #
+    # Bounded to 2**32 rather than the full UInt64 range: the value crosses a JSON wire
+    # into Swift, and an integer above 2**53 cannot survive a round-trip through a Double,
+    # which is what Foundation's JSON layer may use for large numbers.
+    if seed is None:
+        import random
+        seed = random.randrange(RANDOM_SEED_BOUND)
+
     requested = dict(
         recycling_steps=int(recycling_steps),
         diffusion_steps=int(diffusion_steps),
@@ -299,8 +327,8 @@ SEE ALSO
     _JOBS[job.job_id] = job
     register_pending(object_name, job.job_id, _self=_self)
     if not int(quiet):
-        colorprinting.parrot(' predict: job %s submitted, will load as %s'
-                           % (job.job_id, object_name))
+        colorprinting.parrot(' predict: job %s submitted, will load as %s (seed %d)'
+                           % (job.job_id, object_name, options.seed))
     return job
 
 

--- a/modules/pymol/predicting.py
+++ b/modules/pymol/predicting.py
@@ -140,6 +140,25 @@ def deliver_result(path, name, _self=cmd):
     """
     try:
         _self.load(path, name, zoom=0)
+        # Assign secondary structure explicitly. `auto_dss` does NOT fire when loading
+        # into a PRE-EXISTING object, which is exactly what the placeholder makes this --
+        # measured: this path leaves ss='' on every residue, while the same file loaded
+        # under a fresh name comes back H/S/L. Without this, cartoon renders every
+        # prediction as featureless loops, and boltz output carries no HELIX/SHEET
+        # records to fall back on.
+        #
+        # ss is a per-ATOM property in PyMOL, not per-state, so one call covers every
+        # appended model -- but it also means two models with genuinely different
+        # conformations share whichever assignment dss computed, which is a PyMOL
+        # limitation rather than a choice made here.
+        try:
+            _self.dss(name)
+        except Exception as exc:
+            # Not fatal: a structure without ss is still the thing the user asked for.
+            # Reported rather than swallowed, because a silently skipped step here looks
+            # exactly like a prediction that folded to nothing but loops.
+            colorprinting.warning(' predict: could not assign secondary structure to %s'
+                                  ' (%s)' % (name, exc))
     finally:
         _PENDING.pop(name, None)
 

--- a/modules/pymol/predicting.py
+++ b/modules/pymol/predicting.py
@@ -30,6 +30,149 @@ def weight_cache():
     return _CACHE
 
 
+# -- Auto-load: content-derived names and pending placeholders -----------------
+#
+# A prediction takes seconds to tens of minutes, so `cmd.predict` returns a handle
+# rather than blocking. That left the result invisible until the user called
+# `predict_result` by hand. Instead an EMPTY object is created at submit time under a
+# name derived from the input, and the host loads the finished structure into it.
+#
+# The placeholder is deliberately a real, zero-atom object (`cmd.create(name, 'none')`):
+# it shows up in the object panel immediately, and -- verified -- loading into it lands
+# at state 1 rather than appending after a phantom empty state, so re-running the same
+# sequence yields models 1..N in one object with no gaps.
+
+#: Hex digits of the sequence digest used in a derived object name. Eight, not six:
+#: six is 24 bits, and two DIFFERENT sequences colliding would silently merge into one
+#: object, which is worse than a visible name clash. Widen, never narrow.
+OBJECT_NAME_DIGEST_CHARS = 8
+
+#: name -> job_id for placeholders whose job has not finished. Read by the object panel
+#: (to disable the enable-toggle and show hover detail), by the session-save wrapper
+#: (to keep placeholders out of a .pse), and by cleanup on failure/cancel/quit.
+_PENDING = {}
+
+
+def default_object_name(sequence, predictor_id=''):
+    """The object name a prediction lands in when the caller does not pick one.
+
+    Shaped `<method>_prediction_<digest>`, e.g. `boltz2_prediction_f2b2e116`. The method
+    leads so that objects sort and read by predictor -- with several methods registered,
+    the same sequence folded two ways must be two objects, not two models of one, because
+    they are not samples of the same distribution.
+
+    The digest is of the sequence, so re-predicting the same target with the same method
+    appends another model to the same object instead of littering the session. Normalised
+    for case and whitespace -- otherwise 'mktay' and 'MKTAY ' would give two objects for
+    one protein -- but the '/' chain separator is significant, because A/B is a different
+    complex from the concatenation AB.
+    """
+    import hashlib
+    normalised = ''.join(str(sequence).split()).upper()
+    digest = hashlib.sha256(normalised.encode('utf-8')).hexdigest()
+    stem = 'prediction_%s' % digest[:OBJECT_NAME_DIGEST_CHARS]
+    method = ''.join(ch for ch in str(predictor_id) if ch.isalnum() or ch == '_')
+    return '%s_%s' % (method, stem) if method else stem
+
+
+def pending_objects():
+    """Copy of the pending name -> job_id map."""
+    return dict(_PENDING)
+
+
+def pending_detail(name, _self=cmd):
+    """One-line description of the job a placeholder is waiting on, or None.
+
+    This is the string the object panel shows on hover, so it must stay short and must
+    never raise: it is rendered from a 500 ms poll on the main thread.
+    """
+    job_id = _PENDING.get(name)
+    if job_id is None:
+        return None
+    job = _JOBS.get(job_id)
+    if job is None:
+        return 'pending'
+    try:
+        status = job.status()
+    except Exception:
+        return 'pending'
+    phase = status.get('phase') or status.get('state') or 'pending'
+    fraction = status.get('fraction') or 0.0
+    return 'pending: %s %d%%' % (phase, int(float(fraction) * 100))
+
+
+def register_pending(name, job_id, _self=cmd):
+    """Create the empty placeholder and remember what it is waiting for."""
+    _self.create(name, 'none')
+    _PENDING[name] = job_id
+
+
+def discard_pending(name, _self=cmd):
+    """Forget a placeholder, deleting the object only if it never received atoms.
+
+    The atom check is the important part: cleanup can race a job that just finished, and
+    deleting a completed structure would destroy the very thing the user asked for.
+    """
+    _PENDING.pop(name, None)
+    try:
+        if name in _self.get_names('objects') and _self.count_atoms(name) == 0:
+            _self.delete(name)
+    except Exception:
+        pass
+
+
+def clear_pending(_self=cmd):
+    """Drop every placeholder. Used on quit and by tests."""
+    for name in list(_PENDING):
+        discard_pending(name, _self=_self)
+
+
+def deliver_result(path, name, _self=cmd):
+    """Load a finished prediction into its placeholder and retire the pending mark.
+
+    One entry point rather than two calls from the host, so the load and the bookkeeping
+    cannot get out of step -- a name left in `_PENDING` after a successful load would be
+    filtered out of every subsequent session save.
+
+    `zoom=0` on purpose: a prediction can land many minutes after submit, and pulling the
+    camera onto it while the user is working elsewhere is hostile. The object is already
+    visible, because the placeholder appeared at submit time.
+    """
+    try:
+        _self.load(path, name, zoom=0)
+    finally:
+        _PENDING.pop(name, None)
+
+
+def session_save(session, _self=cmd):
+    """Session-save task: keep pending placeholders out of the .pse.
+
+    A placeholder is a real zero-atom object and DOES survive a session round-trip, so a
+    session saved mid-prediction would carry an object that can never fill -- the job is
+    gone on reload. This runs after `_cmd.get_session` has populated `session['names']`
+    (exporting.py:443), so the entry can simply be dropped from the copy being written.
+    The live session is untouched, which is why there is no delete/recreate and no race.
+
+    Only objects that are BOTH pending and still empty are dropped: a job that completed
+    between submit and save has real atoms and must be saved like anything else.
+    """
+    names = session.get('names')
+    if not names or not _PENDING:
+        return 1
+    keep = []
+    for entry in names:
+        # None entries are structural in PyMOL's names list -- preserve them.
+        if entry and entry[0] in _PENDING:
+            try:
+                if _self.count_atoms(entry[0]) == 0:
+                    continue
+            except Exception:
+                continue
+        keep.append(entry)
+    session['names'] = keep
+    return 1
+
+
 def predict(predictor, sequence, name='', recycling_steps=3, diffusion_steps=200,
             seed=0, diffusion_samples=None, quiet=1, _self=cmd):
     """
@@ -125,10 +268,20 @@ SEE ALSO
                                    % (phase, int(fraction * 100)))
         weights_path = cache.ensure(bundle, progress=report)
 
+    # Resolve the object name BEFORE submitting: the host needs it to load the result,
+    # and the placeholder has to exist by the time this call returns so the panel shows
+    # the job immediately rather than after the first poll.
+    object_name = (str(name) if name else
+                   default_object_name(sequence, predictor_obj.id))
+    # PredictionSpec is a __slots__ class, not a namedtuple: assign, don't _replace.
+    spec.name = object_name
+
     job = predictor_obj.submit(spec, options, weights_path)
     _JOBS[job.job_id] = job
+    register_pending(object_name, job.job_id, _self=_self)
     if not int(quiet):
-        colorprinting.parrot(' predict: job %s submitted' % job.job_id)
+        colorprinting.parrot(' predict: job %s submitted, will load as %s'
+                           % (job.job_id, object_name))
     return job
 
 

--- a/modules/pymol/predicting.py
+++ b/modules/pymol/predicting.py
@@ -12,6 +12,7 @@ import sys
 from . import colorprinting
 from .predictors import registry
 from .predictors.base import PredictionOptions  # noqa: F401  (re-export for callers)
+from .predictors.errors import PredictionOptionError
 from .predictors.weights import WeightCache
 
 cmd = sys.modules["pymol.cmd"]
@@ -45,6 +46,11 @@ def weight_cache():
 #: Upper bound for a randomly chosen seed. Below 2**53 so the value survives a JSON
 #: round-trip through a Double on the Swift side; still 4 billion distinct samples.
 RANDOM_SEED_BOUND = 2 ** 32
+
+#: Ceiling on `n_models`. Each model is a FULL run -- see predict()'s docstring -- and a
+#: single 600-residue run already takes ~11 minutes, so an unbounded count is a foot-gun
+#: rather than a feature.
+MAX_MODELS = 20
 
 #: Hex digits of the sequence digest used in a derived object name. Eight, not six:
 #: six is 24 bits, and two DIFFERENT sequences colliding would silently merge into one
@@ -80,8 +86,11 @@ def default_object_name(sequence, predictor_id=''):
 
 
 def pending_objects():
-    """Copy of the pending name -> job_id map."""
-    return dict(_PENDING)
+    """Copy of the pending map: object name -> LIST of outstanding job ids.
+
+    A list because `n_models` submits several runs that all deliver into one object.
+    """
+    return {name: list(ids) for name, ids in _PENDING.items()}
 
 
 def pending_detail(name, _self=cmd):
@@ -90,9 +99,10 @@ def pending_detail(name, _self=cmd):
     This is the string the object panel shows on hover, so it must stay short and must
     never raise: it is rendered from a 500 ms poll on the main thread.
     """
-    job_id = _PENDING.get(name)
-    if job_id is None:
+    job_ids = _PENDING.get(name)
+    if not job_ids:
         return None
+    job_id = job_ids[0]
     job = _JOBS.get(job_id)
     if job is None:
         return 'pending'
@@ -102,13 +112,24 @@ def pending_detail(name, _self=cmd):
         return 'pending'
     phase = status.get('phase') or status.get('state') or 'pending'
     fraction = status.get('fraction') or 0.0
-    return 'pending: %s %d%%' % (phase, int(float(fraction) * 100))
+    detail = 'pending: %s %d%%' % (phase, int(float(fraction) * 100))
+    outstanding = len(job_ids)
+    if outstanding > 1:
+        detail += ' (%d models queued)' % outstanding
+    return detail
 
 
 def register_pending(name, job_id, _self=cmd):
-    """Create the empty placeholder and remember what it is waiting for."""
-    _self.create(name, 'none')
-    _PENDING[name] = job_id
+    """Create the empty placeholder (if new) and remember what it is waiting for.
+
+    A LIST of job ids, not one: `n_models` submits several runs that all deliver into the
+    same object, and the placeholder has to stay pending until the last of them lands.
+    Recording only the newest would clear the pending mark on the first delivery while
+    later models were still running.
+    """
+    if name not in _self.get_names('objects'):
+        _self.create(name, 'none')
+    _PENDING.setdefault(name, []).append(job_id)
 
 
 def discard_pending(name, _self=cmd):
@@ -172,7 +193,13 @@ def deliver_result(path, name, seed=None, _self=cmd):
             colorprinting.warning(' predict: could not assign secondary structure to %s'
                                   ' (%s)' % (name, exc))
     finally:
-        _PENDING.pop(name, None)
+        # Retire only THIS job. With n_models > 1 the object stays pending until the last
+        # model has landed, so the panel keeps showing progress for the rest.
+        remaining = _PENDING.get(name)
+        if remaining:
+            remaining.pop(0)
+            if not remaining:
+                _PENDING.pop(name, None)
 
 
 def session_save(session, _self=cmd):
@@ -205,7 +232,7 @@ def session_save(session, _self=cmd):
 
 
 def predict(predictor, sequence, name='', recycling_steps=3, diffusion_steps=200,
-            seed=None, diffusion_samples=None, quiet=1, _self=cmd):
+            seed=None, n_models=1, diffusion_samples=None, quiet=1, _self=cmd):
     """
 DESCRIPTION
 
@@ -233,7 +260,14 @@ ARGUMENTS
     diffusion_steps = int: reverse-diffusion steps; higher is slower and more
     accurate {default: 200}
 
-    seed = int: random seed {default: 0}
+    seed = int: random seed. Drawn FRESH PER RUN when omitted, so repeat
+    predictions of one sequence are different models rather than identical
+    duplicates. The value used is printed and recorded in each model's state
+    title, so any result can be reproduced exactly with seed=N.
+    {default: None, meaning "choose one"}
+
+    n_models = int: how many models to produce, appended as states 1..N of the
+    same object. Each gets its own seed. {default: 1, maximum: 20}
 
     diffusion_samples = int: accepted only so that a predictor which does not
     plumb it can REJECT it by name instead of ignoring it. No shipped predictor
@@ -243,11 +277,19 @@ EXAMPLES
 
     predict boltz2, MKTAYIAKQRQISFVKSHFSRQLEERLGLIEVQ
     predict boltz2, MKTAY/GSHMA, name=dimer, diffusion_steps=300
+    predict boltz2, MKTAYIAKQRQISFVKSHFSRQLEERLGLIEVQ, n_models=5
 
 NOTES
 
     Defaults follow upstream Boltz. Options a predictor does not implement are
     rejected rather than ignored, so a typo cannot silently degrade a result.
+
+    n_models COSTS N FULL RUNS. Each model repeats the whole prediction with a
+    different seed, including the trunk; it is not several samples drawn from one
+    diffusion run. boltz-mlx does not plumb diffusion_samples -- only sample 0
+    escapes its predictor -- so sharing the trunk across models is not available.
+    Budget accordingly: five models of a 600-residue target is roughly an hour.
+    The runs are sequential, so peak memory is that of ONE model, not N.
 
     THE FIRST CALL BLOCKS. Inference itself is asynchronous, but a predictor whose
     weights are not yet cached downloads them synchronously first -- for boltz2 that
@@ -279,6 +321,10 @@ SEE ALSO
     # Bounded to 2**32 rather than the full UInt64 range: the value crosses a JSON wire
     # into Swift, and an integer above 2**53 cannot survive a round-trip through a Double,
     # which is what Foundation's JSON layer may use for large numbers.
+    count = int(n_models)
+    if not 1 <= count <= MAX_MODELS:
+        raise PredictionOptionError('n_models must be between 1 and %d' % MAX_MODELS)
+
     if seed is None:
         import random
         seed = random.randrange(RANDOM_SEED_BOUND)
@@ -323,13 +369,29 @@ SEE ALSO
     # PredictionSpec is a __slots__ class, not a namedtuple: assign, don't _replace.
     spec.name = object_name
 
-    job = predictor_obj.submit(spec, options, weights_path)
-    _JOBS[job.job_id] = job
-    register_pending(object_name, job.job_id, _self=_self)
-    if not int(quiet):
-        colorprinting.parrot(' predict: job %s submitted, will load as %s (seed %d)'
-                           % (job.job_id, object_name, options.seed))
-    return job
+    jobs = []
+    for index in range(count):
+        # A distinct seed per model, or every model would be the same structure. The
+        # first uses the seed resolved above, so `predict ..., seed=N` still reproduces
+        # exactly and `n_models` extends that run rather than replacing it.
+        if index == 0:
+            model_options = options
+        else:
+            import random
+            model_options = predictor_obj.validate_options(
+                dict(requested, seed=random.randrange(RANDOM_SEED_BOUND)))
+        job = predictor_obj.submit(spec, model_options, weights_path)
+        _JOBS[job.job_id] = job
+        register_pending(object_name, job.job_id, _self=_self)
+        jobs.append(job)
+        if not int(quiet):
+            colorprinting.parrot(
+                ' predict: job %s submitted, will load as %s model %d (seed %d)'
+                % (job.job_id, object_name, index + 1, model_options.seed))
+
+    # A single job for the default, a list when several were asked for. Keeping the
+    # scalar for n_models=1 means existing callers and `job.job_id` keep working.
+    return jobs[0] if count == 1 else jobs
 
 
 def predict_status(job_id='', quiet=1, _self=cmd):

--- a/modules/pymol/predicting.py
+++ b/modules/pymol/predicting.py
@@ -85,6 +85,15 @@ def default_object_name(sequence, predictor_id=''):
     return '%s_%s' % (method, stem) if method else stem
 
 
+def job_ids():
+    """Ids of every job submitted this session, newest last.
+
+    Public because the command-line completer offers them for predict_status /
+    predict_cancel / predict_result, and a completer must not reach into _JOBS.
+    """
+    return list(_JOBS)
+
+
 def pending_objects():
     """Copy of the pending map: object name -> LIST of outstanding job ids.
 

--- a/modules/pymol/predictors/host.py
+++ b/modules/pymol/predictors/host.py
@@ -94,6 +94,10 @@ def submit(spec, options, weights_path):
         'seed': options.seed,
         'out_path': job.out_path,
         'status_path': job.status_path,
+        # The object the host loads the finished structure into. Resolved at submit time
+        # so an empty placeholder can exist in the session immediately, and so the host
+        # needs no second round-trip to find out where the result belongs.
+        'object_name': getattr(spec, 'name', '') or '',
     }
     # Write completely before announcing it: the host reads on the next 100 ms
     # tick and must never see a partial request.

--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -282,7 +282,7 @@
 		F7E41DCBB427678A8F018B0E /* DesignControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignControllerTests.swift; sourceTree = "<group>"; };
 		FB1304C662D9011F7C4505FC /* MCPStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPStatusView.swift; sourceTree = "<group>"; };
 		FF4FB7F151982A2927D612F0 /* DesignController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignController.swift; sourceTree = "<group>"; };
-		"TEMP_AAFA7A48-6D54-4EFB-8228-564880033D44" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
+		"TEMP_5E2672C9-9D8D-4BBD-B51B-4A274304E904" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -484,10 +484,10 @@
 			path = Bridge;
 			sourceTree = "<group>";
 		};
-		"TEMP_81CF8B29-C410-4D58-8199-6BE16162D673" /* swiftui */ = {
+		"TEMP_299BBDF1-5B3C-4E50-A986-644288599BC2" /* swiftui */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_AAFA7A48-6D54-4EFB-8228-564880033D44" /* PyMOLBridge.xcconfig */,
+				"TEMP_5E2672C9-9D8D-4BBD-B51B-4A274304E904" /* PyMOLBridge.xcconfig */,
 			);
 			path = swiftui;
 			sourceTree = "<group>";
@@ -1488,7 +1488,7 @@
 		};
 		76B7E9DB75E073D1E60928FA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_AAFA7A48-6D54-4EFB-8228-564880033D44" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_5E2672C9-9D8D-4BBD-B51B-4A274304E904" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1595,7 +1595,7 @@
 		};
 		D8F44FDFF036013D2F03BA83 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_AAFA7A48-6D54-4EFB-8228-564880033D44" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_5E2672C9-9D8D-4BBD-B51B-4A274304E904" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1753,7 +1753,7 @@
 			repositoryURL = "https://github.com/javierbq/boltz-mlx.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.0;
+				minimumVersion = 0.1.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -282,7 +282,7 @@
 		F7E41DCBB427678A8F018B0E /* DesignControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignControllerTests.swift; sourceTree = "<group>"; };
 		FB1304C662D9011F7C4505FC /* MCPStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPStatusView.swift; sourceTree = "<group>"; };
 		FF4FB7F151982A2927D612F0 /* DesignController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignController.swift; sourceTree = "<group>"; };
-		"TEMP_AA10A211-0C64-4378-B2DB-EE5F871E5961" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
+		"TEMP_AAFA7A48-6D54-4EFB-8228-564880033D44" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -484,10 +484,10 @@
 			path = Bridge;
 			sourceTree = "<group>";
 		};
-		"TEMP_3A98671F-5749-4702-88F6-EE56A9D937ED" /* swiftui */ = {
+		"TEMP_81CF8B29-C410-4D58-8199-6BE16162D673" /* swiftui */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_AA10A211-0C64-4378-B2DB-EE5F871E5961" /* PyMOLBridge.xcconfig */,
+				"TEMP_AAFA7A48-6D54-4EFB-8228-564880033D44" /* PyMOLBridge.xcconfig */,
 			);
 			path = swiftui;
 			sourceTree = "<group>";
@@ -1488,7 +1488,7 @@
 		};
 		76B7E9DB75E073D1E60928FA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_AA10A211-0C64-4378-B2DB-EE5F871E5961" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_AAFA7A48-6D54-4EFB-8228-564880033D44" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1595,7 +1595,7 @@
 		};
 		D8F44FDFF036013D2F03BA83 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_AA10A211-0C64-4378-B2DB-EE5F871E5961" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_AAFA7A48-6D54-4EFB-8228-564880033D44" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/swiftui/PyMOLViewer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/swiftui/PyMOLViewer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/javierbq/boltz-mlx.git",
       "state" : {
-        "revision" : "5aec62ed7723bd5b64be6ceb3d3f9ba46a2299c8",
-        "version" : "0.1.0"
+        "revision" : "d5994771e1e10fe960541dd4c82ffc3adb8e7e1e",
+        "version" : "0.1.1"
       }
     },
     {

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -379,6 +379,12 @@ struct ObjectEntry: Identifiable, Equatable {
     // existing memberwise initializers keep compiling.
     var isGroup: Bool = false
     var parent: String? = nil
+    // Structure prediction (#224): an empty placeholder waiting on a running job.
+    // Its enable-toggle is disabled — there is nothing to show yet — and
+    // `pendingDetail` is the hover tooltip describing the job's progress. Defaults keep
+    // the existing memberwise initializers compiling.
+    var isPending: Bool = false
+    var pendingDetail: String? = nil
 
     var displayName: String {
         if isSelection, let count = atomCount {
@@ -2046,6 +2052,11 @@ private struct ObjectRowContent: View {
             checkboxImage(check ?? (entry.isEnabled ? .on : .off))
         }
         .buttonStyle(.plain)
+        // A pending prediction placeholder has no atoms, so showing/hiding it is
+        // meaningless. Disabled rather than hidden, so the row still reads as a real
+        // object that is on its way.
+        .disabled(entry.isPending)
+        .opacity(entry.isPending ? 0.35 : 1.0)
         .frame(width: kGutterW)
 
         Text(entry.displayName)
@@ -2174,7 +2185,15 @@ private struct ObjectCard: View {
             // A/S/H/L/C controls consume their own taps (expand-only for the
             // chevron); only the dead Spacer gap falls through to here.
             .contentShape(Rectangle())
-            .onTapGesture { engine.setObjectEnabled(entry.name, !entry.isEnabled) }
+            .onTapGesture {
+                // Same reason the checkbox is disabled: nothing to show until the job
+                // lands. Guarded here too, or the dead gap in the row would still toggle.
+                guard !entry.isPending else { return }
+                engine.setObjectEnabled(entry.name, !entry.isEnabled)
+            }
+            // Hover detail for a running prediction: phase and progress, refreshed by the
+            // 500 ms panel poll. `.help` is a tooltip on macOS and a no-op on iOS.
+            .help(entry.pendingDetail ?? "")
             // Long-press (iOS) / right-click (macOS) opens the action menu.
             .contextMenu { actionMenuContent(actionMenuItems(isSelection: entry.isSelection, isGroup: entry.isGroup), name: entry.name, engine: engine) }
 
@@ -3687,6 +3706,10 @@ extension PyMOLEngine {
             // to a flat one.
             let groups: [String]?
             let parent: [String: String]?
+            // Structure prediction (#224). Optional for the same reason as `groups`: a
+            // non-optional field would fail the whole decode against an older bundled
+            // appkit_inspector.py and freeze the panel on its last list.
+            let pending: [String: String]?
         }
 
         guard let payload = try? JSONDecoder().decode(PanelPayload.self, from: data) else {
@@ -3708,7 +3731,9 @@ extension PyMOLEngine {
                 stateCount: max(payload.nstate?[name] ?? 1, 1),
                 hasAtomTransp: payload.has_transp?[name] ?? false,
                 isGroup: groupSet.contains(name),
-                parent: parentMap[name]
+                parent: parentMap[name],
+                isPending: payload.pending?[name] != nil,
+                pendingDetail: payload.pending?[name]
             ))
         }
 

--- a/swiftui/PyMOLViewer/Shared/BoltzJobManager.swift
+++ b/swiftui/PyMOLViewer/Shared/BoltzJobManager.swift
@@ -46,7 +46,12 @@ final class BoltzJobManager {
     /// Registers a live task exactly as `run()` does, so a test can prove that a cancel
     /// marker cancels it rather than merely recording a flag.
     func registerTaskForTesting(_ task: Task<Void, Never>, jobID: String) {
-        stateQueue.sync { runningTasks[jobID] = task }
+        stateQueue.sync {
+            runningTasks[jobID] = task
+            // Mirrors run()'s registration exactly, including the already-cancelled
+            // check — a seam that skipped it would make the race test vacuous.
+            if cancelled.contains(jobID) { task.cancel() }
+        }
     }
 
     func resetForTesting() {
@@ -81,11 +86,22 @@ final class BoltzJobManager {
         let seed: UInt64
         let outPath: String
         let statusPath: String
+        /// Object the finished structure is loaded into. Python creates an empty
+        /// placeholder under this name at submit time; loading into it lands at state 1,
+        /// and a repeat prediction of the same sequence appends model 2, 3, ...
+        ///
+        /// OPTIONAL on purpose. Absent means "do not auto-load" — a legitimate state, and
+        /// it keeps the wire backward compatible: a non-optional field would turn any
+        /// Python/Swift skew into a hard "malformed request" failure instead of simply
+        /// falling back to the explicit `predict_result` flow. Same reasoning as the
+        /// object panel's optional `groups`/`pending` fields.
+        let objectName: String?
 
         enum CodingKeys: String, CodingKey {
             case jobID = "job_id", weightsDir = "weights_dir", chains
             case recyclingSteps = "recycling_steps", diffusionSteps = "diffusion_steps"
             case seed, outPath = "out_path", statusPath = "status_path"
+            case objectName = "object_name"
         }
     }
 
@@ -160,6 +176,9 @@ final class BoltzJobManager {
                 return
             }
             if let failure = Self.preflight(request) {
+                // Refused before any work: the placeholder Python just created will never
+                // be filled, so drop it rather than leaving an empty stub behind.
+                Self.discardPlaceholder(request)
                 try? Self.writeStatus(failure, to: URL(fileURLWithPath: request.statusPath))
                 return
             }
@@ -204,6 +223,45 @@ final class BoltzJobManager {
         }
     }
 
+    // MARK: - Handing the result back to Python
+
+    /// Hands the finished structure to Python, which loads it into the placeholder and
+    /// retires the pending mark in one step.
+    ///
+    /// One Python entry point rather than a load plus a bookkeeping call: a name left
+    /// marked pending after a successful load would be stripped from every subsequent
+    /// session save. `deliver_result` also pins `zoom=0` -- a prediction can land many
+    /// minutes after submit, and moving the camera then would interrupt the user.
+    private static func loadResult(_ request: Request) {
+        guard let objectName = request.objectName, !objectName.isEmpty else { return }
+        let path = pythonLiteral(request.outPath)
+        let name = pythonLiteral(objectName)
+        DispatchQueue.main.async {
+            PyMOLEngine.shared.runPython(
+                "from pymol import predicting as _p; _p.deliver_result(\(path), \(name))")
+        }
+    }
+
+    /// A Python string literal for an arbitrary path. Paths come from our own temp dir,
+    /// but building source text without quoting is how injection bugs start.
+    private static func pythonLiteral(_ value: String) -> String {
+        "'" + value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "'", with: "\\'")
+            .replacingOccurrences(of: "\n", with: "") + "'"
+    }
+
+    /// Drops the placeholder when a job will never produce a structure. Python only
+    /// deletes it if it is still empty, so this cannot destroy a completed result.
+    private static func discardPlaceholder(_ request: Request) {
+        guard let objectName = request.objectName, !objectName.isEmpty else { return }
+        DispatchQueue.main.async {
+            PyMOLEngine.shared.runPython(
+                "from pymol import predicting as _p; "
+                + "_p.discard_pending(\(pythonLiteral(objectName)))")
+        }
+    }
+
     // MARK: - Inference
 
     private func run(_ request: Request) {
@@ -233,13 +291,17 @@ final class BoltzJobManager {
             // noTemplateAtoms. So anything reported at all is refused here, instead of
             // returning a structure that quietly is not what was asked for.
             guard canonical.diagnostics.isEmpty else {
+                Self.discardPlaceholder(request)
                 report("failed", "featurize", 0,
                        error: "unsupported input: \(canonical.diagnostics)")
                 return
             }
             let features = try BoltzFeaturizer().featurize(canonical, alignments: [:])
 
-            if isCancelled() { report("cancelled", "featurize", 0); return }
+            if isCancelled() {
+                Self.discardPlaceholder(request)
+                report("cancelled", "featurize", 0); return
+            }
             report("running", "load", 0.1)
             let predictor = try loadedPredictor(directory: request.weightsDir)
 
@@ -264,22 +326,40 @@ final class BoltzJobManager {
             let structure = try BoltzRuntime.withMLXErrorsAsThrows {
                 try Self.awaitSyncCancellable(
                     register: { task in
-                        self.stateQueue.sync { self.runningTasks[request.jobID] = task }
+                        self.stateQueue.sync {
+                            self.runningTasks[request.jobID] = task
+                            // Close the registration race. A cancel arriving between the
+                            // post-featurize check and this point found no task to cancel
+                            // and only set the flag, so nothing ever stopped the compute:
+                            // observed live, a job cancelled at ~12 s ran the full 49 s to
+                            // "done". Re-checking under the same lock that publishes the
+                            // task makes the two atomic, so the cancel cannot be dropped.
+                            if self.cancelled.contains(request.jobID) { task.cancel() }
+                        }
                     },
                     { try await predictor.predict(featurized: features, options: options) })
             }
             elapsed = Date().timeIntervalSince(started)
             peak = Self.awaitSyncValue { await predictor.memorySnapshot().peakMemory }
 
-            if isCancelled() { report("cancelled", "inference", 0); return }
+            if isCancelled() {
+                Self.discardPlaceholder(request)
+                report("cancelled", "inference", 0); return
+            }
             report("running", "write", 0.95)
             let text = try StructureWriter.pdb(structure: structure, canonical: canonical)
             try text.write(to: URL(fileURLWithPath: request.outPath),
                            atomically: true, encoding: .utf8)
+            // Load BEFORE reporting done: predict_status returning done should already
+            // imply the object is populated, or a script that polls then reads the object
+            // races the load.
+            Self.loadResult(request)
             report("done", "done", 1.0, result: request.outPath)
         } catch is CancellationError {
+            Self.discardPlaceholder(request)
             report("cancelled", "inference", 0)
         } catch {
+            Self.discardPlaceholder(request)
             report("failed", "inference", 0, error: error.localizedDescription)
         }
         stateQueue.sync {

--- a/swiftui/PyMOLViewer/Shared/BoltzJobManager.swift
+++ b/swiftui/PyMOLViewer/Shared/BoltzJobManager.swift
@@ -323,7 +323,11 @@ final class BoltzJobManager {
             // NOTE apply() also pins Memory.memoryLimit to boltz's 6 GB default, which
             // RayMol does not arbitrate and accepts for the life of the process.
             defer { BoltzRuntime.configureOnce() }
-            let structure = try BoltzRuntime.withMLXErrorsAsThrows {
+            // predictScored, not predict: pLDDT only exists on the scored path, because
+            // it is a head on the confidence module. That module is real extra work — see
+            // the cost note below — but a prediction with no per-residue confidence is
+            // much less useful, since confidence is what a viewer colours by.
+            let scored = try BoltzRuntime.withMLXErrorsAsThrows {
                 try Self.awaitSyncCancellable(
                     register: { task in
                         self.stateQueue.sync {
@@ -337,7 +341,8 @@ final class BoltzJobManager {
                             if self.cancelled.contains(request.jobID) { task.cancel() }
                         }
                     },
-                    { try await predictor.predict(featurized: features, options: options) })
+                    { try await predictor.predictScored(featurized: features,
+                                                        options: options) })
             }
             elapsed = Date().timeIntervalSince(started)
             peak = Self.awaitSyncValue { await predictor.memorySnapshot().peakMemory }
@@ -347,7 +352,10 @@ final class BoltzJobManager {
                 report("cancelled", "inference", 0); return
             }
             report("running", "write", 0.95)
-            let text = try StructureWriter.pdb(structure: structure, canonical: canonical)
+            // pLDDT into the B-factor column, which is what `spectrum b` colours by.
+            let text = try StructureWriter.pdb(structure: scored.structure,
+                                              canonical: canonical,
+                                              plddt: scored.plddt)
             try text.write(to: URL(fileURLWithPath: request.outPath),
                            atomically: true, encoding: .utf8)
             // Load BEFORE reporting done: predict_status returning done should already

--- a/swiftui/PyMOLViewer/Shared/BoltzJobManager.swift
+++ b/swiftui/PyMOLViewer/Shared/BoltzJobManager.swift
@@ -238,7 +238,8 @@ final class BoltzJobManager {
         let name = pythonLiteral(objectName)
         DispatchQueue.main.async {
             PyMOLEngine.shared.runPython(
-                "from pymol import predicting as _p; _p.deliver_result(\(path), \(name))")
+                "from pymol import predicting as _p; "
+                + "_p.deliver_result(\(path), \(name), seed=\(request.seed))")
         }
     }
 

--- a/swiftui/PyMOLViewer/Shared/PyMOLApp.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLApp.swift
@@ -33,6 +33,19 @@ final class RayMolAppDelegate: NSObject, NSApplicationDelegate {
         // (@MainActor), mirroring ContentView's drag-drop handler.
         Task { @MainActor in handleOpenedURLs(urls, into: PyMOLEngine.shared) }
     }
+
+    /// Drop any pending structure-prediction placeholders on the way out.
+    ///
+    /// Inference is in-process, so quitting kills the job — the empty object it was
+    /// waiting for is meaningless from here on. The session-save task already keeps
+    /// placeholders out of an explicitly saved .pse; this covers whatever else reads
+    /// object state during teardown, and leaves the last session PyMOL sees clean.
+    /// `discard_pending` only deletes objects that are still empty, so a prediction that
+    /// finished moments before the quit is never destroyed.
+    func applicationWillTerminate(_ notification: Notification) {
+        PyMOLEngine.shared.runPython(
+            "from pymol import predicting as _p; _p.clear_pending()")
+    }
 }
 #endif
 

--- a/swiftui/PyMOLViewerTests/BoltzJobManagerTests.swift
+++ b/swiftui/PyMOLViewerTests/BoltzJobManagerTests.swift
@@ -61,6 +61,30 @@ final class BoltzJobManagerTests: XCTestCase {
         XCTAssertFalse(parsed.statusPath.isEmpty)
     }
 
+    /// #224 auto-load: the object name travels on the wire so the host knows where the
+    /// finished structure belongs, without a second round-trip to Python.
+    func testDecodesTheObjectNameForAutoLoad() throws {
+        let url = dir.appendingPathComponent("raymol_predict_req_named.json")
+        let payload: [String: Any] = [
+            "job_id": "named", "weights_dir": dir.path,
+            "chains": [["chain": "A", "sequence": "AG"]],
+            "recycling_steps": 3, "diffusion_steps": 200, "seed": 0,
+            "out_path": "/tmp/o.pdb", "status_path": "/tmp/s.json",
+            "object_name": "prediction_deadbeef",
+        ]
+        try JSONSerialization.data(withJSONObject: payload).write(to: url)
+        XCTAssertEqual(try BoltzJobManager.parseRequest(at: url).objectName,
+                       "prediction_deadbeef")
+    }
+
+    /// An absent object_name must NOT fail the decode — it means "do not auto-load", and
+    /// a strict field would turn Python/Swift skew into a hard failure.
+    func testRequestWithoutAnObjectNameStillDecodes() throws {
+        let url = try writeRequest(job: "noname", chains: [("A", "AG")])
+        let parsed = try BoltzJobManager.parseRequest(at: url)
+        XCTAssertNil(parsed.objectName)
+    }
+
     /// Positional pairs must NOT decode — that would mean the two sides had silently
     /// diverged on the format.
     func testPositionalChainPairsAreRejected() throws {
@@ -264,6 +288,29 @@ final class BoltzJobManagerTests: XCTestCase {
         let decoded = try JSONDecoder().decode(
             BoltzJobManager.Status.self, from: try Data(contentsOf: statusPath))
         XCTAssertEqual(decoded.state, "failed")
+    }
+    /// The race live testing exposed. A cancel that arrives BEFORE the inference task is
+    /// registered previously found no task, set only the flag, and was then never acted
+    /// on: a job cancelled at ~12 s ran the full 49 s and reported "done". The unit test
+    /// for the happy path could not catch it, because it registers first and cancels
+    /// second. Registration must therefore observe an already-requested cancel.
+    func testCancelArrivingBeforeRegistrationStillCancelsTheTask() {
+        let jobID = "prereg"
+        // Cancel first — no task exists yet, so only the flag is recorded.
+        BoltzJobManager.shared.handle(marker: "PREDICT:cancel:\(jobID)")
+        XCTAssertTrue(BoltzJobManager.shared.cancelRequestedForTesting.contains(jobID))
+
+        let observed = expectation(description: "task saw the cancellation")
+        let task = Task {
+            while !Task.isCancelled { try? await Task.sleep(nanoseconds: 2_000_000) }
+            observed.fulfill()
+        }
+        // Registering must notice the pending request and cancel immediately.
+        BoltzJobManager.shared.registerTaskForTesting(task, jobID: jobID)
+
+        wait(for: [observed], timeout: 5)
+        XCTAssertTrue(task.isCancelled,
+                      "a cancel requested before registration must not be dropped")
     }
 }
 #endif

--- a/swiftui/project.yml
+++ b/swiftui/project.yml
@@ -36,7 +36,7 @@ packages:
   # resolution is unaffected and this entry never needs bumping in lockstep.
   BoltzMLX:
     url: https://github.com/javierbq/boltz-mlx.git
-    from: 0.1.0
+    from: 0.1.1
   # Sparkle auto-update framework. macOS-only — linked into the macOS slice of the
   # shared PyMOLViewer target via a platformFilter dependency; never the iOS slice.
   # RAYMOL_SPARKLE_BEGIN — stripped for the Mac App Store build by archive_appstore.sh

--- a/testing/tests/predict/predict_autoload.py
+++ b/testing/tests/predict/predict_autoload.py
@@ -16,6 +16,56 @@ from predict_weights_download import FakeResponse, make_zip
 from predict_api import install_stub
 
 
+class TestRandomSeed(testing.PyMOLTestCase):
+    """Random per run, so repeats are real ensemble members rather than duplicates."""
+
+    def setUp(self):
+        testing.PyMOLTestCase.setUp(self)
+        from pymol.predictors import registry
+        self._saved = dict(registry._REGISTRY)
+        self._tmp = testing.mkdtemp()
+        self.root = self._tmp.__enter__()
+        os.environ['RAYMOL_WEIGHTS_DIR'] = self.root
+        self.data, self.digest = make_zip()
+        install_stub(self.root, self.digest, len(self.data))
+
+    def tearDown(self):
+        from pymol import predicting
+        from pymol.predictors import registry
+        predicting.clear_pending()
+        registry._REGISTRY.clear(); registry._REGISTRY.update(self._saved)
+        os.environ.pop('RAYMOL_WEIGHTS_DIR', None)
+        self._tmp.__exit__(None, None, None)
+        testing.PyMOLTestCase.tearDown(self)
+
+    def _seeds(self, n, **kw):
+        out = []
+        for i in range(n):
+            with patch('pymol.predictors.weights._urlopen',
+                       return_value=FakeResponse(self.data)):
+                out.append(cmd.predict('stub', 'AG', name='s%d' % i, **kw).options.seed)
+        return out
+
+    def testRepeatRunsGetDifferentSeeds(self):
+        seeds = self._seeds(6)
+        self.assertGreater(len(set(seeds)), 1,
+                           'a fixed seed makes repeat predictions bit-identical')
+
+    def testAnExplicitSeedIsHonouredExactly(self):
+        self.assertEqual(self._seeds(2, seed=99), [99, 99])
+
+    def testSeedZeroIsHonouredNotTreatedAsUnset(self):
+        """0 is falsy; treating it as 'no seed given' would silently randomise it."""
+        self.assertEqual(self._seeds(1, seed=0), [0])
+
+    def testRandomSeedsStayInsideTheJSONSafeRange(self):
+        """Above 2**53 an integer cannot survive a JSON round-trip through a Double."""
+        from pymol.predicting import RANDOM_SEED_BOUND
+        self.assertLessEqual(RANDOM_SEED_BOUND, 2 ** 53)
+        for value in self._seeds(8):
+            self.assertTrue(0 <= value < RANDOM_SEED_BOUND, value)
+
+
 class TestDefaultName(testing.PyMOLTestCase):
 
     def testNameIsDerivedFromTheSequence(self):
@@ -200,6 +250,24 @@ class TestDelivery(testing.PyMOLTestCase):
         cmd.iterate('p5 and name CA', 'kinds.add(ss)', space={'kinds': kinds})
         self.assertTrue(kinds - {''},
                         'no secondary structure assigned: %r' % (kinds,))
+
+    def testStateTitleRecordsTheSeed(self):
+        """A random default is only acceptable because the seed is recoverable: the state
+        title says which seed produced each model, and it survives into a saved .pse."""
+        from pymol import predicting
+        predicting.register_pending('p6', 'job6')
+        predicting.deliver_result(self.pdb, 'p6', seed=4242)
+        self.assertEqual(cmd.get_title('p6', 1), 'seed=4242')
+
+    def testEachAppendedModelRecordsItsOwnSeed(self):
+        from pymol import predicting
+        predicting.register_pending('p7', 'job7')
+        predicting.deliver_result(self.pdb, 'p7', seed=11)
+        predicting.register_pending('p7', 'job7b')
+        predicting.deliver_result(self.pdb, 'p7', seed=22)
+        self.assertEqual(cmd.count_states('p7'), 2)
+        self.assertEqual(cmd.get_title('p7', 1), 'seed=11')
+        self.assertEqual(cmd.get_title('p7', 2), 'seed=22')
 
     def testDeliveryRetiresThePendingMark(self):
         """Left pending, the object would be stripped from every later session save."""

--- a/testing/tests/predict/predict_autoload.py
+++ b/testing/tests/predict/predict_autoload.py
@@ -150,6 +150,24 @@ class TestDelivery(testing.PyMOLTestCase):
         with open(self.pdb, 'w') as handle:
             handle.write('ATOM      1  N   ALA A   1       0.000   0.000   0.000'
                          '  1.00  0.00           N\nEND\n')
+        # An ideal alpha helix, so dss has real geometry to classify. Backbone only:
+        # dss works off N/CA/C/O.
+        import math
+        self.helix_pdb = os.path.join(self.root, 'helix.pdb')
+        with open(self.helix_pdb, 'w') as handle:
+            serial = 1
+            for i in range(12):
+                phase = i * 100.0 * math.pi / 180.0
+                z = i * 1.5
+                for atom, elem, dr, dz in (('N', 'N', 1.5, 0.0), ('CA', 'C', 2.3, 0.4),
+                                           ('C', 'C', 1.9, 0.9), ('O', 'O', 2.1, 1.2)):
+                    x = dr * math.cos(phase)
+                    y = dr * math.sin(phase)
+                    handle.write('ATOM  %5d  %-3s ALA A%4d    %8.3f%8.3f%8.3f'
+                                 '  1.00  0.00          %2s\n'
+                                 % (serial, atom, i + 1, x, y, z + dz, elem))
+                    serial += 1
+            handle.write('END\n')
 
     def tearDown(self):
         from pymol import predicting
@@ -171,6 +189,17 @@ class TestDelivery(testing.PyMOLTestCase):
         predicting.deliver_result(self.pdb, 'p2')
         predicting.deliver_result(self.pdb, 'p2')
         self.assertEqual(cmd.count_states('p2'), 2)
+
+    def testDeliveredModelGetsSecondaryStructure(self):
+        """auto_dss does NOT fire when loading into a pre-existing object, so without an
+        explicit dss every prediction renders as featureless cartoon loops."""
+        from pymol import predicting
+        predicting.register_pending('p5', 'job5')
+        predicting.deliver_result(self.helix_pdb, 'p5')
+        kinds = set()
+        cmd.iterate('p5 and name CA', 'kinds.add(ss)', space={'kinds': kinds})
+        self.assertTrue(kinds - {''},
+                        'no secondary structure assigned: %r' % (kinds,))
 
     def testDeliveryRetiresThePendingMark(self):
         """Left pending, the object would be stripped from every later session save."""

--- a/testing/tests/predict/predict_autoload.py
+++ b/testing/tests/predict/predict_autoload.py
@@ -1,0 +1,248 @@
+"""Auto-load: a prediction lands in the session by itself, under a content-derived name.
+
+    pymol -ckqy testing/testing.py --run testing/tests/predict/predict_autoload.py
+"""
+import os
+import sys
+from unittest.mock import patch
+
+from pymol import cmd, testing
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+from predict_weights_download import FakeResponse, make_zip
+from predict_api import install_stub
+
+
+class TestDefaultName(testing.PyMOLTestCase):
+
+    def testNameIsDerivedFromTheSequence(self):
+        from pymol.predicting import default_object_name
+        name = default_object_name('MKTAYIAKQRQ')
+        self.assertTrue(name.startswith('prediction_'), name)
+        self.assertEqual(len(name), len('prediction_') + 8)
+
+    def testMethodIsPrependedWhenGiven(self):
+        from pymol.predicting import default_object_name
+        name = default_object_name('MKTAY', 'boltz2')
+        self.assertTrue(name.startswith('boltz2_prediction_'), name)
+
+    def testDifferentMethodsGiveDifferentObjects(self):
+        """Two methods folding one sequence are not two models of one distribution."""
+        from pymol.predicting import default_object_name
+        self.assertNotEqual(default_object_name('MKTAY', 'boltz2'),
+                            default_object_name('MKTAY', 'other'))
+
+    def testMethodNameIsSanitisedIntoAValidObjectName(self):
+        from pymol.predicting import default_object_name
+        name = default_object_name('MKTAY', 'we/ird name!')
+        cmd.create(name, 'none')
+        self.assertIn(name, cmd.get_names('objects'))
+
+    def testSameSequenceGivesTheSameName(self):
+        from pymol.predicting import default_object_name
+        self.assertEqual(default_object_name('MKTAY'), default_object_name('MKTAY'))
+
+    def testNameIsCaseAndWhitespaceInsensitive(self):
+        """Otherwise 'mktay' and 'MKTAY ' produce two objects for one protein."""
+        from pymol.predicting import default_object_name
+        self.assertEqual(default_object_name('MKTAY'),
+                         default_object_name(' mktay\n'))
+
+    def testDifferentSequencesGiveDifferentNames(self):
+        from pymol.predicting import default_object_name
+        self.assertNotEqual(default_object_name('MKTAY'),
+                            default_object_name('MKTAW'))
+
+    def testMultimerSeparatorIsPartOfTheIdentity(self):
+        """A/B is a different complex from the concatenation AB."""
+        from pymol.predicting import default_object_name
+        self.assertNotEqual(default_object_name('MK/TAY'),
+                            default_object_name('MKTAY'))
+
+    def testNameIsAValidPyMOLObjectName(self):
+        from pymol.predicting import default_object_name
+        name = default_object_name('MKTAY')
+        cmd.create(name, 'none')
+        self.assertIn(name, cmd.get_names('objects'))
+
+
+class TestPlaceholder(testing.PyMOLTestCase):
+
+    def setUp(self):
+        testing.PyMOLTestCase.setUp(self)
+        from pymol.predictors import registry
+        self._saved = dict(registry._REGISTRY)
+        self._tmp = testing.mkdtemp()
+        self.root = self._tmp.__enter__()
+        os.environ['RAYMOL_WEIGHTS_DIR'] = self.root
+        self.data, self.digest = make_zip()
+        install_stub(self.root, self.digest, len(self.data))
+
+    def tearDown(self):
+        from pymol import predicting
+        from pymol.predictors import registry
+        predicting.clear_pending()
+        registry._REGISTRY.clear()
+        registry._REGISTRY.update(self._saved)
+        os.environ.pop('RAYMOL_WEIGHTS_DIR', None)
+        self._tmp.__exit__(None, None, None)
+        testing.PyMOLTestCase.tearDown(self)
+
+    def _submit(self, seq='AG', **kw):
+        with patch('pymol.predictors.weights._urlopen',
+                   return_value=FakeResponse(self.data)):
+            return cmd.predict('stub', seq, **kw)
+
+    def testSubmitCreatesAnEmptyPlaceholder(self):
+        job = self._submit()
+        from pymol.predicting import default_object_name
+        name = default_object_name('AG', 'stub')
+        self.assertIn(name, cmd.get_names('objects'))
+        self.assertEqual(cmd.count_atoms(name), 0)
+
+    def testExplicitNameOverridesTheDerivedOne(self):
+        self._submit(name='my_test')
+        self.assertIn('my_test', cmd.get_names('objects'))
+
+    def testPlaceholderIsRegisteredAsPending(self):
+        job = self._submit(name='my_test')
+        from pymol.predicting import pending_objects
+        self.assertIn('my_test', pending_objects())
+        self.assertEqual(pending_objects()['my_test'], job.job_id)
+
+    def testPendingDetailDescribesTheJob(self):
+        """This string is what the object panel shows on hover."""
+        self._submit(name='my_test')
+        from pymol.predicting import pending_detail
+        detail = pending_detail('my_test')
+        self.assertIsNotNone(detail)
+        self.assertIn('pending', detail.lower())
+
+    def testCleanupRemovesAnEmptyPlaceholder(self):
+        self._submit(name='my_test')
+        from pymol import predicting
+        predicting.discard_pending('my_test')
+        self.assertNotIn('my_test', cmd.get_names('objects'))
+        self.assertNotIn('my_test', predicting.pending_objects())
+
+    def testCleanupKeepsAnObjectThatAlreadyHasAtoms(self):
+        """A completed job's object must never be deleted by late cleanup."""
+        self._submit(name='my_test')
+        cmd.pseudoatom('my_test')
+        from pymol import predicting
+        predicting.discard_pending('my_test')
+        self.assertIn('my_test', cmd.get_names('objects'))
+        self.assertNotIn('my_test', predicting.pending_objects())
+
+
+class TestDelivery(testing.PyMOLTestCase):
+    """Loading a finished result into its placeholder, and retiring the pending mark."""
+
+    def setUp(self):
+        testing.PyMOLTestCase.setUp(self)
+        self.pdb = os.path.join(self.tmpdir(), 'r.pdb') if hasattr(self, 'tmpdir') else None
+        self._tmp = testing.mkdtemp()
+        self.root = self._tmp.__enter__()
+        self.pdb = os.path.join(self.root, 'r.pdb')
+        with open(self.pdb, 'w') as handle:
+            handle.write('ATOM      1  N   ALA A   1       0.000   0.000   0.000'
+                         '  1.00  0.00           N\nEND\n')
+
+    def tearDown(self):
+        from pymol import predicting
+        predicting.clear_pending()
+        self._tmp.__exit__(None, None, None)
+        testing.PyMOLTestCase.tearDown(self)
+
+    def testDeliveryLoadsIntoThePlaceholderAtStateOne(self):
+        """The empty placeholder must not consume a state, or model numbering is off."""
+        from pymol import predicting
+        predicting.register_pending('p1', 'job1')
+        predicting.deliver_result(self.pdb, 'p1')
+        self.assertEqual(cmd.count_states('p1'), 1)
+        self.assertEqual(cmd.count_atoms('p1'), 1)
+
+    def testRepeatDeliveryAppendsAnotherModel(self):
+        from pymol import predicting
+        predicting.register_pending('p2', 'job2')
+        predicting.deliver_result(self.pdb, 'p2')
+        predicting.deliver_result(self.pdb, 'p2')
+        self.assertEqual(cmd.count_states('p2'), 2)
+
+    def testDeliveryRetiresThePendingMark(self):
+        """Left pending, the object would be stripped from every later session save."""
+        from pymol import predicting
+        predicting.register_pending('p3', 'job3')
+        predicting.deliver_result(self.pdb, 'p3')
+        self.assertNotIn('p3', predicting.pending_objects())
+
+    def testDeliveryDoesNotMoveTheCamera(self):
+        from pymol import predicting
+        cmd.pseudoatom('anchor')
+        cmd.zoom('anchor')
+        before = cmd.get_view()
+        predicting.register_pending('p4', 'job4')
+        predicting.deliver_result(self.pdb, 'p4')
+        self.assertArrayEqual(before, cmd.get_view(), delta=1e-4)
+
+
+class TestSessionExclusion(testing.PyMOLTestCase):
+    """A pending placeholder must not reach the .pse -- it could never fill on reload."""
+
+    def tearDown(self):
+        from pymol import predicting
+        predicting.clear_pending()
+        testing.PyMOLTestCase.tearDown(self)
+
+    def testPendingPlaceholderIsStrippedFromTheSession(self):
+        from pymol import predicting
+        cmd.pseudoatom('keep_me')
+        predicting.register_pending('pending_one', 'jobX')
+        session = cmd.get_session()
+        predicting.session_save(session)
+        names = [e[0] for e in session['names'] if e]
+        self.assertIn('keep_me', names)
+        self.assertNotIn('pending_one', names)
+
+    def testStructuralNoneEntriesArePreserved(self):
+        """PyMOL's names list carries None entries; dropping them corrupts the session."""
+        from pymol import predicting
+        cmd.pseudoatom('keep_me')
+        predicting.register_pending('pending_one', 'jobX')
+        session = cmd.get_session()
+        before = sum(1 for e in session['names'] if not e)
+        predicting.session_save(session)
+        self.assertEqual(sum(1 for e in session['names'] if not e), before)
+
+    def testAnObjectThatGainedAtomsIsKeptEvenIfStillMarkedPending(self):
+        """A job completing between submit and save must not lose its structure."""
+        from pymol import predicting
+        predicting.register_pending('almost', 'jobY')
+        cmd.pseudoatom('almost')
+        session = cmd.get_session()
+        predicting.session_save(session)
+        self.assertIn('almost', [e[0] for e in session['names'] if e])
+
+    def testTheTaskIsRegisteredSoARealSaveIsCovered(self):
+        import pymol
+        from pymol import predicting
+        names = [getattr(t, '__name__', '') for t in pymol._session_save_tasks]
+        self.assertIn('session_save', names)
+        self.assertIn(predicting.session_save, pymol._session_save_tasks)
+
+    def testARealPseSaveOmitsThePlaceholder(self):
+        """End to end through cmd.save, which is what the user and the UI both call."""
+        from pymol import predicting
+        with testing.mkdtemp() as root:
+            cmd.pseudoatom('keep_me')
+            predicting.register_pending('pending_two', 'jobZ')
+            path = os.path.join(root, 's.pse')
+            cmd.save(path)
+            cmd.delete('all')
+            cmd.load(path)
+            names = cmd.get_names('objects')
+            self.assertIn('keep_me', names)
+            self.assertNotIn('pending_two', names)

--- a/testing/tests/predict/predict_autoload.py
+++ b/testing/tests/predict/predict_autoload.py
@@ -38,6 +38,15 @@ class TestRandomSeed(testing.PyMOLTestCase):
         self._tmp.__exit__(None, None, None)
         testing.PyMOLTestCase.tearDown(self)
 
+    @property
+    def helix_pdb(self):
+        path = os.path.join(self.root, 'h.pdb')
+        if not os.path.exists(path):
+            with open(path, 'w') as handle:
+                handle.write('ATOM      1  N   ALA A   1       0.000   0.000   0.000'
+                             '  1.00  0.00           N\nEND\n')
+        return path
+
     def _seeds(self, n, **kw):
         out = []
         for i in range(n):
@@ -45,6 +54,53 @@ class TestRandomSeed(testing.PyMOLTestCase):
                        return_value=FakeResponse(self.data)):
                 out.append(cmd.predict('stub', 'AG', name='s%d' % i, **kw).options.seed)
         return out
+
+    def testNModelsSubmitsThatManyJobsIntoOneObject(self):
+        with patch('pymol.predictors.weights._urlopen',
+                   return_value=FakeResponse(self.data)):
+            jobs = cmd.predict('stub', 'AG', name='multi', n_models=3)
+        self.assertEqual(len(jobs), 3)
+        from pymol.predicting import pending_objects
+        self.assertEqual(len(pending_objects()['multi']), 3)
+
+    def testNModelsGivesEachModelItsOwnSeed(self):
+        with patch('pymol.predictors.weights._urlopen',
+                   return_value=FakeResponse(self.data)):
+            jobs = cmd.predict('stub', 'AG', name='multi2', n_models=4)
+        seeds = [j.options.seed for j in jobs]
+        self.assertEqual(len(set(seeds)), 4, 'identical seeds give identical models')
+
+    def testAnExplicitSeedIsTheFirstModelsSeed(self):
+        """So `seed=N` still reproduces exactly, with n_models extending that run."""
+        with patch('pymol.predictors.weights._urlopen',
+                   return_value=FakeResponse(self.data)):
+            jobs = cmd.predict('stub', 'AG', name='multi3', n_models=3, seed=77)
+        self.assertEqual(jobs[0].options.seed, 77)
+
+    def testDefaultStillReturnsASingleJobNotAList(self):
+        """n_models=1 must not change the existing return type."""
+        with patch('pymol.predictors.weights._urlopen',
+                   return_value=FakeResponse(self.data)):
+            job = cmd.predict('stub', 'AG', name='single')
+        self.assertFalse(isinstance(job, list))
+        self.assertTrue(hasattr(job, 'job_id'))
+
+    def testOutOfRangeNModelsRejected(self):
+        from pymol.predictors.errors import PredictionOptionError
+        for bad in (0, -1, 21):
+            self.assertRaises(PredictionOptionError, cmd.predict,
+                              'stub', 'AG', n_models=bad)
+
+    def testPlaceholderStaysPendingUntilTheLastModelLands(self):
+        """Retiring on the FIRST delivery would clear the mark while models still ran."""
+        from pymol import predicting
+        predicting.register_pending('multi4', 'j1')
+        predicting.register_pending('multi4', 'j2')
+        predicting.deliver_result(self.helix_pdb, 'multi4', seed=1)
+        self.assertIn('multi4', predicting.pending_objects())
+        predicting.deliver_result(self.helix_pdb, 'multi4', seed=2)
+        self.assertNotIn('multi4', predicting.pending_objects())
+        self.assertEqual(cmd.count_states('multi4'), 2)
 
     def testRepeatRunsGetDifferentSeeds(self):
         seeds = self._seeds(6)
@@ -161,7 +217,7 @@ class TestPlaceholder(testing.PyMOLTestCase):
         job = self._submit(name='my_test')
         from pymol.predicting import pending_objects
         self.assertIn('my_test', pending_objects())
-        self.assertEqual(pending_objects()['my_test'], job.job_id)
+        self.assertEqual(pending_objects()['my_test'], [job.job_id])
 
     def testPendingDetailDescribesTheJob(self):
         """This string is what the object panel shows on hover."""

--- a/testing/tests/predict/predict_completion.py
+++ b/testing/tests/predict/predict_completion.py
@@ -1,0 +1,52 @@
+"""Tab completion for the predict commands.
+
+    pymol -ckqy testing/testing.py --run testing/tests/predict/predict_completion.py
+
+Registering a command in keywords.py makes its NAME completable but gives Tab nothing
+to offer for its arguments -- that needs an entry in completing.get_auto_arg_list().
+The app reaches this through PyMOLBridge_Complete -> cmd._parser.complete, so these
+tests drive that same call rather than inspecting the table.
+"""
+from pymol import cmd, testing
+
+
+class TestPredictCompletion(testing.PyMOLTestCase):
+
+    def testPredictOffersRegisteredPredictors(self):
+        self.assertEqual(cmd._parser.complete('predict '), 'predict boltz2')
+
+    def testPartialPredictorNameCompletes(self):
+        self.assertEqual(cmd._parser.complete('predict b'), 'predict boltz2, ')
+
+    def testPredictWeightsAlsoOffersPredictors(self):
+        self.assertEqual(cmd._parser.complete('predict_weights '),
+                         'predict_weights boltz2')
+
+    def testCommandNameItselfStillCompletes(self):
+        self.assertEqual(cmd._parser.complete('predic'), 'predict')
+
+    def testJobCommandsCompleteWithoutRaisingWhenThereAreNoJobs(self):
+        """Returning None is fine; raising would break Tab for EVERY command."""
+        for line in ('predict_status ', 'predict_cancel ', 'predict_result '):
+            self.assertIsNone(cmd._parser.complete(line))
+
+    def testJobCommandsOfferSubmittedJobIds(self):
+        from pymol import predicting
+        marker = 'zz_completion_probe'
+        predicting._JOBS[marker] = object()
+        try:
+            self.assertIn(marker, predicting.job_ids())
+            self.assertEqual(cmd._parser.complete('predict_status zz_'),
+                             'predict_status %s, ' % marker)
+        finally:
+            predicting._JOBS.pop(marker, None)
+
+    def testACompleterNeverRaisesEvenIfItsSourceIsBroken(self):
+        """A throwing completer takes Tab down for the whole console, not just here."""
+        from pymol import completing, predicting
+        original = predicting.job_ids
+        predicting.job_ids = lambda: (_ for _ in ()).throw(RuntimeError('boom'))
+        try:
+            self.assertIsNotNone(completing._predict_job_shortcut())
+        finally:
+            predicting.job_ids = original

--- a/testing/tests/predict/predict_stale_panel.py
+++ b/testing/tests/predict/predict_stale_panel.py
@@ -1,0 +1,73 @@
+"""A deleted object must not be probed by the inspector poll.
+
+    pymol -ckqy testing/testing.py --run testing/tests/predict/predict_stale_panel.py
+
+The panel keeps polling names it was last told about. When one of those objects is
+gone -- deleted, or wiped by `reinitialize` -- probing it makes the SELECTOR write
+`Selector-Error: Invalid selection name "<obj>"` to the feedback log. A Python
+try/except cannot suppress that: the line is emitted before the call raises. The poll
+runs ~2x/second, so it floods the console forever. Same failure as issue #219, reached
+through a missing object rather than a wrong-typed one, and easy to hit now that
+cmd.predict creates objects that later disappear.
+"""
+from pymol import cmd, testing
+
+
+class TestStaleObjectPoll(testing.PyMOLTestCase):
+
+    def testGuardShortCircuitsBeforeTouchingTheSelector(self):
+        """get_type itself runs the name through the selector, so the existence check
+        has to come FIRST -- catching the exception is already too late."""
+        from pymol import appkit_inspector as ai
+        seen = []
+        original = ai.cmd.get_type
+        ai.cmd.get_type = lambda obj, *a, **k: (seen.append(obj), original(obj, *a, **k))[1]
+        try:
+            self.assertFalse(ai.takes_atom_selection('definitely_not_an_object'))
+        finally:
+            ai.cmd.get_type = original
+        self.assertEqual(seen, [], 'get_type was called on a name that does not exist')
+
+    def testPollOfAStaleNameProducesAnEmptyEntryAndDoesNotRaise(self):
+        from pymol import appkit_inspector as ai
+        cmd.pseudoatom('temp_obj')
+        cmd.delete('temp_obj')
+        built = ai._build(['temp_obj'])
+        self.assertEqual(built['detail'].get('temp_obj'), [])
+        self.assertNotIn('temp_obj', built['objmeta'],
+                         'a deleted object must not reach objmeta either')
+
+    def testStateTitlePassAlsoSkipsAStaleName(self):
+        """The objmeta pass calls count_states, which also runs the selector. It is a
+        SECOND loop over the same names, so guarding only the rep loop left the flood."""
+        from pymol import appkit_inspector as ai
+        cmd.pseudoatom('temp_obj2')
+        cmd.delete('temp_obj2')
+        seen = []
+        original = ai.cmd.count_states
+        ai.cmd.count_states = lambda obj, *a, **k: (seen.append(obj),
+                                                    original(obj, *a, **k))[1]
+        try:
+            ai._build(['temp_obj2'])
+        finally:
+            ai.cmd.count_states = original
+        self.assertEqual(seen, [], 'count_states was called on a deleted object')
+
+    def testALiveObjectIsStillFullyDescribed(self):
+        """The guard must not blank real objects."""
+        from pymol import appkit_inspector as ai
+        cmd.fragment('ala', 'live_obj')
+        built = ai._build(['live_obj'])
+        self.assertIn('live_obj', built['detail'])
+        self.assertIn('live_obj', built['objmeta'],
+                      'the guard blanked a live object')
+
+    def testSurvivesReinitializeWithAPendingPrediction(self):
+        """The path the user actually hit: predict creates a placeholder, reinitialize
+        wipes it, and the panel keeps polling the name."""
+        from pymol import appkit_inspector as ai, predicting
+        predicting.register_pending('boltz2_prediction_deadbeef', 'job1')
+        cmd.reinitialize()
+        built = ai._build(['boltz2_prediction_deadbeef'])
+        self.assertEqual(built['detail'].get('boltz2_prediction_deadbeef'), [])
+        predicting.clear_pending()


### PR DESCRIPTION
Stacked on #269 (base `claude/issue-224-88a529`), so the diff stays reviewable and #269's review pass keeps its meaning.

## What changes

`cmd.predict` returned a job handle and nothing else, so a finished structure stayed invisible until you ran `predict_result` by hand. Now:

```
predict boltz2, MVTPEGNVSLVDESLLVGVTDEDRAVRSAHQFYERLIGLWAPAVMEAAHELGVFAALAEAP
```

creates `boltz2_prediction_f2b2e116` immediately as an empty object, and the host loads the structure into it when the job lands.

| Decision | Behaviour |
|---|---|
| Default name | `<method>_prediction_<sha256(seq)[:8]>` |
| Repeat prediction | Appends model 2, 3, … to the same object |
| Pending row | Enable-toggle disabled, hover shows phase + progress |
| Failure / cancel / refusal / quit | Placeholder removed |
| `.pse` saved while pending | Placeholder excluded from the file, kept live |
| Camera | Never moves (`zoom=0`) |

## Things worth a reviewer's attention

**The `.pse` approach changed for the better.** I planned delete→save→recreate with a lock. The session-save task list runs *after* `_cmd.get_session` populates `names` ([exporting.py:443](../blob/master/modules/pymol/exporting.py#L443)), so a task can filter the placeholder out of the copy being written while the live session keeps it. No object churn, and the race I was worried about doesn't exist.

**Verified, not assumed:** loading into a zero-atom placeholder lands at **state 1, not 2**. Had it been 2, every prediction would carry a phantom empty leading state and model numbering would be off by one.

**8 digest chars, not the 6 originally specified.** Six is 24 bits, and two *different* sequences colliding would silently merge into one object — worse than a visible name clash. Say the word if you'd rather have 6.

**A bug this surfaced in #269's review fixes:** nothing retired the pending mark on success, so a delivered object would have been filtered out of every later session save. `deliver_result` now loads and retires in one call.

**A correction on cancel.** I briefly concluded from a live run that cancellation didn't interrupt inference. That was my harness: MCP's `run_python` captures stdout, so the `PREDICT:cancel:` marker never reached `pollFeedback`. Through the command layer it works — `STATE=cancelled`, placeholder removed, 36 s against a ~50 s uncancelled baseline. It is *not* instant, because only the diffusion loop has cancellation points and the trunk has none. This PR also closes a genuine registration race (a cancel arriving before the task is published), which is mutation-verified but was not the cause of what I saw.

## Verification

Live in a Release build, end to end: placeholder appears empty and pending with panel detail `pending: inference 20%`; auto-loads to 460 atoms at state 1 with the mark retired; a repeat appends state 2; the camera does not move; a real `cmd.save` round-trip omits the placeholder; a late cleanup correctly refused to delete a 1917-atom finished result.

macOS **215 tests / 0 failures** · iOS **BUILD SUCCEEDED** · Python **99 tests**. Both slices hand-compiled, since no CI job builds Swift. New behaviour is mutation-checked: neutering the session filter, the pending retirement, or the race check each fails its test.

Refs #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)