### PR TITLE
feat(predict): the runtime seam a second predictor needs, and the knob bug that blocked one

### DIFF
--- a/docs/predictors.md
+++ b/docs/predictors.md
@@ -10,7 +10,7 @@ it is shaped this way.
 
 | File | Responsibility |
 |---|---|
-| `modules/pymol/predicting.py` | the `cmd.*` surface; you should not need to touch it |
+| `modules/pymol/predicting.py` | the `cmd.*` surface; touch it only to NAME a new knob (see step 6) |
 | `modules/pymol/predictors/base.py` | `Predictor` contract, `PredictionSpec`, `PredictionOptions` |
 | `modules/pymol/predictors/weights.py` | `WeightBundle`, `BundledSource`, `WeightCache` |
 | `modules/pymol/predictors/registry.py` | `register` / `get` / `available` / `unregister` |
@@ -19,10 +19,18 @@ it is shaped this way.
 
 ## Shipped predictors
 
-| id | weights | notes |
-|---|---|---|
-| `boltz2` | affine-int8, 507 MB | the default |
-| `boltz2-bf16` | dense bfloat16, 996 MB | same model, same runtime, unquantized |
+| id | runtime | weights | notes |
+|---|---|---|---|
+| `boltz2` | `boltz` | affine-int8, 507 MB | the default |
+| `boltz2-bf16` | `boltz` | dense bfloat16, 996 MB | same model, same runtime, unquantized |
+| `simplefold` | `simplefold` | int4, ~1.6 GB | single chain, single sequence. **Not runnable yet** — see #306 |
+
+A predictor's **runtime** is the Swift backend that runs it, named on the wire by
+`host.submit(..., runtime=)`. `BoltzJobManager` implements `boltz` and refuses any other in
+`preflight`, because weights and featurizer are method-specific — running one method's request
+on another's backend returns a confident wrong structure rather than failing. `PyMOLBridge`
+advertises what is linked in `RAYMOL_PREDICT_RUNTIMES`, which is what lets `check_available`
+refuse before a weight download rather than after.
 
 `boltz2-bf16` subclasses `Boltz2Predictor` and overrides nothing but `weight_bundle`.
 That works because `host.submit` sends `weights_dir` per job and the Swift runtime
@@ -81,6 +89,11 @@ float16 is the closer one at identical size (`--precision float16` exports it).
    rather than failing mid-run. Platform, OS floor, host presence — not weight state, which the
    weight manager is allowed to fix by downloading.
 
+   If your method needs a Swift backend of its own, call `host.require_runtime` after
+   `host.require_available`: the two failures have different remedies ("you are headless" versus
+   "this build does not carry that backend"), and checking here is what refuses BEFORE a
+   multi-hundred-megabyte download rather than after it.
+
 5. **Implement `parse_spec` to reject, not repair.** If the backend silently ignores input it
    does not support, catching that is your job: check what it does with a ligand, a nucleic
    acid, an `X`, and an empty chain, and raise for each. boltz-mlx is the cautionary case —
@@ -93,6 +106,17 @@ float16 is the closer one at identical size (`--precision float16` exports it).
    user believes are something they are not. Note that a knob you want to *reject* must still
    appear as a named parameter on `cmd.predict`, or Python raises `TypeError` before your
    validation runs.
+
+   **A knob your method genuinely has is the one case that touches `predicting.py`**, in three
+   places: a named parameter on `cmd.predict` defaulting to `None`, a conditional line adding it
+   to `requested` only when it is not `None`, and a field on `PredictionOptions` with bounds.
+   `num_steps` is the worked example. The conditional matters more than it looks: a knob added
+   unconditionally is sent on EVERY call, so `validate_options` then rejects it by name for every
+   predictor that did not declare it — which is how `recycling_steps` once made a method with no
+   trunk impossible to call at all, even by a caller who named no knobs.
+
+   Put on the wire only what your method declared, by passing `knobs=self.option_defaults` to
+   `host.submit`. A knob absent from a request is one the runtime defaults for itself.
 
 7. **Declare `supports_msa` — and mean it.** It is `False` on the base class, so a method that
    says nothing REFUSES `predict ..., msa=...` by name. That is the point: a predictor that

--- a/modules/pymol/predicting.py
+++ b/modules/pymol/predicting.py
@@ -711,9 +711,9 @@ def report_alignments(spec, options):
     colorprinting.parrot(' predict: alignments: %s' % ', '.join(parts))
 
 
-def predict(predictor, sequence, name='', recycling_steps=3, diffusion_steps=200,
-            seed=None, n_models=1, diffusion_samples=None, msa='', msa_depth=None,
-            quiet=1, _self=cmd):
+def predict(predictor, sequence, name='', recycling_steps=None,
+            diffusion_steps=None, seed=None, n_models=1, diffusion_samples=None,
+            msa='', msa_depth=None, num_steps=None, quiet=1, _self=cmd):
     """
 DESCRIPTION
 
@@ -741,10 +741,18 @@ ARGUMENTS
 
     name = str: object name for the loaded result {default: <predictor>_pred}
 
-    recycling_steps = int: trunk recycling passes {default: 3}
+    recycling_steps = int: trunk recycling passes. Boltz-2 only; a method with no
+    trunk rejects it by name. {default: None, meaning the predictor's own -- 3 for
+    boltz2}
 
     diffusion_steps = int: reverse-diffusion steps; higher is slower and more
-    accurate {default: 200}
+    accurate. Boltz-2 only. {default: None, meaning the predictor's own -- 200 for
+    boltz2}
+
+    num_steps = int: flow-matching integration steps; higher is slower and more
+    accurate. SimpleFold only -- it has no trunk and no reverse diffusion, so this
+    is its one quality lever, and boltz2 rejects it by name. {default: None,
+    meaning the predictor's own -- 500 for simplefold}
 
     seed = int: random seed. Drawn FRESH PER RUN when omitted, so repeat
     predictions of one sequence are different models rather than identical
@@ -867,10 +875,19 @@ SEE ALSO
         import random
         seed = random.randrange(RANDOM_SEED_BOUND)
 
-    requested = dict(
-        recycling_steps=int(recycling_steps),
-        diffusion_steps=int(diffusion_steps),
-        seed=int(seed))
+    # Only what was actually ASKED for. Every knob but the seed is conditional, and
+    # that is load-bearing rather than tidiness: validate_options rejects any name a
+    # predictor did not declare, so passing recycling_steps unconditionally made a
+    # method without a trunk impossible to call at all -- it would be refused by name
+    # on every invocation, including one that named no knob. The defaults live in each
+    # predictor's option_defaults, which is the thing that knows them.
+    requested = dict(seed=int(seed))
+    if recycling_steps is not None:
+        requested['recycling_steps'] = int(recycling_steps)
+    if diffusion_steps is not None:
+        requested['diffusion_steps'] = int(diffusion_steps)
+    if num_steps is not None:
+        requested['num_steps'] = int(num_steps)
     if diffusion_samples is not None:
         # Forwarded unvalidated on purpose: validate_options rejects it by name.
         # A command function cannot take **kwargs (parsing.py forces NO_CHECK when

--- a/modules/pymol/predictors/__init__.py
+++ b/modules/pymol/predictors/__init__.py
@@ -12,8 +12,10 @@ def _register_builtins():
     """Register the shipped predictors. The only function that changes per predictor."""
     from .boltz2 import Boltz2Predictor
     from .boltz2_bf16 import Boltz2BF16Predictor
+    from .simplefold import SimpleFoldPredictor
     register(Boltz2Predictor(), replace=True)
     register(Boltz2BF16Predictor(), replace=True)
+    register(SimpleFoldPredictor(), replace=True)
 
 
 _register_builtins()

--- a/modules/pymol/predictors/base.py
+++ b/modules/pymol/predictors/base.py
@@ -11,6 +11,10 @@ CHAIN_IDS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 MAX_RECYCLING_STEPS = 100
 MAX_DIFFUSION_STEPS = 10_000
 MAX_SEED = 2 ** 64 - 1
+#: Flow-matching integration steps, for a method that samples a path rather than
+#: denoising a diffusion. Bounded like the two above, and for the same reason:
+#: the value crosses a JSON wire into Swift, which decodes it as Int.
+MAX_NUM_STEPS = 10_000
 
 #: Most alignment rows a prediction may use. boltz-mlx's `BoltzInputLimits.desktop`
 #: `maximumSequences`, which is upstream's `const.max_msa_seqs`. Both ends must agree:
@@ -48,14 +52,16 @@ class PredictionOptions:
     config.json and is not a per-call knob.
     """
 
-    __slots__ = ('recycling_steps', 'diffusion_steps', 'seed', 'msa_depth')
+    __slots__ = ('recycling_steps', 'diffusion_steps', 'seed', 'msa_depth',
+                 'num_steps')
 
     def __init__(self, recycling_steps=3, diffusion_steps=200, seed=0,
-                 msa_depth=MAX_MSA_DEPTH):
+                 msa_depth=MAX_MSA_DEPTH, num_steps=500):
         for name, value in (('recycling_steps', recycling_steps),
                             ('diffusion_steps', diffusion_steps),
                             ('seed', seed),
-                            ('msa_depth', msa_depth)):
+                            ('msa_depth', msa_depth),
+                            ('num_steps', num_steps)):
             if not isinstance(value, int) or isinstance(value, bool):
                 raise PredictionOptionError('%s must be an integer' % name)
         # Bounded at BOTH ends. The lower bounds are semantic; the upper bounds exist
@@ -78,10 +84,14 @@ class PredictionOptions:
         if not 1 <= msa_depth <= MAX_MSA_DEPTH:
             raise PredictionOptionError(
                 'msa_depth must be between 1 and %d' % MAX_MSA_DEPTH)
+        if not 1 <= num_steps <= MAX_NUM_STEPS:
+            raise PredictionOptionError(
+                'num_steps must be between 1 and %d' % MAX_NUM_STEPS)
         self.recycling_steps = recycling_steps
         self.diffusion_steps = diffusion_steps
         self.seed = seed
         self.msa_depth = msa_depth
+        self.num_steps = num_steps
 
     def as_dict(self):
         return {name: getattr(self, name) for name in self.__slots__}

--- a/modules/pymol/predictors/boltz2.py
+++ b/modules/pymol/predictors/boltz2.py
@@ -22,6 +22,10 @@ CANONICAL = set('ACDEFGHIKLMNPQRSTVWY')
 #: BoltzInputLimits.desktop caps at 1024 tokens, and one token is one residue.
 MAX_RESIDUES = 1024
 
+#: The backend the Swift host dispatches to. Also what a request with no `runtime`
+#: at all is taken to mean, so an older Python side keeps working.
+RUNTIME = 'boltz'
+
 
 class Boltz2Predictor(Predictor):
 
@@ -77,4 +81,5 @@ class Boltz2Predictor(Predictor):
         return PredictionSpec(chains, name)
 
     def submit(self, spec, options, weights_path):
-        return host.submit(spec, options, weights_path)
+        return host.submit(spec, options, weights_path, runtime=RUNTIME,
+                           knobs=self.option_defaults)

--- a/modules/pymol/predictors/host.py
+++ b/modules/pymol/predictors/host.py
@@ -17,10 +17,23 @@ import os
 import tempfile
 import uuid
 
+from .base import PredictionOptions
 from .errors import PredictorUnavailable
 
 #: Set by the Swift host next to PYMOL_PATH so Python can tell it is present.
 HOST_ENV = 'RAYMOL_PREDICT_HOST'
+
+#: Comma-separated inference runtimes the host has actually linked, set beside
+#: HOST_ENV. A host is not one capability but several: the app may carry the Boltz
+#: runtime and not the SimpleFold one, and a predictor whose runtime is missing must
+#: say so in check_available rather than submit a job that would be refused, or worse
+#: run on the wrong backend.
+RUNTIMES_ENV = 'RAYMOL_PREDICT_RUNTIMES'
+
+#: What a host that does not declare RUNTIMES_ENV is assumed to carry. Every build
+#: before this variable existed had exactly the Boltz runtime, so this keeps an older
+#: app -- or a test that only sets HOST_ENV -- working unchanged.
+DEFAULT_RUNTIME = 'boltz'
 
 
 def available():
@@ -32,12 +45,33 @@ def available():
     return bool(os.environ.get(HOST_ENV))
 
 
+def supported_runtimes():
+    """Inference runtimes this host can actually run, as a tuple."""
+    declared = os.environ.get(RUNTIMES_ENV, '')
+    names = tuple(part.strip() for part in declared.split(',') if part.strip())
+    return names or (DEFAULT_RUNTIME,)
+
+
 def require_available(predictor_id):
     if not available():
         raise PredictorUnavailable(
             '%s needs the RayMol application host; it is not available in this '
             'process (headless PyMOL cannot run on-device inference)'
             % predictor_id)
+
+
+def require_runtime(predictor_id, runtime):
+    """Raise unless the host declares `runtime`. Call after require_available().
+
+    Separate from require_available() because the two failures have different
+    remedies: no host at all means "you are running headless", while a missing
+    runtime means "this build of RayMol does not carry that backend".
+    """
+    if runtime not in supported_runtimes():
+        raise PredictorUnavailable(
+            '%s needs the %r inference runtime, which this build of RayMol does '
+            'not carry (it has: %s)'
+            % (predictor_id, runtime, ', '.join(supported_runtimes())))
 
 
 def _path(kind, job_id, suffix='json'):
@@ -114,8 +148,16 @@ def _write(path, text):
     os.replace(temp, path)
 
 
-def submit(spec, options, weights_path):
-    """Write the request, print the marker, return the handle. Never blocks."""
+def submit(spec, options, weights_path, runtime=DEFAULT_RUNTIME, knobs=None):
+    """Write the request, print the marker, return the handle. Never blocks.
+
+    `runtime` names the backend the host must dispatch to. `knobs` is the option
+    names to put on the wire -- pass the predictor's own `option_defaults`, so the
+    request carries exactly what that method declared it honours and nothing else.
+    A knob absent from the request is one the runtime at the far end must supply a
+    default for; sending every predictor every knob would put `recycling_steps` in
+    a SimpleFold request, which has no trunk to recycle.
+    """
     job_id = uuid.uuid4().hex[:12]
     job = HostJob(job_id, spec, options)
 
@@ -145,6 +187,10 @@ def submit(spec, options, weights_path):
 
     request = {
         'job_id': job_id,
+        # Which backend runs this. OPTIONAL at the far end, absent meaning boltz, so
+        # a request written by a Python side that predates the second runtime still
+        # decodes -- the same reasoning as `object_name` and `alignments`.
+        'runtime': runtime,
         'weights_dir': weights_path or '',
         # Objects, not pairs: BoltzJobManager.Chain is a Codable struct with named
         # keys, so a positional array would fail to decode.
@@ -154,13 +200,6 @@ def submit(spec, options, weights_path):
         # dummy depth-1 alignment to any chain not listed, which is the designed-binder
         # case: an alignment for the target, none for the binder.
         'alignments': alignments,
-        'recycling_steps': options.recycling_steps,
-        'diffusion_steps': options.diffusion_steps,
-        'seed': options.seed,
-        # How many rows of each a3m to read. Applied on the HOST side, by the same
-        # parser that reads the file, so the truncation is the parser's own -- the a3m
-        # written above is always the whole alignment.
-        'msa_depth': options.msa_depth,
         'out_path': job.out_path,
         'status_path': job.status_path,
         # The object the host loads the finished structure into. Resolved at submit time
@@ -168,6 +207,15 @@ def submit(spec, options, weights_path):
         # needs no second round-trip to find out where the result belongs.
         'object_name': getattr(spec, 'name', '') or '',
     }
+    # The inference knobs, exactly as the predictor declared them. `msa_depth` is one
+    # of these for an MSA-capable method: it says how many rows of each a3m to read,
+    # applied on the HOST side by the same parser that reads the file, so the
+    # truncation is the parser's own -- the a3m written above is always the whole
+    # alignment.
+    if knobs is None:
+        knobs = PredictionOptions.__slots__
+    for knob in knobs:
+        request[knob] = getattr(options, knob)
     # Write completely before announcing it: the host reads on the next 100 ms
     # tick and must never see a partial request.
     _write(job.request_path, json.dumps(request))

--- a/modules/pymol/predictors/simplefold.py
+++ b/modules/pymol/predictors/simplefold.py
@@ -1,0 +1,105 @@
+"""SimpleFold via simplefold-mlx: an MLX-Swift port of Apple's flow-matching folder.
+
+A SINGLE CHAIN, protein, canonical-20. SimpleFold has no notion of a complex --
+`fold(sequence:)` takes one string, the tokenizer wraps it in a single CLS/EOS pair,
+and the port has no chain-break token, no per-chain index and no cross-chain pair
+feature. Handed two chains it would fold their CONCATENATION as one continuous chain
+and emit a PDB nothing downstream could distinguish from a real prediction, so a
+multi-chain input is refused here, plainly, before anything is submitted.
+
+Single-sequence by construction: ESM2 embeddings plus a FoldingDiT sampler, with no
+MSA anywhere in the pipeline. `supports_msa` is therefore False and left False, which
+is what makes `predict ..., msa=...` refuse BY NAME rather than quietly folding
+single-sequence -- see Predictor.bind_alignments.
+
+Its one quality knob is `num_steps`, the number of flow-matching integration steps.
+Nothing it shares with Boltz-2: there is no trunk to recycle and no reverse diffusion,
+so `recycling_steps` and `diffusion_steps` are rejected by name.
+"""
+from . import host
+from .base import Predictor, PredictionSpec, parse_chains
+from .errors import PredictionInputError, PredictorUnavailable
+
+#: The canonical 20. Everything else is refused rather than passed through: the
+#: port's tokenizer resolves an unknown letter to X (`restypes.firstIndex(of:) ?? 20`)
+#: instead of failing, so a typo would fold as an unknown residue with nothing in the
+#: result saying a substitution had happened.
+CANONICAL = set('ACDEFGHIKLMNPQRSTVWY')
+
+#: Largest input measured end to end. Not a limit of the method -- SimpleFold's memory
+#: is dominated by the ESM2 weights and is nearly flat in length -- but the point past
+#: which nothing has been measured, and PredictSizeGuard's history is that an
+#: unmeasured extrapolation is how a run gets jetsam-killed. Raise it with a
+#: measurement, never without one.
+MAX_RESIDUES = 900
+
+#: The backend the Swift host must dispatch to, as it appears on the wire.
+RUNTIME = 'simplefold'
+
+
+class SimpleFoldPredictor(Predictor):
+
+    id = 'simplefold'
+    name = 'SimpleFold (MLX, int4)'
+
+    # None until the quantized pack is published as a release asset, at which point
+    # this becomes a WeightBundle and nothing else here changes.
+    #
+    # Deliberately not a placeholder bundle: `predict_weights download=1` iterates
+    # EVERY registered predictor without consulting check_available, so a bundle
+    # carrying a stand-in URL would be fetched by a command aimed at a different
+    # predictor. The pack is three archive-root members -- esm2_3B_int4.safetensors
+    # (~1.5 GB), fold_100M_int4.safetensors (~74 MB), aa_templates.json (~26 KB) --
+    # and its sha256 must be taken from the bytes actually uploaded, not from a local
+    # re-quantize, which is not bitwise reproducible.
+    weight_bundle = None
+
+    # No trunk, no reverse diffusion: `num_steps` is the flow-matching integration
+    # count and the only quality lever. `msa_depth` is absent because there is no
+    # alignment to have a depth, and its absence is what makes the depth lever
+    # rejected by name rather than accepted and ignored.
+    option_defaults = {'num_steps': 500, 'seed': 0}
+
+    # Single-sequence by construction; see the module docstring.
+    supports_msa = False
+
+    def check_available(self):
+        host.require_available(self.id)
+        host.require_runtime(self.id, RUNTIME)
+        if self.weight_bundle is None:
+            # Weight state is normally none of check_available's business -- the
+            # weight manager is allowed to fix a cold cache by downloading. An
+            # UNPUBLISHED pack is a different thing: there is nothing to download, so
+            # this is a capability the host lacks, which is exactly what belongs here.
+            raise PredictorUnavailable(
+                '%s has no published weight pack yet, so it cannot run. See #306.'
+                % self.id)
+
+    def parse_spec(self, sequence, name=''):
+        chains = parse_chains(sequence)
+        if len(chains) > 1:
+            # A plain error, never a warning and never a fold of the first chain.
+            # Both input paths land here: a typed "A/B", and an object or selection
+            # spanning several chains, which resolve_input joins with "/" before this
+            # is called -- so this one check covers a user who never typed a
+            # separator at all.
+            raise PredictionInputError(
+                'simplefold cannot fold a complex: it models a single chain, and %d '
+                'were given (%s). Fold each chain separately, or use boltz2 for a '
+                'complex.' % (len(chains), ', '.join(c for c, _ in chains)))
+        for chain, seq in chains:
+            bad = sorted(set(seq) - CANONICAL)
+            if bad:
+                raise PredictionInputError(
+                    'chain %s contains residues SimpleFold cannot fold: %s '
+                    '(canonical 20 only; X, U, B and Z are not accepted)'
+                    % (chain, ', '.join(bad)))
+            if len(seq) > MAX_RESIDUES:
+                raise PredictionInputError(
+                    '%d residues exceeds the %d-residue limit'
+                    % (len(seq), MAX_RESIDUES))
+        return PredictionSpec(chains, name)
+
+    def submit(self, spec, options, weights_path):
+        return host.submit(spec, options, weights_path, runtime=RUNTIME,
+                           knobs=self.option_defaults)

--- a/swiftui/PyMOLViewer/Bridge/PyMOLBridge.mm
+++ b/swiftui/PyMOLViewer/Bridge/PyMOLBridge.mm
@@ -110,6 +110,13 @@ void PyMOLBridge_InitPython(PyMOLHandle h, const char *resourcePath)
     // are after init and get away with it only because PyMOL's own Python layer
     // assigns those into os.environ itself.)
     setenv("RAYMOL_PREDICT_HOST", "1", 1);
+    // Which inference runtimes are actually LINKED into this build. A host is not one
+    // capability but several: BoltzJobManager implements "boltz" and nothing else, so a
+    // predictor whose backend is missing refuses in check_available rather than
+    // submitting a job that BoltzJobManager.preflight would refuse -- after the user
+    // had waited out a weight download. Keep in step with
+    // BoltzJobManager.boltzRuntime; add a name here only when its runtime ships.
+    setenv("RAYMOL_PREDICT_RUNTIMES", "boltz", 1);
 #endif
 
     PyStatus status = Py_InitializeFromConfig(&config);

--- a/swiftui/PyMOLViewer/Shared/BoltzJobManager.swift
+++ b/swiftui/PyMOLViewer/Shared/BoltzJobManager.swift
@@ -17,6 +17,13 @@ final class BoltzJobManager {
 
     static let shared = BoltzJobManager()
 
+    /// The one inference runtime this manager implements, as it appears on the wire.
+    /// Kept in step with `pymol.predictors.boltz2.RUNTIME`, and with the value
+    /// `PyMOLBridge` advertises in `RAYMOL_PREDICT_RUNTIMES` — that variable is what
+    /// lets a predictor whose backend is NOT linked here refuse in `check_available`
+    /// instead of submitting a job that only gets refused after a weight download.
+    static let boltzRuntime = "boltz"
+
     /// MLX must never run on the main thread. `cmd.predict` from the console arrives ON
     /// the main thread, which is exactly why submit is fire-and-forget.
     private let queue = DispatchQueue(label: "io.raymol.predict.inference",
@@ -95,8 +102,22 @@ final class BoltzJobManager {
         let jobID: String
         let weightsDir: String
         let chains: [Chain]
-        let recyclingSteps: Int
-        let diffusionSteps: Int
+        /// Which backend must run this job. OPTIONAL, absent meaning ``boltzRuntime`` —
+        /// every Python side that predates a second runtime wrote no such key, and the
+        /// only runtime that existed then was this one. A request naming a runtime this
+        /// build does not carry is REFUSED in `preflight`, never run here: the weights
+        /// and the featurizer are method-specific, so running one method's request on
+        /// another's backend would not fail, it would return a confident wrong answer.
+        let runtime: String?
+        /// Boltz's trunk and diffusion knobs. Optional because a request from a method
+        /// that has neither omits them entirely rather than sending a value it does not
+        /// honour — see `numSteps`. Defaulted at the use site to upstream Boltz's own.
+        let recyclingSteps: Int?
+        let diffusionSteps: Int?
+        /// SimpleFold's flow-matching integration count. Absent from a Boltz request for
+        /// the same reason `recyclingSteps` is absent from a SimpleFold one: each
+        /// predictor puts exactly the knobs it declared it honours on the wire.
+        let numSteps: Int?
         let seed: UInt64
         let outPath: String
         let statusPath: String
@@ -122,8 +143,9 @@ final class BoltzJobManager {
         let objectName: String?
 
         enum CodingKeys: String, CodingKey {
-            case jobID = "job_id", weightsDir = "weights_dir", chains
+            case jobID = "job_id", weightsDir = "weights_dir", chains, runtime
             case recyclingSteps = "recycling_steps", diffusionSteps = "diffusion_steps"
+            case numSteps = "num_steps"
             case seed, outPath = "out_path", statusPath = "status_path"
             case objectName = "object_name"
             case alignments, msaDepth = "msa_depth"
@@ -232,6 +254,13 @@ final class BoltzJobManager {
     /// `pollFeedback`: the alignment's real depth costs a parse of the a3m, which
     /// belongs on the inference queue. `alignmentPreflight` makes that second check.
     static func preflight(_ request: Request) -> Status? {
+        // Runtime first, before any sizing: the size model below is Boltz's, fitted to
+        // Boltz's measured peaks, so applying it to another method's request would be
+        // meaningless even as a refusal. Absent means Boltz, per `Request.runtime`.
+        if let runtime = request.runtime, runtime != boltzRuntime {
+            return refusal("this build of RayMol does not carry the '\(runtime)' "
+                         + "inference runtime")
+        }
         let tokens = request.chains.reduce(0) { $0 + $1.sequence.count }
         switch PredictSizeGuard.decide(tokens: tokens,
                                        availableBytes: PredictSizeGuard.availableBytes) {
@@ -391,8 +420,12 @@ final class BoltzJobManager {
 
             report("running", "inference", 0.2)
             var options = BoltzPredictionOptions()
-            options.recyclingSteps = request.recyclingSteps
-            options.diffusionSteps = request.diffusionSteps
+            // Upstream Boltz's defaults, matching `PredictionOptions` on the Python
+            // side. Reached only if a request omits them, which a Boltz request never
+            // does -- but a default here is what keeps the optional decode honest
+            // rather than forcing an implicitly-unwrapped read.
+            options.recyclingSteps = request.recyclingSteps ?? 3
+            options.diffusionSteps = request.diffusionSteps ?? 200
             options.seed = request.seed
 
             // Reset the high-water mark so each prediction is measured independently --

--- a/swiftui/PyMOLViewerTests/BoltzJobManagerTests.swift
+++ b/swiftui/PyMOLViewerTests/BoltzJobManagerTests.swift
@@ -30,18 +30,28 @@ final class BoltzJobManagerTests: XCTestCase {
     /// Mirrors exactly what host.py writes: `chains` is a list of OBJECTS, not pairs.
     private func writeRequest(job: String,
                               chains: [(String, String)],
-                              diffusionSteps: Int = 200) throws -> URL {
+                              diffusionSteps: Int = 200,
+                              runtime: String? = nil,
+                              extra: [String: Any] = [:],
+                              omittingBoltzKnobs: Bool = false) throws -> URL {
         let url = dir.appendingPathComponent("raymol_predict_req_\(job).json")
-        let payload: [String: Any] = [
+        var payload: [String: Any] = [
             "job_id": job,
             "weights_dir": dir.path,
             "chains": chains.map { ["chain": $0.0, "sequence": $0.1] },
-            "recycling_steps": 3,
-            "diffusion_steps": diffusionSteps,
             "seed": 0,
             "out_path": dir.appendingPathComponent("out_\(job).pdb").path,
             "status_path": dir.appendingPathComponent("raymol_predict_status_\(job).json").path,
         ]
+        // Omitted, not defaulted, when the caller is standing in for a predictor that
+        // has neither knob: host.py puts only the knobs a predictor DECLARED on the
+        // wire, so "absent" is a shape the decoder really has to handle.
+        if !omittingBoltzKnobs {
+            payload["recycling_steps"] = 3
+            payload["diffusion_steps"] = diffusionSteps
+        }
+        if let runtime { payload["runtime"] = runtime }
+        payload.merge(extra) { _, new in new }
         try JSONSerialization.data(withJSONObject: payload).write(to: url)
         return url
     }
@@ -197,6 +207,54 @@ final class BoltzJobManagerTests: XCTestCase {
         let request = try BoltzJobManager.parseRequest(at: url)
         XCTAssertNil(BoltzJobManager.preflight(request),
                      "a 40-residue chain must not be refused on any supported Mac")
+    }
+
+    // MARK: - Runtime dispatch
+
+    /// The safety property of the whole seam. Weights and featurizer are method-
+    /// specific, so running another method's request on this backend would not fail —
+    /// it would return a confident wrong structure.
+    func testARequestNamingAnUnlinkedRuntimeIsRefused() throws {
+        let url = try writeRequest(job: "r1", chains: [("A", "AGCT")],
+                                   runtime: "simplefold")
+        let request = try BoltzJobManager.parseRequest(at: url)
+        let status = BoltzJobManager.preflight(request)
+        XCTAssertEqual(status?.state, "failed")
+        XCTAssertEqual(status?.phase, "preflight")
+        XCTAssertEqual(status?.error?.contains("simplefold"), true,
+                       "the refusal must name the runtime that is missing")
+    }
+
+    func testARequestNamingBoltzExplicitlyIsAccepted() throws {
+        let url = try writeRequest(job: "r2", chains: [("A", "AGCT")], runtime: "boltz")
+        let request = try BoltzJobManager.parseRequest(at: url)
+        XCTAssertEqual(request.runtime, "boltz")
+        XCTAssertNil(BoltzJobManager.preflight(request))
+    }
+
+    /// Absent means Boltz: every Python side predating a second runtime wrote no such
+    /// key, and this manager was the only backend that existed then.
+    func testARequestWithNoRuntimeIsTakenAsBoltz() throws {
+        let url = try writeRequest(job: "r3", chains: [("A", "AGCT")])
+        let request = try BoltzJobManager.parseRequest(at: url)
+        XCTAssertNil(request.runtime)
+        XCTAssertNil(BoltzJobManager.preflight(request))
+    }
+
+    /// A request carrying another method's knobs and none of Boltz's still DECODES, so
+    /// the runtime refusal above is what rejects it — with a message naming the
+    /// runtime, rather than a bare "malformed prediction request".
+    func testARequestWithForeignKnobsDecodesSoItCanBeRefusedByName() throws {
+        let url = try writeRequest(job: "r4", chains: [("A", "AGCT")],
+                                   runtime: "simplefold",
+                                   extra: ["num_steps": 500],
+                                   omittingBoltzKnobs: true)
+        let request = try BoltzJobManager.parseRequest(at: url)
+        XCTAssertEqual(request.numSteps, 500)
+        XCTAssertNil(request.recyclingSteps)
+        XCTAssertNil(request.diffusionSteps)
+        XCTAssertEqual(BoltzJobManager.preflight(request)?.error?.contains("simplefold"),
+                       true)
     }
     // MARK: - Cancellation actually interrupts
 

--- a/testing/tests/predict/predict_completion.py
+++ b/testing/tests/predict/predict_completion.py
@@ -12,8 +12,16 @@ from pymol import cmd, testing
 
 class TestPredictCompletion(testing.PyMOLTestCase):
 
-    def testPredictOffersRegisteredPredictors(self):
-        self.assertEqual(cmd._parser.complete('predict '), 'predict boltz2')
+    def testPredictListsPredictorsWhenNothingIsUnambiguous(self):
+        """Nothing typed yet: the ids share no common prefix, so there is nothing to
+        INSERT and Tab prints the list instead. None means "listed", not "failed" --
+        the completer only returns a string when it has characters to add.
+
+        This changed when simplefold was registered. While boltz2 and boltz2-bf16
+        were the only ids, every id began with 'boltz2' and Tab silently filled that
+        in; an id from a different family is what makes the listing appear.
+        """
+        self.assertIsNone(cmd._parser.complete('predict '))
 
     def testPartialPredictorNameCompletesAsFarAsItIsUnambiguous(self):
         """'boltz2' is a PREFIX of 'boltz2-bf16', so Tab stops there with no separator.
@@ -25,9 +33,15 @@ class TestPredictCompletion(testing.PyMOLTestCase):
         self.assertEqual(cmd._parser.complete('predict boltz2-'),
                          'predict boltz2-bf16, ')
 
+    def testAnIdOutsideTheBoltzFamilyCompletesInOneKeystroke(self):
+        """The payoff for not making the id a prefix-extension of an existing one:
+        'simplefold' is unique from its first letter, separator and all."""
+        self.assertEqual(cmd._parser.complete('predict s'), 'predict simplefold, ')
+
     def testPredictWeightsAlsoOffersPredictors(self):
-        self.assertEqual(cmd._parser.complete('predict_weights '),
-                         'predict_weights boltz2')
+        self.assertIsNone(cmd._parser.complete('predict_weights '))
+        self.assertEqual(cmd._parser.complete('predict_weights s'),
+                         'predict_weights simplefold, ')
 
     def testCommandNameItselfStillCompletes(self):
         self.assertEqual(cmd._parser.complete('predic'), 'predict')

--- a/testing/tests/predict/predict_simplefold.py
+++ b/testing/tests/predict/predict_simplefold.py
@@ -1,0 +1,340 @@
+"""simplefold predictor: availability, the single-chain rule, and what it puts on
+the wire. No Swift and no network -- the host is simulated by the env vars it sets.
+
+    pymol -ckqy testing/testing.py --run testing/tests/predict/predict_simplefold.py
+"""
+import io
+import json
+import os
+from contextlib import redirect_stdout
+
+from pymol import cmd, predicting, testing
+from pymol.predictors import host
+from pymol.predictors.errors import (PredictionInputError, PredictionOptionError,
+                                     PredictorUnavailable)
+from pymol.predictors.simplefold import SimpleFoldPredictor
+
+
+class HostEnvTestCase(testing.PyMOLTestCase):
+    """Restores both host variables, so one test cannot leak into the next."""
+
+    def setUp(self):
+        testing.PyMOLTestCase.setUp(self)
+        self._saved = {name: os.environ.get(name)
+                       for name in (host.HOST_ENV, host.RUNTIMES_ENV)}
+
+    def tearDown(self):
+        for name, value in self._saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        testing.PyMOLTestCase.tearDown(self)
+
+    def declareHost(self, runtimes):
+        os.environ[host.HOST_ENV] = '1'
+        os.environ[host.RUNTIMES_ENV] = runtimes
+
+
+class TestAvailability(HostEnvTestCase):
+
+    def testUnavailableWithoutAHost(self):
+        os.environ.pop(host.HOST_ENV, None)
+        os.environ.pop(host.RUNTIMES_ENV, None)
+        self.assertRaises(PredictorUnavailable,
+                          SimpleFoldPredictor().check_available)
+
+    def testNoHostIsReportedAsNoHostEvenWhenTheRuntimeIsAlsoMissing(self):
+        """Order matters: the two failures have different remedies."""
+        os.environ.pop(host.HOST_ENV, None)
+        os.environ.pop(host.RUNTIMES_ENV, None)
+        try:
+            SimpleFoldPredictor().check_available()
+        except PredictorUnavailable as error:
+            self.assertIn('application host', str(error))
+        else:
+            self.fail('expected PredictorUnavailable')
+
+    def testRefusedOnAHostThatCarriesOnlyBoltz(self):
+        self.declareHost('boltz')
+        try:
+            SimpleFoldPredictor().check_available()
+        except PredictorUnavailable as error:
+            self.assertIn('simplefold', str(error))
+            self.assertIn('does not carry', str(error))
+        else:
+            self.fail('expected PredictorUnavailable')
+
+    def testAHostDeclaringNothingIsAssumedBoltzOnly(self):
+        """Every build before RUNTIMES_ENV existed had exactly the Boltz runtime."""
+        os.environ[host.HOST_ENV] = '1'
+        os.environ.pop(host.RUNTIMES_ENV, None)
+        self.assertEqual(host.supported_runtimes(), ('boltz',))
+        self.assertRaises(PredictorUnavailable,
+                          SimpleFoldPredictor().check_available)
+
+    def testStillRefusedWithTheRuntimeWhileWeightsAreUnpublished(self):
+        self.declareHost('boltz,simplefold')
+        try:
+            SimpleFoldPredictor().check_available()
+        except PredictorUnavailable as error:
+            self.assertIn('weight pack', str(error))
+        else:
+            self.fail('expected PredictorUnavailable')
+
+    def testBoltzIsUnaffectedByTheRuntimeDeclaration(self):
+        from pymol.predictors.boltz2 import Boltz2Predictor
+        os.environ[host.HOST_ENV] = '1'
+        os.environ.pop(host.RUNTIMES_ENV, None)
+        self.assertIsNone(Boltz2Predictor().check_available())
+
+
+class TestSingleChainRule(testing.PyMOLTestCase):
+    """A complex is a plain error -- never a warning, never a partial fold."""
+
+    def predictor(self):
+        return SimpleFoldPredictor()
+
+    def testOneChainIsAccepted(self):
+        spec = self.predictor().parse_spec('ACDEFGHIK', 'p')
+        self.assertEqual(spec.chains, (('A', 'ACDEFGHIK'),))
+
+    def testTwoTypedChainsRejected(self):
+        try:
+            self.predictor().parse_spec('ACDEF/GHIKL')
+        except PredictionInputError as error:
+            self.assertIn('cannot fold a complex', str(error))
+            self.assertIn('A, B', str(error))
+            self.assertIn('2 were given', str(error))
+        else:
+            self.fail('expected PredictionInputError')
+
+    def testThreeTypedChainsRejected(self):
+        self.assertRaises(PredictionInputError,
+                          self.predictor().parse_spec, 'ACDEF/GHIKL/MNPQR')
+
+    def testErrorNamesAWorkingAlternative(self):
+        """The remedy is in the message: fold separately, or use boltz2."""
+        try:
+            self.predictor().parse_spec('ACDEF/GHIKL')
+        except PredictionInputError as error:
+            self.assertIn('separately', str(error))
+            self.assertIn('boltz2', str(error))
+
+    def testAMultiChainSelectionIsRejectedToo(self):
+        """The likelier path: no separator is typed at all.
+
+        resolve_sequence reads one chain per (object, chain id) and joins them with
+        '/', so a selection spanning two objects reaches parse_spec in exactly the
+        shape a typed multimer does -- which is why one check covers both.
+        """
+        cmd.fab('ACDEFG', 'one')
+        cmd.fab('GHIKL', 'two')
+        resolved = predicting.resolve_sequence('one or two')
+        self.assertEqual(resolved, 'ACDEFG/GHIKL')
+        self.assertRaises(PredictionInputError,
+                          self.predictor().parse_spec, resolved)
+
+    def testASingleChainSelectionIsAccepted(self):
+        cmd.fab('ACDEFG', 'one')
+        spec = self.predictor().parse_spec(predicting.resolve_sequence('one'))
+        self.assertEqual(spec.chains, (('A', 'ACDEFG'),))
+
+
+class TestResidueValidation(testing.PyMOLTestCase):
+
+    def predictor(self):
+        return SimpleFoldPredictor()
+
+    def testNonCanonicalRejectedRatherThanFoldedAsX(self):
+        """The port's tokenizer resolves an unknown letter to X instead of failing."""
+        for sequence in ('ACDEFX', 'ACDEFU', 'ACDEFB', 'ACDEFZ'):
+            self.assertRaises(PredictionInputError,
+                              self.predictor().parse_spec, sequence)
+
+    def testTheOffendingLetterIsNamed(self):
+        try:
+            self.predictor().parse_spec('ACDEFJ')
+        except PredictionInputError as error:
+            self.assertIn('J', str(error))
+        else:
+            self.fail('expected PredictionInputError')
+
+    def testTooLongRejected(self):
+        from pymol.predictors.simplefold import MAX_RESIDUES
+        self.assertRaises(PredictionInputError,
+                          self.predictor().parse_spec, 'A' * (MAX_RESIDUES + 1))
+
+    def testAtTheLimitAccepted(self):
+        from pymol.predictors.simplefold import MAX_RESIDUES
+        spec = self.predictor().parse_spec('A' * MAX_RESIDUES)
+        self.assertEqual(len(spec.chains[0][1]), MAX_RESIDUES)
+
+
+class TestOptions(testing.PyMOLTestCase):
+
+    def predictor(self):
+        return SimpleFoldPredictor()
+
+    def testNumStepsIsHonoured(self):
+        options = self.predictor().validate_options({'num_steps': 250})
+        self.assertEqual(options.num_steps, 250)
+
+    def testDefaultIsFiveHundred(self):
+        self.assertEqual(self.predictor().validate_options({}).num_steps, 500)
+
+    def testBoltzKnobsRejectedByName(self):
+        for knob in ('recycling_steps', 'diffusion_steps', 'msa_depth',
+                     'diffusion_samples'):
+            try:
+                self.predictor().validate_options({knob: 1})
+            except PredictionOptionError as error:
+                self.assertIn(knob, str(error))
+            else:
+                self.fail('expected %s to be rejected by name' % knob)
+
+    def testNumStepsRejectedByBoltz(self):
+        from pymol.predictors.boltz2 import Boltz2Predictor
+        try:
+            Boltz2Predictor().validate_options({'num_steps': 10})
+        except PredictionOptionError as error:
+            self.assertIn('num_steps', str(error))
+        else:
+            self.fail('expected num_steps to be rejected by name')
+
+    def testNumStepsIsBounded(self):
+        from pymol.predictors.base import MAX_NUM_STEPS
+        for bad in (0, -1, MAX_NUM_STEPS + 1):
+            self.assertRaises(PredictionOptionError,
+                              self.predictor().validate_options,
+                              {'num_steps': bad})
+
+    def testNumStepsMustBeAnInteger(self):
+        for bad in (1.5, '250', True):
+            self.assertRaises(PredictionOptionError,
+                              self.predictor().validate_options,
+                              {'num_steps': bad})
+
+
+class TestAlignmentsRefused(testing.PyMOLTestCase):
+    """supports_msa is False, so an alignment is refused BY NAME."""
+
+    def testAnAlignmentIsRefused(self):
+        predictor = SimpleFoldPredictor()
+        spec = predictor.parse_spec('ACDEFG')
+
+        class FakeMSA:
+            name = 'aln'
+            query = 'ACDEFG'
+            depth = 32
+
+        try:
+            predictor.bind_alignments(spec, {'A': FakeMSA()})
+        except PredictionInputError as error:
+            self.assertIn('cannot use a multiple-sequence alignment', str(error))
+        else:
+            self.fail('expected PredictionInputError')
+
+    def testNoAlignmentIsFine(self):
+        predictor = SimpleFoldPredictor()
+        spec = predictor.parse_spec('ACDEFG')
+        self.assertEqual(predictor.bind_alignments(spec, {}).alignments, {})
+
+
+class TestWireFormat(testing.PyMOLTestCase):
+    """What reaches the Swift host: its runtime, and only its own knobs."""
+
+    def submit(self, options=None):
+        predictor = SimpleFoldPredictor()
+        spec = predictor.parse_spec('ACDEFG', 'pred')
+        options = predictor.validate_options(options or {})
+        with redirect_stdout(io.StringIO()) as buf:
+            job = predictor.submit(spec, options, '/tmp/weights')
+        with open(job.request_path) as handle:
+            request = json.load(handle)
+        os.unlink(job.request_path)
+        return job, request, buf.getvalue()
+
+    def testRequestNamesTheSimpleFoldRuntime(self):
+        _, request, _ = self.submit()
+        self.assertEqual(request['runtime'], 'simplefold')
+
+    def testRequestCarriesNumStepsAndSeed(self):
+        _, request, _ = self.submit({'num_steps': 250, 'seed': 7})
+        self.assertEqual(request['num_steps'], 250)
+        self.assertEqual(request['seed'], 7)
+
+    def testRequestOmitsKnobsSimpleFoldDoesNotHave(self):
+        """A SimpleFold request has no recycling_steps: there is no trunk."""
+        _, request, _ = self.submit()
+        for absent in ('recycling_steps', 'diffusion_steps', 'msa_depth'):
+            self.assertNotIn(absent, request)
+
+    def testMarkerIsPrinted(self):
+        job, _, out = self.submit()
+        self.assertIn('PREDICT:submit:%s' % job.job_id, out)
+
+    def testBoltzRequestIsUnchanged(self):
+        """The knob split must not have altered what boltz2 sends."""
+        from pymol.predictors.boltz2 import Boltz2Predictor
+        predictor = Boltz2Predictor()
+        spec = predictor.parse_spec('ACDEFG', 'pred')
+        options = predictor.validate_options({})
+        with redirect_stdout(io.StringIO()):
+            job = predictor.submit(spec, options, '/tmp/weights')
+        with open(job.request_path) as handle:
+            request = json.load(handle)
+        os.unlink(job.request_path)
+        self.assertEqual(request['runtime'], 'boltz')
+        self.assertEqual(request['recycling_steps'], 3)
+        self.assertEqual(request['diffusion_steps'], 200)
+        self.assertEqual(request['msa_depth'], 16384)
+        self.assertNotIn('num_steps', request)
+
+
+class TestRegistration(testing.PyMOLTestCase):
+
+    def testRegisteredUnderItsId(self):
+        from pymol.predictors import registry
+        self.assertIn('simplefold', registry.available())
+        self.assertEqual(registry.get('simplefold').id, 'simplefold')
+
+    def testIdIsNotAPrefixExtensionOfAnother(self):
+        """docs/predictors.md step 1: a shared prefix breaks tab completion."""
+        from pymol.predictors import registry
+        others = [i for i in registry.available() if i != 'simplefold']
+        for other in others:
+            self.assertFalse('simplefold'.startswith(other))
+            self.assertFalse(other.startswith('simplefold'))
+
+    def testWeightsCommandSkipsAnUnpublishedPack(self):
+        """predict_weights iterates EVERY predictor; nothing may be fetched here."""
+        out = cmd.predict_weights('simplefold', download=1, async_=0)
+        self.assertIsNone(out['simplefold']['bundle'])
+
+
+class TestCommandSurface(HostEnvTestCase):
+    """cmd.predict's own layer: the knob must be nameable to be rejectable."""
+
+    def testNumStepsIsAcceptedByTheSignature(self):
+        """A knob absent from the signature raises TypeError before validation."""
+        import inspect
+        self.assertIn('num_steps', inspect.signature(cmd.predict).parameters)
+
+    def testPredictRefusesCleanlyWithoutTheRuntime(self):
+        self.declareHost('boltz')
+        self.assertRaises(PredictorUnavailable,
+                          cmd.predict, 'simplefold', 'ACDEFG')
+
+    def testPredictRefusesCleanlyAtQuietZeroToo(self):
+        """parsing.py forces quiet=0 for command-line invocations."""
+        self.declareHost('boltz')
+        self.assertRaises(PredictorUnavailable,
+                          cmd.predict, 'simplefold', 'ACDEFG', quiet=0)
+
+    def testBoltzStillRunsWithNoKnobsNamed(self):
+        """The conditional-knob change must not have broken the default call."""
+        from pymol.predictors.boltz2 import Boltz2Predictor
+        options = Boltz2Predictor().validate_options({'seed': 0})
+        self.assertEqual(options.recycling_steps, 3)
+        self.assertEqual(options.diffusion_steps, 200)


### PR DESCRIPTION
#306 is **closed** — Apple's `LICENSE_MODEL` restricts the SimpleFold weights to non-commercial research and excludes product use, so RayMol cannot serve the pack as a `WeightBundle` the way `boltz-mlx` does. See [the closing comment](https://github.com/javierbq/RayMol/issues/306#issuecomment-5309744565) for the full finding.

This PR is the part of that work which was never SimpleFold-specific, and stands on its own.

## A latent bug: a non-Boltz predictor was impossible to call

`predicting.py` put `recycling_steps` and `diffusion_steps` into `requested` unconditionally, so `validate_options` rejected them **by name** for any predictor that had not declared them — including on a call that named no knobs at all. Any method without a trunk was uncallable. Both are conditional now, as `msa_depth` already was; the defaults live in each predictor's `option_defaults`, which is the thing that knows them.

## The runtime seam

`BoltzJobManager` *is* the Boltz backend, not a dispatcher to one, and the request named no runtime.

- `host.submit` writes `runtime`; `preflight` refuses one this build does not carry. Weights and featurizer are method-specific, so running another method's request on the Boltz backend would not fail — it would return a confident wrong structure.
- Optional at the far end, absent meaning `boltz`, so an older Python side still decodes.
- `PyMOLBridge` advertises what is linked in `RAYMOL_PREDICT_RUNTIMES`; `host.require_runtime` reads it, so `check_available` can refuse *before* a weight download instead of after.
- Each predictor puts only its declared knobs on the wire (`knobs=self.option_defaults`). A Boltz request is unchanged.

## The simplefold module

Kept, registered, and inert: it validates input and refuses with "no published weight pack yet." It is the concrete exercise that proved the seam, and it documents the method's real constraints in code — single chain only (the port would fold two chains as their concatenation and emit a plausible-looking PDB), canonical 20 only (its tokenizer maps unknown letters to X), and `supports_msa = False`.

Say so if you would rather not carry a predictor that may never run, and I will strip that module and its tests, leaving the seam and the bug fix.

## Behaviour change worth a look

`predict <Tab>` now lists the three ids instead of silently inserting `boltz2`. While every id began with `boltz2` the completer had a common prefix to fill in; an id from another family removes it. `predict s` completes to `simplefold, ` in one keystroke. Two completion tests encoded the old two-Boltz world and were updated.

## Verification

- 36 new Python tests, 4 new Swift tests. `testing/tests/predict` 263 green, `testing/tests/msa` 127 green — the latter includes the source-reading test that pins Python's wire keys against Swift's `CodingKeys`, which caught the missing `runtime`/`num_steps` decode.
- Full Swift unit suite green; macOS slice compiles.
- **Exercised in the real app**: a Boltz-2 fold of villin HP36 ran end to end through the changed wire (request carried `runtime: "boltz"` and no `num_steps`), finished in 25.5 s at 620 MB peak, and auto-loaded with the seed in the state title and real pLDDT in the B-factor — mean 96.2, correct three-helix bundle. The refusal paths were checked live too.
- **iOS slice not verified**: it fails identically on master with an AppIcon asset-catalog error, before any Swift compiles. This change is invisible to that slice — both edits sit behind `#if os(macOS)` / `#if TARGET_OS_OSX`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)