### PR TITLE
feat(predict): fold an object or selection, not just a typed sequence

### DIFF
--- a/modules/pymol/predicting.py
+++ b/modules/pymol/predicting.py
@@ -403,6 +403,178 @@ def session_save(session, _self=cmd):
     return 1
 
 
+# -- Input resolution: a sequence, an object, or a selection -------------------
+#
+# `predict boltz2, MKTAY` and `predict boltz2, 1ubq` both have to work, and the two are
+# told apart by ASKING THE SESSION -- whatever selects atoms is a selection, anything
+# else that could be residues is a sequence. That order is the safe one: sniffing the
+# text first would fold `polymer` (seven perfectly good residue letters) as a peptide
+# while the structure the user meant sat loaded in the session.
+
+#: Alternative SPELLINGS of a canonical residue, missing from exporting._resn_to_aa:
+#: force-field names for a protonation or disulfide state (CHARMM HSD/HSE/HSP, AMBER
+#: HID/HIE/HIP/CYX/CYM/ASH/GLH/LYN). Same residue, different name, so these are
+#: substituted silently.
+_RESN_ALIASES = {
+    'HSD': 'H', 'HSE': 'H', 'HSP': 'H',
+    'HID': 'H', 'HIE': 'H', 'HIP': 'H',
+    'CYX': 'C', 'CYM': 'C',
+    'ASH': 'D', 'GLH': 'E', 'LYN': 'K',
+}
+
+#: Modified residues, mapped to the parent they are made from. Folding the parent is
+#: the only thing any predictor here can do -- none of them model the modification --
+#: and it is what every folding pipeline does with a PDB entry, so the alternative is
+#: not a better prediction but no prediction at all: MSE alone (selenomethionine, a
+#: phasing trick rather than biology) appears in a large share of crystal structures,
+#: and oxidised cysteines and phospho-residues are common enough that refusing them
+#: would make the object path fail on ordinary entries -- 1VJE, picked at random from
+#: an MSE search, carries two CSD.
+#:
+#: Unlike the aliases above this DOES drop chemistry -- a phosphate, an acetyl -- so
+#: every substitution is reported. Only unambiguous parents are listed: D-amino acids
+#: and selenocysteine are deliberately absent, because there the parent is a guess.
+_MODIFIED_TO_PARENT = {
+    'MSE': 'M', 'FME': 'M',                                       # methionine
+    'CSO': 'C', 'CSD': 'C', 'CSS': 'C', 'CSW': 'C', 'CSX': 'C',   # oxidised /
+    'CME': 'C', 'OCS': 'C', 'SMC': 'C', 'YCM': 'C',               # alkylated cys
+    'SEP': 'S', 'TPO': 'T', 'PTR': 'Y', 'TYS': 'Y',               # phospho / sulfo
+    'MLY': 'K', 'MLZ': 'K', 'M3L': 'K', 'ALY': 'K',               # modified lysine
+    'KCX': 'K', 'LLP': 'K',
+    'HYP': 'P', 'PCA': 'E', 'CGU': 'E',
+}
+
+
+def _is_sequence_shaped(text):
+    """True if `text` could be a bare one-letter sequence.
+
+    Residue letters, the '/' chain separator, and the line breaks of a pasted FASTA
+    block -- nothing else. A SPACE disqualifies it, deliberately: every multi-word
+    selection ('chain A', 'polymer and 1ubq') carries one, so a mistyped selection that
+    fails to resolve is reported as a bad selection instead of being quietly folded
+    letter by letter -- 'chian A' is not the pentapeptide CHIANA.
+    """
+    return bool(text) and all(ch.isalpha() or ch in '/\r\n' for ch in text)
+
+
+def sequence_from_selection(selection, _self=cmd):
+    """One-letter sequence of the protein chains in `selection`, '/'-joined.
+
+    One chain per (object, chain id) in the order PyMOL iterates them, so predicting
+    from a dimer folds A/B as a complex rather than as two independent monomers, and
+    predicting from `objA or objB` builds the complex of the two.
+
+    Only `polymer.protein` is read. Waters and ligands have no place in a protein-only
+    prediction, and nucleic acids are excluded for a sharper reason: A, G, C and T are
+    all valid residue letters, so a DNA chain would come back looking like a perfectly
+    good protein sequence and be folded as one.
+
+    Gaps are NOT filled: a chain with residues 1-10 and 21-30 yields the 20 OBSERVED
+    residues as one continuous run, because that is the sequence PyMOL actually has.
+    Pass the full sequence as a string to fold the missing loop.
+
+    Modified residues are folded as the residue they are made from (MSE as M, SEP as
+    S...) and reported; a residue with no unambiguous parent is refused.
+    """
+    import collections
+
+    from .exporting import _resn_to_aa
+    from .predictors.errors import PredictionInputError
+
+    chains = collections.OrderedDict()
+    # `guide & alt +A` is get_fastastr's reduction: one atom per residue (CA for
+    # protein), first altloc only, so a disordered side chain cannot duplicate a residue.
+    _self.iterate('(%s) & polymer.protein & guide & alt +A' % selection,
+                  'chains.setdefault((model, chain), []).append(resn)',
+                  space={'chains': chains})
+    if not chains:
+        raise PredictionInputError(
+            '"%s" contains no protein residues to fold' % selection)
+
+    sequences, unknown, substituted = [], [], {}
+    for resn_list in chains.values():
+        letters = []
+        for resn in resn_list:
+            aa = _resn_to_aa.get(resn) or _RESN_ALIASES.get(resn)
+            if aa is None:
+                aa = _MODIFIED_TO_PARENT.get(resn)
+                if aa is not None:
+                    substituted[resn] = substituted.get(resn, 0) + 1
+            if aa is None:
+                unknown.append(resn)
+            else:
+                letters.append(aa)
+        sequences.append(''.join(letters))
+    if unknown:
+        # Refused rather than skipped: dropping a residue would hand the predictor a
+        # sequence one residue shorter than the structure it came from, spliced across
+        # the hole, and nothing downstream could tell that had happened. For the same
+        # reason the advice is NOT "exclude it from the selection" -- that produces
+        # exactly the spliced sequence this is refusing to produce.
+        raise PredictionInputError(
+            '"%s" contains residues with no one-letter code: %s. Pass the sequence as'
+            ' a string, or rename them to the residue they are made from'
+            ' (alter <sel>, resn="CYS").'
+            % (selection, ', '.join(sorted(set(unknown)))))
+    if substituted:
+        # Warned regardless of `quiet`: the sequence being folded no longer matches the
+        # structure it came from, and a user comparing the two needs to know why.
+        colorprinting.warning(
+            ' predict: %s: %d modified residue(s) folded as the residue they are made'
+            ' from (%s); the modification itself is not modelled.'
+            % (selection, sum(substituted.values()),
+               ', '.join('%d %s->%s' % (count, resn, _MODIFIED_TO_PARENT[resn])
+                         for resn, count in sorted(substituted.items()))))
+    return '/'.join(sequences)
+
+
+def resolve_sequence(sequence, quiet=1, _self=cmd):
+    """Return the one-letter sequence to fold, given a sequence, object or selection.
+
+    Resolution order, and why:
+
+    1. Anything that selects atoms is read from the session. An object name wins over
+       a same-spelled sequence -- with an object called `AAA` loaded, `predict m, AAA`
+       folds the object. Rename it if you meant the tripeptide.
+    2. Otherwise, text that could be residues is taken literally, so a sequence still
+       works with an empty session or alongside unrelated objects.
+    3. Otherwise it was a selection that matched nothing, and that is an error -- NOT
+       a sequence. Silently folding the letters of a typo'd selection is the one
+       failure mode worth going out of the way to prevent.
+    """
+    from .predictors.errors import PredictionInputError
+
+    if not isinstance(sequence, str):
+        raise PredictionInputError('sequence must be a string')
+    text = sequence.strip()
+    if not text:
+        raise PredictionInputError('no sequence, object or selection given')
+
+    literal = _is_sequence_shaped(text)
+    try:
+        n_atoms = _self.count_atoms(text)
+    except Exception:
+        # Not parseable as a selection at all: a bare word that names no object comes
+        # back as 'Invalid selection name "MKTAY"', which is exactly what a sequence
+        # looks like to the selection parser. Fine if it could be residues; otherwise
+        # the caller wrote a broken selection and deserves to hear about it.
+        if literal:
+            return text
+        raise
+    if n_atoms > 0:
+        resolved = sequence_from_selection(text, _self=_self)
+        if not int(quiet):
+            parts = resolved.split('/')
+            colorprinting.parrot(
+                ' predict: %s -> %d residues in %d chain(s)'
+                % (text, sum(len(part) for part in parts), len(parts)))
+        return resolved
+    if literal:
+        return text
+    raise PredictionInputError(
+        '"%s" selects no atoms and is not a one-letter sequence' % text)
+
+
 def predict(predictor, sequence, name='', recycling_steps=3, diffusion_steps=200,
             seed=None, n_models=1, diffusion_samples=None, quiet=1, _self=cmd):
     """
@@ -421,9 +593,14 @@ ARGUMENTS
 
     predictor = str: id of a registered predictor, e.g. boltz2
 
-    sequence = str: one-letter sequence. Use "/" to separate chains of a
-    multimer -- NOT a comma, which the command parser treats as an argument
-    separator. Chains are assigned ids A, B, C...
+    sequence = str: one-letter sequence, or the name of a loaded object, or an
+    atom selection. Anything that selects atoms is read from the session -- one
+    chain per (object, chain id), in the order they appear -- and everything else
+    is taken as a literal sequence.
+
+    In a literal sequence, use "/" to separate chains of a multimer -- NOT a
+    comma, which the command parser treats as an argument separator. Chains are
+    assigned ids A, B, C...
 
     name = str: object name for the loaded result {default: <predictor>_pred}
 
@@ -451,10 +628,26 @@ EXAMPLES
     predict boltz2, MKTAY/GSHMA, name=dimer, diffusion_steps=300
     predict boltz2, MKTAYIAKQRQISFVKSHFSRQLEERLGLIEVQ, n_models=5
 
+    fetch 1ubq
+    predict boltz2, 1ubq                  # re-fold the whole object
+    predict boltz2, 1ubq and chain A      # one chain of it
+    predict boltz2, 1ubq and resi 1-40    # a fragment
+
 NOTES
 
     Defaults follow upstream Boltz. Options a predictor does not implement are
     rejected rather than ignored, so a typo cannot silently degrade a result.
+
+    Reading from the session takes only protein residues -- waters, ligands and
+    nucleic acids are skipped -- and does not fill gaps: unobserved residues are
+    absent from the object, so they are absent from the sequence too. Pass the
+    full sequence as a string to fold a missing loop.
+
+    A modified residue is folded as the residue it is made from (MSE as M, SEP as
+    S, ...), which is reported, because no predictor here models the modification.
+
+    An object name wins over a same-spelled sequence: with an object called AAA
+    loaded, "predict boltz2, AAA" folds the object, not the tripeptide.
 
     n_models COSTS N FULL RUNS. Each model repeats the whole prediction with a
     different seed, including the trunk; it is not several samples drawn from one
@@ -483,6 +676,11 @@ SEE ALSO
     predictor_obj = registry.get(predictor)
     predictor_obj.check_available()
 
+    # Resolved once, up front: everything downstream -- validation, the digest the
+    # object name is built from, the spec the predictor gets -- must see the same
+    # residues, and re-reading the session later could see a different one if the
+    # user deleted or edited the source object in between.
+    sequence = resolve_sequence(sequence, quiet=quiet, _self=_self)
     spec = predictor_obj.parse_spec(sequence, name=name or (predictor + '_pred'))
 
     # A fresh seed per run unless one is given, so repeat predictions of the same sequence

--- a/testing/tests/predict/predict_api.py
+++ b/testing/tests/predict/predict_api.py
@@ -209,6 +209,36 @@ class PredictAPITest(testing.PyMOLTestCase):
             settle()
         self.assertEqual(job.spec.chains, (('A', 'AA'), ('B', 'GG')))
 
+    def testObjectIsFoldedAsItsSequence(self):
+        """The whole point of the object path: no retyping the sequence."""
+        cmd.fab('ACDEFG', 'pep')
+        with patch('pymol.predictors.weights._urlopen',
+                   return_value=FakeResponse(self.data)):
+            job = cmd.predict('stub', 'pep')
+            settle()
+        self.assertEqual(job.spec.chains, (('A', 'ACDEFG'),))
+
+    def testSelectionIsFoldedAsItsSequence(self):
+        cmd.fab('ACDEFG', 'pep')
+        with patch('pymol.predictors.weights._urlopen',
+                   return_value=FakeResponse(self.data)):
+            job = cmd.predict('stub', 'pep and resi 1-3')
+            settle()
+        self.assertEqual(job.spec.chains, (('A', 'ACD'),))
+
+    def testObjectAndItsSequenceLandInTheSameObject(self):
+        """The auto-load name is a digest of the RESOLVED sequence, so folding an
+        object and typing out its sequence append models to one object rather than
+        littering the session with two."""
+        cmd.fab('ACDEFG', 'pep')
+        with patch('pymol.predictors.weights._urlopen',
+                   return_value=FakeResponse(self.data)):
+            from_object = cmd.predict('stub', 'pep')
+            settle()
+            from_string = cmd.predict('stub', 'ACDEFG')
+            settle()
+        self.assertEqual(from_object.spec.name, from_string.spec.name)
+
     def testPredictIsRegisteredAsACommandKeyword(self):
         self.assertIn('predict', cmd.keyword)
         self.assertIn('predict_status', cmd.keyword)

--- a/testing/tests/predict/predict_input.py
+++ b/testing/tests/predict/predict_input.py
@@ -1,0 +1,136 @@
+"""Resolving the `sequence` argument: a sequence string, an object, or a selection.
+
+No predictor, no weights, no network -- just the session read that turns whatever the
+user typed into the one-letter sequence a predictor is handed.
+
+    pymol -ckqy testing/testing.py --run testing/tests/predict/predict_input.py
+"""
+from pymol import cmd, predicting, testing
+from pymol.predictors.errors import PredictionInputError
+
+#: One residue per line, with a full backbone so PyMOL classifies it as protein even
+#: when the record is HETATM (Selector.cpp falls back to atom names + the C-N bond).
+#: Written out rather than built with fab because the point of the fixture is the
+#: NON-canonical residue in the middle, which fab cannot make.
+MSE_PDB = """\
+ATOM      1  N   ALA A   1       0.000   0.000   0.000  1.00  0.00           N
+ATOM      2  CA  ALA A   1       1.458   0.000   0.000  1.00  0.00           C
+ATOM      3  C   ALA A   1       2.009   1.420   0.000  1.00  0.00           C
+ATOM      4  O   ALA A   1       1.251   2.390   0.000  1.00  0.00           O
+HETATM    5  N   MSE A   2       3.332   1.540   0.000  1.00  0.00           N
+HETATM    6  CA  MSE A   2       3.970   2.850   0.000  1.00  0.00           C
+HETATM    7  C   MSE A   2       5.480   2.700   0.000  1.00  0.00           C
+HETATM    8  O   MSE A   2       6.000   1.590   0.000  1.00  0.00           O
+ATOM      9  N   GLY A   3       6.150   3.840   0.000  1.00  0.00           N
+ATOM     10  CA  GLY A   3       7.600   3.900   0.000  1.00  0.00           C
+ATOM     11  C   GLY A   3       8.200   5.290   0.000  1.00  0.00           C
+ATOM     12  O   GLY A   3       7.500   6.300   0.000  1.00  0.00           O
+END
+"""
+
+
+class PredictInputTest(testing.PyMOLTestCase):
+
+    # -- literal sequences ------------------------------------------------------
+
+    def testPlainSequencePassesThrough(self):
+        self.assertEqual(predicting.resolve_sequence('MKTAY'), 'MKTAY')
+
+    def testMultimerSequencePassesThrough(self):
+        """'/' reads as a selection macro, so this must survive the selection probe."""
+        self.assertEqual(predicting.resolve_sequence('MKTAY/GSHMA'), 'MKTAY/GSHMA')
+
+    def testSequenceIsStrippedButNotOtherwiseTouched(self):
+        self.assertEqual(predicting.resolve_sequence('  MKTAY\n'), 'MKTAY')
+
+    def testEmptyInputRejected(self):
+        self.assertRaises(PredictionInputError, predicting.resolve_sequence, '   ')
+
+    def testNonStringRejected(self):
+        self.assertRaises(PredictionInputError, predicting.resolve_sequence, 42)
+
+    # -- objects and selections -------------------------------------------------
+
+    def testObjectNameBecomesItsSequence(self):
+        cmd.fab('ACDEFG', 'pep')
+        self.assertEqual(predicting.resolve_sequence('pep'), 'ACDEFG')
+
+    def testSelectionExpressionBecomesItsSequence(self):
+        cmd.fab('ACDEFG', 'pep')
+        self.assertEqual(predicting.resolve_sequence('pep and resi 1-3'), 'ACD')
+
+    def testTwoObjectsFoldAsAComplex(self):
+        """One chain per (object, chain id) -- a complex, not two monomers."""
+        cmd.fab('ACDEFG', 'one')
+        cmd.fab('GHIKL', 'two')
+        self.assertEqual(predicting.resolve_sequence('one or two'), 'ACDEFG/GHIKL')
+
+    def testAnObjectWinsOverASameSpelledSequence(self):
+        """Documented precedence: the session is asked first."""
+        cmd.fab('ACDEFG', 'AAA')
+        self.assertEqual(predicting.resolve_sequence('AAA'), 'ACDEFG')
+
+    def testNonProteinIsIgnored(self):
+        cmd.fab('ACDEFG', 'pep')
+        cmd.pseudoatom('pep', pos=[20., 20., 20.], resn='LIG', name='C1', elem='C')
+        cmd.pseudoatom('pep', pos=[25., 25., 25.], resn='HOH', name='O', elem='O')
+        self.assertEqual(predicting.resolve_sequence('pep'), 'ACDEFG')
+
+    def testSelectionWithNoProteinRejected(self):
+        cmd.pseudoatom('lig', pos=[0., 0., 0.], resn='LIG', name='C1', elem='C')
+        self.assertRaises(PredictionInputError, predicting.resolve_sequence, 'lig')
+
+    def testModifiedResidueReadsAsItsParent(self):
+        """MSE -> M. Selenomethionine is in a large share of crystal structures, and
+        get_fastastr's '?' would make every one of them unfoldable. Verified against
+        real entries too: 1A8O is 4x MSE and comes back as the HIV-1 capsid sequence."""
+        cmd.read_pdbstr(MSE_PDB, 'mse')
+        self.assertEqual(predicting.resolve_sequence('mse'), 'AMG')
+
+    def testPhosphoResidueReadsAsItsParent(self):
+        """The modification is not modelled by any predictor here, so the choice is
+        the parent residue or no prediction at all."""
+        cmd.read_pdbstr(MSE_PDB, 'mse')
+        cmd.alter('mse and resi 2', 'resn="PTR"')
+        cmd.sort('mse')
+        self.assertEqual(predicting.resolve_sequence('mse'), 'AYG')
+
+    def testResidueWithNoUnambiguousParentRejected(self):
+        """Refused, not silently dropped: a sequence shorter than the structure it
+        came from, spliced across the hole, is a wrong answer nothing downstream
+        could detect. DAL is a D-amino acid -- listing a parent would be a guess."""
+        cmd.read_pdbstr(MSE_PDB, 'mse')
+        cmd.alter('mse and resi 2', 'resn="DAL"')
+        cmd.sort('mse')
+        with self.assertRaises(PredictionInputError) as caught:
+            predicting.resolve_sequence('mse')
+        self.assertIn('DAL', str(caught.exception))
+
+    # -- the failure that motivates the resolution ORDER ------------------------
+
+    def testSelectionKeywordIsNotFoldedAsAPeptide(self):
+        """'polymer' is seven valid residue letters. Sniffing the text instead of
+        asking the session would fold it while the real structure sat loaded."""
+        cmd.fab('ACDEFG', 'pep')
+        self.assertEqual(predicting.resolve_sequence('polymer'), 'ACDEFG')
+
+    def testMistypedSelectionRaisesInsteadOfFolding(self):
+        """'chian A' must not become the pentapeptide CHIANA."""
+        cmd.fab('ACDEFG', 'pep')
+        self.assertRaises(Exception, predicting.resolve_sequence, 'chian A')
+
+    def testSelectionMatchingNothingRaises(self):
+        cmd.fab('ACDEFG', 'pep')
+        self.assertRaises(PredictionInputError,
+                          predicting.resolve_sequence, 'pep and resi 999')
+
+    def testUnknownObjectNameRaises(self):
+        """Not sequence-shaped (digits), so it is a selection -- and a broken one."""
+        self.assertRaises(Exception, predicting.resolve_sequence, '1ubq')
+
+    # -- verbose path -----------------------------------------------------------
+
+    def testVerboseResolutionDoesNotRaise(self):
+        """quiet=0 is what the command line uses (parsing.py:417)."""
+        cmd.fab('ACDEFG', 'pep')
+        self.assertEqual(predicting.resolve_sequence('pep', quiet=0), 'ACDEFG')


### PR DESCRIPTION
## The problem

`predict` took a one-letter sequence string and nothing else. Folding something already loaded meant copying its sequence out by hand — and `get_fastastr` renders MSE and every other modified residue as `?`, so for many fetched entries the copy-paste is not even a foldable sequence. `predict boltz2, 1ubq` was the obvious thing to type and it did not work.

## What changed

**`resolve_sequence()`** decides what the argument is by *asking the session*: anything that selects atoms is read from it, anything else that could be residues is taken literally, and a selection matching nothing is an error rather than a sequence.

That order is the load-bearing part. Sniffing the text first would fold `polymer` — seven perfectly good residue letters — as a peptide while the structure the user meant sat loaded. And a space in the input marks it as a selection expression, so `chian A` raises `Invalid selection name` instead of quietly becoming the pentapeptide CHIANA. An object name wins over a same-spelled sequence, which is documented in the docstring.

**`sequence_from_selection()`** reads `polymer.protein & guide & alt +A` — `get_fastastr`'s own reduction — one chain per (object, chain id), joined with `/`, so a dimer folds as a complex and `objA or objB` builds the complex of the two. Nucleic acids are excluded deliberately: A, G, C and T are all valid residue letters, so a DNA chain would come back looking like a perfectly good protein sequence and be folded as one. Gaps are not filled — unobserved residues are absent from the object, so they are absent from the sequence.

**Modified residues** fold as the residue they are made from (`MSE`→M, `CSD`/`CSO`/`CME`→C, `SEP`→S, `PTR`→Y, `MLY`→K…), with every substitution reported, because no predictor here models the modification — the alternative is not a better prediction but no prediction at all. Force-field spellings of a protonation state (`HSD`, `HID`, `CYX`…) are substituted silently since they name the same residue. A residue with no unambiguous parent — D-amino acids, selenocysteine — is refused, and the advice is to pass a sequence or rename the residue, *not* to exclude it from the selection, which would splice the chain and produce exactly the silently-wrong sequence being refused.

`predict()` resolves once, up front, so validation, the name digest, and the predictor's spec all see the same residues. That also means folding an object and typing out its sequence append models to the same object instead of littering the session.

## Verification

**Tests** — 19 new in `testing/tests/predict/predict_input.py`, 3 added to `predict_api.py`. Whole predict suite on this branch: 169 tests, all passing.

**Real structures**, driven through a live RayMol session:

| input | result |
|---|---|
| `1ubq` | 76 aa, exactly the canonical ubiquitin sequence |
| `4hhb` | 4 chains 141/146/141/146 — HEM and waters excluded |
| `1lmb` (protein+DNA) | 2 × 92 aa; the 814 nucleic atoms excluded |
| `1bna` (pure DNA) | `contains no protein residues to fold` |
| `1a8o` (4× SeMet) | full 70 aa where `get_fastastr` gives `?DIRQ…W?TETL…` |
| `1vje` | 2× `CSD` folded as C and reported; the 2 *free* SeMet ligands correctly dropped |
| `polymer` | read as a selection, not folded as a peptide |

**End to end on-device**, branch build with the real MLX host:

- `predict boltz2, 1ubq` → 76 aa read off the object → 28.3 s → 601 atoms, ss assigned, **1.85 Å CA-RMSD vs the crystal structure**
- `predict boltz2, 1ubq and resi 1-40` → 40 aa → 22.7 s → its own object, sequence identical to the selection

## Not in this PR

While testing I hit a separate bug: `host.submit()` announces a job with `print('PREDICT:submit:<id>')`, which the app reads from PyMOL's feedback buffer, but the MCP `run_python` tool redirects `sys.stdout` for the duration of a call — so a prediction submitted through the MCP writes its request file, prints the marker into the capture, and **never starts**, with the placeholder pending forever and no error. `PREDICT:cancel` has the same hole. Happy to fix separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)