### PR TITLE
feat(msa): show a search in flight, where its alignment will appear

### DIFF
--- a/modules/pymol/appkit_inspector.py
+++ b/modules/pymol/appkit_inspector.py
@@ -476,6 +476,51 @@ def _alignment_map():
         return {}
 
 
+#: Seconds of granularity for a search row's age. The panel repaints when this payload
+#: changes, so sending the raw float would repaint it on every 500 ms tick for the
+#: several MINUTES a search runs. A bucket makes the row change 12 times a minute
+#: instead of 120, and it costs nothing that is visible: the row shows a coarse age
+#: because the server reports no progress fraction, and inventing one would be a
+#: plausible-looking lie (see Search.snapshot).
+SEARCH_ELAPSED_BUCKET = 5
+
+
+def _search_map():
+    """In-flight MSA searches (#298), oldest first, for the panel's progress rows.
+
+    An alignment takes MINUTES to build and does not exist until it lands, so without
+    this the object panel shows nothing at all while one is being searched for -- and
+    the ALIGNMENTS section hides itself when empty, so a user's first search gives no
+    sign anything is happening. `searching.active()` was written for this ("Drives the
+    app's progress row") and had no consumer until now.
+
+    Never raises, for the same reason _pending_map() and _alignment_map() do not: the
+    caller's single `except` writes no file at all, so a throw here freezes the panel
+    on a stale list.
+
+    Cheap by construction, and O(searches) rather than O(objects): `active()` is
+    normally EMPTY, and a snapshot is a handful of scalars copied under a short lock.
+    Nothing here reads the network or touches an a3m.
+    """
+    try:
+        from pymol.msas import searching
+        rows = []
+        for search in searching.active():
+            snapshot = search.snapshot()
+            elapsed = snapshot.get('elapsed') or 0
+            rows.append({
+                'id': snapshot['id'],
+                'name': snapshot['name'],
+                'phase': snapshot['phase'],
+                'server': snapshot['server'],
+                'elapsed': int(elapsed // SEARCH_ELAPSED_BUCKET
+                               * SEARCH_ELAPSED_BUCKET),
+            })
+        return rows
+    except Exception:
+        return []
+
+
 def poll_panel():
     """Write the object-list JSON to a temp file and print a short marker.
 
@@ -543,6 +588,11 @@ def poll_panel():
             # the Executive knows about them -- so the panel draws them as their own
             # section rather than as rows in the object list.
             'alignments': _alignment_map(),
+            # Searches still running (#298). Gathered AFTER the pump above, so a search
+            # that just finished has already become an alignment and is counted once,
+            # in the section below it -- never as both a progress row and a result on
+            # the same tick.
+            'msa_searches': _search_map(),
         }
         # Multiple RayMol windows may run as separate processes. A process-local
         # filename prevents an empty instance from replacing another instance's

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -426,6 +426,49 @@ struct AlignmentEntry: Identifiable, Equatable {
     }
 }
 
+/// One MSA search still running (#298).
+///
+/// A search takes MINUTES and produces nothing until it lands, so without a row for it
+/// the panel is silent for the whole time — and because the ALIGNMENTS section hides
+/// itself when empty, a user's first search shows no sign of anything happening at all.
+///
+/// Carries no progress fraction because the ColabFold server reports none. The phase
+/// and the age are what is actually known, and showing a bar derived from neither would
+/// be a plausible-looking lie.
+struct MSASearchEntry: Identifiable, Equatable {
+    let id: String
+    /// The name the alignment will land under, so the row and its result read the same.
+    let name: String
+    /// submit | queued | search | download | read | cached
+    let phase: String
+    let server: String
+    /// Seconds since the search began, quantised by the Python side — see
+    /// `appkit_inspector.SEARCH_ELAPSED_BUCKET` for why it is not the raw value.
+    let elapsed: Int
+
+    /// "searching" — what the phase means to someone who did not write it.
+    var phaseText: String {
+        switch phase {
+        case "submit": return "submitting"
+        case "queued": return "queued"
+        case "search": return "searching"
+        case "download": return "downloading"
+        case "read": return "reading"
+        case "cached": return "cached"
+        default: return phase
+        }
+    }
+
+    /// "searching · 2m 15s". Coarse on purpose; see the type comment.
+    var detail: String {
+        guard elapsed > 0 else { return phaseText }
+        let minutes = elapsed / 60, seconds = elapsed % 60
+        let age = minutes > 0 ? "\(minutes)m \(String(format: "%02d", seconds))s"
+                              : "\(seconds)s"
+        return "\(phaseText) · \(age)"
+    }
+}
+
 // MARK: - Group tree (#255)
 
 /// One drawn row of the flattened object tree.
@@ -1129,13 +1172,28 @@ struct ObjectPanel: View {
                     // Unlike OBJECTS and SELECTIONS, which are always meaningful, a
                     // permanently empty third section would be pure chrome for the
                     // many sessions that never load an alignment.
-                    if !engine.alignments.isEmpty {
-                        sectionHeader("ALIGNMENTS", id: "alignments",
-                                      tag: "\(engine.alignments.count)") { EmptyView() }
+                    //
+                    // A running search counts too (#298), or the section stays hidden
+                    // for the several minutes before the first alignment lands — which
+                    // is precisely when a user most needs to see that something is
+                    // happening.
+                    if !engine.alignments.isEmpty || !engine.msaSearches.isEmpty {
+                        sectionHeader(
+                            "ALIGNMENTS", id: "alignments",
+                            tag: "\(engine.alignments.count + engine.msaSearches.count)"
+                        ) { EmptyView() }
                         if openSections.contains("alignments") {
+                            // Searches first: they are what is changing, and each one
+                            // is replaced in place by its own result when it lands.
+                            ForEach(Array(engine.msaSearches.enumerated()),
+                                    id: \.element.id) { index, search in
+                                MSASearchRowView(entry: search, isAlt: index % 2 == 1)
+                            }
                             ForEach(Array(engine.alignments.enumerated()),
                                     id: \.element.id) { index, aln in
-                                AlignmentRowView(entry: aln, isAlt: index % 2 == 1)
+                                AlignmentRowView(
+                                    entry: aln,
+                                    isAlt: (index + engine.msaSearches.count) % 2 == 1)
                             }
                         }
                     }
@@ -1437,6 +1495,68 @@ private struct AlignmentRowView: View {
                                  : ", for \(attachment), which is not in this session"
         }
         return text
+    }
+}
+
+// MARK: - MSA search row (#298)
+
+/// One search in flight, in the place its result will appear.
+///
+/// Deliberately in the ALIGNMENTS section rather than a banner or a sheet: a search is
+/// a BACKGROUND operation — `msa_search` returns immediately and the user is expected to
+/// keep working — so a modal would be wrong, and the row turning into the alignment it
+/// produces is the clearest statement of what is going on.
+///
+/// An indeterminate spinner, not a bar. The ColabFold server reports queue position and
+/// nothing else; a percentage here would have to be invented.
+private struct MSASearchRowView: View {
+    let entry: MSASearchEntry
+    let isAlt: Bool
+    @EnvironmentObject var engine: PyMOLEngine
+
+    var body: some View {
+        HStack(spacing: 6) {
+            // Line up with the object rows' chevron + checkbox gutter, as the
+            // alignment rows do.
+            Spacer().frame(width: 13 + kGutterW)
+
+            ProgressView()
+                .progressViewStyle(.circular)
+                .controlSize(.mini)
+                .frame(width: 10, height: 10)
+
+            Text(entry.name)
+                .font(.system(size: 11))
+                .foregroundColor(PanelTheme.disabledColor)
+                .lineLimit(1)
+                .truncationMode(.tail)
+
+            Spacer(minLength: 4)
+
+            Text(entry.detail)
+                .font(.system(size: 9).monospacedDigit())
+                .foregroundColor(PanelTheme.disabledColor)
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 4)
+        .padding(.vertical, 2)
+        .frame(height: kRowH)
+        .background(isAlt ? PanelTheme.rowAltBackground : PanelTheme.rowBackground)
+        .contentShape(Rectangle())
+        .help(tooltip)
+        .contextMenu {
+            // The one action there is. Cancelling by SEARCH ID rather than by name:
+            // the name is not unique until the alignment lands, and two searches for
+            // the same object would otherwise cancel whichever msa_cancel found first.
+            Button("Cancel search", role: .destructive) {
+                engine.runCommand("msa_cancel \(entry.id)")
+            }
+        }
+    }
+
+    private var tooltip: String {
+        "Building \(entry.name) on \(entry.server) — \(entry.detail)."
+            + " It runs in the background; the alignment appears here when it lands."
     }
 }
 
@@ -3860,6 +3980,15 @@ extension PyMOLEngine {
             // Alignments (#296), same reasoning again. Values are scalars only — no a3m
             // bytes travel through this payload.
             let alignments: [String: AlignmentSummary]?
+            // Searches still running (#298), oldest first. A LIST, unlike `alignments`:
+            // the order is the order they were started, and a JSON object would lose it
+            // the way the alignments decode has to sort to get it back.
+            //
+            // Optional for the same reason as every field above, and it matters more
+            // here than anywhere: this decode is a single `guard let`, so one missing
+            // key does not cost the ALIGNMENTS section, it freezes the ENTIRE object
+            // panel on its last list.
+            let msa_searches: [MSASearchSummary]?
 
             struct AlignmentSummary: Decodable {
                 let depth: Int
@@ -3867,6 +3996,14 @@ extension PyMOLEngine {
                 let residues: Int
                 let target: String
                 let chain: String
+            }
+
+            struct MSASearchSummary: Decodable {
+                let id: String
+                let name: String
+                let phase: String
+                let server: String
+                let elapsed: Int
             }
         }
 
@@ -3914,12 +4051,21 @@ extension PyMOLEngine {
                            target: $0.value.target, chain: $0.value.chain)
         }
 
+        // Already oldest-first, so no sort: see the payload comment.
+        let searches = (payload.msa_searches ?? []).map {
+            MSASearchEntry(id: $0.id, name: $0.name, phase: $0.phase,
+                           server: $0.server, elapsed: $0.elapsed)
+        }
+
         DispatchQueue.main.async {
             // Guard: the ~500ms poll usually returns the same object list;
             // re-assigning an equal array still fires @Published and re-renders
             // the panel (resetting open menus). Only assign on real changes.
             if self.objects != entries { self.objects = entries }
             if self.alignments != alignments { self.alignments = alignments }
+            // Same guard, and it carries the weight here: with no search running this
+            // is empty every tick and must not repaint the panel twice a second.
+            if self.msaSearches != searches { self.msaSearches = searches }
         }
     }
 }

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -3085,6 +3085,18 @@ final class PyMOLEngine: ObservableObject {
                     // sheet is platform-neutral, so gating it here would leave iOS
                     // silently frozen the day a downloadable bundle ships there.
                     parseWeightsFeedback(line)
+                } else if line.hasPrefix("MSA:") {
+                    // Swallowed, now that the object panel's ALIGNMENTS section shows a
+                    // search while it runs (#298). Until it did, this marker had no
+                    // branch at all and fell through to the console below, where each
+                    // search printed several lines of raw JSON — the only indication a
+                    // search was happening, and not a deliberate one.
+                    //
+                    // Nothing is parsed here on purpose: the marker fires exactly twice
+                    // (worker start, worker settle), so it cannot drive a row that shows
+                    // the phase advancing. The panel's 500 ms poll reads the live state
+                    // instead. The human-readable account of what landed or failed is
+                    // printed separately, by msa.pump(), and is not this.
                 } else if line.hasPrefix("PREDICT:") {
                     // Structure prediction (#224). cmd.predict writes a request JSON to
                     // the temp dir and prints this marker; there is no Python->Swift call

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -105,6 +105,10 @@ final class PyMOLEngine: ObservableObject {
     // and the Executive knows nothing about them, so they ride the same OBJPANEL:
     // payload but live in their own list and their own panel section.
     @Published var alignments: [AlignmentEntry] = []
+    // MSA searches still running (#298). Separate from `alignments` because a search is
+    // not an alignment yet — it has no depth, no columns and nothing to attach — and it
+    // stops existing the moment it becomes one.
+    @Published var msaSearches: [MSASearchEntry] = []
     @Published var sequences: [SequenceObject] = []
     @Published var selectedResidueKeys: Set<String> = []
     // Set when an iOS long-press identifies an atom/residue (or empty space);

--- a/testing/tests/msa/msa_e2e.py
+++ b/testing/tests/msa/msa_e2e.py
@@ -17,6 +17,7 @@ import io
 import json
 import os
 import tarfile
+import threading
 
 from contextlib import redirect_stdout
 from unittest.mock import patch
@@ -349,8 +350,6 @@ class SearchToFoldTest(MSAEndToEndTestCase):
         land into a session that was not open when it started. It must not bind to an
         object that merely inherited the name: the check is re-run at landing, and a
         mismatch stores the alignment unattached rather than silently folding with it."""
-        import threading
-
         stub_predictor('e2e')
         server = FakeServer()
         release = threading.Event()
@@ -645,6 +644,37 @@ class PanelPollTest(MSAEndToEndTestCase):
         MSAEndToEndTestCase.setUp(self)
         install_appkit_stubs()
 
+    def poll_payload(self):
+        """Run one panel tick and return the JSON the Swift panel reads."""
+        import tempfile
+        from pymol import appkit_inspector
+
+        with redirect_stdout(io.StringIO()):
+            appkit_inspector.poll_panel()
+        path = os.path.join(tempfile.gettempdir(),
+                            'pymol_objpanel_%d.json' % os.getpid())
+        with open(path) as handle:
+            return json.load(handle)
+
+    def swift_search_fields(self):
+        """Field names of ObjectPanel.swift's `MSASearchSummary`.
+
+        Its fields are plain `let`s rather than CodingKeys, so the JSON names ARE the
+        property names -- which is exactly why a rename on either side is silent.
+        """
+        import re
+
+        root = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, os.pardir)
+        path = os.path.normpath(os.path.join(
+            root, 'swiftui', 'PyMOLViewer', 'Panels', 'ObjectPanel.swift'))
+        if not os.path.isfile(path):
+            self.skipTest('ObjectPanel.swift not present; not a repo checkout')
+        with open(path) as handle:
+            source = handle.read()
+        block = source[source.index('struct MSASearchSummary'):]
+        block = block[:block.index('}')]
+        return set(re.findall(r'let\s+(\w+)\s*:', block))
+
     def testThePollLandsAFinishedSearchAndShowsItInTheSameTick(self):
         """poll_panel pumps before it gathers, so a search that finished between ticks
         appears on this tick rather than the next."""
@@ -688,6 +718,92 @@ class PanelPollTest(MSAEndToEndTestCase):
             self.assertIsInstance(summary[field], kind, field)
         self.assertEqual(summary['depth'], MERGED_DEPTH)
         self.assertEqual(summary['target'], 'prot')
+
+    def testASearchInFlightGetsAProgressRowBeforeItHasAnAlignment(self):
+        """The gap this closes: a search takes minutes and produces nothing until it
+        lands, so with only the ALIGNMENTS list -- which is landed alignments only --
+        the panel is silent for the whole time, and hides the section while it is."""
+        from pymol import appkit_inspector
+
+        server = FakeServer()
+        release = threading.Event()
+        polling = threading.Event()
+
+        def hold(request, timeout=None):
+            url = request.full_url
+            if '/ticket/' in url and not url.endswith('/ticket/msa'):
+                polling.set()
+                if not release.is_set():
+                    return FakeServer._json({'id': 'ticket-1', 'status': 'RUNNING'})
+            return server(request, timeout)
+
+        with patch('pymol.msas.colabfold._urlopen', hold):
+            search_id = cmd.msa_search(QUERY, name='aln')
+            self.assertTrue(polling.wait(10))
+
+            payload = self.poll_payload()
+            self.assertEqual(payload['alignments'], {}, 'landed before it finished')
+            rows = payload['msa_searches']
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]['id'], search_id)
+            self.assertEqual(rows[0]['name'], 'aln')
+            self.assertEqual(rows[0]['server'], PRIVATE)
+            self.assertIn(rows[0]['phase'],
+                          ('submit', 'queued', 'search', 'download', 'read'))
+
+            release.set()
+            searching.join(search_id, timeout=10)
+            after = self.poll_payload()
+
+        # The row is replaced by its result in ONE tick, never shown as both: the poll
+        # pumps before it gathers.
+        self.assertEqual(after['msa_searches'], [])
+        self.assertEqual(list(after['alignments']), ['aln'])
+
+    def testTheProgressRowCarriesEverySwiftFieldItRequires(self):
+        """MSASearchSummary's five fields are non-optional, and the payload decode is
+        one `guard let` -- so a missing field here freezes the whole object panel."""
+        server = FakeServer()
+        polling = threading.Event()
+
+        def hold(request, timeout=None):
+            url = request.full_url
+            if '/ticket/' in url and not url.endswith('/ticket/msa'):
+                polling.set()
+                return FakeServer._json({'id': 'ticket-1', 'status': 'RUNNING'})
+            return server(request, timeout)
+
+        with patch('pymol.msas.colabfold._urlopen', hold):
+            search_id = cmd.msa_search(QUERY, name='aln')
+            self.assertTrue(polling.wait(10))
+            row = self.poll_payload()['msa_searches'][0]
+            cmd.msa_cancel(search_id)
+            searching.join(search_id, timeout=10)
+
+        swift = self.swift_search_fields()
+        self.assertEqual(set(row), swift)
+        for field, kind in (('id', str), ('name', str), ('phase', str),
+                            ('server', str), ('elapsed', int)):
+            self.assertIsInstance(row[field], kind, field)
+
+    def testTheAgeIsQuantisedSoTheSectionDoesNotRepaintEveryTick(self):
+        """The panel repaints when this payload changes and the poll runs at 2 Hz for
+        the several minutes a search lasts, so the raw float would repaint it 120 times
+        a minute for a row whose text is coarse anyway."""
+        from pymol import appkit_inspector
+
+        self.assertEqual(appkit_inspector.SEARCH_ELAPSED_BUCKET, 5)
+        for raw, expected in ((0.0, 0), (4.9, 0), (5.1, 5), (12.4, 10), (61.0, 60)):
+            self.assertEqual(
+                int(raw // appkit_inspector.SEARCH_ELAPSED_BUCKET
+                    * appkit_inspector.SEARCH_ELAPSED_BUCKET),
+                expected)
+
+    def testNoSearchMeansAnEmptyListRatherThanAMissingKey(self):
+        """Present and empty, so Swift's decode has one shape to handle -- and so the
+        common case (no search ever) cannot be confused with an older Python."""
+        payload = self.poll_payload()
+        self.assertEqual(payload['msa_searches'], [])
 
     def testAFoldableAlignmentShowsTheChainItIsAttachedTo(self):
         """The panel row is how a user checks, before spending minutes folding, that


### PR DESCRIPTION
Answers "when the MSA is computing, is there any UI component indicating this?"
— there wasn't one. Stacked on #302, which the four new tests live in.

## The gap

An MSA search takes **minutes** and produces nothing until it lands. The
ALIGNMENTS section is fed by the alignment *store*, which a search does not
enter until it finishes — and the section hides itself when empty. So a user's
first `msa_search` showed **no sign anything was happening at all**.

The only thing reaching the app was the `MSA:` marker, and nothing consumes it:
`pollFeedback` has branches for `WEIGHTS:`, `PREDICT:`, `OBJPANEL:` and `MCP:`,
but not this one — so both lines a search emits fell through to the terminal
`else` and were appended to the console verbatim as raw JSON:

```
MSA:{"id":"msa-1351...","name":"prot_msa","state":"running","phase":"submit",...}
```

Its two siblings are properly surfaced; this was the odd one out:

| Operation | Marker | Handler | UI |
|---|---|---|---|
| Weight download (#286) | `WEIGHTS:` | `parseWeightsFeedback` | progress sheet |
| Prediction (#224) | `PREDICT:` | `BoltzJobManager` | placeholder + tooltip |
| MSA search (#298) — **before** | `MSA:` | none | none |
| MSA search — **after** | — | panel poll | row in ALIGNMENTS |

## Approach

Carried on the object panel's **existing 500 ms poll**, not by teaching Swift
the marker. The marker fires exactly twice — worker start and worker settle,
never in between — so a row driven by it could show neither the phase changing
nor the time passing. The poll already calls `msa.pump()`, so the tick that
lands an alignment also stops reporting the search: a row is never shown as
both a search and a result.

`searching.active()` already existed, documented as *"Drives the app's progress
row"*, with **zero callers**. This is its consumer.

## Design notes

- **No percentage.** The ColabFold server reports queue position and nothing else, so a bar would have to be invented — the same reasoning `Search.snapshot` already gives for reporting elapsed time instead.
- **In the ALIGNMENTS section, not a banner or sheet.** `msa_search` returns immediately and the user is expected to keep working, so a modal would be wrong; the row turning into the alignment it produces is the clearest statement of what happened.
- **Cancel by search ID, not name** — the name is not unique until the alignment lands.
- **The age is quantised to 5 s** (`SEARCH_ELAPSED_BUCKET`). The panel repaints when this payload changes and the poll runs at 2 Hz for minutes, so the raw float would repaint the section 120×/min to move a digit the row does not show.
- **`msa_searches` is optional Swift-side**, like every other field there: that decode is a single `guard let`, so one unknown key would not cost the alignments section — it would freeze the whole object panel on its last list.

## Tests

Four added to `msa_e2e.py` (from #302):

- a search in flight gets a row while `alignments` is still empty, and is replaced by its result in **one** tick;
- the row carries every field `MSASearchSummary` requires, read out of the Swift source — the same contract check #302 introduced, and it matters more here because those fields have no `CodingKeys`, so the JSON names *are* the property names;
- the age is quantised;
- no search means an empty list, not a missing key.

## Verification

- Python: **378 tests OK** — `msa` + `predict` + `raymol` + the two existing appkit object-panel suites, which validate the payload shape and are unaffected.
- Swift `UnitTests_macOS`: **256 tests, 0 failures** (4 env-gated skips), compiles clean.

Not verified in a running app: the installed RayMol.app predates the MSA PRs, so I could not drive the panel live. The row's *rendering* is unexercised by tests — the payload, the contract and the lifecycle are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
