### PR TITLE
feat(predict): add boltz2-bf16, a dense bfloat16 weight pack as a second method

### DIFF
--- a/docs/predictors.md
+++ b/docs/predictors.md
@@ -17,10 +17,38 @@ it is shaped this way.
 | `modules/pymol/predictors/host.py` | transport to the Swift inference host |
 | `modules/pymol/predictors/_template.py` | copy-me skeleton |
 
+## Shipped predictors
+
+| id | weights | notes |
+|---|---|---|
+| `boltz2` | affine-int8, 507 MB | the default |
+| `boltz2-bf16` | dense bfloat16, 996 MB | same model, same runtime, unquantized |
+
+`boltz2-bf16` subclasses `Boltz2Predictor` and overrides nothing but `weight_bundle`.
+That works because `host.submit` sends `weights_dir` per job and the Swift runtime
+picks its matmul path from the artifact manifest — a dense pack declares no
+quantization block — so one runtime serves both with no host change. It needs
+boltz-mlx >= 0.2.0.
+
+It is **not** an upgrade. On an M3 Pro at 117 tokens, recycling 3 / 200 steps, dense
+bfloat16 costs 2x the disk, +63% peak RSS (620 MiB -> 1012 MiB) and +22% wall clock
+(14.50 s -> 17.76 s), because MLX's `quantizedMM` beats a dense fp16 matmul on these
+memory-bound shapes. And it buys no *demonstrated* accuracy: the two packs differ by
+3.1 A at a fixed seed, while the model's own seed-to-seed spread within int8 alone is
+4.9-7.0 A. Ranking them needs ground truth and many samples per condition. It exists so
+that experiment is possible on-device.
+
+Note also that the Boltz-2 checkpoint is float32 throughout — there are no original
+bfloat16 weights to load. Both dense widths are a narrowing of that float32, and
+float16 is the closer one at identical size (`--precision float16` exports it).
+
 ## Steps
 
 1. **Copy the template** to `modules/pymol/predictors/<your_id>.py` and pick a permanent
-   `id`. It appears in user scripts and saved sessions: treat it as API.
+   `id`. It appears in user scripts and saved sessions: treat it as API. Avoid making it
+   an *extension* of an existing id if you can: `boltz2-bf16` shares a prefix with
+   `boltz2`, so `predict b<Tab>` now stops at `boltz2` with no `, ` separator instead of
+   completing to a runnable command.
 
 2. **Write the tests first.** Add `testing/tests/predict/predict_<your_id>.py` subclassing
    `pymol.testing.PyMOLTestCase`. Do **not** name it `test_*.py` unless you want the pytest

--- a/modules/pymol/predictors/__init__.py
+++ b/modules/pymol/predictors/__init__.py
@@ -11,7 +11,9 @@ from .registry import register, get, available, unregister  # noqa: F401
 def _register_builtins():
     """Register the shipped predictors. The only function that changes per predictor."""
     from .boltz2 import Boltz2Predictor
+    from .boltz2_bf16 import Boltz2BF16Predictor
     register(Boltz2Predictor(), replace=True)
+    register(Boltz2BF16Predictor(), replace=True)
 
 
 _register_builtins()

--- a/modules/pymol/predictors/boltz2_bf16.py
+++ b/modules/pymol/predictors/boltz2_bf16.py
@@ -1,0 +1,49 @@
+"""Boltz-2 with dense bfloat16 weights instead of the affine-int8 pack.
+
+Same model, same Swift runtime, same inputs -- only the weight representation
+differs, so everything but the bundle is inherited from Boltz2Predictor. The Swift
+side branches on the artifact manifest (a dense pack declares no quantization
+block), which is why one runtime serves both.
+
+The trade is unfavourable on every axis measured so far, and this predictor exists
+to let that be re-measured rather than argued about. On an M3 Pro at 117 tokens,
+recycling 3 / 200 steps, dense bfloat16 against the int8 pack:
+
+    pack on disk   507 MB  ->  996 MB
+    wall clock    14.50 s  ->  17.76 s   (quantizedMM beats a dense fp16 matmul
+                                          on these memory-bound shapes)
+    peak RSS      620 MiB  ->  1012 MiB
+
+and the structures the two produce differ by less than the model's own
+seed-to-seed spread (3.1 A between packs at one seed; 4.9-7.0 A across seeds
+within the int8 pack alone), so no accuracy claim in either direction is
+supported yet.
+
+NOTE ALSO: the Boltz-2 checkpoint is float32 throughout -- there are no original
+bfloat16 weights to load. This pack is a narrowing of that float32, and float16
+would be a strictly closer one at identical size. Both are exportable
+(`boltz-mlx export-model --precision`); bfloat16 is offered because it is the
+width Boltz was trained in.
+"""
+from .boltz2 import Boltz2Predictor
+from .weights import WeightBundle
+
+
+class Boltz2BF16Predictor(Boltz2Predictor):
+
+    id = 'boltz2-bf16'
+    name = 'Boltz-2 (MLX, bfloat16)'
+
+    # sha256 and size are of the zip's bytes. Unlike the int8 pack these ARE
+    # reproducible from the checkpoint -- a dense export is a pure narrowing with no
+    # Metal-side quantization -- but the published asset must still be re-hashed after
+    # upload, because what matters is the bytes GitHub serves back.
+    weight_bundle = WeightBundle(
+        id='boltz2-mlx-bf16',
+        version='v1',
+        url='https://github.com/javierbq/boltz-mlx/releases/download/weights-bf16-v1/'
+            'boltz2-mlx-bf16-v1.zip',
+        sha256='9d33ba489407f0066fc3e7421e4c7b2db9f528774f28c345df9fe242087f5128',
+        size=1_044_050_191,
+        members=('config.json', 'manifest.json', 'model.safetensors'),
+    )

--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -289,7 +289,7 @@
 		F7E41DCBB427678A8F018B0E /* DesignControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignControllerTests.swift; sourceTree = "<group>"; };
 		FB1304C662D9011F7C4505FC /* MCPStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPStatusView.swift; sourceTree = "<group>"; };
 		FF4FB7F151982A2927D612F0 /* DesignController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignController.swift; sourceTree = "<group>"; };
-		"TEMP_12CBC40D-DB9F-44EB-B69B-F9E9D4C8F8A5" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
+		"TEMP_1BAF0648-9440-486B-B819-2D0B940D3D8C" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -494,10 +494,10 @@
 			path = Bridge;
 			sourceTree = "<group>";
 		};
-		"TEMP_DA1383D8-2FC3-4B75-928B-ECB775BE5A46" /* swiftui */ = {
+		"TEMP_B4247C30-6CF5-4A6A-9930-D2E781006CFF" /* swiftui */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_12CBC40D-DB9F-44EB-B69B-F9E9D4C8F8A5" /* PyMOLBridge.xcconfig */,
+				"TEMP_1BAF0648-9440-486B-B819-2D0B940D3D8C" /* PyMOLBridge.xcconfig */,
 			);
 			path = swiftui;
 			sourceTree = "<group>";
@@ -1502,7 +1502,7 @@
 		};
 		76B7E9DB75E073D1E60928FA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_12CBC40D-DB9F-44EB-B69B-F9E9D4C8F8A5" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_1BAF0648-9440-486B-B819-2D0B940D3D8C" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1609,7 +1609,7 @@
 		};
 		D8F44FDFF036013D2F03BA83 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_12CBC40D-DB9F-44EB-B69B-F9E9D4C8F8A5" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_1BAF0648-9440-486B-B819-2D0B940D3D8C" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1767,7 +1767,7 @@
 			repositoryURL = "https://github.com/javierbq/boltz-mlx.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.1;
+				minimumVersion = 0.2.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/swiftui/PyMOLViewer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/swiftui/PyMOLViewer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/javierbq/boltz-mlx.git",
       "state" : {
-        "revision" : "d5994771e1e10fe960541dd4c82ffc3adb8e7e1e",
-        "version" : "0.1.1"
+        "revision" : "c1856f22de567d200633c45b4786c97bca308282",
+        "version" : "0.2.0"
       }
     },
     {

--- a/swiftui/project.yml
+++ b/swiftui/project.yml
@@ -36,7 +36,10 @@ packages:
   # resolution is unaffected and this entry never needs bumping in lockstep.
   BoltzMLX:
     url: https://github.com/javierbq/boltz-mlx.git
-    from: 0.1.1
+    # 0.2.0 adds the dense fp16/bfloat16 weight path: BoltzWeightStore selects it when
+    # an artifact manifest declares no quantization block, which is what the
+    # boltz2-bf16 predictor's pack does.
+    from: 0.2.0
   # Sparkle auto-update framework. macOS-only — linked into the macOS slice of the
   # shared PyMOLViewer target via a platformFilter dependency; never the iOS slice.
   # RAYMOL_SPARKLE_BEGIN — stripped for the Mac App Store build by archive_appstore.sh

--- a/testing/tests/predict/predict_completion.py
+++ b/testing/tests/predict/predict_completion.py
@@ -15,8 +15,15 @@ class TestPredictCompletion(testing.PyMOLTestCase):
     def testPredictOffersRegisteredPredictors(self):
         self.assertEqual(cmd._parser.complete('predict '), 'predict boltz2')
 
-    def testPartialPredictorNameCompletes(self):
-        self.assertEqual(cmd._parser.complete('predict b'), 'predict boltz2, ')
+    def testPartialPredictorNameCompletesAsFarAsItIsUnambiguous(self):
+        """'boltz2' is a PREFIX of 'boltz2-bf16', so Tab stops there with no separator.
+
+        The trailing ', ' only appears once one predictor is uniquely identified --
+        which for the shorter id means the user has to type the comma themselves.
+        """
+        self.assertEqual(cmd._parser.complete('predict b'), 'predict boltz2')
+        self.assertEqual(cmd._parser.complete('predict boltz2-'),
+                         'predict boltz2-bf16, ')
 
     def testPredictWeightsAlsoOffersPredictors(self):
         self.assertEqual(cmd._parser.complete('predict_weights '),


### PR DESCRIPTION
Adds a **second prediction method**, `boltz2-bf16`, running the same Boltz-2 model from a dense bfloat16 weight pack instead of the affine-int8 one.

```
predict boltz2-bf16, MKTAYIAKQRQISFVKSHFSRQLEERLGLIEVQ
```

### Why it's cheap to add

`Boltz2BF16Predictor` subclasses `Boltz2Predictor` and overrides **nothing but `weight_bundle`**. That works because `host.submit` already sends `weights_dir` per job, and boltz-mlx picks its matmul path from the artifact manifest — a dense pack simply declares no quantization block. No Swift, no host change, no UI change on this side (prediction is console-driven, so a registered id is immediately reachable).

The runtime half is boltz-mlx [v0.2.0](https://github.com/javierbq/boltz-mlx/releases/tag/v0.2.0): the storage kind moved into a `MatrixStorage` enum *inside* the existing `AffineLinear`/`AffineEmbedding` rather than into new types, so the dense path cost none of the 122 call sites that name them.

Weights: [weights-bf16-v1](https://github.com/javierbq/boltz-mlx/releases/tag/weights-bf16-v1), 996 MB, sha256 pinned and **verified against the bytes GitHub serves back**, not against the local export.

### This is not an upgrade

M3 Pro, 117 tokens, recycling 3 / 200 steps, dense bfloat16 vs int8:

| | int8 | bfloat16 |
|---|---|---|
| pack | 507 MB | 996 MB |
| wall clock | 14.50 s | **17.76 s** (+22%) |
| peak RSS | 620 MiB | **1012 MiB** (+63%) |

Dense is **slower**, not faster: MLX's `quantizedMM` beats a dense fp16 matmul on these memory-bound shapes.

And it buys no *demonstrated* accuracy. The two packs differ by 3.1 Å at a fixed seed — which looks meaningful until you run the control: int8 against **itself** across seeds 0/1/2 differs by 4.9–7.0 Å. The precision delta sits below the model's own sampling noise, so a single-seed RMSD cannot rank the packs. Doing that needs ground truth and many samples per condition.

It's here so that experiment can be run on-device rather than argued about.

### One correction worth recording

The premise this started from — "load the full bfloat16 original Boltz weights" — doesn't exist. `boltz2_conf.ckpt` is **5,102 tensors, 521,047,871 params, every one float32**. Both dense widths are a *narrowing* of that float32, and float16 (10-bit mantissa) is the closer one at identical size; bfloat16 is faithful only in the sense that Boltz was trained in it. boltz-mlx exports either (`--precision {int8,float16,bfloat16}`), so float16 is a one-line follow-up if the experiment says precision is what matters.

### Behaviour change

`boltz2` is a prefix of `boltz2-bf16`, so `predict b<Tab>` now stops at `boltz2` instead of completing to `boltz2, `. Real, if minor. `predict_completion.py` is updated to assert the new truth rather than paper over it, and `docs/predictors.md` now warns id authors about prefix collisions.

### Verification

- `testing/tests/predict` — **137 tests, OK**
- boltz-mlx: `swift build` clean; `PrimitiveParityTests` 9/9 including two new dense-path tests (dense linear is a plain matmul with no padding; dense embedding rows are verbatim, tolerance 0)
- **macOS** slice `** BUILD SUCCEEDED **`, **iOS** slice `** BUILD SUCCEEDED **` (no CI compiles Swift, so both were built by hand)
- Ran end to end in a local Debug build: 33 residues → 276 atoms, 17.6 s, peak 1.24 GB, loaded into the session. int8 in the same session: 15.5 s, peak 0.62 GB.
- The published asset itself is confirmed: downloaded from the release URL and re-hashed to the pinned sha256, byte count exact.
- **Cold fetch through the app has not completed yet — see below.**

### Known issue: the downloader has no resume, and 1 GB makes that bite

Exercising the cold path with the hand-seeded cache removed, the fetch **failed at ~84%**:

```
download of .../boltz2-mlx-bf16-v1.zip was interrupted: The read operation timed out
```

`_stream_to_part()` in `predictors/weights.py` issues a single `_urlopen(request, timeout=DEFAULT_TIMEOUT)` with no `Range` header and no retry loop, so one socket read stalling past 30 s aborts the transfer — and the retry restarts from byte zero (observed: 9 MB after 20 s, not 875 MB). GitHub's release CDN served this at roughly 0.5–1 MB/s, i.e. a ~17-minute window in which any single stall is fatal.

This is **pre-existing** and applies to the 529 MB int8 bundle too; doubling the pack size just widens the window enough to make it show up. It is not caused by this PR, but it does mean `boltz2-bf16` is currently hard to install over a slow or flaky link, so it is worth landing resume + bounded retry (with a correct resumed sha256, and a guard for a server that ignores `Range`) before leaning on this predictor. Tracked separately.

Also spotted while testing: `weights/.incoming/` holds an orphaned 529 MB `.part` and a `.d` directory from an earlier interrupted int8 download that nothing reclaims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
