### PR TITLE
Add Protenix, and the runtime seam a second backend needs (#309)

### DIFF
--- a/docs/predictors.md
+++ b/docs/predictors.md
@@ -19,16 +19,39 @@ it is shaped this way.
 
 ## Shipped predictors
 
-| id | weights | notes |
-|---|---|---|
-| `boltz2` | affine-int8, 507 MB | the default |
-| `boltz2-bf16` | dense bfloat16, 996 MB | same model, same runtime, unquantized |
+| id | runtime | weights | notes |
+|---|---|---|---|
+| `boltz2` | `boltz` | affine-int8, 507 MB | the default |
+| `boltz2-bf16` | `boltz` | dense bfloat16, 996 MB | same model, same runtime, unquantized |
+| `protenix-base` | `protenix` | affine-int8, 214 MB | complexes, single sequence. **Not runnable yet** — no build carries the `protenix` runtime, see #309 |
 
-`boltz2-bf16` subclasses `Boltz2Predictor` and overrides nothing but `weight_bundle`.
-That works because `host.submit` sends `weights_dir` per job and the Swift runtime
-picks its matmul path from the artifact manifest — a dense pack declares no
-quantization block — so one runtime serves both with no host change. It needs
-boltz-mlx >= 0.2.0.
+## Runtimes
+
+A predictor's **runtime** is the Swift backend that runs it, named on the wire by
+`host.submit(..., runtime=)`. It is a separate axis from the predictor id: `boltz2` and
+`boltz2-bf16` are two predictors and one runtime, because `host.submit` sends `weights_dir`
+per job and the Swift side picks its matmul path from the artifact manifest — a dense pack
+declares no quantization block — so one runtime serves both.
+
+The distinction has to be on the wire because weights and featurizer are method-specific.
+Running one method's request on another's backend does not fail; it tokenizes with the
+wrong featurizer and returns a confident wrong structure. So:
+
+- `BoltzJobManager` implements `boltz` and **refuses** any other in `preflight`, before it
+  applies its size model — which is fitted to Boltz's measured peaks and would be
+  meaningless applied to another method's request even as a refusal.
+- `PyMOLBridge` advertises what is actually linked in `RAYMOL_PREDICT_RUNTIMES`, which is
+  what lets `check_available` refuse **before** a weight download rather than after.
+- `Request.runtime` is **optional** on the Swift side, absent meaning `boltz`. A
+  non-optional field would turn any Python/Swift version skew into "malformed prediction
+  request" instead of a refusal that names the missing runtime. The same reasoning applies
+  to `object_name` and `alignments`.
+
+That default is also the trap: a new predictor that forgets to pass `runtime=` is silently
+dispatched to Boltz. `predict_runtime.py` asserts every registered predictor names one.
+
+`boltz2-bf16` subclasses `Boltz2Predictor` and overrides nothing but `weight_bundle`, which
+is what "two predictors, one runtime" looks like in practice. It needs boltz-mlx >= 0.2.0.
 
 It is **not** an upgrade. On an M3 Pro at 117 tokens, recycling 3 / 200 steps, dense
 bfloat16 costs 2x the disk, +63% peak RSS (620 MiB -> 1012 MiB) and +22% wall clock
@@ -80,6 +103,13 @@ float16 is the closer one at identical size (`--precision float16` exports it).
 4. **Implement `check_available`** so the predictor disappears cleanly where it cannot run
    rather than failing mid-run. Platform, OS floor, host presence — not weight state, which the
    weight manager is allowed to fix by downloading.
+
+   If your method needs a Swift backend of its own, call `host.require_runtime` after
+   `host.require_available`: the two failures have different remedies ("you are headless"
+   versus "this build does not carry that backend"), and checking here is what refuses
+   BEFORE a multi-hundred-megabyte download rather than after it. A bulk
+   `predict_weights download=1` also consults this, so a predictor that cannot run is
+   reported but not fetched.
 
 5. **Implement `parse_spec` to reject, not repair.** If the backend silently ignores input it
    does not support, catching that is your job: check what it does with a ligand, a nucleic

--- a/modules/pymol/predicting.py
+++ b/modules/pymol/predicting.py
@@ -1081,9 +1081,26 @@ SEE ALSO
     wait = not host.available() if int(async_) < 0 else not int(async_)
     out = {}
     for pid in ids:
-        bundle = registry.get(pid).weight_bundle
+        predictor_obj = registry.get(pid)
+        bundle = predictor_obj.weight_bundle
         if bundle is None:
             out[pid] = {'cached': True, 'path': None, 'bundle': None}
+            continue
+        # A BULK fetch downloads only what this build could actually run. Asking for one
+        # predictor BY NAME still downloads it -- that is someone pre-warming a cache
+        # deliberately, possibly for a build they do not have yet.
+        #
+        # Without this, "fetch everything" means every registered pack whether or not the
+        # host carries its runtime: `protenix-base` alone is 214 MB that no shipping build
+        # can use yet, pulled down by a command aimed at the predictors that do work.
+        if int(download) and not predictor and not _can_run(predictor_obj):
+            out[pid] = {'cached': bool(cache.is_cached(bundle)),
+                        'path': cache.path_for(bundle),
+                        'bundle': bundle.id}
+            if not int(quiet):
+                colorprinting.parrot(
+                    ' predict: %s cannot run in this build; not fetching its weights'
+                    % pid)
             continue
         if int(download) and not cache.is_cached(bundle):
             fetching.start(bundle, cache)
@@ -1096,6 +1113,21 @@ SEE ALSO
             colorprinting.parrot(' predict: %s weights cached=%s at %s' % (
                 pid, out[pid]['cached'], out[pid]['path']))
     return out
+
+
+def _can_run(predictor_obj):
+    """True if this predictor could run here, for deciding whether to pre-fetch.
+
+    Never raises: `check_available` is a predictor's own code, and a bulk pre-warm must
+    not be derailed by one method's availability check. An error means "cannot say", and a
+    bulk fetch treats that as "do not download" -- the cheap direction to be wrong in,
+    since naming the predictor explicitly still fetches it.
+    """
+    try:
+        predictor_obj.check_available()
+    except Exception:
+        return False
+    return True
 
 
 def _wait_for_fetch(bundle, quiet, _poll=0.1):

--- a/modules/pymol/predictors/__init__.py
+++ b/modules/pymol/predictors/__init__.py
@@ -12,8 +12,10 @@ def _register_builtins():
     """Register the shipped predictors. The only function that changes per predictor."""
     from .boltz2 import Boltz2Predictor
     from .boltz2_bf16 import Boltz2BF16Predictor
+    from .protenix import ProtenixBasePredictor
     register(Boltz2Predictor(), replace=True)
     register(Boltz2BF16Predictor(), replace=True)
+    register(ProtenixBasePredictor(), replace=True)
 
 
 _register_builtins()

--- a/modules/pymol/predictors/boltz2.py
+++ b/modules/pymol/predictors/boltz2.py
@@ -22,6 +22,10 @@ CANONICAL = set('ACDEFGHIKLMNPQRSTVWY')
 #: BoltzInputLimits.desktop caps at 1024 tokens, and one token is one residue.
 MAX_RESIDUES = 1024
 
+#: The backend the Swift host dispatches to. Also what a request with no `runtime` at all
+#: is taken to mean, so an older Python side keeps working -- see host.DEFAULT_RUNTIME.
+RUNTIME = 'boltz'
+
 
 class Boltz2Predictor(Predictor):
 
@@ -77,4 +81,5 @@ class Boltz2Predictor(Predictor):
         return PredictionSpec(chains, name)
 
     def submit(self, spec, options, weights_path):
-        return host.submit(spec, options, weights_path)
+        return host.submit(spec, options, weights_path, runtime=RUNTIME,
+                           knobs=self.option_defaults)

--- a/modules/pymol/predictors/host.py
+++ b/modules/pymol/predictors/host.py
@@ -17,10 +17,24 @@ import os
 import tempfile
 import uuid
 
+from .base import PredictionOptions
 from .errors import PredictorUnavailable
 
 #: Set by the Swift host next to PYMOL_PATH so Python can tell it is present.
 HOST_ENV = 'RAYMOL_PREDICT_HOST'
+
+#: Comma-separated inference runtimes the host has actually LINKED, set beside HOST_ENV.
+#: A host is not one capability but several: the app may carry the Boltz runtime and not
+#: another method's, and a predictor whose runtime is missing must say so in
+#: check_available rather than submit a job that would be refused -- or worse, run on the
+#: wrong backend, since the weights and the featurizer are method-specific and a mismatch
+#: does not fail, it returns a confident wrong structure.
+RUNTIMES_ENV = 'RAYMOL_PREDICT_RUNTIMES'
+
+#: What a host that does not declare RUNTIMES_ENV is assumed to carry. Every build before
+#: this variable existed had exactly the Boltz runtime, so this keeps an older app -- or a
+#: test that only sets HOST_ENV -- working unchanged.
+DEFAULT_RUNTIME = 'boltz'
 
 
 def available():
@@ -32,12 +46,34 @@ def available():
     return bool(os.environ.get(HOST_ENV))
 
 
+def supported_runtimes():
+    """Inference runtimes this host can actually run, as a tuple."""
+    declared = os.environ.get(RUNTIMES_ENV, '')
+    names = tuple(part.strip() for part in declared.split(',') if part.strip())
+    return names or (DEFAULT_RUNTIME,)
+
+
 def require_available(predictor_id):
     if not available():
         raise PredictorUnavailable(
             '%s needs the RayMol application host; it is not available in this '
             'process (headless PyMOL cannot run on-device inference)'
             % predictor_id)
+
+
+def require_runtime(predictor_id, runtime):
+    """Raise unless the host declares `runtime`. Call after require_available().
+
+    Separate from require_available() because the two failures have different remedies:
+    no host at all means "you are running headless", while a missing runtime means "this
+    build of RayMol does not carry that backend". Checking here is also what refuses
+    BEFORE a multi-hundred-megabyte weight download rather than after it.
+    """
+    if runtime not in supported_runtimes():
+        raise PredictorUnavailable(
+            '%s needs the %r inference runtime, which this build of RayMol does '
+            'not carry (it has: %s)'
+            % (predictor_id, runtime, ', '.join(supported_runtimes())))
 
 
 def _path(kind, job_id, suffix='json'):
@@ -114,8 +150,14 @@ def _write(path, text):
     os.replace(temp, path)
 
 
-def submit(spec, options, weights_path):
-    """Write the request, print the marker, return the handle. Never blocks."""
+def submit(spec, options, weights_path, runtime=DEFAULT_RUNTIME, knobs=None):
+    """Write the request, print the marker, return the handle. Never blocks.
+
+    `runtime` names the backend the host must dispatch to. `knobs` is the option names to
+    put on the wire -- pass the predictor's own `option_defaults`, so the request carries
+    exactly what that method declared it honours and nothing else. Both default to what
+    the only predictor before them wanted, so an existing call site is unaffected.
+    """
     job_id = uuid.uuid4().hex[:12]
     job = HostJob(job_id, spec, options)
 
@@ -145,6 +187,12 @@ def submit(spec, options, weights_path):
 
     request = {
         'job_id': job_id,
+        # Which backend must run this. OPTIONAL at the far end, absent meaning boltz, so
+        # a request written by a Python side that predates the second runtime still
+        # decodes -- the same reasoning as `object_name` and `alignments`. A non-optional
+        # field would turn any Python/Swift skew into "malformed prediction request"
+        # instead of a refusal that names the missing runtime.
+        'runtime': runtime,
         'weights_dir': weights_path or '',
         # Objects, not pairs: BoltzJobManager.Chain is a Codable struct with named
         # keys, so a positional array would fail to decode.
@@ -154,13 +202,6 @@ def submit(spec, options, weights_path):
         # dummy depth-1 alignment to any chain not listed, which is the designed-binder
         # case: an alignment for the target, none for the binder.
         'alignments': alignments,
-        'recycling_steps': options.recycling_steps,
-        'diffusion_steps': options.diffusion_steps,
-        'seed': options.seed,
-        # How many rows of each a3m to read. Applied on the HOST side, by the same
-        # parser that reads the file, so the truncation is the parser's own -- the a3m
-        # written above is always the whole alignment.
-        'msa_depth': options.msa_depth,
         'out_path': job.out_path,
         'status_path': job.status_path,
         # The object the host loads the finished structure into. Resolved at submit time
@@ -168,6 +209,14 @@ def submit(spec, options, weights_path):
         # needs no second round-trip to find out where the result belongs.
         'object_name': getattr(spec, 'name', '') or '',
     }
+    # The inference knobs, exactly as the predictor declared them -- not every knob
+    # PredictionOptions can hold. A method that has no alignment must not send
+    # `msa_depth`: on the wire it would read as a depth it honours, and the run would be
+    # recorded as having used an alignment it never saw.
+    if knobs is None:
+        knobs = PredictionOptions.__slots__
+    for knob in knobs:
+        request[knob] = getattr(options, knob)
     # Write completely before announcing it: the host reads on the next 100 ms
     # tick and must never see a partial request.
     _write(job.request_path, json.dumps(request))

--- a/modules/pymol/predictors/protenix.py
+++ b/modules/pymol/predictors/protenix.py
@@ -1,0 +1,163 @@
+"""Protenix via protenix-mlx: ByteDance's AlphaFold3-class predictor, in Swift/MLX.
+
+Protein-only, canonical-20, complexes included: the port's featurizer groups chains into
+entities and builds the cross-chain pair features, so a multimer is something this method
+genuinely models rather than something it approximates. What it carries no reference
+conformers for -- ligands, nucleic acids, modified residues, anything needing the chemical
+component dictionary at fold time -- is refused by name rather than folded as an
+approximation of itself.
+
+This is also the SECOND inference runtime, and the first request that has to say so. The
+`runtime` field, `host.require_runtime` and `RAYMOL_PREDICT_RUNTIMES` exist because of it:
+weights and featurizer are method-specific, so a Protenix request that reached the Boltz
+backend would not fail, it would return a confident wrong structure.
+
+Single-sequence. `supports_msa` is False and staying False until an a3m can actually
+reach `msa_features`: the port feeds the network upstream's depth-1 dummy alignment, and
+a method that accepted a real alignment and then folded against that dummy would return
+a worse structure with nothing in the result saying so. The MSA module itself IS ported,
+so this becomes possible rather than remaining structural -- see #274.
+
+The port DOES have a confidence head -- pLDDT, PAE, PDE and resolved, verified against
+PyTorch to 2e-4 -- and this predictor deliberately declares none of it yet. `metric_specs`
+needs the per-object metric store (#308) to have somewhere to put a per-residue array, so
+the declaration lands with that rather than here. Until then a fold arrives with its
+provenance and cost and no confidence numbers, which is the honest state: the runtime can
+compute them and RayMol cannot yet keep them.
+
+Worth knowing before running it: single-sequence output degrades sharply with length. On
+complete domains, mean pLDDT goes 94.8 at 35 residues, 67.5 at 76, 58.9 at 110, 37.0 at
+129, and sits near 26 from 400 up. That is the documented behaviour of an AF3-class model
+with no alignment rather than a fault in the port, and it means this method earns its time
+on small domains and not much else until #274 gives it a real one.
+"""
+from . import host
+from .base import Predictor, PredictionSpec, parse_chains
+from .errors import PredictionInputError, PredictorUnavailable
+from .weights import WeightBundle
+
+#: The canonical 20. Everything else is refused rather than substituted: the port's
+#: featurizer raises on an unknown letter instead of resolving it to X, so accepting one
+#: here would only defer the same error past a 214 MB download.
+CANONICAL = set('ACDEFGHIKLMNPQRSTVWY')
+
+#: Measured peak memory at the shipped operating point (recycling 10 / 200 steps, with
+#: the confidence head), on an M-series Mac against the base int8 pack. This is MLX's own
+#: high-water mark, not process RSS: the two are different numbers and RSS is not even
+#: monotonic in problem size, because MLX recycles buffers in a cache it need not return
+#: to the OS -- measured by RSS, 400 residues appears to cost LESS than 60.
+#:
+#:     residues     60    120    250    400    550    700
+#:     peak        547    942   2279   3868   6303   8622  MiB
+#:     mean pLDDT 82.7   47.3   30.9   27.2   26.2   26.3
+MEASURED_PEAK_MIB = ((60, 547), (120, 942), (250, 2279), (400, 3868), (550, 6303),
+                     (700, 8622))
+
+#: The cap sits BELOW the largest measurement rather than at it, which is the one place
+#: this file departs from "the largest input measured".
+#:
+#: 700 residues runs, at 8.6 GB and six minutes. That is not a fold to permit by default:
+#: alongside a loaded session it is where a jetsam kill takes the user's unsaved work,
+#: which `PredictSizeGuard` exists to prevent and which no Swift handler can intercept.
+#: And the model's own confidence at that length is 26 -- the run costs six minutes to
+#: produce a structure it says nothing can be concluded from.
+#:
+#: 400 (3.9 GB) is the largest length that both fits comfortably and is worth the wait.
+#: Raise it with a measurement AND a reason, never with either alone.
+MAX_RESIDUES = 400
+
+#: What single-sequence folding is actually worth here, measured on the same pack. Mean
+#: pLDDT against length, over COMPLETE domains rather than truncations (a truncation
+#: scores badly for reasons of its own):
+#:
+#:     villin 35   GB1 56   ubiquitin 76   barnase 110   lysozyme 129
+#:       94.8       72.3        67.5          58.9          37.0
+#:
+#: That is the documented behaviour of an AF3-class model with no alignment, not a fault
+#: in the port -- the same pack discriminates correctly at small sizes (villin 94.8
+#: against 78.4 for poly-alanine of the same length). It is recorded here because it is
+#: the single most useful thing to know before spending two minutes on a fold: past
+#: roughly a hundred residues, single-sequence output is not worth much, and #274 is what
+#: changes that rather than a bigger pack. Lysozyme is the low outlier for a second
+#: reason worth naming -- it has four disulfides, and `token_bonds` is all zeros here.
+MEASURED_CONFIDENCE = ((35, 94.8), (56, 72.3), (76, 67.5), (110, 58.9), (129, 37.0))
+
+#: The backend the Swift host must dispatch to, as it appears on the wire.
+RUNTIME = 'protenix'
+
+
+class ProtenixBasePredictor(Predictor):
+
+    id = 'protenix-base'
+    name = 'Protenix base (MLX, int8)'
+
+    # sha256 and size are of the bytes GitHub serves, taken from protenix-mlx's
+    # WEIGHTS.md, which records the digest of the uploaded asset rather than of a local
+    # rebuild -- int8 quantization runs on Metal and is not bitwise reproducible across
+    # machines, so a re-export would not match.
+    #
+    # Three members, the same shape boltz2's pack has, so WeightCache needs no change.
+    # `config.json` is not optional decoration here: a Protenix checkpoint carries no
+    # architecture at all (it is `{"model": state_dict, "model_version"}`), and the four
+    # variants share tensor NAMES while differing in depth and width, so the runtime
+    # cannot tell an 8-block Pairformer from a 48-block one without it.
+    weight_bundle = WeightBundle(
+        id='protenix-base-mlx-int8',
+        version='v1',
+        url='https://github.com/javierbq/protenix-mlx/releases/download/weights-base-v1/'
+            'protenix-base-mlx-int8-v1.zip',
+        sha256='6a405fbfb0f3b331315bc317106f22ed5daf10eb7b9b1122c4eae5db77b26977',
+        size=224_688_268,
+        members=('config.json', 'manifest.json', 'model.safetensors'),
+    )
+
+    # The released model's own operating point, from its config.json: 10 recycles and
+    # 200 diffusion steps. Both knobs already exist on cmd.predict because Boltz-2 has
+    # them and they mean the same thing here -- Protenix recycles a trunk and runs
+    # reverse diffusion -- so this is the first predictor that adds no knob to
+    # predicting.py at all.
+    #
+    # msa_depth is absent, which is what makes the depth lever rejected by name rather
+    # than accepted and ignored: there is no alignment to have a depth.
+    option_defaults = {'recycling_steps': 10, 'diffusion_steps': 200, 'seed': 0}
+
+    # Single-sequence; see the module docstring.
+    supports_msa = False
+
+    # Deliberately not declared yet: the runtime computes pLDDT and the PAE matrix, and
+    # a per-residue array needs the metric store (#308) to land in. Declaring keys with
+    # nowhere to write them would put numbers in the schema that never arrive.
+    metric_specs = ()
+
+    def check_available(self):
+        host.require_available(self.id)
+        # After require_available, because the two failures have different remedies:
+        # "you are headless" versus "this build does not carry that backend". Checking
+        # here is what refuses BEFORE a 214 MB download rather than after it.
+        host.require_runtime(self.id, RUNTIME)
+
+    def parse_spec(self, sequence, name=''):
+        chains = parse_chains(sequence)
+        total = 0
+        for chain, seq in chains:
+            bad = sorted(set(seq) - CANONICAL)
+            if bad:
+                raise PredictionInputError(
+                    'chain %s contains residues Protenix cannot fold here: %s. This '
+                    'runtime carries reference conformers for the canonical 20 only, '
+                    'so ligands, nucleic acids, modified residues and X, U, B and Z '
+                    'are refused rather than folded as something else.'
+                    % (chain, ', '.join(bad)))
+            total += len(seq)
+        if total > MAX_RESIDUES:
+            raise PredictionInputError(
+                '%d residues exceeds the %d-residue limit. That limit is the largest '
+                'input measured on this device class, not a limit of the method: '
+                'Protenix is ~N^2 in tokens across 48 Pairformer blocks and ten '
+                'recycles, and an unmeasured extrapolation is how a run gets killed '
+                'mid-fold.' % (total, MAX_RESIDUES))
+        return PredictionSpec(chains, name)
+
+    def submit(self, spec, options, weights_path):
+        return host.submit(spec, options, weights_path, runtime=RUNTIME,
+                           knobs=self.option_defaults)

--- a/swiftui/PyMOLViewer/Bridge/PyMOLBridge.mm
+++ b/swiftui/PyMOLViewer/Bridge/PyMOLBridge.mm
@@ -110,6 +110,13 @@ void PyMOLBridge_InitPython(PyMOLHandle h, const char *resourcePath)
     // are after init and get away with it only because PyMOL's own Python layer
     // assigns those into os.environ itself.)
     setenv("RAYMOL_PREDICT_HOST", "1", 1);
+    // Which inference runtimes are actually LINKED into this build. A host is not one
+    // capability but several: BoltzJobManager implements "boltz" and nothing else, so a
+    // predictor whose backend is missing refuses in check_available rather than
+    // submitting a job that BoltzJobManager.preflight would refuse -- after the user had
+    // waited out a weight download. Keep in step with BoltzJobManager.boltzRuntime; add
+    // a name here only when its runtime actually ships.
+    setenv("RAYMOL_PREDICT_RUNTIMES", "boltz", 1);
 #endif
 
     PyStatus status = Py_InitializeFromConfig(&config);

--- a/swiftui/PyMOLViewer/Shared/BoltzJobManager.swift
+++ b/swiftui/PyMOLViewer/Shared/BoltzJobManager.swift
@@ -17,6 +17,13 @@ final class BoltzJobManager {
 
     static let shared = BoltzJobManager()
 
+    /// The one inference runtime this manager implements, as it appears on the wire.
+    /// Kept in step with `pymol.predictors.boltz2.RUNTIME`, and with the value
+    /// `PyMOLBridge` advertises in `RAYMOL_PREDICT_RUNTIMES` — that variable is what lets
+    /// a predictor whose backend is NOT linked here refuse in `check_available` instead
+    /// of submitting a job that only gets refused after a weight download.
+    static let boltzRuntime = "boltz"
+
     /// MLX must never run on the main thread. `cmd.predict` from the console arrives ON
     /// the main thread, which is exactly why submit is fire-and-forget.
     private let queue = DispatchQueue(label: "io.raymol.predict.inference",
@@ -95,6 +102,13 @@ final class BoltzJobManager {
         let jobID: String
         let weightsDir: String
         let chains: [Chain]
+        /// Which backend must run this job. OPTIONAL, absent meaning ``boltzRuntime`` —
+        /// every Python side that predates a second runtime wrote no such key, and the
+        /// only runtime that existed then was this one. A request naming a runtime this
+        /// build does not carry is REFUSED in `preflight`, never run here: the weights and
+        /// the featurizer are method-specific, so running one method's request on
+        /// another's backend would not fail, it would return a confident wrong answer.
+        let runtime: String?
         let recyclingSteps: Int
         let diffusionSteps: Int
         let seed: UInt64
@@ -122,7 +136,7 @@ final class BoltzJobManager {
         let objectName: String?
 
         enum CodingKeys: String, CodingKey {
-            case jobID = "job_id", weightsDir = "weights_dir", chains
+            case jobID = "job_id", weightsDir = "weights_dir", chains, runtime
             case recyclingSteps = "recycling_steps", diffusionSteps = "diffusion_steps"
             case seed, outPath = "out_path", statusPath = "status_path"
             case objectName = "object_name"
@@ -232,6 +246,13 @@ final class BoltzJobManager {
     /// `pollFeedback`: the alignment's real depth costs a parse of the a3m, which
     /// belongs on the inference queue. `alignmentPreflight` makes that second check.
     static func preflight(_ request: Request) -> Status? {
+        // Runtime first, before any sizing: the size model below is Boltz's, fitted to
+        // Boltz's measured peaks, so applying it to another method's request would be
+        // meaningless even as a refusal. Absent means Boltz, per `Request.runtime`.
+        if let runtime = request.runtime, runtime != boltzRuntime {
+            return refusal("this build of RayMol does not carry the '\(runtime)' "
+                         + "inference runtime")
+        }
         let tokens = request.chains.reduce(0) { $0 + $1.sequence.count }
         switch PredictSizeGuard.decide(tokens: tokens,
                                        availableBytes: PredictSizeGuard.availableBytes) {

--- a/testing/tests/predict/predict_completion.py
+++ b/testing/tests/predict/predict_completion.py
@@ -12,8 +12,16 @@ from pymol import cmd, testing
 
 class TestPredictCompletion(testing.PyMOLTestCase):
 
-    def testPredictOffersRegisteredPredictors(self):
-        self.assertEqual(cmd._parser.complete('predict '), 'predict boltz2')
+    def testPredictCompletesNothingWhenTheIdsShareNoPrefix(self):
+        """Tab extends the line to the LONGEST COMMON PREFIX, or not at all.
+
+        With `boltz2`, `boltz2-bf16` and `protenix-base` registered there is no common
+        prefix, so an empty argument completes to nothing and the parser returns None.
+        The candidate list is still shown -- that is `complete`'s side effect, not its
+        return value. This assertion is about the registry's contents, so it moves every
+        time a predictor whose id starts with a new letter is added.
+        """
+        self.assertIsNone(cmd._parser.complete('predict '))
 
     def testPartialPredictorNameCompletesAsFarAsItIsUnambiguous(self):
         """'boltz2' is a PREFIX of 'boltz2-bf16', so Tab stops there with no separator.
@@ -25,9 +33,19 @@ class TestPredictCompletion(testing.PyMOLTestCase):
         self.assertEqual(cmd._parser.complete('predict boltz2-'),
                          'predict boltz2-bf16, ')
 
+    def testAnIdSharingNoPrefixCompletesInOneStep(self):
+        """The payoff for NOT naming it `protenix`: 'p' identifies it uniquely.
+
+        Had a second Protenix pack shipped as `protenix`, this would stop at the bare
+        `protenix` with no separator -- the dead end `boltz2` already creates above.
+        """
+        self.assertEqual(cmd._parser.complete('predict p'),
+                         'predict protenix-base, ')
+
     def testPredictWeightsAlsoOffersPredictors(self):
-        self.assertEqual(cmd._parser.complete('predict_weights '),
+        self.assertEqual(cmd._parser.complete('predict_weights b'),
                          'predict_weights boltz2')
+        self.assertIsNone(cmd._parser.complete('predict_weights '))
 
     def testCommandNameItselfStillCompletes(self):
         self.assertEqual(cmd._parser.complete('predic'), 'predict')

--- a/testing/tests/predict/predict_protenix.py
+++ b/testing/tests/predict/predict_protenix.py
@@ -1,0 +1,411 @@
+"""protenix-base predictor: availability, what it accepts, and what it puts on the wire.
+No Swift and no network -- the host is simulated by the env vars it sets.
+
+    pymol -ckqy testing/testing.py --run testing/tests/predict/predict_protenix.py
+"""
+import io
+import json
+import os
+from contextlib import redirect_stdout
+
+from pymol import cmd, predicting, testing
+from pymol.predictors import host
+from pymol.predictors.errors import (PredictionInputError, PredictionOptionError,
+                                     PredictorUnavailable)
+from pymol.predictors.protenix import MAX_RESIDUES, ProtenixBasePredictor
+
+
+class HostEnvTestCase(testing.PyMOLTestCase):
+    """Restores both host variables, so one test cannot leak into the next."""
+
+    def setUp(self):
+        testing.PyMOLTestCase.setUp(self)
+        self._saved = {name: os.environ.get(name)
+                       for name in (host.HOST_ENV, host.RUNTIMES_ENV)}
+
+    def tearDown(self):
+        for name, value in self._saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        testing.PyMOLTestCase.tearDown(self)
+
+    def declareHost(self, runtimes):
+        os.environ[host.HOST_ENV] = '1'
+        os.environ[host.RUNTIMES_ENV] = runtimes
+
+
+class TestAvailability(HostEnvTestCase):
+
+    def testUnavailableWithoutAHost(self):
+        os.environ.pop(host.HOST_ENV, None)
+        os.environ.pop(host.RUNTIMES_ENV, None)
+        self.assertRaises(PredictorUnavailable,
+                          ProtenixBasePredictor().check_available)
+
+    def testNoHostIsReportedAsNoHostEvenWhenTheRuntimeIsAlsoMissing(self):
+        """Order matters: the two failures have different remedies."""
+        os.environ.pop(host.HOST_ENV, None)
+        os.environ.pop(host.RUNTIMES_ENV, None)
+        try:
+            ProtenixBasePredictor().check_available()
+        except PredictorUnavailable as error:
+            self.assertIn('application host', str(error))
+        else:
+            self.fail('expected PredictorUnavailable')
+
+    def testRefusedOnAHostThatCarriesOnlyBoltz(self):
+        """This is today's state: no build carries the protenix runtime yet."""
+        self.declareHost('boltz')
+        try:
+            ProtenixBasePredictor().check_available()
+        except PredictorUnavailable as error:
+            self.assertIn('protenix-base', str(error))
+            self.assertIn('does not carry', str(error))
+        else:
+            self.fail('expected PredictorUnavailable')
+
+    def testRefusalNamesWhatTheBuildDoesCarry(self):
+        """So the user can tell "wrong build" from "wrong predictor name"."""
+        self.declareHost('boltz,mystery')
+        try:
+            ProtenixBasePredictor().check_available()
+        except PredictorUnavailable as error:
+            self.assertIn('boltz', str(error))
+        else:
+            self.fail('expected PredictorUnavailable')
+
+    def testAvailableOnAHostCarryingProtenix(self):
+        self.declareHost('boltz,protenix')
+        self.assertIsNone(ProtenixBasePredictor().check_available())
+
+    def testAHostDeclaringNothingIsAssumedBoltzOnly(self):
+        os.environ[host.HOST_ENV] = '1'
+        os.environ.pop(host.RUNTIMES_ENV, None)
+        self.assertRaises(PredictorUnavailable,
+                          ProtenixBasePredictor().check_available)
+
+
+class TestComplexesAreAccepted(testing.PyMOLTestCase):
+    """Protenix genuinely models a complex, so a multimer is accepted.
+
+    The port's featurizer groups chains into entities and builds the cross-chain pair
+    features, so refusing a multimer here would withhold something the method does. A
+    method that CANNOT model one must refuse instead: folding the concatenation would
+    emit a PDB nothing downstream could distinguish from a real prediction.
+    """
+
+    def predictor(self):
+        return ProtenixBasePredictor()
+
+    def testOneChainIsAccepted(self):
+        spec = self.predictor().parse_spec('ACDEFGHIK', 'p')
+        self.assertEqual(spec.chains, (('A', 'ACDEFGHIK'),))
+
+    def testTwoTypedChainsAccepted(self):
+        spec = self.predictor().parse_spec('ACDEF/GHIKL')
+        self.assertEqual(spec.chains, (('A', 'ACDEF'), ('B', 'GHIKL')))
+
+    def testAHomodimerIsAccepted(self):
+        """Identical sequences are the case the featurizer groups into one entity."""
+        spec = self.predictor().parse_spec('ACDEF/ACDEF')
+        self.assertEqual(spec.chains, (('A', 'ACDEF'), ('B', 'ACDEF')))
+
+    def testAMultiChainSelectionIsAccepted(self):
+        cmd.fab('ACDEFG', 'one')
+        cmd.fab('GHIKL', 'two')
+        resolved = predicting.resolve_sequence('one or two')
+        self.assertEqual(resolved, 'ACDEFG/GHIKL')
+        spec = self.predictor().parse_spec(resolved)
+        self.assertEqual(len(spec.chains), 2)
+
+    def testTheLimitIsOnTheTotalNotPerChain(self):
+        """Peak memory is ~N^2 in TOTAL tokens, so the cap has to be on the sum."""
+        half = 'A' * (MAX_RESIDUES // 2 + 1)
+        self.assertRaises(PredictionInputError,
+                          self.predictor().parse_spec, '%s/%s' % (half, half))
+
+
+class TestResidueValidation(testing.PyMOLTestCase):
+
+    def predictor(self):
+        return ProtenixBasePredictor()
+
+    def testNonCanonicalRejectedRatherThanSubstituted(self):
+        for sequence in ('ACDEFX', 'ACDEFU', 'ACDEFB', 'ACDEFZ'):
+            self.assertRaises(PredictionInputError,
+                              self.predictor().parse_spec, sequence)
+
+    def testTheOffendingLetterIsNamed(self):
+        try:
+            self.predictor().parse_spec('ACDEFJ')
+        except PredictionInputError as error:
+            self.assertIn('J', str(error))
+        else:
+            self.fail('expected PredictionInputError')
+
+    def testTheChainIsNamedToo(self):
+        """With a complex, "there is a bad residue" is not actionable on its own."""
+        try:
+            self.predictor().parse_spec('ACDEF/GHIKX')
+        except PredictionInputError as error:
+            self.assertIn('chain B', str(error))
+        else:
+            self.fail('expected PredictionInputError')
+
+    def testTheRefusalSaysWhyRatherThanJustNo(self):
+        """The reason is the remedy: this runtime carries no CCD, so no ligands."""
+        try:
+            self.predictor().parse_spec('ACDEFX')
+        except PredictionInputError as error:
+            self.assertIn('canonical 20', str(error))
+        else:
+            self.fail('expected PredictionInputError')
+
+    def testTooLongRejected(self):
+        self.assertRaises(PredictionInputError,
+                          self.predictor().parse_spec, 'A' * (MAX_RESIDUES + 1))
+
+    def testAtTheLimitAccepted(self):
+        spec = self.predictor().parse_spec('A' * MAX_RESIDUES)
+        self.assertEqual(len(spec.chains[0][1]), MAX_RESIDUES)
+
+    def testTheLimitSaysItIsMeasuredRatherThanIntrinsic(self):
+        try:
+            self.predictor().parse_spec('A' * (MAX_RESIDUES + 1))
+        except PredictionInputError as error:
+            self.assertIn('measured', str(error))
+        else:
+            self.fail('expected PredictionInputError')
+
+
+class TestOptions(testing.PyMOLTestCase):
+    """Protenix recycles a trunk and runs reverse diffusion, so it takes Boltz's knobs."""
+
+    def predictor(self):
+        return ProtenixBasePredictor()
+
+    def testTheReleasedOperatingPointIsTheDefault(self):
+        options = self.predictor().validate_options({})
+        self.assertEqual(options.recycling_steps, 10)
+        self.assertEqual(options.diffusion_steps, 200)
+
+    def testBothKnobsAreHonoured(self):
+        options = self.predictor().validate_options(
+            {'recycling_steps': 3, 'diffusion_steps': 50})
+        self.assertEqual(options.recycling_steps, 3)
+        self.assertEqual(options.diffusion_steps, 50)
+
+    def testMsaDepthRejectedByName(self):
+        """There is no alignment to have a depth."""
+        try:
+            self.predictor().validate_options({'msa_depth': 64})
+        except PredictionOptionError as error:
+            self.assertIn('msa_depth', str(error))
+        else:
+            self.fail('expected msa_depth to be rejected by name')
+
+    def testKnobsAreStillBounded(self):
+        for bad in ({'recycling_steps': -1}, {'diffusion_steps': 0}, {'seed': -1}):
+            self.assertRaises(PredictionOptionError,
+                              self.predictor().validate_options, bad)
+
+
+class TestAlignmentsRefused(testing.PyMOLTestCase):
+    """supports_msa is False, so an alignment is refused BY NAME rather than dropped."""
+
+    def testAnAlignmentIsRefused(self):
+        predictor = ProtenixBasePredictor()
+        spec = predictor.parse_spec('ACDEFG')
+
+        class FakeMSA:
+            name = 'aln'
+            query = 'ACDEFG'
+            depth = 32
+
+        try:
+            predictor.bind_alignments(spec, {'A': FakeMSA()})
+        except PredictionInputError as error:
+            self.assertIn('cannot use a multiple-sequence alignment', str(error))
+        else:
+            self.fail('expected PredictionInputError')
+
+    def testNoAlignmentIsFine(self):
+        predictor = ProtenixBasePredictor()
+        spec = predictor.parse_spec('ACDEFG')
+        self.assertEqual(predictor.bind_alignments(spec, {}).alignments, {})
+
+
+class TestWireFormat(testing.PyMOLTestCase):
+    """What reaches the Swift host: its runtime, and only its own knobs."""
+
+    def submit(self, sequence='ACDEFG', options=None):
+        predictor = ProtenixBasePredictor()
+        spec = predictor.parse_spec(sequence, 'pred')
+        options = predictor.validate_options(options or {})
+        with redirect_stdout(io.StringIO()) as buf:
+            job = predictor.submit(spec, options, '/tmp/weights')
+        with open(job.request_path) as handle:
+            request = json.load(handle)
+        os.unlink(job.request_path)
+        return job, request, buf.getvalue()
+
+    def testRequestNamesTheProtenixRuntime(self):
+        _, request, _ = self.submit()
+        self.assertEqual(request['runtime'], 'protenix')
+
+    def testRequestCarriesItsOwnKnobs(self):
+        _, request, _ = self.submit(
+            options={'recycling_steps': 4, 'diffusion_steps': 20, 'seed': 7})
+        self.assertEqual(request['recycling_steps'], 4)
+        self.assertEqual(request['diffusion_steps'], 20)
+        self.assertEqual(request['seed'], 7)
+
+    def testRequestOmitsKnobsProtenixDoesNotHave(self):
+        _, request, _ = self.submit()
+        for absent in ('msa_depth',):
+            self.assertNotIn(absent, request)
+
+    def testAComplexReachesTheWireAsBothChains(self):
+        _, request, _ = self.submit('ACDEF/GHIKL')
+        self.assertEqual(request['chains'],
+                         [{'chain': 'A', 'sequence': 'ACDEF'},
+                          {'chain': 'B', 'sequence': 'GHIKL'}])
+
+    def testMarkerIsPrinted(self):
+        job, _, out = self.submit()
+        self.assertIn('PREDICT:submit:%s' % job.job_id, out)
+
+
+class TestRegistration(testing.PyMOLTestCase):
+
+    def testRegisteredUnderItsId(self):
+        from pymol.predictors import registry
+        self.assertIn('protenix-base', registry.available())
+        self.assertEqual(registry.get('protenix-base').id, 'protenix-base')
+
+    def testIdIsNotAPrefixExtensionOfAnother(self):
+        """docs/predictors.md step 1: a shared prefix breaks tab completion.
+
+        This is why the id is `protenix-base` and not `protenix` -- a later
+        `protenix-v2` would otherwise stop `predict protenix<Tab>` at a bare
+        `protenix` that names no runnable predictor.
+        """
+        from pymol.predictors import registry
+        for other in (i for i in registry.available() if i != 'protenix-base'):
+            self.assertFalse('protenix-base'.startswith(other))
+            self.assertFalse(other.startswith('protenix-base'))
+
+    def testWeightBundleIsDeclaredWithARealDigest(self):
+        bundle = ProtenixBasePredictor().weight_bundle
+        self.assertEqual(len(bundle.sha256), 64)
+        self.assertNotEqual(set(bundle.sha256), {'0'})
+        self.assertGreater(bundle.size, 0)
+        self.assertEqual(bundle.members,
+                         ('config.json', 'manifest.json', 'model.safetensors'))
+
+    def testConfigJsonIsAMandatoryMember(self):
+        """A Protenix checkpoint carries no architecture, so the pack must."""
+        self.assertIn('config.json', ProtenixBasePredictor().weight_bundle.members)
+
+
+class TestCommandSurface(HostEnvTestCase):
+    """cmd.predict's own layer, at quiet=0 as well as the default.
+
+    parsing.py sets quiet=0 for any command-line invocation, so a suite that only
+    exercises quiet=1 never takes a single message-emitting branch.
+    """
+
+    def testAnUnknownPredictorNamesThisOneAmongTheAlternatives(self):
+        """The registry's own error is how a user discovers the id."""
+        from pymol.predictors import registry
+        from pymol.predictors.errors import PredictorNotFound
+        try:
+            registry.get('protenix')
+        except PredictorNotFound as error:
+            self.assertIn('protenix-base', str(error))
+        else:
+            self.fail('expected a bare "protenix" to be unknown')
+
+    def testRefusalIsReportedAtBothVerbosities(self):
+        self.declareHost('boltz')
+        for quiet in (0, 1):
+            with redirect_stdout(io.StringIO()):
+                self.assertRaises(PredictorUnavailable, cmd.predict,
+                                  'protenix-base', 'ACDEFG', quiet=quiet)
+
+    def testWeightsSurfaceReportsTheBundleWithoutFetchingIt(self):
+        """predict_weights iterates EVERY predictor, so this must not download."""
+        for quiet in (0, 1):
+            out = cmd.predict_weights('protenix-base', download=0, quiet=quiet)
+            self.assertEqual(out['protenix-base']['bundle'],
+                             'protenix-base-mlx-int8')
+
+
+class TestBulkPrefetchSkipsWhatCannotRun(HostEnvTestCase):
+    """`predict_weights download=1` with no id must not fetch an unusable pack.
+
+    It iterates every registered predictor, and protenix-base is 214 MB whose runtime
+    no shipping build carries yet -- so without a filter, a command aimed at the
+    predictors that DO work pulls it down anyway. Naming it explicitly still fetches:
+    that is someone deliberately pre-warming, possibly for a build they do not have.
+    """
+
+    def setUp(self):
+        HostEnvTestCase.setUp(self)
+        self.started = []
+        from pymol.predictors import fetching
+        self._real_start = fetching.start
+        fetching.start = lambda bundle, cache, **kw: self.started.append(bundle.id)
+
+    def tearDown(self):
+        from pymol.predictors import fetching
+        fetching.start = self._real_start
+        HostEnvTestCase.tearDown(self)
+
+    def testBulkFetchSkipsAPredictorWhoseRuntimeIsAbsent(self):
+        self.declareHost('boltz')
+        cmd.predict_weights(download=1, async_=1)
+        self.assertNotIn('protenix-base-mlx-int8', self.started)
+
+    def testBulkFetchStillTakesTheOnesThatWork(self):
+        """Asserted as "fetched OR already cached", not "fetched".
+
+        Whether a bundle downloads depends on the machine's cache, so asserting a
+        download makes the test pass or fail on local state rather than on the filter.
+        """
+        self.declareHost('boltz')
+        out = cmd.predict_weights(download=1, async_=1)
+        self.assertTrue(out['boltz2']['cached']
+                        or 'boltz2-mlx-int8' in self.started)
+
+    def testNamingItExplicitlyStillFetches(self):
+        self.declareHost('boltz')
+        cmd.predict_weights('protenix-base', download=1, async_=1)
+        self.assertIn('protenix-base-mlx-int8', self.started)
+
+    def testBulkFetchTakesItOnceTheRuntimeIsThere(self):
+        self.declareHost('boltz,protenix')
+        cmd.predict_weights(download=1, async_=1)
+        self.assertIn('protenix-base-mlx-int8', self.started)
+
+    def testItIsStillReportedEvenWhenNotFetched(self):
+        """Skipping the download must not hide the predictor from the report."""
+        self.declareHost('boltz')
+        out = cmd.predict_weights(download=1, async_=1)
+        self.assertIn('protenix-base', out)
+        self.assertEqual(out['protenix-base']['bundle'], 'protenix-base-mlx-int8')
+
+    def testTheSkipIsExplainedAtQuietZero(self):
+        self.declareHost('boltz')
+        with redirect_stdout(io.StringIO()) as buf:
+            cmd.predict_weights(download=1, async_=1, quiet=0)
+        self.assertIn('cannot run in this build', buf.getvalue())
+
+    def testNoKnobHadToBeAddedToTheSignature(self):
+        """Every knob it declares already existed, so cmd.predict is untouched."""
+        import inspect
+        parameters = inspect.signature(predicting.predict).parameters
+        for knob in ProtenixBasePredictor().option_defaults:
+            self.assertIn(knob, parameters)

--- a/testing/tests/predict/predict_runtime.py
+++ b/testing/tests/predict/predict_runtime.py
@@ -1,0 +1,165 @@
+"""The runtime seam: a request names the backend that must run it.
+
+Before a second method existed, every prediction was Boltz and the request said nothing
+about which backend it was for. It does now, because weights and featurizer are
+method-specific: a request that reached the wrong backend would not fail, it would
+featurize with the wrong tokenizer and return a confident wrong structure. So a predictor
+declares its runtime, the host declares what it linked, and the mismatch is refused twice
+-- once in check_available before any download, once in the Swift preflight.
+
+Tested here rather than only through one predictor because the mechanism is shared, and
+because its back-compatibility properties (absent means boltz, on both sides) are exactly
+the kind of thing that rots silently.
+
+    pymol -ckqy testing/testing.py --run testing/tests/predict/predict_runtime.py
+"""
+import io
+import json
+import os
+from contextlib import redirect_stdout
+
+from pymol import testing
+from pymol.predictors import host, registry
+from pymol.predictors.errors import PredictorUnavailable
+
+
+class RuntimeEnvTestCase(testing.PyMOLTestCase):
+
+    def setUp(self):
+        testing.PyMOLTestCase.setUp(self)
+        self._saved = {name: os.environ.get(name)
+                       for name in (host.HOST_ENV, host.RUNTIMES_ENV)}
+
+    def tearDown(self):
+        for name, value in self._saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        testing.PyMOLTestCase.tearDown(self)
+
+
+class TestSupportedRuntimes(RuntimeEnvTestCase):
+
+    def testAHostDeclaringNothingIsAssumedBoltzOnly(self):
+        """Every build before this variable existed had exactly the Boltz runtime."""
+        os.environ[host.HOST_ENV] = '1'
+        os.environ.pop(host.RUNTIMES_ENV, None)
+        self.assertEqual(host.supported_runtimes(), ('boltz',))
+
+    def testAnEmptyDeclarationIsTreatedAsUndeclared(self):
+        """setenv with an empty value must not read as "no runtimes at all"."""
+        os.environ[host.RUNTIMES_ENV] = ''
+        self.assertEqual(host.supported_runtimes(), ('boltz',))
+
+    def testDeclarationIsSplitAndStripped(self):
+        os.environ[host.RUNTIMES_ENV] = ' boltz , protenix '
+        self.assertEqual(host.supported_runtimes(), ('boltz', 'protenix'))
+
+    def testTrailingSeparatorsAreIgnored(self):
+        os.environ[host.RUNTIMES_ENV] = 'boltz,,'
+        self.assertEqual(host.supported_runtimes(), ('boltz',))
+
+
+class TestRequireRuntime(RuntimeEnvTestCase):
+
+    def testPassesWhenDeclared(self):
+        os.environ[host.HOST_ENV] = '1'
+        os.environ[host.RUNTIMES_ENV] = 'boltz,protenix'
+        self.assertIsNone(host.require_runtime('some-predictor', 'protenix'))
+
+    def testRaisesWhenAbsent(self):
+        os.environ[host.HOST_ENV] = '1'
+        os.environ[host.RUNTIMES_ENV] = 'boltz'
+        self.assertRaises(PredictorUnavailable,
+                          host.require_runtime, 'some-predictor', 'protenix')
+
+    def testTheErrorNamesBothTheWantedAndTheAvailable(self):
+        """"Not available" is unactionable; "you have boltz, this needs protenix" is not."""
+        os.environ[host.HOST_ENV] = '1'
+        os.environ[host.RUNTIMES_ENV] = 'boltz'
+        try:
+            host.require_runtime('some-predictor', 'protenix')
+        except PredictorUnavailable as error:
+            self.assertIn('protenix', str(error))
+            self.assertIn('boltz', str(error))
+            self.assertIn('some-predictor', str(error))
+        else:
+            self.fail('expected PredictorUnavailable')
+
+
+class TestRequestNamesItsRuntime(testing.PyMOLTestCase):
+
+    def submit(self, predictor_id, sequence='ACDEFG'):
+        predictor = registry.get(predictor_id)
+        spec = predictor.parse_spec(sequence, 'pred')
+        options = predictor.validate_options({})
+        with redirect_stdout(io.StringIO()):
+            job = predictor.submit(spec, options, '/tmp/weights')
+        with open(job.request_path) as handle:
+            request = json.load(handle)
+        os.unlink(job.request_path)
+        return request
+
+    def testBoltzRequestSaysBoltz(self):
+        self.assertEqual(self.submit('boltz2')['runtime'], 'boltz')
+
+    def testTheDenseVariantIsTheSameRuntime(self):
+        """boltz2-bf16 is one runtime and two tools: same backend, different weights."""
+        self.assertEqual(self.submit('boltz2-bf16')['runtime'], 'boltz')
+
+    def testProtenixRequestSaysProtenix(self):
+        self.assertEqual(self.submit('protenix-base')['runtime'], 'protenix')
+
+    def testEveryRegisteredPredictorNamesARuntime(self):
+        """A request with no runtime is read as BOLTZ at the far end, deliberately.
+
+        That default is what keeps an older Python side working, and it is also the trap:
+        a new predictor that forgets to pass one is silently dispatched to Boltz's
+        featurizer and weights. So every registered predictor is checked.
+        """
+        for pid in registry.available():
+            self.assertIn('runtime', self.submit(pid), pid)
+
+
+class TestOnlyDeclaredKnobsReachTheWire(testing.PyMOLTestCase):
+    """A knob on the wire reads as one the method honours."""
+
+    def submit(self, predictor_id):
+        predictor = registry.get(predictor_id)
+        spec = predictor.parse_spec('ACDEFG', 'pred')
+        options = predictor.validate_options({})
+        with redirect_stdout(io.StringIO()):
+            job = predictor.submit(spec, options, '/tmp/weights')
+        with open(job.request_path) as handle:
+            request = json.load(handle)
+        os.unlink(job.request_path)
+        return request
+
+    def testBoltzStillSendsEverythingItHonours(self):
+        request = self.submit('boltz2')
+        self.assertEqual(request['recycling_steps'], 3)
+        self.assertEqual(request['diffusion_steps'], 200)
+        self.assertEqual(request['msa_depth'], 16384)
+
+    def testAMethodWithNoAlignmentSendsNoDepth(self):
+        """msa_depth on the wire would record a run as having used an alignment."""
+        self.assertNotIn('msa_depth', self.submit('protenix-base'))
+
+    def testKnobsDefaultToEveryOptionWhenUnspecified(self):
+        """An explicit `knobs=None` keeps the pre-seam behaviour for any caller."""
+        predictor = registry.get('boltz2')
+        spec = predictor.parse_spec('ACDEFG', 'pred')
+        options = predictor.validate_options({})
+        with redirect_stdout(io.StringIO()):
+            job = host.submit(spec, options, '/tmp/weights')
+        with open(job.request_path) as handle:
+            request = json.load(handle)
+        os.unlink(job.request_path)
+        from pymol.predictors.base import PredictionOptions
+        for knob in PredictionOptions.__slots__:
+            self.assertIn(knob, request)
+
+    def testTheDefaultRuntimeIsBoltz(self):
+        """host.submit's own default, for a caller that names no runtime."""
+        self.assertEqual(host.DEFAULT_RUNTIME, 'boltz')


### PR DESCRIPTION
Adds **Protenix** — ByteDance's AlphaFold3-class predictor — via
[`protenix-mlx` v0.1.0](https://github.com/javierbq/protenix-mlx/releases/tag/v0.1.0),
and with it the seam a request needs to name which backend runs it. Closes the Python
half of #309.

Python side only. No build carries the `protenix` runtime yet, so `check_available`
refuses before anything is downloaded.

## Why this PR carries the runtime seam

#307 drafted that seam for SimpleFold, which is not going to be integrated. Protenix is
now the first method that is not Boltz, so the seam lands here — the same design, minus
everything SimpleFold-specific:

- **`Request.runtime`**, optional on the Swift side, absent meaning `boltz`. A required
  field would turn any Python/Swift skew into "malformed prediction request" instead of a
  refusal naming the runtime — the reasoning `object_name` and `alignments` already follow.
- **`preflight` refuses an unknown runtime first**, before the size model, which is fitted
  to Boltz's measured peaks and would be meaningless applied to another method's request
  even as a refusal.
- **`RAYMOL_PREDICT_RUNTIMES`**, advertising what is actually linked, so a predictor whose
  backend is missing refuses in `check_available` rather than after a weight download.
- **`host.submit(knobs=)`**, so a request carries exactly the knobs its method declared.
  Protenix has no alignment, and `msa_depth` on the wire would record a run as having used
  one.

Not carried over: SimpleFold itself, its `num_steps` knob, and making Boltz's two knobs
optional — Protenix declares both, so no request omits them.

The reason any of this exists rather than dispatching on the predictor id: weights and
featurizer are method-specific, so a Protenix request reaching the Boltz backend would not
fail. It would tokenize with the wrong featurizer and return a confident wrong structure.

## The predictor

Accepts **complexes**, which the method #307 was written for could not: the port's
featurizer groups chains into entities and builds the cross-chain pair features, so a
multimer is modelled rather than approximated. Identical sequences become copies of one
entity, which is what tells the model a homodimer's chains are related. The residue cap is
on the total, since peak memory follows total tokens rather than the longest chain.

It is also the first predictor that **adds no knob to `predicting.py`** — it recycles a
trunk and runs reverse diffusion, so `recycling_steps` and `diffusion_steps` already mean
what it needs.

## MAX_RESIDUES is 400, and sits below the largest measurement

| residues | 60 | 120 | 250 | 400 | 550 | 700 |
|---|---|---|---|---|---|---|
| peak (MiB) | 547 | 942 | 2279 | 3868 | 6303 | 8622 |
| mean pLDDT | 82.7 | 47.3 | 30.9 | 27.2 | 26.2 | 26.3 |

700 residues runs, at 8.6 GB and six minutes. Alongside a loaded session that is where a
jetsam kill takes unsaved work, and the model's own confidence there is 26 — six minutes
to produce a structure it says nothing can be concluded from. 400 (3.9 GB) is the largest
length that both fits comfortably and is worth the wait.

Measured against **MLX's own high-water mark, not process RSS**. That distinction is not
pedantry: by RSS, 400 residues appears to cost *less* than 60, because MLX allocates
through Metal and recycles buffers in a cache it need not return to the OS. The first
sweep I ran was thrown away for this reason.

## What it deliberately does not declare

`metric_specs` is empty, even though the runtime computes pLDDT, PAE, PDE and resolved
(verified against PyTorch to 2e-4). A per-residue array needs the metric store from #308
to land in, and declaring keys with nowhere to write them would put numbers in the schema
that never arrive. The declaration follows #310.

`supports_msa` is `False` and staying so until an a3m can reach `msa_features`: the port
feeds the network upstream's depth-1 dummy alignment, and a method that accepted a real
alignment then folded against that dummy would return a worse structure with nothing
saying so.

## Single-sequence confidence collapses with length

Worth knowing before this ships to anyone. Mean pLDDT over **complete domains**, not
truncations:

| villin 35aa | GB1 56aa | ubiquitin 76aa | barnase 110aa | lysozyme 129aa |
|---|---|---|---|---|
| 94.8 | 72.3 | 67.5 | 58.9 | 37.0 |

This is the documented behaviour of an AF3-class model with no alignment, not a fault in
the port — the same pack scores villin 94.8 against poly-alanine 78.4 at equal length, and
all four confidence outputs match PyTorch to 2e-4. It means Protenix earns its two minutes
on small domains and not much else until #274 gives it a real alignment. Lysozyme is the
low outlier for a second reason: four disulfides, and `token_bonds` is all zeros here.

## Two adjustments this forces elsewhere

- **`predict_weights download=1`** with no id iterates every predictor without consulting
  `check_available`, so a 214 MB pack for an unlinked runtime would have been pulled by a
  command aimed at the predictors that work. A bulk fetch now takes only what the build can
  run; naming a predictor explicitly still fetches it.
- **`predict <Tab>` no longer completes.** `boltz2*` and `protenix-base` share no prefix,
  so the parser has nothing unambiguous to extend and returns `None`. Two tests in
  `predict_completion.py` had encoded the old registry's contents; they now assert the
  mechanism, plus a new one showing `predict p<Tab>` completes in one step — the payoff for
  not naming it a bare `protenix`, which would have created the same dead end `boltz2`
  already does for `boltz2-bf16`.

## Testing

285 predict tests pass, 58 of them new, including `predict_runtime.py` which tests the
seam directly rather than only through one predictor — the back-compat properties (absent
declaration means boltz, on both sides; every registered predictor names a runtime) are
exactly the kind that rot silently. 127 MSA tests still pass.

macOS app slice compiles. **The iOS slice fails** on a pre-existing missing `AppIcon` named
"RayMol" in `Assets.xcassets` — reproduced identically on `master` with these changes
stashed. Both files touched here are inside macOS-only guards (`#if os(macOS)`,
`#if TARGET_OS_OSX`), so nothing added reaches the iOS slice.

## Follow-ups

- The Swift `protenix` runtime — a `ProtenixJobManager`, per-runtime `PredictSizeGuard`,
  and the metrics document. Tracked in #309.
- `metric_specs` once #310 lands.
- Real MSAs (#274), which is what would make this method useful above ~130 residues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
