### PR TITLE
fix(predict): resume weight downloads instead of restarting from zero

### DIFF
--- a/modules/pymol/predictors/fetching.py
+++ b/modules/pymol/predictors/fetching.py
@@ -206,7 +206,9 @@ def shutdown(timeout=5.0):
     Records are dropped even if a worker overran the timeout: it is a daemon writing
     only to scratch under .incoming, and the sentinel that makes a cache valid is
     written last, so the worst case is a stray temp file -- never a cache another run
-    could mistake for complete.
+    could mistake for complete. That temp file is not left forever either: it can be
+    half a gigabyte, and WeightCache.sweep_incoming reclaims it once the pid that
+    owned it is gone.
     """
     cancel()
     with _LOCK:

--- a/modules/pymol/predictors/weights.py
+++ b/modules/pymol/predictors/weights.py
@@ -17,7 +17,7 @@ import shutil
 import sys
 import time
 import zipfile
-from urllib.error import URLError
+from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from .errors import (WeightBundleLayoutError, WeightCacheUnwritable,
@@ -28,14 +28,38 @@ from .errors import (WeightBundleLayoutError, WeightCacheUnwritable,
 #: existence -- is what makes a cache valid.
 SENTINEL = '.ok'
 
-#: Patch point for tests. Never call urllib.request.urlopen directly below.
+#: Patch points for tests. Never call urllib.request.urlopen or time.sleep
+#: directly below.
 _urlopen = urlopen
+_sleep = time.sleep
 
 #: Stream in 1 MiB chunks: bundles are hundreds of MiB (see WeightBundle.size)
 #: and must never be buffered whole.
 CHUNK_BYTES = 1 << 20
 
 DEFAULT_TIMEOUT = 30.0
+
+#: Hard ceiling on transfer attempts for one bundle. Two budgets rather than one
+#: because they bound different failures: MAX_STALLED_ATTEMPTS ends a transfer that
+#: cannot get past a given byte, while MAX_DOWNLOAD_ATTEMPTS ends one that keeps
+#: creeping forward. A ~1 GiB bundle over a CDN serving under 1 MiB/s takes tens of
+#: minutes, so a handful of stalls along the way is normal and must not be fatal --
+#: only a stall that no longer makes progress is.
+MAX_DOWNLOAD_ATTEMPTS = 20
+MAX_STALLED_ATTEMPTS = 4
+
+RETRY_BACKOFF_BASE = 0.5
+RETRY_BACKOFF_MAX = 15.0
+
+#: Statuses worth another attempt. Any other 4xx is a bad URL or a withdrawn
+#: release asset, where retrying only delays the error the user needs to see.
+#: 416 is handled separately: it means our .part is longer than the resource,
+#: which is a local problem to fix by restarting, not a server problem to wait out.
+RETRYABLE_STATUSES = frozenset([408, 429, 500, 502, 503, 504, 507, 509])
+
+#: Errno values that mean the cache -- not the network -- is the problem.
+UNWRITABLE_ERRNOS = frozenset(
+    [errno.ENOSPC, errno.EACCES, errno.EROFS, errno.ENOTDIR])
 
 
 class WeightBundle:
@@ -142,6 +166,42 @@ class WeightCache:
             raise WeightCacheUnwritable(
                 'cannot create %s: %s' % (path, exc))
 
+    def sweep_incoming(self):
+        """Reclaim scratch left behind by a process that is no longer running.
+
+        ensure()'s `finally` covers every exit path it is given the chance to run on,
+        but the fetch runs on a daemon thread (see predictors.fetching): quitting the
+        app mid-download tears the interpreter down without unwinding it, and a
+        half-gigabyte `.part` plus its `.d` staging directory are stranded under
+        .incoming with nothing that would ever look at them again. One observed
+        instance held 529 MiB for weeks.
+
+        The pid baked into the scratch token is what makes them reclaimable -- the
+        same liveness test the stale-lock path already relies on, and the reason the
+        token carries a pid in the first place. A recycled pid only means the debris
+        waits for the next sweep.
+
+        Never fatal: this is housekeeping in front of a download, and an entry that
+        cannot be classified or removed is simply left where it is.
+        """
+        incoming = self._incoming()
+        try:
+            entries = os.listdir(incoming)
+        except OSError:
+            return
+        for name in entries:
+            stem, extension = os.path.splitext(name)
+            if extension not in ('.part', '.d'):
+                continue
+            pid = _pid_from_token(stem)
+            if pid is None or _pid_alive(pid):
+                continue
+            path = os.path.join(incoming, name)
+            if extension == '.d':
+                _rmtree(path)
+            else:
+                _unlink(path)
+
     def _lock_path(self, bundle):
         return os.path.join(self._incoming(),
                             '%s-%s.lock' % (bundle.id, bundle.version))
@@ -201,7 +261,9 @@ class WeightCache:
 
         Nothing partial survives either way: the `finally` below removes the scratch
         file and staging directory, and the sentinel that makes a cache valid is only
-        written by _publish.
+        written by _publish. The one exit that skips that `finally` -- the process
+        dying under the daemon thread this runs on -- is swept up here on the next
+        call rather than left on disk (see sweep_incoming).
         """
         if isinstance(bundle, BundledSource):
             return bundle.resolve()
@@ -210,6 +272,7 @@ class WeightCache:
 
         incoming = self._incoming()
         self._makedirs(incoming)
+        self.sweep_incoming()
         if not self._acquire_lock(bundle):
             return self.path_for(bundle)         # someone else finished it
 
@@ -237,41 +300,72 @@ class WeightCache:
         return target
 
     def _download(self, bundle, part, progress, should_cancel=None):
-        """Stream to `part`, hashing as we go, and verify before anything is published."""
-        digest = hashlib.sha256()
-        received = 0
-        expected = bundle.size or 0
+        """Stream to `part`, hashing as we go, and verify before anything is published.
+
+        Resumable, because one stalled socket must not cost the whole transfer.
+        Bundles here run 500 MiB to 1 GiB and the release CDN routinely serves them at
+        well under 1 MiB/s, which leaves a window of tens of minutes in which a single
+        read that stalls past DEFAULT_TIMEOUT used to discard everything received so
+        far and restart from byte zero (observed on the 996 MiB boltz2-mlx-bf16 bundle:
+        a timeout at ~84% threw away ~875 MiB).
+
+        The resume is per-call: `part` is keyed on this process's pid, so an attempt
+        only ever continues a prefix this call itself wrote. Scratch stranded by an
+        earlier process is reclaimed by sweep_incoming, not adopted -- adopting it
+        would mean trusting bytes whose provenance nothing here can check.
+        """
         # Before opening the socket at all: a cancel that arrives while this caller was
         # queued on the lock should cost nothing.
         _raise_if_cancelled(should_cancel, bundle)
-        try:
-            request = Request(bundle.url, headers={'User-Agent': 'RayMol'})
-            with _urlopen(request, timeout=DEFAULT_TIMEOUT) as response:
-                with open(part, 'wb') as handle:
-                    while True:
-                        chunk = response.read(CHUNK_BYTES)
-                        if not chunk:
-                            break
-                        handle.write(chunk)
-                        digest.update(chunk)
-                        received += len(chunk)
-                        if progress and expected:
-                            progress('download',
-                                     min(1.0, float(received) / expected))
-                        # After the write, not before: a cancelled chunk is still
-                        # hashed and written, so `received` never overstates the file.
-                        _raise_if_cancelled(should_cancel, bundle)
-        except URLError as exc:
-            _unlink(part)
-            raise WeightDownloadFailed(
-                'failed to fetch %s: %s' % (bundle.url, exc.reason))
-        except OSError as exc:
-            _unlink(part)
-            if exc.errno in (errno.ENOSPC, errno.EACCES, errno.EROFS, errno.ENOTDIR):
-                raise WeightCacheUnwritable(
-                    'cannot write %s: %s' % (part, exc))
-            raise WeightDownloadFailed(
-                'download of %s was interrupted: %s' % (bundle.url, exc))
+        _unlink(part)
+        expected = bundle.size or 0
+        received, digest = 0, hashlib.sha256()
+        attempts = stalled = 0
+        while True:
+            try:
+                received, digest = self._stream_to_part(
+                    bundle, part, received, digest, progress, should_cancel)
+                if not expected or received >= expected:
+                    break
+                # A body that simply stops short raises nothing at all. Before
+                # resume existed this could only ever become a checksum mismatch;
+                # now it is just another interrupted transfer to continue.
+                reason = ('download of %s ended early at %d of %d bytes'
+                          % (bundle.url, received, expected))
+            except HTTPError as exc:
+                if exc.code == 416 and received:
+                    # We asked to resume past the end of the resource: the .part is
+                    # longer than what the server holds. That is ours to fix.
+                    _unlink(part)
+                elif exc.code not in RETRYABLE_STATUSES:
+                    _unlink(part)
+                    raise WeightDownloadFailed(
+                        'failed to fetch %s: %s' % (bundle.url, exc))
+                reason = 'failed to fetch %s: %s' % (bundle.url, exc)
+            except URLError as exc:
+                reason = 'failed to fetch %s: %s' % (bundle.url, exc.reason)
+            except OSError as exc:
+                if exc.errno in UNWRITABLE_ERRNOS:
+                    _unlink(part)
+                    raise WeightCacheUnwritable(
+                        'cannot write %s: %s' % (part, exc))
+                reason = ('download of %s was interrupted: %s'
+                          % (bundle.url, exc))
+
+            # Re-derive both the byte count and the running hash from the file on
+            # disk. The hasher inside the failed attempt may have absorbed bytes that
+            # never reached the disk, and a sha256 cannot be rolled back -- so the
+            # file, which is what the next attempt appends to, is the only honest
+            # source for both.
+            resumed, digest = _rehash_part(part, should_cancel, bundle)
+            stalled = 0 if resumed > received else stalled + 1
+            received = resumed
+            attempts += 1
+            if attempts >= MAX_DOWNLOAD_ATTEMPTS or stalled >= MAX_STALLED_ATTEMPTS:
+                _unlink(part)
+                raise WeightDownloadFailed(
+                    '%s (gave up after %d attempts)' % (reason, attempts))
+            _backoff(stalled, should_cancel, bundle)
 
         actual = digest.hexdigest()
         if actual != bundle.sha256:
@@ -279,6 +373,49 @@ class WeightCache:
             raise WeightChecksumMismatch(
                 'checksum mismatch for %s: expected %s, got %s'
                 % (bundle.id, bundle.sha256, actual))
+
+    def _stream_to_part(self, bundle, part, offset, digest, progress,
+                        should_cancel):
+        """One transfer attempt. Returns (bytes on disk, hash of those bytes).
+
+        With `offset` > 0 this asks for `Range: bytes=<offset>-` and appends the
+        response. A server that ignores Range answers 200 with the WHOLE body:
+        appending that would splice a duplicate prefix into the file and surface only
+        much later, as a checksum mismatch after another full download. So anything
+        but a 206 discards the prefix and restarts the attempt from zero, which is
+        exactly what the un-resumed path did anyway.
+        """
+        headers = {'User-Agent': 'RayMol'}
+        if offset:
+            headers['Range'] = 'bytes=%d-' % offset
+        request = Request(bundle.url, headers=headers)
+        expected = bundle.size or 0
+        with _urlopen(request, timeout=DEFAULT_TIMEOUT) as response:
+            resuming = bool(offset) and _status_of(response) == 206
+            if not resuming:
+                offset, digest = 0, hashlib.sha256()
+            received = offset
+            with open(part, 'r+b' if resuming else 'wb') as handle:
+                if resuming:
+                    # Write exactly where the hash ends, whatever else is in the
+                    # file: `digest` covers the first `offset` bytes and nothing
+                    # beyond them may survive.
+                    handle.seek(offset)
+                    handle.truncate()
+                while True:
+                    chunk = response.read(CHUNK_BYTES)
+                    if not chunk:
+                        break
+                    handle.write(chunk)
+                    digest.update(chunk)
+                    received += len(chunk)
+                    if progress and expected:
+                        progress('download',
+                                 min(1.0, float(received) / expected))
+                    # After the write, not before: a cancelled chunk is still
+                    # hashed and written, so `received` never overstates the file.
+                    _raise_if_cancelled(should_cancel, bundle)
+        return received, digest
 
     def _extract(self, bundle, part, staging, progress, should_cancel=None):
         """Extract to staging, then assert the layout is exactly what was declared."""
@@ -327,6 +464,79 @@ def _raise_if_cancelled(should_cancel, bundle):
     if should_cancel is not None and should_cancel():
         raise WeightDownloadCancelled(
             'fetch of %s weights was cancelled' % bundle.id)
+
+
+def _status_of(response):
+    """HTTP status of an urlopen result, or 200 when it does not report one.
+
+    200 is the safe default because of what the caller does with it: it reads as
+    "the server did not honour Range", which restarts the transfer. Guessing 206
+    from a response that never said so would append onto a prefix.
+    """
+    status = getattr(response, 'status', None)
+    if status is None:
+        status = getattr(response, 'code', None)
+    try:
+        return int(status)
+    except (TypeError, ValueError):
+        return 200
+
+
+def _rehash_part(part, should_cancel=None, bundle=None):
+    """Return (bytes on disk, sha256 of those bytes) for a partial download.
+
+    Re-reading ~1 GiB costs well under a second -- three orders of magnitude less
+    than re-fetching it over the link these bundles actually arrive on.
+
+    A partial file we cannot read is not worth diagnosing: dropping it costs one
+    restart, whereas resuming from a length we could not verify corrupts the result.
+    """
+    digest = hashlib.sha256()
+    total = 0
+    try:
+        with open(part, 'rb') as handle:
+            while True:
+                chunk = handle.read(CHUNK_BYTES)
+                if not chunk:
+                    break
+                digest.update(chunk)
+                total += len(chunk)
+                _raise_if_cancelled(should_cancel, bundle)
+    except OSError:
+        _unlink(part)
+        return 0, hashlib.sha256()
+    return total, digest
+
+
+def _backoff(stalled, should_cancel, bundle):
+    """Wait before the next attempt, without swallowing a cancel.
+
+    Slept in short slices rather than one long call: a user who hits cancel during
+    the wait should not be made to sit through the rest of it.
+    """
+    deadline = time.monotonic() + min(RETRY_BACKOFF_MAX,
+                                      RETRY_BACKOFF_BASE * (2 ** stalled))
+    while True:
+        _raise_if_cancelled(should_cancel, bundle)
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return
+        _sleep(min(0.05, remaining))
+
+
+def _pid_from_token(stem):
+    """The pid encoded in a `<sha256>-<pid>` scratch token, or None.
+
+    None means "leave it alone": an entry that does not match the shape this module
+    writes belongs to something else, and .incoming is not ours to empty.
+    """
+    sha, _, pid = stem.rpartition('-')
+    if len(sha) != 64:
+        return None
+    try:
+        return int(pid)
+    except ValueError:
+        return None
 
 
 def _read_pid(path):

--- a/testing/tests/predict/predict_weights_cache.py
+++ b/testing/tests/predict/predict_weights_cache.py
@@ -92,6 +92,72 @@ class TestCacheValidity(testing.PyMOLTestCase):
             self.assertTrue(cache.is_cached(make_bundle()))
 
 
+class TestIncomingSweep(testing.PyMOLTestCase):
+    """Scratch stranded by a process that died mid-download must be reclaimed.
+
+    ensure()'s `finally` never ran for these: the fetch is a daemon thread, so
+    quitting the app takes the interpreter down without unwinding it and leaves a
+    half-gigabyte .part behind for good.
+    """
+
+    def _incoming(self, cache):
+        path = cache._incoming()
+        os.makedirs(path, exist_ok=True)
+        return path
+
+    def _debris(self, incoming, pid):
+        token = '%s-%d' % ('c' * 64, pid)
+        part = os.path.join(incoming, token + '.part')
+        staging = os.path.join(incoming, token + '.d')
+        with open(part, 'wb') as handle:
+            handle.write(b'partial')
+        os.makedirs(staging)
+        return part, staging
+
+    def testDeadOwnersScratchIsReclaimed(self):
+        from pymol.predictors.weights import WeightCache
+        with testing.mkdtemp() as root:
+            cache = WeightCache(root)
+            incoming = self._incoming(cache)
+            # A pid that cannot be running: os.getpid() is this process, and
+            # _pid_alive treats an unreachable pid as gone.
+            part, staging = self._debris(incoming, 999999)
+            cache.sweep_incoming()
+            self.assertFalse(os.path.exists(part))
+            self.assertFalse(os.path.exists(staging))
+
+    def testLiveOwnersScratchIsLeftAlone(self):
+        """A concurrent downloader's scratch is not ours to delete."""
+        from pymol.predictors.weights import WeightCache
+        with testing.mkdtemp() as root:
+            cache = WeightCache(root)
+            incoming = self._incoming(cache)
+            part, staging = self._debris(incoming, os.getpid())
+            cache.sweep_incoming()
+            self.assertTrue(os.path.exists(part))
+            self.assertTrue(os.path.exists(staging))
+
+    def testUnrecognizedEntriesAreLeftAlone(self):
+        """.incoming is not this method's to empty -- only its own token shape."""
+        from pymol.predictors.weights import WeightCache
+        with testing.mkdtemp() as root:
+            cache = WeightCache(root)
+            incoming = self._incoming(cache)
+            keep = [os.path.join(incoming, name) for name in
+                    ('notes.txt', 'stub-v1.lock', 'short-999999.part')]
+            for path in keep:
+                with open(path, 'w') as handle:
+                    handle.write('x')
+            cache.sweep_incoming()
+            for path in keep:
+                self.assertTrue(os.path.exists(path), path)
+
+    def testSweepSurvivesAMissingIncoming(self):
+        from pymol.predictors.weights import WeightCache
+        with testing.mkdtemp() as root:
+            WeightCache(root).sweep_incoming()      # must not raise
+
+
 class TestBundledSource(testing.PyMOLTestCase):
 
     def testResolveReturnsAnExistingPath(self):

--- a/testing/tests/predict/predict_weights_download.py
+++ b/testing/tests/predict/predict_weights_download.py
@@ -2,6 +2,7 @@
 
     pymol -ckqy testing/testing.py --run testing/tests/predict/predict_weights_download.py
 """
+import contextlib
 import hashlib
 import io
 import os
@@ -9,6 +10,19 @@ import zipfile
 from unittest.mock import patch
 
 from pymol import testing
+
+
+@contextlib.contextmanager
+def no_backoff():
+    """Collapse the retry ladder's waits to nothing.
+
+    The delays are zeroed rather than the sleeping stubbed: _backoff waits on a
+    real monotonic deadline, so a no-op _sleep would only turn seconds of sleeping
+    into seconds of spinning. Every attempt still runs, in the same order.
+    """
+    with patch('pymol.predictors.weights.RETRY_BACKOFF_BASE', 0.0), \
+         patch('pymol.predictors.weights.RETRY_BACKOFF_MAX', 0.0):
+        yield
 
 
 def make_zip(members=(('config.json', '{}'), ('model.bin', 'weights'))):
@@ -39,6 +53,55 @@ class FakeResponse:
 
     def __exit__(self, *exc):
         return False
+
+
+class _Connection(FakeResponse):
+    """One RangeServer response; raises a socket timeout after `fail_after` bytes."""
+
+    def __init__(self, server, body, status, fail_after):
+        FakeResponse.__init__(self, body)
+        self._server = server
+        self._served = 0
+        self._fail_after = fail_after
+        self.status = status
+
+    def read(self, size=-1):
+        if self._fail_after is not None and self._served >= self._fail_after:
+            raise TimeoutError('The read operation timed out')
+        if size and size > 0 and self._fail_after is not None:
+            size = min(size, self._fail_after - self._served)
+        chunk = FakeResponse.read(self, size)
+        self._served += len(chunk)
+        self._server.served[-1] = self._served
+        return chunk
+
+
+class RangeServer:
+    """urlopen stand-in that honours (or pointedly ignores) Range and can stall.
+
+    `fail_after` is consumed one entry per connection: the Nth connection raises a
+    socket timeout once it has handed out that many bytes. With `honour_range`
+    false it answers every request with 200 and the whole body, which is what a
+    CDN edge that does not do partial content looks like.
+    """
+
+    def __init__(self, payload, fail_after=(), honour_range=True):
+        self.payload = payload
+        self.fail_after = list(fail_after)
+        self.honour_range = honour_range
+        self.connections = []       # (Range header or None, status) per connection
+        self.served = []            # bytes actually handed out per connection
+
+    def __call__(self, request, timeout=None):
+        header = request.get_header('Range')
+        offset = 0
+        if header and self.honour_range:
+            offset = int(header.split('=', 1)[1].split('-', 1)[0])
+        status = 206 if offset else 200
+        limit = self.fail_after.pop(0) if self.fail_after else None
+        self.connections.append((header, status))
+        self.served.append(0)
+        return _Connection(self, self.payload[offset:], status, limit)
 
 
 def bundle_for(data, digest, **kwargs):
@@ -108,8 +171,8 @@ class TestEnsure(testing.PyMOLTestCase):
 
         with testing.mkdtemp() as root:
             cache = WeightCache(root)
-            with patch('pymol.predictors.weights._urlopen',
-                       return_value=Dying(data)):
+            with no_backoff(), patch('pymol.predictors.weights._urlopen',
+                                     return_value=Dying(data)):
                 self.assertRaises(WeightDownloadFailed, cache.ensure, bundle)
             self.assertFalse(cache.is_cached(bundle))
             self.assertFalse(os.path.exists(cache.path_for(bundle)))
@@ -187,6 +250,120 @@ class TestEnsure(testing.PyMOLTestCase):
         with patch('pymol.predictors.weights._urlopen',
                    return_value=FakeResponse(data)):
             self.assertRaises(WeightCacheUnwritable, cache.ensure, bundle)
+
+    def testResumeContinuesWhereTheStreamDied(self):
+        """A mid-stream timeout must cost the stalled read, not the whole transfer."""
+        from pymol.predictors.weights import WeightCache
+        data, digest = make_zip(members=[('config.json', 'x' * 4000),
+                                         ('model.bin', 'y' * 4000)])
+        bundle = bundle_for(data, digest)
+        server = RangeServer(data, fail_after=[len(data) // 2])
+        with testing.mkdtemp() as root:
+            cache = WeightCache(root)
+            with no_backoff(), patch('pymol.predictors.weights._urlopen', server):
+                path = cache.ensure(bundle)
+            self.assertTrue(cache.is_cached(bundle))
+            with open(os.path.join(path, 'model.bin')) as handle:
+                self.assertEqual(handle.read(), 'y' * 4000)
+        # Two connections: the second asked to resume and was told 206.
+        self.assertEqual([status for _, status in server.connections],
+                         [200, 206])
+        self.assertEqual(server.connections[1][0],
+                         'bytes=%d-' % (len(data) // 2))
+        # The point of the exercise: the bytes before the stall were not re-fetched.
+        self.assertEqual(sum(server.served), len(data))
+
+    def testResumeSurvivesRepeatedStalls(self):
+        """Several stalls are normal on a slow CDN; each one must only cost itself."""
+        from pymol.predictors.weights import WeightCache
+        data, digest = make_zip(members=[('config.json', 'x' * 4000),
+                                         ('model.bin', 'y' * 4000)])
+        bundle = bundle_for(data, digest)
+        stalls = [len(data) // 8] * 6           # more than MAX_STALLED_ATTEMPTS
+        server = RangeServer(data, fail_after=stalls)
+        with testing.mkdtemp() as root:
+            cache = WeightCache(root)
+            with no_backoff(), patch('pymol.predictors.weights._urlopen', server):
+                cache.ensure(bundle)
+            self.assertTrue(cache.is_cached(bundle))
+        self.assertEqual(len(server.connections), len(stalls) + 1)
+        self.assertEqual(sum(server.served), len(data))
+
+    def testRangeIgnoringServerStillEndsWithACorrectDigest(self):
+        """A 200 answer to a Range request must restart, never append a duplicate."""
+        from pymol.predictors.weights import WeightCache
+        data, digest = make_zip(members=[('config.json', 'x' * 4000),
+                                         ('model.bin', 'y' * 4000)])
+        bundle = bundle_for(data, digest)
+        server = RangeServer(data, fail_after=[len(data) // 2],
+                             honour_range=False)
+        with testing.mkdtemp() as root:
+            cache = WeightCache(root)
+            with no_backoff(), patch('pymol.predictors.weights._urlopen', server):
+                path = cache.ensure(bundle)
+            self.assertTrue(cache.is_cached(bundle))
+            with open(os.path.join(path, 'config.json')) as handle:
+                self.assertEqual(handle.read(), 'x' * 4000)
+        # It did ask to resume, was answered with the whole body, and started over --
+        # so the second connection served everything, not the tail.
+        self.assertEqual([status for _, status in server.connections],
+                         [200, 200])
+        self.assertIsNotNone(server.connections[1][0])
+        self.assertEqual(server.served[1], len(data))
+
+    def testRetriesAreBounded(self):
+        """A link that never advances must fail, not retry forever."""
+        from pymol.predictors import weights
+        from pymol.predictors.errors import WeightDownloadFailed
+        data, digest = make_zip()
+        bundle = bundle_for(data, digest)
+        server = RangeServer(data, fail_after=[0] * 100)
+        with testing.mkdtemp() as root:
+            with no_backoff(), patch('pymol.predictors.weights._urlopen', server):
+                self.assertRaises(WeightDownloadFailed,
+                                  weights.WeightCache(root).ensure, bundle)
+        self.assertEqual(len(server.connections), weights.MAX_STALLED_ATTEMPTS)
+
+    def testBadUrlIsNotRetried(self):
+        """404 is the answer, not a hiccup: retrying only delays it."""
+        from pymol.predictors.weights import WeightCache
+        from pymol.predictors.errors import WeightDownloadFailed
+        from urllib.error import HTTPError
+        data, digest = make_zip()
+        bundle = bundle_for(data, digest)
+        opener = patch('pymol.predictors.weights._urlopen',
+                       side_effect=HTTPError(bundle.url, 404, 'Not Found',
+                                             {}, None))
+        with testing.mkdtemp() as root:
+            with no_backoff(), opener as mock:
+                self.assertRaises(WeightDownloadFailed,
+                                  WeightCache(root).ensure, bundle)
+            self.assertEqual(mock.call_count, 1)
+
+    def testCancelDuringBackoffIsPrompt(self):
+        """Cancelling while waiting to retry must not wait out the backoff."""
+        from pymol.predictors.weights import WeightCache
+        from pymol.predictors.errors import WeightDownloadCancelled
+        data, digest = make_zip()
+        bundle = bundle_for(data, digest)
+        server = RangeServer(data, fail_after=[0] * 100)
+        # Cancel only once a transfer has actually failed, so the wait is what gets
+        # interrupted rather than the download never starting.
+        state = {'failed': False}
+
+        def should_cancel():
+            state['failed'] = bool(server.connections)
+            return state['failed']
+
+        slept = []
+        with testing.mkdtemp() as root:
+            with patch('pymol.predictors.weights._sleep', slept.append), \
+                 patch('pymol.predictors.weights._urlopen', server):
+                self.assertRaises(WeightDownloadCancelled,
+                                  WeightCache(root).ensure, bundle,
+                                  should_cancel=should_cancel)
+        self.assertEqual(len(server.connections), 1)
+        self.assertEqual(slept, [])         # cancelled before the first slice
 
     def testProgressIsReportedForDownloadAndExtract(self):
         from pymol.predictors.weights import WeightCache


### PR DESCRIPTION
## The problem

`_download` fetched a weight bundle with one `_urlopen` call streaming to a `.part` file — no `Range` header, no resume, no retry. **Any** single socket read that stalled longer than `DEFAULT_TIMEOUT` (30 s) aborted the whole transfer, and the next attempt restarted at byte zero.

Observed 2026-08-14: the new 996 MB `boltz2-mlx-bf16` bundle from the GitHub release CDN at ~0.5–1 MB/s failed at ~84% with "The read operation timed out", discarding ~875 MB. The existing 529 MB int8 bundle has the same exposure; the larger pack just widens the window (~17 minutes at that rate) in which one stall is fatal.

## What changed

`_download` is now a bounded retry loop around a new `_stream_to_part`:

- **Resume** — each attempt sends `Range: bytes=<n>-` and appends; the `.part` and its byte count survive across attempts.
- **Hash resumption** — the offset *and* the running sha256 are re-derived from the file on disk after each failure rather than carried forward. The failed attempt's hasher absorbed bytes that may never have reached the disk, and a sha256 cannot be rolled back. Re-reading ~1 GiB costs well under a second against a re-fetch of tens of minutes.
- **Range-ignoring servers** — anything but a `206` resets the offset and hasher to zero and reopens `'wb'`, so a 200-with-full-body can never be spliced onto a prefix (which would surface only much later, as a checksum mismatch after another full download). On a real 206 it opens `'r+b'`, seeks to the hash's end and truncates, so nothing past the hashed prefix survives.
- **Two retry budgets** — `MAX_STALLED_ATTEMPTS = 4` consecutive no-progress attempts, `MAX_DOWNLOAD_ATTEMPTS = 20` total. A single budget would either kill a legitimately slow 1 GiB transfer that stalls six times while advancing, or spin forever on a dead link.
- **Error classification** — 4xx fails immediately (a retry ladder in front of a bad URL or withdrawn asset only delays the error the user needs); `408/429/5xx`, socket timeouts and connection resets retry; `416` discards an over-long `.part`; `ENOSPC`/`EACCES`/`EROFS`/`ENOTDIR` still raise `WeightCacheUnwritable`.
- **Cancellation** — `_backoff` waits in 50 ms slices, checking `_raise_if_cancelled` first, so a cancel during a 15 s backoff is still prompt.
- **Short bodies** — a stream that simply stops short of `bundle.size` now resumes instead of becoming a checksum mismatch after a full re-download.

The integrity contract is unchanged: sha256 verified before publish, atomic `os.replace`, sentinel (`.ok`) written last.

## The `.incoming/` leak

The leaking exit path is **not** an error branch — `ensure()`'s `finally` covers all of those. It is the **daemon thread** the fetch runs on (`predictors/fetching.py`): quitting the app mid-download tears the interpreter down without unwinding it, so nothing runs, and a `.part` plus its `.d` staging directory are stranded with nothing that would ever look at them again. One instance held 529 MB for weeks.

New `WeightCache.sweep_incoming()` runs before each download and reclaims `.part`/`.d` entries whose token pid is gone — reusing the same liveness test the stale-lock path already relies on, which is why the scratch token carries a pid in the first place. Entries that don't match that exact `<sha256>-<pid>` shape are left alone; `.incoming` is not this method's to empty. A recycled pid just means the debris waits for the next sweep.

## Reviewer notes

- **Resume is per-call by design.** `.part` is keyed on the pid, so an attempt only ever continues a prefix the same call wrote. Quitting the app still discards a partial download. Surviving an app restart would mean adopting bytes whose provenance nothing here can check, and it conflicts directly with the dead-pid sweep — it would need a different trust story (keying the `.part` on the digest alone and validating the prefix).
- `_sleep` joins `_urlopen` as a module-level patch point.

## Testing

`testing/tests/predict` — **147 tests, OK** (was 137):

```
PYMOL_DATA="$PWD/data" PYTHONPATH="$SHADOW" pymol -ckqy testing/testing.py --run testing/tests/predict
```

New coverage, all patching `weights._urlopen` with a `RangeServer` fake that honours (or pointedly ignores) `Range` and stalls mid-stream:

- `testResumeContinuesWhereTheStreamDied` — asserts the second connection carried `bytes=<n>-`, was answered 206, and that **total bytes served equals the payload** (i.e. it resumed rather than restarted)
- `testResumeSurvivesRepeatedStalls` — 6 stalls, more than `MAX_STALLED_ATTEMPTS`, each making progress → still succeeds
- `testRangeIgnoringServerStillEndsWithACorrectDigest` — a 200 answer to a Range request restarts cleanly and the digest is correct
- `testRetriesAreBounded`, `testBadUrlIsNotRetried`, `testCancelDuringBackoffIsPrompt`
- Four `TestIncomingSweep` cases: dead-owner scratch reclaimed, live-owner scratch untouched, unrecognized entries untouched, missing `.incoming` survivable

**Also verified against real HTTP**, not just the fake: a live `http.server` that honours Range and hangs up mid-body. The first connection died at byte 70071, the retry sent `Range: bytes=70071-`, got a 206, and the digest verified — confirming the 206/`.status` handling works against real `HTTPResponse` plumbing.

The stranded 529 MB `.part` + `.d` on the reporter's machine were reclaimed by running the new sweep; `.incoming/` is now empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)