### PR TITLE
Add Protenix: the second inference runtime, and six weight packs (#309)

### DIFF
--- a/docs/predictors.md
+++ b/docs/predictors.md
@@ -23,16 +23,20 @@ it is shaped this way.
 |---|---|---|---|
 | `boltz2` | `boltz` | affine-int8, 507 MB | the default |
 | `boltz2-bf16` | `boltz` | dense bfloat16, 996 MB | same model, same runtime, unquantized |
-| `protenix-{tiny,mini,base,v2}-{int8,fp16,bf16}` | `protenix` | 84–582 MB | twelve packs, complexes, single sequence, confidence head |
+| `protenix-{base,v2}-{int8,fp16,bf16}` | `protenix` | 225–610 MB | six packs, complexes, single sequence, confidence head |
 
-`protenix-base-int8` is the default choice. tiny and mini are v0.5.0 models at 4 recycles /
-5 diffusion steps — seconds rather than minutes, and correspondingly rough. The dense
-precisions cost roughly twice the disk for no demonstrated accuracy, exactly as
-`boltz2-bf16` does. The `v2` packs are **mirror-sourced** — its official checkpoint has
-answered 403 since April 2026 — which their `name` says where a user picking a predictor
-will see it.
+`protenix-base-int8` is the default choice. The dense precisions cost roughly twice the
+disk for no demonstrated accuracy, exactly as `boltz2-bf16` does. The `v2` packs are
+**mirror-sourced** — its official checkpoint has answered 403 since April 2026 — which
+their `name` says where a user picking a predictor will see it.
 
-Twelve ids rather than one predictor with a `pack=` option, because that is what
+protenix-mlx also publishes `tiny` and `mini`, which are **deliberately not registered**:
+they are v0.5.0 models at 4 recycles / 5 diffusion steps, and five steps does not converge
+the geometry — CA-CA 3.26 Å against base's 3.67 and an ideal 3.80, loose enough that DSSP
+stops calling helices. They fold in 11 s against base's 35, but a fold nobody should trust
+is not worth 11 seconds either.
+
+Six ids rather than one predictor with a `pack=` option, because that is what
 `WeightBundle` already models: one bundle per predictor, pinned by digest. They are built
 from a table generated out of protenix-mlx's `WEIGHTS.md` rather than hand-copied — twelve
 transcribed digests is twelve chances to paste one that fails only on a user's machine,

--- a/docs/predictors.md
+++ b/docs/predictors.md
@@ -19,16 +19,39 @@ it is shaped this way.
 
 ## Shipped predictors
 
-| id | weights | notes |
-|---|---|---|
-| `boltz2` | affine-int8, 507 MB | the default |
-| `boltz2-bf16` | dense bfloat16, 996 MB | same model, same runtime, unquantized |
+| id | runtime | weights | notes |
+|---|---|---|---|
+| `boltz2` | `boltz` | affine-int8, 507 MB | the default |
+| `boltz2-bf16` | `boltz` | dense bfloat16, 996 MB | same model, same runtime, unquantized |
+| `protenix-base` | `protenix` | affine-int8, 214 MB | complexes, single sequence. **Not runnable yet** — no build carries the `protenix` runtime, see #309 |
 
-`boltz2-bf16` subclasses `Boltz2Predictor` and overrides nothing but `weight_bundle`.
-That works because `host.submit` sends `weights_dir` per job and the Swift runtime
-picks its matmul path from the artifact manifest — a dense pack declares no
-quantization block — so one runtime serves both with no host change. It needs
-boltz-mlx >= 0.2.0.
+## Runtimes
+
+A predictor's **runtime** is the Swift backend that runs it, named on the wire by
+`host.submit(..., runtime=)`. It is a separate axis from the predictor id: `boltz2` and
+`boltz2-bf16` are two predictors and one runtime, because `host.submit` sends `weights_dir`
+per job and the Swift side picks its matmul path from the artifact manifest — a dense pack
+declares no quantization block — so one runtime serves both.
+
+The distinction has to be on the wire because weights and featurizer are method-specific.
+Running one method's request on another's backend does not fail; it tokenizes with the
+wrong featurizer and returns a confident wrong structure. So:
+
+- `BoltzJobManager` implements `boltz` and **refuses** any other in `preflight`, before it
+  applies its size model — which is fitted to Boltz's measured peaks and would be
+  meaningless applied to another method's request even as a refusal.
+- `PyMOLBridge` advertises what is actually linked in `RAYMOL_PREDICT_RUNTIMES`, which is
+  what lets `check_available` refuse **before** a weight download rather than after.
+- `Request.runtime` is **optional** on the Swift side, absent meaning `boltz`. A
+  non-optional field would turn any Python/Swift version skew into "malformed prediction
+  request" instead of a refusal that names the missing runtime. The same reasoning applies
+  to `object_name` and `alignments`.
+
+That default is also the trap: a new predictor that forgets to pass `runtime=` is silently
+dispatched to Boltz. `predict_runtime.py` asserts every registered predictor names one.
+
+`boltz2-bf16` subclasses `Boltz2Predictor` and overrides nothing but `weight_bundle`, which
+is what "two predictors, one runtime" looks like in practice. It needs boltz-mlx >= 0.2.0.
 
 It is **not** an upgrade. On an M3 Pro at 117 tokens, recycling 3 / 200 steps, dense
 bfloat16 costs 2x the disk, +63% peak RSS (620 MiB -> 1012 MiB) and +22% wall clock
@@ -80,6 +103,13 @@ float16 is the closer one at identical size (`--precision float16` exports it).
 4. **Implement `check_available`** so the predictor disappears cleanly where it cannot run
    rather than failing mid-run. Platform, OS floor, host presence — not weight state, which the
    weight manager is allowed to fix by downloading.
+
+   If your method needs a Swift backend of its own, call `host.require_runtime` after
+   `host.require_available`: the two failures have different remedies ("you are headless"
+   versus "this build does not carry that backend"), and checking here is what refuses
+   BEFORE a multi-hundred-megabyte download rather than after it. A bulk
+   `predict_weights download=1` also consults this, so a predictor that cannot run is
+   reported but not fetched.
 
 5. **Implement `parse_spec` to reject, not repair.** If the backend silently ignores input it
    does not support, catching that is your job: check what it does with a ligand, a nucleic

--- a/docs/predictors.md
+++ b/docs/predictors.md
@@ -23,7 +23,21 @@ it is shaped this way.
 |---|---|---|---|
 | `boltz2` | `boltz` | affine-int8, 507 MB | the default |
 | `boltz2-bf16` | `boltz` | dense bfloat16, 996 MB | same model, same runtime, unquantized |
-| `protenix-base` | `protenix` | affine-int8, 214 MB | complexes, single sequence. **Not runnable yet** — no build carries the `protenix` runtime, see #309 |
+| `protenix-{tiny,mini,base,v2}-{int8,fp16,bf16}` | `protenix` | 84–582 MB | twelve packs, complexes, single sequence, confidence head |
+
+`protenix-base-int8` is the default choice. tiny and mini are v0.5.0 models at 4 recycles /
+5 diffusion steps — seconds rather than minutes, and correspondingly rough. The dense
+precisions cost roughly twice the disk for no demonstrated accuracy, exactly as
+`boltz2-bf16` does. The `v2` packs are **mirror-sourced** — its official checkpoint has
+answered 403 since April 2026 — which their `name` says where a user picking a predictor
+will see it.
+
+Twelve ids rather than one predictor with a `pack=` option, because that is what
+`WeightBundle` already models: one bundle per predictor, pinned by digest. They are built
+from a table generated out of protenix-mlx's `WEIGHTS.md` rather than hand-copied — twelve
+transcribed digests is twelve chances to paste one that fails only on a user's machine,
+after the download. Every id ends in a precision suffix so none is a prefix of another;
+see step 1.
 
 ## Runtimes
 

--- a/modules/pymol/predicting.py
+++ b/modules/pymol/predicting.py
@@ -1081,9 +1081,26 @@ SEE ALSO
     wait = not host.available() if int(async_) < 0 else not int(async_)
     out = {}
     for pid in ids:
-        bundle = registry.get(pid).weight_bundle
+        predictor_obj = registry.get(pid)
+        bundle = predictor_obj.weight_bundle
         if bundle is None:
             out[pid] = {'cached': True, 'path': None, 'bundle': None}
+            continue
+        # A BULK fetch downloads only what this build could actually run. Asking for one
+        # predictor BY NAME still downloads it -- that is someone pre-warming a cache
+        # deliberately, possibly for a build they do not have yet.
+        #
+        # Without this, "fetch everything" means every registered pack whether or not the
+        # host carries its runtime: `protenix-base` alone is 214 MB that no shipping build
+        # can use yet, pulled down by a command aimed at the predictors that do work.
+        if int(download) and not predictor and not _can_run(predictor_obj):
+            out[pid] = {'cached': bool(cache.is_cached(bundle)),
+                        'path': cache.path_for(bundle),
+                        'bundle': bundle.id}
+            if not int(quiet):
+                colorprinting.parrot(
+                    ' predict: %s cannot run in this build; not fetching its weights'
+                    % pid)
             continue
         if int(download) and not cache.is_cached(bundle):
             fetching.start(bundle, cache)
@@ -1096,6 +1113,21 @@ SEE ALSO
             colorprinting.parrot(' predict: %s weights cached=%s at %s' % (
                 pid, out[pid]['cached'], out[pid]['path']))
     return out
+
+
+def _can_run(predictor_obj):
+    """True if this predictor could run here, for deciding whether to pre-fetch.
+
+    Never raises: `check_available` is a predictor's own code, and a bulk pre-warm must
+    not be derailed by one method's availability check. An error means "cannot say", and a
+    bulk fetch treats that as "do not download" -- the cheap direction to be wrong in,
+    since naming the predictor explicitly still fetches it.
+    """
+    try:
+        predictor_obj.check_available()
+    except Exception:
+        return False
+    return True
 
 
 def _wait_for_fetch(bundle, quiet, _poll=0.1):

--- a/modules/pymol/predictors/__init__.py
+++ b/modules/pymol/predictors/__init__.py
@@ -12,10 +12,14 @@ def _register_builtins():
     """Register the shipped predictors. The only function that changes per predictor."""
     from .boltz2 import Boltz2Predictor
     from .boltz2_bf16 import Boltz2BF16Predictor
-    from .protenix import ProtenixBasePredictor
+    from .protenix import PREDICTORS as PROTENIX_PREDICTORS
     register(Boltz2Predictor(), replace=True)
     register(Boltz2BF16Predictor(), replace=True)
-    register(ProtenixBasePredictor(), replace=True)
+    # One id per published pack -- nine of them, variant x precision. A loop rather than
+    # nine lines because they differ only in which pack they name, and the list is
+    # generated from the digests protenix-mlx publishes; see protenix.py.
+    for predictor in PROTENIX_PREDICTORS:
+        register(predictor(), replace=True)
 
 
 _register_builtins()

--- a/modules/pymol/predictors/__init__.py
+++ b/modules/pymol/predictors/__init__.py
@@ -12,8 +12,10 @@ def _register_builtins():
     """Register the shipped predictors. The only function that changes per predictor."""
     from .boltz2 import Boltz2Predictor
     from .boltz2_bf16 import Boltz2BF16Predictor
+    from .protenix import ProtenixBasePredictor
     register(Boltz2Predictor(), replace=True)
     register(Boltz2BF16Predictor(), replace=True)
+    register(ProtenixBasePredictor(), replace=True)
 
 
 _register_builtins()

--- a/modules/pymol/predictors/boltz2.py
+++ b/modules/pymol/predictors/boltz2.py
@@ -22,6 +22,10 @@ CANONICAL = set('ACDEFGHIKLMNPQRSTVWY')
 #: BoltzInputLimits.desktop caps at 1024 tokens, and one token is one residue.
 MAX_RESIDUES = 1024
 
+#: The backend the Swift host dispatches to. Also what a request with no `runtime` at all
+#: is taken to mean, so an older Python side keeps working -- see host.DEFAULT_RUNTIME.
+RUNTIME = 'boltz'
+
 
 class Boltz2Predictor(Predictor):
 
@@ -77,4 +81,5 @@ class Boltz2Predictor(Predictor):
         return PredictionSpec(chains, name)
 
     def submit(self, spec, options, weights_path):
-        return host.submit(spec, options, weights_path)
+        return host.submit(spec, options, weights_path, runtime=RUNTIME,
+                           knobs=self.option_defaults)

--- a/modules/pymol/predictors/host.py
+++ b/modules/pymol/predictors/host.py
@@ -17,10 +17,24 @@ import os
 import tempfile
 import uuid
 
+from .base import PredictionOptions
 from .errors import PredictorUnavailable
 
 #: Set by the Swift host next to PYMOL_PATH so Python can tell it is present.
 HOST_ENV = 'RAYMOL_PREDICT_HOST'
+
+#: Comma-separated inference runtimes the host has actually LINKED, set beside HOST_ENV.
+#: A host is not one capability but several: the app may carry the Boltz runtime and not
+#: another method's, and a predictor whose runtime is missing must say so in
+#: check_available rather than submit a job that would be refused -- or worse, run on the
+#: wrong backend, since the weights and the featurizer are method-specific and a mismatch
+#: does not fail, it returns a confident wrong structure.
+RUNTIMES_ENV = 'RAYMOL_PREDICT_RUNTIMES'
+
+#: What a host that does not declare RUNTIMES_ENV is assumed to carry. Every build before
+#: this variable existed had exactly the Boltz runtime, so this keeps an older app -- or a
+#: test that only sets HOST_ENV -- working unchanged.
+DEFAULT_RUNTIME = 'boltz'
 
 
 def available():
@@ -32,12 +46,34 @@ def available():
     return bool(os.environ.get(HOST_ENV))
 
 
+def supported_runtimes():
+    """Inference runtimes this host can actually run, as a tuple."""
+    declared = os.environ.get(RUNTIMES_ENV, '')
+    names = tuple(part.strip() for part in declared.split(',') if part.strip())
+    return names or (DEFAULT_RUNTIME,)
+
+
 def require_available(predictor_id):
     if not available():
         raise PredictorUnavailable(
             '%s needs the RayMol application host; it is not available in this '
             'process (headless PyMOL cannot run on-device inference)'
             % predictor_id)
+
+
+def require_runtime(predictor_id, runtime):
+    """Raise unless the host declares `runtime`. Call after require_available().
+
+    Separate from require_available() because the two failures have different remedies:
+    no host at all means "you are running headless", while a missing runtime means "this
+    build of RayMol does not carry that backend". Checking here is also what refuses
+    BEFORE a multi-hundred-megabyte weight download rather than after it.
+    """
+    if runtime not in supported_runtimes():
+        raise PredictorUnavailable(
+            '%s needs the %r inference runtime, which this build of RayMol does '
+            'not carry (it has: %s)'
+            % (predictor_id, runtime, ', '.join(supported_runtimes())))
 
 
 def _path(kind, job_id, suffix='json'):
@@ -114,8 +150,14 @@ def _write(path, text):
     os.replace(temp, path)
 
 
-def submit(spec, options, weights_path):
-    """Write the request, print the marker, return the handle. Never blocks."""
+def submit(spec, options, weights_path, runtime=DEFAULT_RUNTIME, knobs=None):
+    """Write the request, print the marker, return the handle. Never blocks.
+
+    `runtime` names the backend the host must dispatch to. `knobs` is the option names to
+    put on the wire -- pass the predictor's own `option_defaults`, so the request carries
+    exactly what that method declared it honours and nothing else. Both default to what
+    the only predictor before them wanted, so an existing call site is unaffected.
+    """
     job_id = uuid.uuid4().hex[:12]
     job = HostJob(job_id, spec, options)
 
@@ -145,6 +187,12 @@ def submit(spec, options, weights_path):
 
     request = {
         'job_id': job_id,
+        # Which backend must run this. OPTIONAL at the far end, absent meaning boltz, so
+        # a request written by a Python side that predates the second runtime still
+        # decodes -- the same reasoning as `object_name` and `alignments`. A non-optional
+        # field would turn any Python/Swift skew into "malformed prediction request"
+        # instead of a refusal that names the missing runtime.
+        'runtime': runtime,
         'weights_dir': weights_path or '',
         # Objects, not pairs: BoltzJobManager.Chain is a Codable struct with named
         # keys, so a positional array would fail to decode.
@@ -154,13 +202,6 @@ def submit(spec, options, weights_path):
         # dummy depth-1 alignment to any chain not listed, which is the designed-binder
         # case: an alignment for the target, none for the binder.
         'alignments': alignments,
-        'recycling_steps': options.recycling_steps,
-        'diffusion_steps': options.diffusion_steps,
-        'seed': options.seed,
-        # How many rows of each a3m to read. Applied on the HOST side, by the same
-        # parser that reads the file, so the truncation is the parser's own -- the a3m
-        # written above is always the whole alignment.
-        'msa_depth': options.msa_depth,
         'out_path': job.out_path,
         'status_path': job.status_path,
         # The object the host loads the finished structure into. Resolved at submit time
@@ -168,6 +209,14 @@ def submit(spec, options, weights_path):
         # needs no second round-trip to find out where the result belongs.
         'object_name': getattr(spec, 'name', '') or '',
     }
+    # The inference knobs, exactly as the predictor declared them -- not every knob
+    # PredictionOptions can hold. A method that has no alignment must not send
+    # `msa_depth`: on the wire it would read as a depth it honours, and the run would be
+    # recorded as having used an alignment it never saw.
+    if knobs is None:
+        knobs = PredictionOptions.__slots__
+    for knob in knobs:
+        request[knob] = getattr(options, knob)
     # Write completely before announcing it: the host reads on the next 100 ms
     # tick and must never see a partial request.
     _write(job.request_path, json.dumps(request))

--- a/modules/pymol/predictors/protenix.py
+++ b/modules/pymol/predictors/protenix.py
@@ -1,143 +1,226 @@
 """Protenix via protenix-mlx: ByteDance's AlphaFold3-class predictor, in Swift/MLX.
 
+Twelve packs: four model variants at three precisions each, every one a separate
+predictor id. That is the `boltz2` / `boltz2-bf16` pattern taken to its conclusion — one
+runtime, many tools — and it works for the same reason: `host.submit` sends `weights_dir`
+per job and the Swift side picks its matmul path from the artifact manifest, so a dense
+pack needs no code of its own.
+
 Protein-only, canonical-20, complexes included: the port's featurizer groups chains into
 entities and builds the cross-chain pair features, so a multimer is something this method
-genuinely models rather than something it approximates. What it carries no reference
-conformers for -- ligands, nucleic acids, modified residues, anything needing the chemical
-component dictionary at fold time -- is refused by name rather than folded as an
-approximation of itself.
+genuinely models rather than approximates. What it carries no reference conformers for --
+ligands, nucleic acids, modified residues, anything needing the chemical component
+dictionary at fold time -- is refused by name rather than folded as an approximation.
 
-This is also the SECOND inference runtime, and the first request that has to say so. The
-`runtime` field, `host.require_runtime` and `RAYMOL_PREDICT_RUNTIMES` exist because of it:
-weights and featurizer are method-specific, so a Protenix request that reached the Boltz
-backend would not fail, it would return a confident wrong structure.
+Single-sequence. `supports_msa` is False and staying so until an a3m can reach
+`msa_features`: the port feeds the network upstream's depth-1 dummy alignment, and a
+method that accepted a real alignment then folded against that dummy would return a worse
+structure with nothing in the result saying so. The MSA module IS ported, so this becomes
+reachable rather than remaining structural -- see #274.
 
-Single-sequence. `supports_msa` is False and staying False until an a3m can actually
-reach `msa_features`: the port feeds the network upstream's depth-1 dummy alignment, and
-a method that accepted a real alignment and then folded against that dummy would return
-a worse structure with nothing in the result saying so. The MSA module itself IS ported,
-so this becomes possible rather than remaining structural -- see #274.
+**Which one to use.** `protenix-base-int8` is the default choice and the one whose memory
+is measured most thoroughly. tiny and mini are v0.5.0 models at 4 recycles / 5 diffusion
+steps: seconds rather than minutes, and correspondingly rough -- they exist for iteration,
+not for answers. The dense precisions cost roughly twice the disk and more memory for no
+demonstrated accuracy, exactly as `boltz2-bf16` does; they are here so that experiment is
+possible on-device rather than because they are better.
 
-The port DOES have a confidence head -- pLDDT, PAE, PDE and resolved, verified against
-PyTorch to 2e-4 -- and this predictor deliberately declares none of it yet. `metric_specs`
-needs the per-object metric store (#308) to have somewhere to put a per-residue array, so
-the declaration lands with that rather than here. Until then a fold arrives with its
-provenance and cost and no confidence numbers, which is the honest state: the runtime can
-compute them and RayMol cannot yet keep them.
-
-Worth knowing before running it: single-sequence output degrades sharply with length. On
-complete domains, mean pLDDT goes 94.8 at 35 residues, 67.5 at 76, 58.9 at 110, 37.0 at
-129, and sits near 26 from 400 up. That is the documented behaviour of an AF3-class model
-with no alignment rather than a fault in the port, and it means this method earns its time
-on small domains and not much else until #274 gives it a real one.
+**What single-sequence folding is worth.** Mean pLDDT falls off sharply with length, on
+complete domains: 94.8 at 35 residues, 67.5 at 76, 58.9 at 110, 37.0 at 129, ~26 from 400
+up. That is the documented behaviour of an AF3-class model with no alignment, not a fault
+in the port -- the same pack scores villin 94.8 against poly-alanine 78.4 at equal length.
+It means this method earns its time on small domains until #274 gives it an alignment.
 """
 from . import host
 from .base import Predictor, PredictionSpec, parse_chains
-from .errors import PredictionInputError, PredictorUnavailable
+from .errors import PredictionInputError
 from .weights import WeightBundle
 
 #: The canonical 20. Everything else is refused rather than substituted: the port's
 #: featurizer raises on an unknown letter instead of resolving it to X, so accepting one
-#: here would only defer the same error past a 214 MB download.
+#: here would only defer the same error past a multi-hundred-megabyte download.
 CANONICAL = set('ACDEFGHIKLMNPQRSTVWY')
 
-#: Measured peak memory at the shipped operating point (recycling 10 / 200 steps, with
-#: the confidence head), on an M-series Mac against the base int8 pack. This is MLX's own
-#: high-water mark, not process RSS: the two are different numbers and RSS is not even
-#: monotonic in problem size, because MLX recycles buffers in a cache it need not return
-#: to the OS -- measured by RSS, 400 residues appears to cost LESS than 60.
-#:
-#:     residues     60    120    250    400    550    700
-#:     peak        547    942   2279   3868   6303   8622  MiB
-#:     mean pLDDT 82.7   47.3   30.9   27.2   26.2   26.3
-MEASURED_PEAK_MIB = ((60, 547), (120, 942), (250, 2279), (400, 3868), (550, 6303),
-                     (700, 8622))
-
-#: The cap sits BELOW the largest measurement rather than at it, which is the one place
-#: this file departs from "the largest input measured".
-#:
-#: 700 residues runs, at 8.6 GB and six minutes. That is not a fold to permit by default:
-#: alongside a loaded session it is where a jetsam kill takes the user's unsaved work,
-#: which `PredictSizeGuard` exists to prevent and which no Swift handler can intercept.
-#: And the model's own confidence at that length is 26 -- the run costs six minutes to
-#: produce a structure it says nothing can be concluded from.
-#:
-#: 400 (3.9 GB) is the largest length that both fits comfortably and is worth the wait.
-#: Raise it with a measurement AND a reason, never with either alone.
-MAX_RESIDUES = 400
-
-#: What single-sequence folding is actually worth here, measured on the same pack. Mean
-#: pLDDT against length, over COMPLETE domains rather than truncations (a truncation
-#: scores badly for reasons of its own):
-#:
-#:     villin 35   GB1 56   ubiquitin 76   barnase 110   lysozyme 129
-#:       94.8       72.3        67.5          58.9          37.0
-#:
-#: That is the documented behaviour of an AF3-class model with no alignment, not a fault
-#: in the port -- the same pack discriminates correctly at small sizes (villin 94.8
-#: against 78.4 for poly-alanine of the same length). It is recorded here because it is
-#: the single most useful thing to know before spending two minutes on a fold: past
-#: roughly a hundred residues, single-sequence output is not worth much, and #274 is what
-#: changes that rather than a bigger pack. Lysozyme is the low outlier for a second
-#: reason worth naming -- it has four disulfides, and `token_bonds` is all zeros here.
-MEASURED_CONFIDENCE = ((35, 94.8), (56, 72.3), (76, 67.5), (110, 58.9), (129, 37.0))
-
-#: The backend the Swift host must dispatch to, as it appears on the wire.
+#: The backend the Swift host must dispatch to, as it appears on the wire. One runtime
+#: serves every pack below.
 RUNTIME = 'protenix'
 
+#: Measured peak memory (MiB) at each variant's own operating point, int8, with the
+#: confidence head, on an M-series Mac. MLX's own high-water mark, not process RSS --
+#: measured by RSS the same sweep reads 400 residues as costing LESS than 60, because MLX
+#: recycles buffers in a cache it need not return to the OS.
+#:
+#:                60 res   250 res   400 res
+#:     tiny          250      2083      3494
+#:     mini          298      2172      3625
+#:     base          547      2279      3868
+#:     v2            -- (509 MiB at 15 residues; its 256-wide pair track costs more)
+#:
+#: The variants converge as the input grows: at 400 residues they are within 10% of each
+#: other, because the N^2 pair representation dwarfs the weights. Which is why the cap
+#: below is the same for all of them rather than scaled by parameter count -- the thing
+#: that decides whether a fold fits is the sequence, not the pack.
+MEASURED_PEAK_MIB = {
+    'tiny': ((60, 250), (250, 2083), (400, 3494)),
+    'mini': ((60, 298), (250, 2172), (400, 3625)),
+    'base': ((60, 547), (120, 942), (250, 2279), (400, 3868), (550, 6303), (700, 8622)),
+    # v2 is swept only at the short end so far. Its pair track is 256 wide against every
+    # other variant's 128, so the N^2 term is doubled and base's curve UNDERSTATES it --
+    # which is the direction that gets a session jetsam-killed. Until it is swept
+    # properly, V2_MAX_RESIDUES caps it well inside what has been run.
+    'v2': ((15, 509),),
+}
 
-class ProtenixBasePredictor(Predictor):
+#: Hard ceiling, in residues, across every variant.
+#:
+#: Below the largest measurement (700 for base, at 8.6 GB and six minutes) on purpose:
+#: alongside a loaded session that is where a jetsam kill takes the user's unsaved work,
+#: and the model's own confidence at that length is 26 -- six minutes to produce a
+#: structure it says nothing can be concluded from. 400 is the largest length that both
+#: fits comfortably and is worth the wait. Raise it with a measurement AND a reason.
+MAX_RESIDUES = 400
 
-    id = 'protenix-base'
-    name = 'Protenix base (MLX, int8)'
+#: v2's own ceiling, lower because its memory is only measured at the short end and its
+#: pair representation is twice as wide. Not a judgement about the model -- it scores
+#: highest of the four on a short probe -- but about what has been measured.
+V2_MAX_RESIDUES = 250
 
-    # sha256 and size are of the bytes GitHub serves, taken from protenix-mlx's
-    # WEIGHTS.md, which records the digest of the uploaded asset rather than of a local
-    # rebuild -- int8 quantization runs on Metal and is not bitwise reproducible across
-    # machines, so a re-export would not match.
-    #
-    # Three members, the same shape boltz2's pack has, so WeightCache needs no change.
-    # `config.json` is not optional decoration here: a Protenix checkpoint carries no
-    # architecture at all (it is `{"model": state_dict, "model_version"}`), and the four
-    # variants share tensor NAMES while differing in depth and width, so the runtime
-    # cannot tell an 8-block Pairformer from a 48-block one without it.
-    weight_bundle = WeightBundle(
-        id='protenix-base-mlx-int8',
-        version='v1',
-        url='https://github.com/javierbq/protenix-mlx/releases/download/weights-base-v1/'
-            'protenix-base-mlx-int8-v1.zip',
-        sha256='6a405fbfb0f3b331315bc317106f22ed5daf10eb7b9b1122c4eae5db77b26977',
-        size=224_688_268,
-        members=('config.json', 'manifest.json', 'model.safetensors'),
-    )
 
-    # The released model's own operating point, from its config.json: 10 recycles and
-    # 200 diffusion steps. Both knobs already exist on cmd.predict because Boltz-2 has
-    # them and they mean the same thing here -- Protenix recycles a trunk and runs
-    # reverse diffusion -- so this is the first predictor that adds no knob to
-    # predicting.py at all.
-    #
-    # msa_depth is absent, which is what makes the depth lever rejected by name rather
-    # than accepted and ignored: there is no alignment to have a depth.
-    option_defaults = {'recycling_steps': 10, 'diffusion_steps': 200, 'seed': 0}
+class _Pack:
+    """One published weight pack: what to fetch, and how the model it holds behaves."""
 
-    # Single-sequence; see the module docstring.
+    __slots__ = ('variant', 'precision', 'url', 'sha256', 'size')
+
+    def __init__(self, variant, precision, url, sha256, size):
+        self.variant = variant
+        self.precision = precision
+        self.url = url
+        self.sha256 = sha256
+        self.size = size
+
+
+#: Precision as it appears in a predictor id. Shortened for the same reason `boltz2-bf16`
+#: is: the id is typed at a prompt. Every id ends in one of these, so no id is a PREFIX of
+#: another and `predict protenix-b<Tab>` never lands on a dead end -- the trap
+#: docs/predictors.md step 1 records `boltz2` falling into.
+_SUFFIX = {'int8': 'int8', 'float16': 'fp16', 'bfloat16': 'bf16'}
+
+#: Recycles and diffusion steps, from each variant's own config.json. tiny and mini are
+#: v0.5.0 models trained to a much shorter schedule; using base's 10/200 on them would
+#: spend forty times the compute on a model that was not trained to use it.
+_OPERATING_POINT = {
+    'tiny': (4, 5),
+    'mini': (4, 5),
+    'base': (10, 200),
+    'v2': (10, 200),
+}
+
+_DESCRIPTION = {
+    'tiny': 'Protenix tiny v0.5.0',
+    'mini': 'Protenix mini v0.5.0',
+    'base': 'Protenix base v1.0.0',
+    'v2': 'Protenix v2',
+}
+
+#: Every published pack, transcribed from protenix-mlx's WEIGHTS.md, which records the
+#: digest of the UPLOADED asset rather than of a local rebuild -- int8 quantization runs
+#: on Metal and is not bitwise reproducible across machines, so a re-export would not
+#: match. Generated from that file rather than typed: twelve hand-copied digests is
+#: twelve chances to paste the wrong one, and a wrong digest fails only on a user's
+#: machine, after the download.
+_PACKS = (
+    _Pack('tiny', 'int8',
+          'https://github.com/javierbq/protenix-mlx/releases/download/weights-tiny-v1/'
+          'protenix-tiny-mlx-int8-v1.zip',
+          '11716a7c69d10c0b9c90410503bc2b4b05a3c83f8b39c572bf4d962a56094858',
+          87_543_789),
+    _Pack('tiny', 'float16',
+          'https://github.com/javierbq/protenix-mlx/releases/download/weights-tiny-v1/'
+          'protenix-tiny-mlx-float16-v1.zip',
+          '73fdf864366461380cee4b316b354018118e55f5d0ce6ee7be698d30b64274a1',
+          173_209_981),
+    _Pack('tiny', 'bfloat16',
+          'https://github.com/javierbq/protenix-mlx/releases/download/weights-tiny-v1/'
+          'protenix-tiny-mlx-bfloat16-v1.zip',
+          '77777d1a40dc45b5de900978e2d0018fd361e93fdebb4384c4928c07866b99b9',
+          151_635_809),
+    _Pack('mini', 'int8',
+          'https://github.com/javierbq/protenix-mlx/releases/download/weights-mini-v1/'
+          'protenix-mini-mlx-int8-v1.zip',
+          'ea3a8f81ad8ce055b5b3d1dba92f595b5284dfc2c13b8eedd0458827babc0cea',
+          96_248_656),
+    _Pack('mini', 'float16',
+          'https://github.com/javierbq/protenix-mlx/releases/download/weights-mini-v1/'
+          'protenix-mini-mlx-float16-v1.zip',
+          '159206251babea99824110da45546707ed1428f0cf1b5a38025cc2db76f7337d',
+          193_494_769),
+    _Pack('mini', 'bfloat16',
+          'https://github.com/javierbq/protenix-mlx/releases/download/weights-mini-v1/'
+          'protenix-mini-mlx-bfloat16-v1.zip',
+          '9dc3a7397d054421d1b9a64959477c927a86b56446b1f24fa642a57d4a5a8837',
+          171_699_965),
+    _Pack('base', 'int8',
+          'https://github.com/javierbq/protenix-mlx/releases/download/weights-base-v1/'
+          'protenix-base-mlx-int8-v1.zip',
+          '6a405fbfb0f3b331315bc317106f22ed5daf10eb7b9b1122c4eae5db77b26977',
+          224_688_268),
+    _Pack('base', 'float16',
+          'https://github.com/javierbq/protenix-mlx/releases/download/weights-base-v1/'
+          'protenix-base-mlx-float16-v1.zip',
+          'b849de70134b8b64f63274c7ec6b578b8ab83d22960d22fd76226ad76c17873d',
+          468_919_887),
+    _Pack('base', 'bfloat16',
+          'https://github.com/javierbq/protenix-mlx/releases/download/weights-base-v1/'
+          'protenix-base-mlx-bfloat16-v1.zip',
+          'ee2d1d8e2070c2325eff3c2f5803ebe1266e8c182ea4e58fa14a1f6d280907e9',
+          417_731_102),
+    _Pack('v2', 'int8',
+          'https://github.com/javierbq/protenix-mlx/releases/download/weights-v2-v1/'
+          'protenix-v2-mlx-int8-v1.zip',
+          '1eef8793e18be9f4a5dd040392e4358fbac1bfbf1d63dee33b7a5bc9398d4432',
+          299_351_203),
+    _Pack('v2', 'float16',
+          'https://github.com/javierbq/protenix-mlx/releases/download/weights-v2-v1/'
+          'protenix-v2-mlx-float16-v1.zip',
+          '130018dec413a2c8054fa3f89c99bde7158a403b58462f5c429144098a06d860',
+          610_453_479),
+    _Pack('v2', 'bfloat16',
+          'https://github.com/javierbq/protenix-mlx/releases/download/weights-v2-v1/'
+          'protenix-v2-mlx-bfloat16-v1.zip',
+          '80232df8dfb6b04db6163a6c845598d45f3bef9239f909fcd66e23688fb2c00e',
+          560_585_456),
+)
+
+
+class ProtenixPredictor(Predictor):
+    """One pack. Subclasses differ only in which -- see `_build`."""
+
+    #: The pack this predictor folds with. Set per subclass.
+    pack = None
+
+    #: Longest input this pack may be handed. Per-variant, because v2's is measured less
+    #: thoroughly and its pair track is twice as wide.
+    max_residues = MAX_RESIDUES
+
     supports_msa = False
 
-    # Deliberately not declared yet: the runtime computes pLDDT and the PAE matrix, and
-    # a per-residue array needs the metric store (#308) to land in. Declaring keys with
-    # nowhere to write them would put numbers in the schema that never arrive.
+    # Deliberately not declared yet: the runtime computes pLDDT, PAE, PDE and resolved
+    # (verified against PyTorch to 2e-4), but a per-residue array needs the metric store
+    # from #308 to land in. Declaring keys with nowhere to write them would put numbers
+    # in the schema that never arrive. pLDDT still reaches the viewer, in the B-factor
+    # column, which is what `spectrum b` colours by.
     metric_specs = ()
 
     def check_available(self):
         host.require_available(self.id)
         # After require_available, because the two failures have different remedies:
         # "you are headless" versus "this build does not carry that backend". Checking
-        # here is what refuses BEFORE a 214 MB download rather than after it.
+        # here is what refuses BEFORE the download rather than after it.
         host.require_runtime(self.id, RUNTIME)
 
     def parse_spec(self, sequence, name=''):
         chains = parse_chains(sequence)
+        limit = self.max_residues
         total = 0
         for chain, seq in chains:
             bad = sorted(set(seq) - CANONICAL)
@@ -149,15 +232,68 @@ class ProtenixBasePredictor(Predictor):
                     'are refused rather than folded as something else.'
                     % (chain, ', '.join(bad)))
             total += len(seq)
-        if total > MAX_RESIDUES:
+        if total > limit:
             raise PredictionInputError(
-                '%d residues exceeds the %d-residue limit. That limit is the largest '
-                'input measured on this device class, not a limit of the method: '
-                'Protenix is ~N^2 in tokens across 48 Pairformer blocks and ten '
-                'recycles, and an unmeasured extrapolation is how a run gets killed '
-                'mid-fold.' % (total, MAX_RESIDUES))
+                '%d residues exceeds %s\'s %d-residue limit. That limit is measured, '
+                'not intrinsic: peak memory is ~N^2 in tokens and reaches 8.6 GB at 700 '
+                'residues, where the model\'s own confidence is 26 anyway.'
+                % (total, self.id, limit))
         return PredictionSpec(chains, name)
 
     def submit(self, spec, options, weights_path):
         return host.submit(spec, options, weights_path, runtime=RUNTIME,
                            knobs=self.option_defaults)
+
+
+def _build(pack):
+    """One Predictor subclass per pack, so each is a first-class id with its own bundle."""
+    recycling, diffusion = _OPERATING_POINT[pack.variant]
+    identifier = 'protenix-%s-%s' % (pack.variant, _SUFFIX[pack.precision])
+    label = '%s (MLX, %s)' % (_DESCRIPTION[pack.variant], pack.precision)
+    if pack.variant == 'v2':
+        # Said in the NAME, where a user choosing a predictor sees it, not only in a
+        # comment. protenix-v2's official checkpoint has answered 403 since April 2026
+        # pending a ByteDance internal review, so these packs are built from a Hugging
+        # Face mirror by an uploader who states no affiliation. The file audits clean
+        # structurally and is pinned by digest, but no official checksum exists for ANY
+        # Protenix checkpoint, so nothing authoritative confirms the weight values.
+        label += ' - mirror-sourced'
+    return type(
+        'Protenix%s%sPredictor' % (pack.variant.title(), _SUFFIX[pack.precision].title()),
+        (ProtenixPredictor,),
+        {
+            'id': identifier,
+            'name': label,
+            'pack': pack,
+            'weight_bundle': WeightBundle(
+                id='protenix-%s-mlx-%s' % (pack.variant, pack.precision),
+                version='v1',
+                url=pack.url,
+                sha256=pack.sha256,
+                size=pack.size,
+                # The same three members boltz2's pack has, so WeightCache needs no
+                # change. config.json is not decoration: a Protenix checkpoint carries no
+                # architecture at all, and the four variants share tensor NAMES while
+                # differing in depth and width, so the runtime cannot tell an 8-block
+                # Pairformer from a 48-block one without it.
+                members=('config.json', 'manifest.json', 'model.safetensors'),
+            ),
+            # From this variant's own config.json. msa_depth is absent throughout, which
+            # is what makes the depth lever rejected by name rather than accepted and
+            # ignored: there is no alignment to have a depth.
+            'max_residues': V2_MAX_RESIDUES if pack.variant == 'v2' else MAX_RESIDUES,
+            'option_defaults': {'recycling_steps': recycling,
+                                'diffusion_steps': diffusion,
+                                'seed': 0},
+            '__doc__': '%s at %s precision, %d recycles / %d diffusion steps.'
+                       % (_DESCRIPTION[pack.variant], pack.precision,
+                          recycling, diffusion),
+        })
+
+
+#: Every pack as a registered predictor, in the order they should be offered.
+PREDICTORS = tuple(_build(pack) for pack in _PACKS)
+
+#: The one to reach for. Named so `predict_weights` and documentation have something to
+#: point at without hardcoding a string in three places.
+DEFAULT_ID = 'protenix-base-int8'

--- a/modules/pymol/predictors/protenix.py
+++ b/modules/pymol/predictors/protenix.py
@@ -56,8 +56,8 @@ RUNTIME = 'protenix'
 #: measured by RSS the same sweep reads 400 residues as costing LESS than 60, because MLX
 #: recycles buffers in a cache it need not return to the OS.
 #:
-#:                60 res   250 res   400 res   550 res   700 res
-#:     base          547      2279      3868      6303      8622
+#:                60 res   250 res   400 res   550 res   700 res   900 res
+#:     base          547      2279      3868      6303      8622     16513
 #:     v2            -- (509 MiB at 15 residues; its 256-wide pair track costs more)
 #:
 #: Variants converge as the input grows: the now-unshipped tiny and mini measured 3494 and
@@ -66,7 +66,8 @@ RUNTIME = 'protenix'
 #: length rather than scaled by parameter count -- what decides whether a fold fits is how
 #: long it is, not which pack runs it.
 MEASURED_PEAK_MIB = {
-    'base': ((60, 547), (120, 942), (250, 2279), (400, 3868), (550, 6303), (700, 8622)),
+    'base': ((60, 547), (120, 942), (250, 2279), (400, 3868), (550, 6303), (700, 8622),
+             (900, 16513)),
     # v2 is swept only at the short end so far. Its pair track is 256 wide against every
     # other variant's 128, so the N^2 term is doubled and base's curve UNDERSTATES it --
     # which is the direction that gets a session jetsam-killed. Until it is swept
@@ -80,11 +81,20 @@ MEASURED_PEAK_MIB = {
 #: 400 -- chosen because a fold whose own confidence is 26 is rarely worth six minutes --
 #: and was raised deliberately, since that is a judgement for whoever is waiting.
 #:
-#: Still not an extrapolation: beyond 700 nothing has been run, and the Swift guard's
-#: history is that guessing past the data runs optimistic. Raise it again with a
-#: measurement, and note that the memory budget (ProtenixSizeGuard.budgetBytes, now 32 GB)
-#: is the other half of the policy -- on a 32 GiB machine that is effectively all of it,
-#: so a long fold and an unsaved session are a bad combination.
+#: 900 residues IS measured and does fit -- 16.1 GiB, half the 32 GB budget -- and the cap
+#: still sits below it, for a reason that only measuring found: it took **2.5 hours**.
+#: That is 24x the wall clock of 700 residues for 1.3x the length, because at 16 GiB on a
+#: 32 GiB machine the fold stops being compute-bound and starts paging. The model's own
+#: confidence there is 26.4, so it is two and a half hours for a structure that says
+#: nothing can be concluded from it.
+#:
+#: So the ceiling is no longer "where the data runs out" but "where the time stops being
+#: worth it", which is a judgement -- raise it to 900 if you want the option and can leave
+#: a machine to it. Beyond 900 nothing has been run at all.
+#:
+#: The memory budget (ProtenixSizeGuard.budgetBytes, 32 GB) is the other half of the
+#: policy: on a 32 GiB machine that is effectively all of it, so a long fold and an
+#: unsaved session are a bad combination.
 MAX_RESIDUES = 700
 
 #: v2's own ceiling, lower because its memory is only measured at the short end and its

--- a/modules/pymol/predictors/protenix.py
+++ b/modules/pymol/predictors/protenix.py
@@ -1,0 +1,163 @@
+"""Protenix via protenix-mlx: ByteDance's AlphaFold3-class predictor, in Swift/MLX.
+
+Protein-only, canonical-20, complexes included: the port's featurizer groups chains into
+entities and builds the cross-chain pair features, so a multimer is something this method
+genuinely models rather than something it approximates. What it carries no reference
+conformers for -- ligands, nucleic acids, modified residues, anything needing the chemical
+component dictionary at fold time -- is refused by name rather than folded as an
+approximation of itself.
+
+This is also the SECOND inference runtime, and the first request that has to say so. The
+`runtime` field, `host.require_runtime` and `RAYMOL_PREDICT_RUNTIMES` exist because of it:
+weights and featurizer are method-specific, so a Protenix request that reached the Boltz
+backend would not fail, it would return a confident wrong structure.
+
+Single-sequence. `supports_msa` is False and staying False until an a3m can actually
+reach `msa_features`: the port feeds the network upstream's depth-1 dummy alignment, and
+a method that accepted a real alignment and then folded against that dummy would return
+a worse structure with nothing in the result saying so. The MSA module itself IS ported,
+so this becomes possible rather than remaining structural -- see #274.
+
+The port DOES have a confidence head -- pLDDT, PAE, PDE and resolved, verified against
+PyTorch to 2e-4 -- and this predictor deliberately declares none of it yet. `metric_specs`
+needs the per-object metric store (#308) to have somewhere to put a per-residue array, so
+the declaration lands with that rather than here. Until then a fold arrives with its
+provenance and cost and no confidence numbers, which is the honest state: the runtime can
+compute them and RayMol cannot yet keep them.
+
+Worth knowing before running it: single-sequence output degrades sharply with length. On
+complete domains, mean pLDDT goes 94.8 at 35 residues, 67.5 at 76, 58.9 at 110, 37.0 at
+129, and sits near 26 from 400 up. That is the documented behaviour of an AF3-class model
+with no alignment rather than a fault in the port, and it means this method earns its time
+on small domains and not much else until #274 gives it a real one.
+"""
+from . import host
+from .base import Predictor, PredictionSpec, parse_chains
+from .errors import PredictionInputError, PredictorUnavailable
+from .weights import WeightBundle
+
+#: The canonical 20. Everything else is refused rather than substituted: the port's
+#: featurizer raises on an unknown letter instead of resolving it to X, so accepting one
+#: here would only defer the same error past a 214 MB download.
+CANONICAL = set('ACDEFGHIKLMNPQRSTVWY')
+
+#: Measured peak memory at the shipped operating point (recycling 10 / 200 steps, with
+#: the confidence head), on an M-series Mac against the base int8 pack. This is MLX's own
+#: high-water mark, not process RSS: the two are different numbers and RSS is not even
+#: monotonic in problem size, because MLX recycles buffers in a cache it need not return
+#: to the OS -- measured by RSS, 400 residues appears to cost LESS than 60.
+#:
+#:     residues     60    120    250    400    550    700
+#:     peak        547    942   2279   3868   6303   8622  MiB
+#:     mean pLDDT 82.7   47.3   30.9   27.2   26.2   26.3
+MEASURED_PEAK_MIB = ((60, 547), (120, 942), (250, 2279), (400, 3868), (550, 6303),
+                     (700, 8622))
+
+#: The cap sits BELOW the largest measurement rather than at it, which is the one place
+#: this file departs from "the largest input measured".
+#:
+#: 700 residues runs, at 8.6 GB and six minutes. That is not a fold to permit by default:
+#: alongside a loaded session it is where a jetsam kill takes the user's unsaved work,
+#: which `PredictSizeGuard` exists to prevent and which no Swift handler can intercept.
+#: And the model's own confidence at that length is 26 -- the run costs six minutes to
+#: produce a structure it says nothing can be concluded from.
+#:
+#: 400 (3.9 GB) is the largest length that both fits comfortably and is worth the wait.
+#: Raise it with a measurement AND a reason, never with either alone.
+MAX_RESIDUES = 400
+
+#: What single-sequence folding is actually worth here, measured on the same pack. Mean
+#: pLDDT against length, over COMPLETE domains rather than truncations (a truncation
+#: scores badly for reasons of its own):
+#:
+#:     villin 35   GB1 56   ubiquitin 76   barnase 110   lysozyme 129
+#:       94.8       72.3        67.5          58.9          37.0
+#:
+#: That is the documented behaviour of an AF3-class model with no alignment, not a fault
+#: in the port -- the same pack discriminates correctly at small sizes (villin 94.8
+#: against 78.4 for poly-alanine of the same length). It is recorded here because it is
+#: the single most useful thing to know before spending two minutes on a fold: past
+#: roughly a hundred residues, single-sequence output is not worth much, and #274 is what
+#: changes that rather than a bigger pack. Lysozyme is the low outlier for a second
+#: reason worth naming -- it has four disulfides, and `token_bonds` is all zeros here.
+MEASURED_CONFIDENCE = ((35, 94.8), (56, 72.3), (76, 67.5), (110, 58.9), (129, 37.0))
+
+#: The backend the Swift host must dispatch to, as it appears on the wire.
+RUNTIME = 'protenix'
+
+
+class ProtenixBasePredictor(Predictor):
+
+    id = 'protenix-base'
+    name = 'Protenix base (MLX, int8)'
+
+    # sha256 and size are of the bytes GitHub serves, taken from protenix-mlx's
+    # WEIGHTS.md, which records the digest of the uploaded asset rather than of a local
+    # rebuild -- int8 quantization runs on Metal and is not bitwise reproducible across
+    # machines, so a re-export would not match.
+    #
+    # Three members, the same shape boltz2's pack has, so WeightCache needs no change.
+    # `config.json` is not optional decoration here: a Protenix checkpoint carries no
+    # architecture at all (it is `{"model": state_dict, "model_version"}`), and the four
+    # variants share tensor NAMES while differing in depth and width, so the runtime
+    # cannot tell an 8-block Pairformer from a 48-block one without it.
+    weight_bundle = WeightBundle(
+        id='protenix-base-mlx-int8',
+        version='v1',
+        url='https://github.com/javierbq/protenix-mlx/releases/download/weights-base-v1/'
+            'protenix-base-mlx-int8-v1.zip',
+        sha256='6a405fbfb0f3b331315bc317106f22ed5daf10eb7b9b1122c4eae5db77b26977',
+        size=224_688_268,
+        members=('config.json', 'manifest.json', 'model.safetensors'),
+    )
+
+    # The released model's own operating point, from its config.json: 10 recycles and
+    # 200 diffusion steps. Both knobs already exist on cmd.predict because Boltz-2 has
+    # them and they mean the same thing here -- Protenix recycles a trunk and runs
+    # reverse diffusion -- so this is the first predictor that adds no knob to
+    # predicting.py at all.
+    #
+    # msa_depth is absent, which is what makes the depth lever rejected by name rather
+    # than accepted and ignored: there is no alignment to have a depth.
+    option_defaults = {'recycling_steps': 10, 'diffusion_steps': 200, 'seed': 0}
+
+    # Single-sequence; see the module docstring.
+    supports_msa = False
+
+    # Deliberately not declared yet: the runtime computes pLDDT and the PAE matrix, and
+    # a per-residue array needs the metric store (#308) to land in. Declaring keys with
+    # nowhere to write them would put numbers in the schema that never arrive.
+    metric_specs = ()
+
+    def check_available(self):
+        host.require_available(self.id)
+        # After require_available, because the two failures have different remedies:
+        # "you are headless" versus "this build does not carry that backend". Checking
+        # here is what refuses BEFORE a 214 MB download rather than after it.
+        host.require_runtime(self.id, RUNTIME)
+
+    def parse_spec(self, sequence, name=''):
+        chains = parse_chains(sequence)
+        total = 0
+        for chain, seq in chains:
+            bad = sorted(set(seq) - CANONICAL)
+            if bad:
+                raise PredictionInputError(
+                    'chain %s contains residues Protenix cannot fold here: %s. This '
+                    'runtime carries reference conformers for the canonical 20 only, '
+                    'so ligands, nucleic acids, modified residues and X, U, B and Z '
+                    'are refused rather than folded as something else.'
+                    % (chain, ', '.join(bad)))
+            total += len(seq)
+        if total > MAX_RESIDUES:
+            raise PredictionInputError(
+                '%d residues exceeds the %d-residue limit. That limit is the largest '
+                'input measured on this device class, not a limit of the method: '
+                'Protenix is ~N^2 in tokens across 48 Pairformer blocks and ten '
+                'recycles, and an unmeasured extrapolation is how a run gets killed '
+                'mid-fold.' % (total, MAX_RESIDUES))
+        return PredictionSpec(chains, name)
+
+    def submit(self, spec, options, weights_path):
+        return host.submit(spec, options, weights_path, runtime=RUNTIME,
+                           knobs=self.option_defaults)

--- a/modules/pymol/predictors/protenix.py
+++ b/modules/pymol/predictors/protenix.py
@@ -1,10 +1,17 @@
 """Protenix via protenix-mlx: ByteDance's AlphaFold3-class predictor, in Swift/MLX.
 
-Twelve packs: four model variants at three precisions each, every one a separate
-predictor id. That is the `boltz2` / `boltz2-bf16` pattern taken to its conclusion — one
-runtime, many tools — and it works for the same reason: `host.submit` sends `weights_dir`
-per job and the Swift side picks its matmul path from the artifact manifest, so a dense
-pack needs no code of its own.
+Six packs: the base and v2 variants at three precisions each, every one a separate
+predictor id. That is the `boltz2` / `boltz2-bf16` pattern -- one runtime, many tools --
+and it works for the same reason: `host.submit` sends `weights_dir` per job and the Swift
+side picks its matmul path from the artifact manifest, so a dense pack needs no code.
+
+**tiny and mini are published but NOT offered here.** They are v0.5.0 models trained to 4
+recycles / 5 diffusion steps, and five steps does not converge the geometry: at a fixed
+seed tiny gives CA-CA distances of 3.26 A against base's 3.67 and an ideal 3.80, which is
+loose enough that DSSP stops calling helices and the cartoon breaks into segments. They
+are fast -- 11 s against base's 35 -- but a fold nobody should trust is not worth 11
+seconds either, and offering it invites exactly that. protenix-mlx still builds and
+publishes them; add them back here if a use appears that wants speed over geometry.
 
 Protein-only, canonical-20, complexes included: the port's featurizer groups chains into
 entities and builds the cross-chain pair features, so a multimer is something this method
@@ -19,9 +26,8 @@ structure with nothing in the result saying so. The MSA module IS ported, so thi
 reachable rather than remaining structural -- see #274.
 
 **Which one to use.** `protenix-base-int8` is the default choice and the one whose memory
-is measured most thoroughly. tiny and mini are v0.5.0 models at 4 recycles / 5 diffusion
-steps: seconds rather than minutes, and correspondingly rough -- they exist for iteration,
-not for answers. The dense precisions cost roughly twice the disk and more memory for no
+is measured most thoroughly. v2 scores highest on a short probe but is mirror-sourced and
+measured least. The dense precisions cost roughly twice the disk and more memory for no
 demonstrated accuracy, exactly as `boltz2-bf16` does; they are here so that experiment is
 possible on-device rather than because they are better.
 
@@ -50,19 +56,16 @@ RUNTIME = 'protenix'
 #: measured by RSS the same sweep reads 400 residues as costing LESS than 60, because MLX
 #: recycles buffers in a cache it need not return to the OS.
 #:
-#:                60 res   250 res   400 res
-#:     tiny          250      2083      3494
-#:     mini          298      2172      3625
-#:     base          547      2279      3868
+#:                60 res   250 res   400 res   550 res   700 res
+#:     base          547      2279      3868      6303      8622
 #:     v2            -- (509 MiB at 15 residues; its 256-wide pair track costs more)
 #:
-#: The variants converge as the input grows: at 400 residues they are within 10% of each
-#: other, because the N^2 pair representation dwarfs the weights. Which is why the cap
-#: below is the same for all of them rather than scaled by parameter count -- the thing
-#: that decides whether a fold fits is the sequence, not the pack.
+#: Variants converge as the input grows: the now-unshipped tiny and mini measured 3494 and
+#: 3625 MiB at 400 residues against base's 3868, within 10% of each other, because the
+#: N^2 pair representation dwarfs the weights. That is why the cap is driven by sequence
+#: length rather than scaled by parameter count -- what decides whether a fold fits is how
+#: long it is, not which pack runs it.
 MEASURED_PEAK_MIB = {
-    'tiny': ((60, 250), (250, 2083), (400, 3494)),
-    'mini': ((60, 298), (250, 2172), (400, 3625)),
     'base': ((60, 547), (120, 942), (250, 2279), (400, 3868), (550, 6303), (700, 8622)),
     # v2 is swept only at the short end so far. Its pair track is 256 wide against every
     # other variant's 128, so the N^2 term is doubled and base's curve UNDERSTATES it --
@@ -71,14 +74,18 @@ MEASURED_PEAK_MIB = {
     'v2': ((15, 509),),
 }
 
-#: Hard ceiling, in residues, across every variant.
+#: Hard ceiling, in residues, across every variant except v2.
 #:
-#: Below the largest measurement (700 for base, at 8.6 GB and six minutes) on purpose:
-#: alongside a loaded session that is where a jetsam kill takes the user's unsaved work,
-#: and the model's own confidence at that length is 26 -- six minutes to produce a
-#: structure it says nothing can be concluded from. 400 is the largest length that both
-#: fits comfortably and is worth the wait. Raise it with a measurement AND a reason.
-MAX_RESIDUES = 400
+#: The largest length actually MEASURED (700 for base, at 8.6 GB and six minutes). It was
+#: 400 -- chosen because a fold whose own confidence is 26 is rarely worth six minutes --
+#: and was raised deliberately, since that is a judgement for whoever is waiting.
+#:
+#: Still not an extrapolation: beyond 700 nothing has been run, and the Swift guard's
+#: history is that guessing past the data runs optimistic. Raise it again with a
+#: measurement, and note that the memory budget (ProtenixSizeGuard.budgetBytes, now 32 GB)
+#: is the other half of the policy -- on a 32 GiB machine that is effectively all of it,
+#: so a long fold and an unsaved session are a bad combination.
+MAX_RESIDUES = 700
 
 #: v2's own ceiling, lower because its memory is only measured at the short end and its
 #: pair representation is twice as wide. Not a judgement about the model -- it scores
@@ -109,15 +116,11 @@ _SUFFIX = {'int8': 'int8', 'float16': 'fp16', 'bfloat16': 'bf16'}
 #: v0.5.0 models trained to a much shorter schedule; using base's 10/200 on them would
 #: spend forty times the compute on a model that was not trained to use it.
 _OPERATING_POINT = {
-    'tiny': (4, 5),
-    'mini': (4, 5),
     'base': (10, 200),
     'v2': (10, 200),
 }
 
 _DESCRIPTION = {
-    'tiny': 'Protenix tiny v0.5.0',
-    'mini': 'Protenix mini v0.5.0',
     'base': 'Protenix base v1.0.0',
     'v2': 'Protenix v2',
 }
@@ -129,36 +132,6 @@ _DESCRIPTION = {
 #: twelve chances to paste the wrong one, and a wrong digest fails only on a user's
 #: machine, after the download.
 _PACKS = (
-    _Pack('tiny', 'int8',
-          'https://github.com/javierbq/protenix-mlx/releases/download/weights-tiny-v1/'
-          'protenix-tiny-mlx-int8-v1.zip',
-          '11716a7c69d10c0b9c90410503bc2b4b05a3c83f8b39c572bf4d962a56094858',
-          87_543_789),
-    _Pack('tiny', 'float16',
-          'https://github.com/javierbq/protenix-mlx/releases/download/weights-tiny-v1/'
-          'protenix-tiny-mlx-float16-v1.zip',
-          '73fdf864366461380cee4b316b354018118e55f5d0ce6ee7be698d30b64274a1',
-          173_209_981),
-    _Pack('tiny', 'bfloat16',
-          'https://github.com/javierbq/protenix-mlx/releases/download/weights-tiny-v1/'
-          'protenix-tiny-mlx-bfloat16-v1.zip',
-          '77777d1a40dc45b5de900978e2d0018fd361e93fdebb4384c4928c07866b99b9',
-          151_635_809),
-    _Pack('mini', 'int8',
-          'https://github.com/javierbq/protenix-mlx/releases/download/weights-mini-v1/'
-          'protenix-mini-mlx-int8-v1.zip',
-          'ea3a8f81ad8ce055b5b3d1dba92f595b5284dfc2c13b8eedd0458827babc0cea',
-          96_248_656),
-    _Pack('mini', 'float16',
-          'https://github.com/javierbq/protenix-mlx/releases/download/weights-mini-v1/'
-          'protenix-mini-mlx-float16-v1.zip',
-          '159206251babea99824110da45546707ed1428f0cf1b5a38025cc2db76f7337d',
-          193_494_769),
-    _Pack('mini', 'bfloat16',
-          'https://github.com/javierbq/protenix-mlx/releases/download/weights-mini-v1/'
-          'protenix-mini-mlx-bfloat16-v1.zip',
-          '9dc3a7397d054421d1b9a64959477c927a86b56446b1f24fa642a57d4a5a8837',
-          171_699_965),
     _Pack('base', 'int8',
           'https://github.com/javierbq/protenix-mlx/releases/download/weights-base-v1/'
           'protenix-base-mlx-int8-v1.zip',

--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -321,7 +321,7 @@
 		F7E41DCBB427678A8F018B0E /* DesignControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignControllerTests.swift; sourceTree = "<group>"; };
 		FB1304C662D9011F7C4505FC /* MCPStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPStatusView.swift; sourceTree = "<group>"; };
 		FF4FB7F151982A2927D612F0 /* DesignController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignController.swift; sourceTree = "<group>"; };
-		"TEMP_62BF5AF2-E869-4D4F-9CB3-4CAF6663ACF0" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
+		"TEMP_98520FB1-4E58-4C25-BBA3-B7077B92E87D" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -555,10 +555,10 @@
 			path = Bridge;
 			sourceTree = "<group>";
 		};
-		"TEMP_88E98988-3554-4C20-82A0-7E5D8D0B7388" /* swiftui */ = {
+		"TEMP_E818E59A-C281-41D5-AEBB-1E2E8752DE81" /* swiftui */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_62BF5AF2-E869-4D4F-9CB3-4CAF6663ACF0" /* PyMOLBridge.xcconfig */,
+				"TEMP_98520FB1-4E58-4C25-BBA3-B7077B92E87D" /* PyMOLBridge.xcconfig */,
 			);
 			path = swiftui;
 			sourceTree = "<group>";
@@ -1585,7 +1585,7 @@
 		};
 		76B7E9DB75E073D1E60928FA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_62BF5AF2-E869-4D4F-9CB3-4CAF6663ACF0" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_98520FB1-4E58-4C25-BBA3-B7077B92E87D" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1692,7 +1692,7 @@
 		};
 		D8F44FDFF036013D2F03BA83 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_62BF5AF2-E869-4D4F-9CB3-4CAF6663ACF0" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_98520FB1-4E58-4C25-BBA3-B7077B92E87D" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1858,7 +1858,7 @@
 			repositoryURL = "https://github.com/javierbq/protenix-mlx.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.2;
+				minimumVersion = 0.1.3;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -19,8 +19,10 @@
 		104B27F848D308735A6D6DD2 /* MetalViewport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E9F8D36908E3216D1C8F893 /* MetalViewport.swift */; };
 		124F6E6764C7D94831B8AC7E /* AppVersionFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3F3410F7C0D3C85783B985F /* AppVersionFooter.swift */; };
 		13B48E7F8C2A51ADAF48F4C3 /* SequencePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474D18A43D0D9A6BDD69EEFD /* SequencePanel.swift */; };
+		13C5A803C8072DE180EB23CC /* ProtenixRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7845A3EB6A6BF8A14F090062 /* ProtenixRuntime.swift */; };
 		13E8687216067D92666E3078 /* openssl-PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = CB0108E0FA1F204BE0E41F0D /* openssl-PrivacyInfo.xcprivacy */; };
 		142D8657C5BC7DCD8648D407 /* DesignCompactPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D7FF883D3762DC6E40908F /* DesignCompactPanel.swift */; };
+		154E7F765059977CA80711DA /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 98AC6A7391B7E7A564A30A61 /* Sparkle */; };
 		1624BC38CDD73398C68FC135 /* MPNNGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56BE219EF1CF1EB2B05E44AD /* MPNNGate.swift */; };
 		174EA423F2E0ED999474C506 /* DesignInferenceSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45634C95AE991CC91CFBA75 /* DesignInferenceSmokeTests.swift */; };
 		1A580F6792CD440D91FA9F45 /* DesignSizeGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E69AA2C12DC2D1583FBF8C8 /* DesignSizeGuard.swift */; };
@@ -30,6 +32,7 @@
 		217461B479C6F851A9A6C4C7 /* WhatsNewModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4D170B35BCCF683A6B3D655 /* WhatsNewModal.swift */; };
 		238B6F24D467D70AE012E2CB /* BoltzJobManagerMSATests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A75842F74BFC453CE7BA777 /* BoltzJobManagerMSATests.swift */; };
 		24169A74B9EBFD202258A5E4 /* PyMOLBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 356FC561FA1515B3D15A26E2 /* PyMOLBridge.mm */; };
+		25B6234DE09C8513458832EB /* ProtenixMLX in Frameworks */ = {isa = PBXBuildFile; productRef = 6A6ADC55CC1EDE5686605DCB /* ProtenixMLX */; };
 		272C379DFEE54E979E9A15D2 /* whatsnew-190-scenes.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 6A0950CBB18F3934DDA02CBE /* whatsnew-190-scenes.mp4 */; };
 		2A4E93771E38C19B96D375BA /* 4_R.svg in Resources */ = {isa = PBXBuildFile; fileRef = 97069E4E1D42FC4C9760D2AB /* 4_R.svg */; };
 		2B6E59F50398ACB89A0BB029 /* DesignModeStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E47D8905CF71AF7BDF4BE074 /* DesignModeStateTests.swift */; };
@@ -40,6 +43,7 @@
 		33925DA4B65039A7C4C0DE8F /* BoltzRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2367C4CEE5BD2E682055D3F /* BoltzRuntime.swift */; };
 		33C46A7EB6127A6A99D7048D /* TimelinePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B820FE9080BF73526A54CD66 /* TimelinePanel.swift */; };
 		3494764DF6FC43A45FB259AF /* PredictSizeGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C07F661E0541060409A09F7 /* PredictSizeGuard.swift */; };
+		34985FCB3C0FBC450384D4C9 /* ProtenixSizeGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EE8A26A41F551AB296B2F8E /* ProtenixSizeGuard.swift */; };
 		36D99340CCDDAD7C67680476 /* whatsnew-161-hover.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 6E2FC2AD1A8FEE912986DF9D /* whatsnew-161-hover.mp4 */; };
 		3A8107D094C920B600681B74 /* ThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC5E722722DEF7FBB1D649F /* ThemeManager.swift */; };
 		3D6FE0218915810960306973 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 589928DEEE69075B965DB9F2 /* Assets.xcassets */; };
@@ -82,6 +86,7 @@
 		64DDBC57197D8C3A9AB0B68D /* MCPServerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F3D56C490BC7C6166DD79F /* MCPServerManager.swift */; };
 		65CE08E50C85C8ACDAC92D07 /* DesignSizeGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E69AA2C12DC2D1583FBF8C8 /* DesignSizeGuard.swift */; };
 		667B289D123B261F82B10FFC /* MovieBuilderSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ED5BFF3FEE9D6621BB40AE5 /* MovieBuilderSheet.swift */; };
+		68AB212502F00E7E297F8208 /* ProtenixSizeGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EE8A26A41F551AB296B2F8E /* ProtenixSizeGuard.swift */; };
 		6A1DB5F97E3738FD1819FF6E /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3E805AC2D63B01AB7EE29C /* Theme.swift */; };
 		6A3892FDD5939A57DC9FFCCE /* CopyRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0B47016374F32C7BB13017 /* CopyRoutingTests.swift */; };
 		6C028EE83C8A29A4FDCF2222 /* BoltzJobManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 193D4D739151970412BB6EDF /* BoltzJobManagerTests.swift */; };
@@ -96,6 +101,7 @@
 		768E23FCAB4D2B27205900B6 /* KeyRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3697F74BD2283492B5A7790C /* KeyRouting.swift */; };
 		77612C0A58360E932EDC3CA7 /* whatsnew-190-scenes.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 6A0950CBB18F3934DDA02CBE /* whatsnew-190-scenes.mp4 */; };
 		77947569BB49AFA9845B7283 /* MCPDrivingBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9EC978B16F58D988575E206 /* MCPDrivingBanner.swift */; };
+		783033ED2463B78CD831611D /* ProtenixJobManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2D0B8DEF98F905922AE2FD /* ProtenixJobManager.swift */; };
 		78893185798035F798A26A9B /* DesignAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4300265954DF2B8309EDAA6C /* DesignAvailability.swift */; };
 		79604AC1AF5212DADC4C2DE3 /* CopyRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CC639810B19E8F5E637E93 /* CopyRouting.swift */; };
 		7B6E4F8683D469C6984163AA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 589928DEEE69075B965DB9F2 /* Assets.xcassets */; };
@@ -118,9 +124,11 @@
 		97F0B5805CD3B11723C7B43B /* whatsnew-152-timeline.png in Resources */ = {isa = PBXBuildFile; fileRef = 55094A33AFF9AEF5561CFD96 /* whatsnew-152-timeline.png */; };
 		983BCF8F1E0F251E82C1CF0E /* DesignController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4FB7F151982A2927D612F0 /* DesignController.swift */; };
 		999E9CD4AA6508F8AA9162AE /* 0_background.svg in Resources */ = {isa = PBXBuildFile; fileRef = D444C3F1A58D875A887AD16E /* 0_background.svg */; };
-		9E056CF2985B57F6BF968798 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 98AC6A7391B7E7A564A30A61 /* Sparkle */; };
+		9E056CF2985B57F6BF968798 /* ProtenixMLX in Frameworks */ = {isa = PBXBuildFile; productRef = 90EE4E4414E8FBDC2271BEA2 /* ProtenixMLX */; };
+		9FDA615BBA4A6BBDF131EF7F /* ProtenixRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56746569540D202277F2B47F /* ProtenixRuntimeTests.swift */; };
 		A15088BB076A83B581850C0D /* 4_R.svg in Resources */ = {isa = PBXBuildFile; fileRef = 97069E4E1D42FC4C9760D2AB /* 4_R.svg */; };
 		A4E8C9619C9B7F0C169BFAFF /* BoltzMLX in Frameworks */ = {isa = PBXBuildFile; productRef = B20D95BF3CA7BA300F0AF09F /* BoltzMLX */; };
+		A76B8F620DCFED6F7AD69FEE /* ProtenixRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7845A3EB6A6BF8A14F090062 /* ProtenixRuntime.swift */; };
 		AA00B9355E30A51B8F4C207B /* AppBuildInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525F338CAB2EE18987CD1701 /* AppBuildInfo.swift */; };
 		AA36D034CEC68207CFC82340 /* WhatsNewModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4D170B35BCCF683A6B3D655 /* WhatsNewModal.swift */; };
 		ACBE8F70B980BCCE6730141A /* MovieBuilderSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ED5BFF3FEE9D6621BB40AE5 /* MovieBuilderSheet.swift */; };
@@ -134,6 +142,7 @@
 		B84291E694521C66BCB749CD /* whatsnew-161-hover.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 6E2FC2AD1A8FEE912986DF9D /* whatsnew-161-hover.mp4 */; };
 		B88942D786AB0D1CDC354C1F /* DesignAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2345D7E2703CF29D4A2AA277 /* DesignAvailabilityTests.swift */; };
 		BA6C9B288CFD5EB53D0E0057 /* RayMolMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9371B6FFB30D6166234C678B /* RayMolMain.swift */; };
+		BAF51FE61B64C23C51DF4AAF /* ProtenixJobManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2D0B8DEF98F905922AE2FD /* ProtenixJobManager.swift */; };
 		BE397E89274A3180A2E649BF /* DesignColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F2DF248B756BF6CA3CBE92 /* DesignColor.swift */; };
 		BF09C330B7686E39A51C8626 /* BoltzRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2367C4CEE5BD2E682055D3F /* BoltzRuntime.swift */; };
 		C0BCE174EC5A1E6CBFBFA91F /* openssl-PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = CB0108E0FA1F204BE0E41F0D /* openssl-PrivacyInfo.xcprivacy */; };
@@ -236,9 +245,11 @@
 		4A2C1E1633D1E93E9914BEC3 /* OpenFilesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenFilesTests.swift; sourceTree = "<group>"; };
 		4C570F9CAC877E201F237016 /* whatsnew-170-move.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "whatsnew-170-move.png"; sourceTree = "<group>"; };
 		4D6A959CC1590FC60333582B /* DesignEditInferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignEditInferenceTests.swift; sourceTree = "<group>"; };
+		4EE8A26A41F551AB296B2F8E /* ProtenixSizeGuard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtenixSizeGuard.swift; sourceTree = "<group>"; };
 		525F338CAB2EE18987CD1701 /* AppBuildInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBuildInfo.swift; sourceTree = "<group>"; };
 		55094A33AFF9AEF5561CFD96 /* whatsnew-152-timeline.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "whatsnew-152-timeline.png"; sourceTree = "<group>"; };
 		55F4F52D951CF1F96606F41C /* SmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmokeTests.swift; sourceTree = "<group>"; };
+		56746569540D202277F2B47F /* ProtenixRuntimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtenixRuntimeTests.swift; sourceTree = "<group>"; };
 		56BE219EF1CF1EB2B05E44AD /* MPNNGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPNNGate.swift; sourceTree = "<group>"; };
 		57E9E81F5C4757D03AAF7ABD /* dylib-Info-template.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "dylib-Info-template.plist"; sourceTree = "<group>"; };
 		589928DEEE69075B965DB9F2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -252,6 +263,7 @@
 		6E2FC2AD1A8FEE912986DF9D /* whatsnew-161-hover.mp4 */ = {isa = PBXFileReference; path = "whatsnew-161-hover.mp4"; sourceTree = "<group>"; };
 		6ECDA98647B184340BC7934F /* DesignIOSPortTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignIOSPortTests.swift; sourceTree = "<group>"; };
 		75F059BB95517CE91BD3E26E /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		7845A3EB6A6BF8A14F090062 /* ProtenixRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtenixRuntime.swift; sourceTree = "<group>"; };
 		786939619F7871E32E2BB123 /* MCPDesktopInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPDesktopInstaller.swift; sourceTree = "<group>"; };
 		7AD9869000B548D9F7CDF9DE /* MLXRuntimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLXRuntimeTests.swift; sourceTree = "<group>"; };
 		7D10B5CB9ECF81346BD9CAE8 /* whatsnew-190-raymolrc.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "whatsnew-190-raymolrc.png"; sourceTree = "<group>"; };
@@ -264,6 +276,7 @@
 		97069E4E1D42FC4C9760D2AB /* 4_R.svg */ = {isa = PBXFileReference; path = 4_R.svg; sourceTree = "<group>"; };
 		99E8403E056CB6DA5DD9A3CA /* PyMOLViewerUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = PyMOLViewerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A2CE99D9A3C57ACBBDBF3B5 /* DesignRegionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignRegionTests.swift; sourceTree = "<group>"; };
+		9B2D0B8DEF98F905922AE2FD /* ProtenixJobManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtenixJobManager.swift; sourceTree = "<group>"; };
 		9E69AA2C12DC2D1583FBF8C8 /* DesignSizeGuard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSizeGuard.swift; sourceTree = "<group>"; };
 		A2367C4CEE5BD2E682055D3F /* BoltzRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoltzRuntime.swift; sourceTree = "<group>"; };
 		A4CC639810B19E8F5E637E93 /* CopyRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyRouting.swift; sourceTree = "<group>"; };
@@ -308,7 +321,7 @@
 		F7E41DCBB427678A8F018B0E /* DesignControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignControllerTests.swift; sourceTree = "<group>"; };
 		FB1304C662D9011F7C4505FC /* MCPStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPStatusView.swift; sourceTree = "<group>"; };
 		FF4FB7F151982A2927D612F0 /* DesignController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignController.swift; sourceTree = "<group>"; };
-		"TEMP_7D9CCD29-564E-4DC1-B733-4AAB8070439E" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
+		"TEMP_62BF5AF2-E869-4D4F-9CB3-4CAF6663ACF0" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -318,6 +331,7 @@
 			files = (
 				484D9DFA048A6444660199CB /* MPNNKit in Frameworks */,
 				A4E8C9619C9B7F0C169BFAFF /* BoltzMLX in Frameworks */,
+				25B6234DE09C8513458832EB /* ProtenixMLX in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -328,7 +342,8 @@
 				48E340346AD8FF81AF09F501 /* MPNNKit in Frameworks */,
 				6E945630A8B9A6195B98A958 /* MLX in Frameworks */,
 				B6FBF55DD1FA97A86C678618 /* BoltzMLX in Frameworks */,
-				9E056CF2985B57F6BF968798 /* Sparkle in Frameworks */,
+				9E056CF2985B57F6BF968798 /* ProtenixMLX in Frameworks */,
+				154E7F765059977CA80711DA /* Sparkle in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -457,6 +472,9 @@
 				56BE219EF1CF1EB2B05E44AD /* MPNNGate.swift */,
 				E2D0BB6A1E7959881767F049 /* MPNNRuntime.swift */,
 				6C07F661E0541060409A09F7 /* PredictSizeGuard.swift */,
+				9B2D0B8DEF98F905922AE2FD /* ProtenixJobManager.swift */,
+				7845A3EB6A6BF8A14F090062 /* ProtenixRuntime.swift */,
+				4EE8A26A41F551AB296B2F8E /* ProtenixSizeGuard.swift */,
 				D965CB609C447033E5DB0046 /* PyMOLApp.swift */,
 				33D6A753E4525628B96C259C /* PyMOLEngine.swift */,
 				9371B6FFB30D6166234C678B /* RayMolMain.swift */,
@@ -498,6 +516,7 @@
 				4A2C1E1633D1E93E9914BEC3 /* OpenFilesTests.swift */,
 				48793845CB95A609CD9F37BF /* PredictMSAMemorySweepTests.swift */,
 				D177C9A043AE57844A9AEB95 /* PredictSizeGuardTests.swift */,
+				56746569540D202277F2B47F /* ProtenixRuntimeTests.swift */,
 				55F4F52D951CF1F96606F41C /* SmokeTests.swift */,
 				0C4E3216DAFC42C515FD0C3E /* WeightsFetchStateTests.swift */,
 			);
@@ -536,10 +555,10 @@
 			path = Bridge;
 			sourceTree = "<group>";
 		};
-		"TEMP_9DC3B7D1-19BF-49AF-B101-4054966F8E6A" /* swiftui */ = {
+		"TEMP_88E98988-3554-4C20-82A0-7E5D8D0B7388" /* swiftui */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_7D9CCD29-564E-4DC1-B733-4AAB8070439E" /* PyMOLBridge.xcconfig */,
+				"TEMP_62BF5AF2-E869-4D4F-9CB3-4CAF6663ACF0" /* PyMOLBridge.xcconfig */,
 			);
 			path = swiftui;
 			sourceTree = "<group>";
@@ -576,6 +595,7 @@
 				7A0C20547CE6C050BA30EDA0 /* MPNNKit */,
 				FBA4CCD670BAF318F243E692 /* MLX */,
 				8426817F16C801044FDCCB94 /* BoltzMLX */,
+				90EE4E4414E8FBDC2271BEA2 /* ProtenixMLX */,
 				98AC6A7391B7E7A564A30A61 /* Sparkle */,
 			);
 			productName = PyMOLViewer_macOS;
@@ -649,6 +669,7 @@
 			packageProductDependencies = (
 				791C3459ADD4745BE10E27AA /* MPNNKit */,
 				B20D95BF3CA7BA300F0AF09F /* BoltzMLX */,
+				6A6ADC55CC1EDE5686605DCB /* ProtenixMLX */,
 			);
 			productName = PyMOLViewerTests;
 			productReference = E9D0FEF5D42BDC6E514B7BB9 /* PyMOLViewerTests.xctest */;
@@ -680,6 +701,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				C2A63CE2513FB93FA639FB61 /* XCRemoteSwiftPackageReference "boltz-mlx" */,
+				E6B120B2ECAC9D805AC713E0 /* XCRemoteSwiftPackageReference "protenix-mlx" */,
 				58A6BB52C9446E5F8EFF49B1 /* XCRemoteSwiftPackageReference "Sparkle" */,
 				59736E03D73BFCCFF74027FA /* XCRemoteSwiftPackageReference "mlx-swift" */,
 				B72CB82F75F09314D45355C3 /* XCRemoteSwiftPackageReference "proteinmpnn-mlx" */,
@@ -1265,6 +1287,7 @@
 				C89E138879C40C8FB6C0478A /* OpenFilesTests.swift in Sources */,
 				615CCED824D7A973408A6CBD /* PredictMSAMemorySweepTests.swift in Sources */,
 				D1A6B8D3D1B74B4D1142ADE5 /* PredictSizeGuardTests.swift in Sources */,
+				9FDA615BBA4A6BBDF131EF7F /* ProtenixRuntimeTests.swift in Sources */,
 				5CAB662574D238626A8F4D68 /* SmokeTests.swift in Sources */,
 				047FD10B437F95938AB4B3B0 /* WeightsFetchStateTests.swift in Sources */,
 			);
@@ -1306,6 +1329,9 @@
 				0DDA865CB0C8ACAC1BFD0FE9 /* NotesInspectorView.swift in Sources */,
 				4679E36960C9AE8AAE3B1F7D /* ObjectPanel.swift in Sources */,
 				3494764DF6FC43A45FB259AF /* PredictSizeGuard.swift in Sources */,
+				783033ED2463B78CD831611D /* ProtenixJobManager.swift in Sources */,
+				13C5A803C8072DE180EB23CC /* ProtenixRuntime.swift in Sources */,
+				68AB212502F00E7E297F8208 /* ProtenixSizeGuard.swift in Sources */,
 				F6C4DEEFED66EB440E6359AF /* PyMOLApp.swift in Sources */,
 				24169A74B9EBFD202258A5E4 /* PyMOLBridge.mm in Sources */,
 				56CC6A9A8A95D5B1B8D92688 /* PyMOLEngine.swift in Sources */,
@@ -1359,6 +1385,9 @@
 				E9B0CF8BC5F291107F7C872B /* NotesInspectorView.swift in Sources */,
 				5992346BC7D06026A673BA71 /* ObjectPanel.swift in Sources */,
 				F5BEB7A4A5B270B0A64476D2 /* PredictSizeGuard.swift in Sources */,
+				BAF51FE61B64C23C51DF4AAF /* ProtenixJobManager.swift in Sources */,
+				A76B8F620DCFED6F7AD69FEE /* ProtenixRuntime.swift in Sources */,
+				34985FCB3C0FBC450384D4C9 /* ProtenixSizeGuard.swift in Sources */,
 				5C923361D76329D2A466FFA9 /* PyMOLApp.swift in Sources */,
 				5D4BC69196C1256F5164E56A /* PyMOLBridge.mm in Sources */,
 				8852A9FA93BDAAB188D4103C /* PyMOLEngine.swift in Sources */,
@@ -1556,7 +1585,7 @@
 		};
 		76B7E9DB75E073D1E60928FA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_7D9CCD29-564E-4DC1-B733-4AAB8070439E" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_62BF5AF2-E869-4D4F-9CB3-4CAF6663ACF0" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1663,7 +1692,7 @@
 		};
 		D8F44FDFF036013D2F03BA83 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_7D9CCD29-564E-4DC1-B733-4AAB8070439E" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_62BF5AF2-E869-4D4F-9CB3-4CAF6663ACF0" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1824,6 +1853,14 @@
 				minimumVersion = 0.2.0;
 			};
 		};
+		E6B120B2ECAC9D805AC713E0 /* XCRemoteSwiftPackageReference "protenix-mlx" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/javierbq/protenix-mlx.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.2;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1831,6 +1868,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 59736E03D73BFCCFF74027FA /* XCRemoteSwiftPackageReference "mlx-swift" */;
 			productName = MLX;
+		};
+		6A6ADC55CC1EDE5686605DCB /* ProtenixMLX */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E6B120B2ECAC9D805AC713E0 /* XCRemoteSwiftPackageReference "protenix-mlx" */;
+			productName = ProtenixMLX;
 		};
 		791C3459ADD4745BE10E27AA /* MPNNKit */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -1851,6 +1893,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = C2A63CE2513FB93FA639FB61 /* XCRemoteSwiftPackageReference "boltz-mlx" */;
 			productName = BoltzMLX;
+		};
+		90EE4E4414E8FBDC2271BEA2 /* ProtenixMLX */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E6B120B2ECAC9D805AC713E0 /* XCRemoteSwiftPackageReference "protenix-mlx" */;
+			productName = ProtenixMLX;
 		};
 		98AC6A7391B7E7A564A30A61 /* Sparkle */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/swiftui/PyMOLViewer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/swiftui/PyMOLViewer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b91c31a349f929b1906f517fae13f04085d0506bd25dcecf3db1bb097004fe0d",
+  "originHash" : "3f07e7ebcba532a1cffd5811489b6a22b88c92323632d559dfef6fbc8228736a",
   "pins" : [
     {
       "identity" : "boltz-mlx",
@@ -25,6 +25,15 @@
       "location" : "https://github.com/javierbq/proteinmpnn-mlx.git",
       "state" : {
         "revision" : "9cc71d2840a527c139eb9bacd624be01f8f48d95",
+        "version" : "0.1.2"
+      }
+    },
+    {
+      "identity" : "protenix-mlx",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/javierbq/protenix-mlx.git",
+      "state" : {
+        "revision" : "3afa72b06f6434c7ecc850df579bfc82721df12c",
         "version" : "0.1.2"
       }
     },

--- a/swiftui/PyMOLViewer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/swiftui/PyMOLViewer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/javierbq/protenix-mlx.git",
       "state" : {
-        "revision" : "3afa72b06f6434c7ecc850df579bfc82721df12c",
-        "version" : "0.1.2"
+        "revision" : "965e5143429bd8321cf21971a29c772610f69b7f",
+        "version" : "0.1.3"
       }
     },
     {

--- a/swiftui/PyMOLViewer/Bridge/PyMOLBridge.mm
+++ b/swiftui/PyMOLViewer/Bridge/PyMOLBridge.mm
@@ -114,9 +114,10 @@ void PyMOLBridge_InitPython(PyMOLHandle h, const char *resourcePath)
     // capability but several: BoltzJobManager implements "boltz" and nothing else, so a
     // predictor whose backend is missing refuses in check_available rather than
     // submitting a job that BoltzJobManager.preflight would refuse -- after the user had
-    // waited out a weight download. Keep in step with BoltzJobManager.boltzRuntime; add
-    // a name here only when its runtime actually ships.
-    setenv("RAYMOL_PREDICT_RUNTIMES", "boltz", 1);
+    // waited out a weight download. Keep in step with BoltzJobManager.boltzRuntime and
+    // ProtenixJobManager.runtimeName; add a name here only when its runtime actually
+    // ships, because check_available trusts this list to decide what can run.
+    setenv("RAYMOL_PREDICT_RUNTIMES", "boltz,protenix", 1);
 #endif
 
     PyStatus status = Py_InitializeFromConfig(&config);

--- a/swiftui/PyMOLViewer/Bridge/PyMOLBridge.mm
+++ b/swiftui/PyMOLViewer/Bridge/PyMOLBridge.mm
@@ -110,6 +110,13 @@ void PyMOLBridge_InitPython(PyMOLHandle h, const char *resourcePath)
     // are after init and get away with it only because PyMOL's own Python layer
     // assigns those into os.environ itself.)
     setenv("RAYMOL_PREDICT_HOST", "1", 1);
+    // Which inference runtimes are actually LINKED into this build. A host is not one
+    // capability but several: BoltzJobManager implements "boltz" and nothing else, so a
+    // predictor whose backend is missing refuses in check_available rather than
+    // submitting a job that BoltzJobManager.preflight would refuse -- after the user had
+    // waited out a weight download. Keep in step with BoltzJobManager.boltzRuntime; add
+    // a name here only when its runtime actually ships.
+    setenv("RAYMOL_PREDICT_RUNTIMES", "boltz", 1);
 #endif
 
     PyStatus status = Py_InitializeFromConfig(&config);

--- a/swiftui/PyMOLViewer/Shared/BoltzJobManager.swift
+++ b/swiftui/PyMOLViewer/Shared/BoltzJobManager.swift
@@ -195,6 +195,10 @@ final class BoltzJobManager {
                     cancelled.insert(marker.jobID)
                 }
             }
+            // Broadcast: a cancel marker carries only a job id, so there is nothing in it
+            // to route on. Every manager keeps only its own ids, and a cancel for a job
+            // this one never had is a no-op.
+            ProtenixJobManager.shared.cancel(jobID: marker.jobID)
         case .submit:
             let url = URL(fileURLWithPath: NSTemporaryDirectory())
                 .appendingPathComponent("raymol_predict_req_\(marker.jobID).json")
@@ -212,6 +216,17 @@ final class BoltzJobManager {
                                 + error.localizedDescription,
                            resultPath: nil, peakBytes: nil, elapsedSeconds: nil),
                     to: Self.statusURL(jobID: marker.jobID))
+                return
+            }
+            // Routed BEFORE preflight, because preflight below is Boltz's: its size model
+            // is fitted to Boltz's peaks, and its runtime check exists to refuse backends
+            // nothing implements. A protenix request is not that -- it has a manager.
+            //
+            // This manager owns the marker only because it was here first. When a third
+            // runtime lands, lift the parse-and-route out into a dispatcher rather than
+            // adding another branch here.
+            if request.runtime == ProtenixJobManager.runtimeName {
+                ProtenixJobManager.shared.submit(request)
                 return
             }
             if let failure = Self.preflight(request) {
@@ -307,7 +322,7 @@ final class BoltzJobManager {
     }
 
     /// Both refusals read the same to a caller; only the advice differs.
-    private static func refusal(_ message: String) -> Status {
+    static func refusal(_ message: String) -> Status {
         Status(state: "failed", phase: "preflight", fraction: 0, error: message,
                resultPath: nil, peakBytes: nil, elapsedSeconds: nil)
     }
@@ -321,7 +336,7 @@ final class BoltzJobManager {
     /// marked pending after a successful load would be stripped from every subsequent
     /// session save. `deliver_result` also pins `zoom=0` -- a prediction can land many
     /// minutes after submit, and moving the camera then would interrupt the user.
-    private static func loadResult(_ request: Request) {
+    static func loadResult(_ request: Request) {
         guard let objectName = request.objectName, !objectName.isEmpty else { return }
         let path = pythonLiteral(request.outPath)
         let name = pythonLiteral(objectName)
@@ -343,7 +358,7 @@ final class BoltzJobManager {
 
     /// Drops the placeholder when a job will never produce a structure. Python only
     /// deletes it if it is still empty, so this cannot destroy a completed result.
-    private static func discardPlaceholder(_ request: Request) {
+    static func discardPlaceholder(_ request: Request) {
         guard let objectName = request.objectName, !objectName.isEmpty else { return }
         DispatchQueue.main.async {
             PyMOLEngine.shared.runPython(

--- a/swiftui/PyMOLViewer/Shared/BoltzJobManager.swift
+++ b/swiftui/PyMOLViewer/Shared/BoltzJobManager.swift
@@ -17,6 +17,13 @@ final class BoltzJobManager {
 
     static let shared = BoltzJobManager()
 
+    /// The one inference runtime this manager implements, as it appears on the wire.
+    /// Kept in step with `pymol.predictors.boltz2.RUNTIME`, and with the value
+    /// `PyMOLBridge` advertises in `RAYMOL_PREDICT_RUNTIMES` — that variable is what lets
+    /// a predictor whose backend is NOT linked here refuse in `check_available` instead
+    /// of submitting a job that only gets refused after a weight download.
+    static let boltzRuntime = "boltz"
+
     /// MLX must never run on the main thread. `cmd.predict` from the console arrives ON
     /// the main thread, which is exactly why submit is fire-and-forget.
     private let queue = DispatchQueue(label: "io.raymol.predict.inference",
@@ -95,6 +102,13 @@ final class BoltzJobManager {
         let jobID: String
         let weightsDir: String
         let chains: [Chain]
+        /// Which backend must run this job. OPTIONAL, absent meaning ``boltzRuntime`` —
+        /// every Python side that predates a second runtime wrote no such key, and the
+        /// only runtime that existed then was this one. A request naming a runtime this
+        /// build does not carry is REFUSED in `preflight`, never run here: the weights and
+        /// the featurizer are method-specific, so running one method's request on
+        /// another's backend would not fail, it would return a confident wrong answer.
+        let runtime: String?
         let recyclingSteps: Int
         let diffusionSteps: Int
         let seed: UInt64
@@ -122,7 +136,7 @@ final class BoltzJobManager {
         let objectName: String?
 
         enum CodingKeys: String, CodingKey {
-            case jobID = "job_id", weightsDir = "weights_dir", chains
+            case jobID = "job_id", weightsDir = "weights_dir", chains, runtime
             case recyclingSteps = "recycling_steps", diffusionSteps = "diffusion_steps"
             case seed, outPath = "out_path", statusPath = "status_path"
             case objectName = "object_name"
@@ -232,6 +246,13 @@ final class BoltzJobManager {
     /// `pollFeedback`: the alignment's real depth costs a parse of the a3m, which
     /// belongs on the inference queue. `alignmentPreflight` makes that second check.
     static func preflight(_ request: Request) -> Status? {
+        // Runtime first, before any sizing: the size model below is Boltz's, fitted to
+        // Boltz's measured peaks, so applying it to another method's request would be
+        // meaningless even as a refusal. Absent means Boltz, per `Request.runtime`.
+        if let runtime = request.runtime, runtime != boltzRuntime {
+            return refusal("this build of RayMol does not carry the '\(runtime)' "
+                         + "inference runtime")
+        }
         let tokens = request.chains.reduce(0) { $0 + $1.sequence.count }
         switch PredictSizeGuard.decide(tokens: tokens,
                                        availableBytes: PredictSizeGuard.availableBytes) {

--- a/swiftui/PyMOLViewer/Shared/MCPServerManager.swift
+++ b/swiftui/PyMOLViewer/Shared/MCPServerManager.swift
@@ -15,7 +15,24 @@ final class MCPServerManager: ObservableObject {
     @Published var pendingApproval = false
 
     let token: String
-    private let preferredPort = 51737
+    private let defaultPort = 51737
+    /// The handoff this instance wrote, so shutdown removes its own and no one else's.
+    private var writtenHandoff: URL?
+
+    /// The port to ask for, honouring `RAYMOL_MCP_PORT` when it is set.
+    ///
+    /// Dev/testing, like `RAYMOL_MCP_ENABLE` / `RAYMOL_MCP_BIND` / `RAYMOL_MCP_AUTOTRUST`
+    /// and never present in a Finder or `open` launch. It exists because a dev build and
+    /// an installed RayMol cannot both have 51737: the second to start fails to bind and
+    /// comes up with no server at all, so the one you are trying to test is the one you
+    /// cannot drive. `RAYMOL_MCP_PORT=0` asks the OS for any free port, which the Python
+    /// side already supports and reports back on the `MCP:started` line.
+    private var preferredPort: Int {
+        guard let declared = ProcessInfo.processInfo.environment["RAYMOL_MCP_PORT"],
+              let port = Int(declared), (0...65535).contains(port)
+        else { return defaultPort }
+        return port
+    }
     private weak var engine: PyMOLEngine?
     private var pulseWork: DispatchWorkItem?
     // When the "Claude is controlling RayMol" banner first appeared in the current
@@ -279,13 +296,23 @@ final class MCPServerManager: ObservableObject {
 
     // MARK: Handoff file (for the Phase 2 Claude Mac app bridge)
 
+    /// Where a client looks up this instance's port and token.
+    ///
+    /// A build running on an overridden port writes a SIBLING file rather than the
+    /// canonical `mcp.json`. The override exists so a dev build can run beside an
+    /// installed RayMol; clobbering the installed app's handoff on the way past would
+    /// trade one collision for another, and the dev instance is not the canonical one.
     private func handoffURL() -> URL? {
         let fm = FileManager.default
         guard let base = fm.urls(for: .applicationSupportDirectory,
                                  in: .userDomainMask).first else { return nil }
         let dir = base.appendingPathComponent("RayMol", isDirectory: true)
         try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
-        return dir.appendingPathComponent("mcp.json")
+        let overridden = ProcessInfo.processInfo.environment["RAYMOL_MCP_PORT"] != nil
+        guard overridden, let live = port else {
+            return dir.appendingPathComponent("mcp.json")
+        }
+        return dir.appendingPathComponent("mcp-\(live).json")
     }
 
     private func writeHandoff(port: Int?) {
@@ -295,11 +322,19 @@ final class MCPServerManager: ObservableObject {
             try? data.write(to: url, options: .atomic)
             try? FileManager.default.setAttributes([.posixPermissions: 0o600],
                                                    ofItemAtPath: url.path)
+            writtenHandoff = url
         }
     }
 
+    /// Remove the file this instance actually wrote, not the one it would write now.
+    ///
+    /// `handleFeedbackEvent` clears `port` before calling this, so recomputing the path
+    /// would resolve an overridden instance back to the canonical `mcp.json` and delete
+    /// another RayMol's handoff on the way out — the collision the override exists to
+    /// avoid, arriving at shutdown instead of startup.
     private func removeHandoff() {
-        if let url = handoffURL() { try? FileManager.default.removeItem(at: url) }
+        if let url = writtenHandoff { try? FileManager.default.removeItem(at: url) }
+        writtenHandoff = nil
     }
 
     private static func randomHex(_ bytes: Int) -> String {

--- a/swiftui/PyMOLViewer/Shared/ProtenixJobManager.swift
+++ b/swiftui/PyMOLViewer/Shared/ProtenixJobManager.swift
@@ -1,0 +1,207 @@
+#if os(macOS)
+import Foundation
+import MLX
+import ProtenixMLX
+
+/// Runs the `protenix` inference runtime: the second backend behind `cmd.predict`.
+///
+/// The job SHELL is shared with ``BoltzJobManager`` — marker parsing, request decoding,
+/// atomic status writes, placeholder discard and result autoload are its static helpers,
+/// used here rather than reimplemented, because "the status file went missing on a
+/// cancelled job" is the class of bug you only find in production. What is not shared is
+/// everything inside `run`: the featurizer, the weights and the network are
+/// method-specific, which is the whole reason a request has to name its runtime.
+///
+/// Three differences from the Boltz path are worth knowing:
+///
+/// * **Featurization happens here, in Swift.** Boltz's featurizer needs a
+///   `CanonicalStructure`; Protenix's needs only the sequences, because the canonical-20
+///   reference conformers ship inside `ProtenixMLX`. There is no CCD on the device.
+/// * **Cancellation is a callback, not a `Task`.** `ProtenixPredictor.fold` is
+///   synchronous, so there is no `Task` to cancel; instead the progress handler returns
+///   false and the fold throws. That handler fires after every trunk recycle and every
+///   diffusion step, which is finer than the Boltz path manages — its trunk has no
+///   cancellation points at all.
+/// * **Progress is real.** `FoldProgress.fraction` is weighted by measured phase cost, so
+///   the reported fraction tracks the wall clock instead of jumping at phase boundaries.
+final class ProtenixJobManager {
+
+    static let shared = ProtenixJobManager()
+
+    /// The runtime this manager implements, as it appears on the wire. Kept in step with
+    /// `pymol.predictors.protenix.RUNTIME` and with what `PyMOLBridge` advertises in
+    /// `RAYMOL_PREDICT_RUNTIMES`.
+    static let runtimeName = "protenix"
+
+    /// MLX must never run on the main thread; `cmd.predict` arrives ON it. Serial, so two
+    /// folds cannot both hold a 3.9 GB peak — the guard sizes one run, not two.
+    private let queue = DispatchQueue(label: "io.raymol.predict.protenix",
+                                      qos: .userInitiated)
+    /// Guards `cancelled`, which the inference thread reads and the main thread writes.
+    private let stateQueue = DispatchQueue(label: "io.raymol.predict.protenix.state")
+    private var cancelled = Set<String>()
+
+    /// One loaded predictor per weights directory, so a second fold with the same pack
+    /// does not re-read 214 MB. Touched only from `queue`.
+    private var loaded: [String: ProtenixPredictor] = [:]
+
+    private init() {}
+
+    // MARK: Entry points, called by BoltzJobManager's marker routing
+
+    /// Refuse or accept a submitted request. Runs on the MAIN thread.
+    func submit(_ request: BoltzJobManager.Request) {
+        if let failure = Self.preflight(request) {
+            BoltzJobManager.discardPlaceholder(request)
+            try? BoltzJobManager.writeStatus(
+                failure, to: URL(fileURLWithPath: request.statusPath))
+            return
+        }
+        queue.async { self.run(request) }
+    }
+
+    /// Note a cancel. Idempotent, and safe for a job id this manager never had — the
+    /// marker carries no runtime, so cancels are broadcast to every manager and each
+    /// keeps only its own.
+    func cancel(jobID: String) {
+        stateQueue.sync {
+            guard !BoltzJobManager.hasTerminalStatus(jobID: jobID) else { return }
+            cancelled.insert(jobID)
+        }
+    }
+
+    /// Refuse before allocating anything, on what the request alone says.
+    static func preflight(_ request: BoltzJobManager.Request) -> BoltzJobManager.Status? {
+        let tokens = request.chains.reduce(0) { $0 + $1.sequence.count }
+        switch ProtenixSizeGuard.decide(tokens: tokens,
+                                        availableBytes: PredictSizeGuard.availableBytes) {
+        case .refuse(let maxFitting):
+            return BoltzJobManager.refusal(
+                "\(tokens) residues is too large for this machine; at most "
+                + "\(maxFitting) fit")
+        case .refuseDepth:
+            // Unreachable: Protenix declares no msa_depth, so no request carries one.
+            // Handled rather than defaulted away so that adding alignments later cannot
+            // silently become "proceed".
+            return BoltzJobManager.refusal("alignments are not supported by protenix")
+        case .ok, .warn:
+            // `.warn` proceeds, matching the Boltz path: the tier is not surfaced
+            // anywhere yet, and inventing a caution channel for it here would be
+            // speculative.
+            return nil
+        }
+    }
+
+    // MARK: Inference
+
+    private func run(_ request: BoltzJobManager.Request) {
+        let statusURL = URL(fileURLWithPath: request.statusPath)
+        var peak: Int? = nil
+        var elapsed: Double? = nil
+        @Sendable func report(_ state: String, _ phase: String, _ fraction: Double,
+                              error: String? = nil, result: String? = nil) {
+            try? BoltzJobManager.writeStatus(
+                BoltzJobManager.Status(state: state, phase: phase, fraction: fraction,
+                                       error: error, resultPath: result,
+                                       peakBytes: peak, elapsedSeconds: elapsed),
+                to: statusURL)
+        }
+        func isCancelled() -> Bool {
+            stateQueue.sync { cancelled.contains(request.jobID) }
+        }
+
+        report("running", "featurize", 0.0)
+        do {
+            ProtenixRuntime.configureOnce()
+
+            // Featurized HERE, from sequence alone. The reference conformers are a
+            // resource inside ProtenixMLX, so nothing on this machine needs the CCD.
+            // Non-canonical residues throw rather than being folded as X — the Python
+            // side refuses them first, so reaching this is a bug, not a user error.
+            let bundle = try Featurizer.bundle(
+                chains: request.chains.map {
+                    Featurizer.Chain(id: $0.chain, sequence: $0.sequence)
+                },
+                name: request.objectName ?? "prediction")
+
+            if isCancelled() {
+                BoltzJobManager.discardPlaceholder(request)
+                report("cancelled", "featurize", 0); return
+            }
+
+            report("running", "load", 0.05)
+            let predictor = try loadedPredictor(directory: request.weightsDir)
+
+            report("running", "inference", 0.1)
+            // Reset the high-water mark so each fold is measured independently rather
+            // than reporting the largest fold this process has ever run.
+            Memory.peakMemory = 0
+            let started = Date()
+
+            // The progress handler is the ONLY cancellation point: fold() is synchronous,
+            // so there is no Task to cancel. Returning false makes it throw. It fires per
+            // trunk recycle and per diffusion step, so the worst case is one step rather
+            // than the whole run — which is better than the Boltz path manages, where the
+            // trunk cannot be interrupted at all.
+            let prediction = try ProtenixRuntime.withMLXErrorsAsThrows {
+                try predictor.foldScored(
+                    bundle: bundle,
+                    seed: request.seed,
+                    recyclingSteps: request.recyclingSteps,
+                    diffusionSteps: request.diffusionSteps,
+                    progress: { [weak self] progress in
+                        guard let self else { return true }
+                        if self.stateQueue.sync(
+                            execute: { self.cancelled.contains(request.jobID) })
+                        {
+                            return false
+                        }
+                        // Status is a file write per step. At 200 steps over minutes that
+                        // is cheap next to a Pairformer pass, and it is what makes the
+                        // panel's poll show motion instead of a frozen 10%.
+                        report("running", progress.phase.rawValue,
+                               0.1 + 0.85 * progress.fraction)
+                        return true
+                    })
+            }
+            elapsed = Date().timeIntervalSince(started)
+            peak = Memory.peakMemory
+
+            report("running", "write", 0.95)
+            // pLDDT into the B-factor column, which is what `spectrum b` colours by. The
+            // scores are real here — Protenix's confidence head is ported and verified —
+            // even though this branch's predictor declares no metric_specs yet, so the
+            // per-residue array reaches the viewer through the PDB rather than the store.
+            let text = StructureWriter.pdb(
+                coordinates: prediction.coordinates,
+                atoms: bundle.metadata.atoms,
+                bFactors: prediction.scores?.plddt)
+            try text.write(to: URL(fileURLWithPath: request.outPath),
+                           atomically: true, encoding: .utf8)
+            // Load BEFORE reporting done, so a script that polls then reads the object
+            // does not race the load.
+            BoltzJobManager.loadResult(request)
+            report("done", "done", 1.0, result: request.outPath)
+        } catch ProtenixError.cancelled {
+            BoltzJobManager.discardPlaceholder(request)
+            report("cancelled", "inference", 0)
+        } catch {
+            BoltzJobManager.discardPlaceholder(request)
+            report("failed", "inference", 0,
+                   error: (error as? LocalizedError)?.errorDescription
+                       ?? error.localizedDescription)
+        }
+    }
+
+    /// The predictor for `directory`, loaded once.
+    private func loadedPredictor(directory: String) throws -> ProtenixPredictor {
+        if let cached = loaded[directory] { return cached }
+        let artifact = try ProtenixArtifact.load(from: URL(fileURLWithPath: directory))
+        let predictor = try ProtenixPredictor(artifact: artifact)
+        // One pack at a time: two 214 MB packs plus their activations is not a budget the
+        // size guard sized for, and nothing switches packs mid-session today.
+        loaded = [directory: predictor]
+        return predictor
+    }
+}
+#endif

--- a/swiftui/PyMOLViewer/Shared/ProtenixRuntime.swift
+++ b/swiftui/PyMOLViewer/Shared/ProtenixRuntime.swift
@@ -1,0 +1,34 @@
+#if os(macOS)
+import Foundation
+
+/// Protenix's MLX policy, registered rather than assigned.
+///
+/// The mirror of ``BoltzRuntime``, and separate from it for the reason that type's own
+/// docstring gives: ``MLXRuntime`` keeps the most conservative ceiling any owner
+/// requires, so each runtime must register under its OWN name. Registering under
+/// `"Boltz"` would overwrite Boltz's requirement rather than being arbitrated against
+/// it, and whichever ran last would win — silently, and by call order.
+enum ProtenixRuntime {
+
+    /// Larger than Boltz's 256 MB request, because Protenix leans on the pair
+    /// representation harder: 48 Pairformer blocks over an N×N×c_z tensor, ten recycles,
+    /// then a confidence head over the same tensor. Bigger reusable buffers are exactly
+    /// what the cache exists to keep. Still a *request* — ``MLXRuntime`` resolves any
+    /// disagreement downward, so Design mode's 96 MB ceiling cannot be raised by this.
+    static let cacheLimitBytes = 512 * 1024 * 1024
+
+    /// Identifies this requirement in ``MLXRuntime/cacheLimitRequirements``.
+    static let cacheLimitOwner = "Protenix"
+
+    /// Idempotent; safe from any thread. Call before constructing a predictor.
+    static func configureOnce() {
+        MLXRuntime.requireCacheLimit(cacheLimitBytes, owner: cacheLimitOwner)
+    }
+
+    /// Run `body` with MLX errors surfaced as Swift `throws` rather than terminating the
+    /// process. Does **not** protect against jetsam — see ``ProtenixSizeGuard``.
+    static func withMLXErrorsAsThrows<R>(_ body: () throws -> R) throws -> R {
+        try MLXRuntime.withMLXErrorsAsThrows(body)
+    }
+}
+#endif

--- a/swiftui/PyMOLViewer/Shared/ProtenixSizeGuard.swift
+++ b/swiftui/PyMOLViewer/Shared/ProtenixSizeGuard.swift
@@ -1,0 +1,102 @@
+#if os(macOS)
+import Foundation
+
+/// Decides whether a Protenix fold fits on this machine, from MEASURED peaks.
+///
+/// A separate type from ``PredictSizeGuard`` rather than a parameterisation of it. That
+/// guard's constants are fitted to *Boltz* — its own docstring records three occasions
+/// where extrapolating past its data ran optimistic, the last two by 27% each — and
+/// Protenix is a different network at a different operating point in exactly the
+/// directions that fit is weakest: 48 Pairformer blocks over an N×N pair tensor, ten
+/// recycles rather than three, and a confidence head that runs four more Pairformer
+/// blocks over that same tensor after the sampler. Sharing the numbers would have been
+/// the fourth instance of the documented failure mode; sharing the *type* would have
+/// risked Boltz's behaviour to save a few lines.
+///
+/// This guard does not fit a curve at all. It interpolates between measured points and
+/// refuses beyond the last one, so it can never be optimistic about a size nobody has
+/// run — the failure mode is "refuses something that would have worked", which costs a
+/// user a message rather than their unsaved session.
+enum ProtenixSizeGuard {
+
+    /// (residues, peak MiB) at the shipped operating point — recycling 10 / 200 steps,
+    /// confidence head included — for the base int8 pack on an M-series Mac.
+    ///
+    /// Measured against MLX's own high-water mark, NOT process RSS. That distinction is
+    /// load-bearing: measured by RSS the same sweep reads 444 MiB at 60 residues and
+    /// 323 MiB at 400, i.e. *falling* with problem size, because MLX allocates through
+    /// Metal and recycles buffers in a cache it need not return to the OS. A guard fitted
+    /// to those numbers would have concluded big inputs are cheap.
+    static let measured: [(tokens: Int, peakMiB: Int)] = [
+        (60, 547), (120, 942), (250, 2279), (400, 3868), (550, 6303), (700, 8622),
+    ]
+
+    /// Hard ceiling, matching `pymol.predictors.protenix.MAX_RESIDUES`.
+    ///
+    /// Below the largest measurement (700) on purpose: 700 runs, at 8.6 GB and six
+    /// minutes, and the model's own confidence at that length is 26 — so it costs six
+    /// minutes to produce a structure it says nothing can be concluded from. Both ends
+    /// enforce it: Python refuses before the download, this refuses before the tensors.
+    static let maximumTokens = 400
+
+    /// Same tiers as `PredictSizeGuard`, deliberately: whatever fraction of a machine is
+    /// prudent to hand one MLX model does not depend on which model it is.
+    static let okFraction = PredictSizeGuard.okFraction
+    static let warnFraction = PredictSizeGuard.warnFraction
+
+    /// Peak bytes for `tokens`, by linear interpolation between measured points.
+    ///
+    /// Below the first point the first point's cost is used rather than scaling down to
+    /// zero: ~500 MiB of that is the weight pack, which a 4-residue peptide pays in full.
+    static func estimatedBytes(tokens: Int) -> Int {
+        let mib = estimatedPeakMiB(tokens: tokens)
+        return mib * 1024 * 1024
+    }
+
+    static func estimatedPeakMiB(tokens: Int) -> Int {
+        guard let first = measured.first, let last = measured.last else { return 0 }
+        if tokens <= first.tokens { return first.peakMiB }
+        if tokens >= last.tokens {
+            // Only reachable above `maximumTokens`, which `decide` refuses first. Kept
+            // honest rather than extrapolating: the last measured cost, not a guess.
+            return last.peakMiB
+        }
+        for (low, high) in zip(measured, measured.dropFirst()) {
+            guard tokens >= low.tokens, tokens <= high.tokens else { continue }
+            let span = Double(high.tokens - low.tokens)
+            let position = Double(tokens - low.tokens) / span
+            let cost = Double(low.peakMiB)
+                + position * Double(high.peakMiB - low.peakMiB)
+            return Int(cost.rounded(.up))
+        }
+        return last.peakMiB
+    }
+
+    /// Refuse, caution, or proceed. `nil`-free: every outcome is a case.
+    static func decide(tokens: Int, availableBytes: Int) -> PredictSizeGuard.Decision {
+        guard tokens <= maximumTokens else {
+            return .refuse(maxFittingTokens: min(maximumTokens,
+                                                 largestFittingTokenCount(availableBytes)))
+        }
+        let estimate = estimatedBytes(tokens: tokens)
+        let fraction = Double(estimate) / Double(max(availableBytes, 1))
+        if fraction <= okFraction { return .ok }
+        if fraction <= warnFraction {
+            return .warn(estimatedBytes: estimate, availableBytes: availableBytes)
+        }
+        return .refuse(maxFittingTokens: largestFittingTokenCount(availableBytes))
+    }
+
+    /// The largest token count whose estimate stays inside the warn budget.
+    static func largestFittingTokenCount(_ availableBytes: Int) -> Int {
+        let budget = Int(Double(availableBytes) * warnFraction)
+        var best = 0
+        var tokens = 1
+        while tokens <= maximumTokens {
+            if estimatedBytes(tokens: tokens) <= budget { best = tokens } else { break }
+            tokens += 1
+        }
+        return best
+    }
+}
+#endif

--- a/swiftui/PyMOLViewer/Shared/ProtenixSizeGuard.swift
+++ b/swiftui/PyMOLViewer/Shared/ProtenixSizeGuard.swift
@@ -29,6 +29,11 @@ enum ProtenixSizeGuard {
     /// to those numbers would have concluded big inputs are cheap.
     static let measured: [(tokens: Int, peakMiB: Int)] = [
         (60, 547), (120, 942), (250, 2279), (400, 3868), (550, 6303), (700, 8622),
+        // 900 fits — 16.1 GiB, half the budget — and took 2.5 HOURS: 24x the wall clock
+        // of 700 for 1.3x the length, because at 16 GiB on a 32 GiB machine the fold
+        // starts paging. Kept in the table because interpolation between 700 and 900 is
+        // then real rather than fitted, even though `maximumTokens` stops at 700.
+        (900, 16513),
     ]
 
     /// Hard ceiling, matching `pymol.predictors.protenix.MAX_RESIDUES`.
@@ -38,10 +43,13 @@ enum ProtenixSizeGuard {
     /// confidence is 26 — and was raised deliberately: that is a judgement about whether
     /// a fold is worth the wait, which belongs to whoever is waiting.
     ///
-    /// It is still not an extrapolation. 700 is measured; beyond it nothing has been run,
-    /// and `PredictSizeGuard`'s docstring records three separate occasions where guessing
-    /// past the data ran optimistic. Both ends enforce this: Python refuses before the
-    /// download, this refuses before the tensors.
+    /// Below the largest measurement (900) on purpose, and for a reason only measuring
+    /// found: 900 residues FITS, at 16.1 GiB against a 32 GB budget, and takes 2.5 hours.
+    /// That is 24x the wall clock of 700 for 1.3x the length — the fold stops being
+    /// compute-bound and starts paging — for a structure whose own confidence is 26.4.
+    /// The ceiling is therefore "where the time stops being worth it" rather than "where
+    /// the data runs out". Both ends enforce it: Python refuses before the download, this
+    /// refuses before the tensors.
     static let maximumTokens = 700
 
     /// The most memory one fold may target.

--- a/swiftui/PyMOLViewer/Shared/ProtenixSizeGuard.swift
+++ b/swiftui/PyMOLViewer/Shared/ProtenixSizeGuard.swift
@@ -33,11 +33,30 @@ enum ProtenixSizeGuard {
 
     /// Hard ceiling, matching `pymol.predictors.protenix.MAX_RESIDUES`.
     ///
-    /// Below the largest measurement (700) on purpose: 700 runs, at 8.6 GB and six
-    /// minutes, and the model's own confidence at that length is 26 — so it costs six
-    /// minutes to produce a structure it says nothing can be concluded from. Both ends
-    /// enforce it: Python refuses before the download, this refuses before the tensors.
-    static let maximumTokens = 400
+    /// Now the largest length actually MEASURED, rather than below it. It was 400 —
+    /// chosen because 700 costs 8.6 GB and six minutes for a structure whose own
+    /// confidence is 26 — and was raised deliberately: that is a judgement about whether
+    /// a fold is worth the wait, which belongs to whoever is waiting.
+    ///
+    /// It is still not an extrapolation. 700 is measured; beyond it nothing has been run,
+    /// and `PredictSizeGuard`'s docstring records three separate occasions where guessing
+    /// past the data ran optimistic. Both ends enforce this: Python refuses before the
+    /// download, this refuses before the tensors.
+    static let maximumTokens = 700
+
+    /// The most memory one fold may target.
+    ///
+    /// Raised to 32 GB by request, from the previous `0.75 × physical`. On a 32 GiB
+    /// machine that is effectively all of it, which is a deliberate trade and worth
+    /// naming: MLX allocating to the ceiling while the app holds a session is how a
+    /// jetsam SIGKILL happens, and that kill is asynchronous — no Swift handler can
+    /// intercept it, and on macOS it takes the user's unsaved work with it. The mitigation
+    /// is to save before a long fold, not to catch anything.
+    ///
+    /// Lower it here to go back to the conservative behaviour; the fractions below are
+    /// applied to THIS rather than to physical memory, so one number moves the whole
+    /// policy.
+    static let budgetBytes = 32 * 1024 * 1024 * 1024
 
     /// Same tiers as `PredictSizeGuard`, deliberately: whatever fraction of a machine is
     /// prudent to hand one MLX model does not depend on which model it is.
@@ -73,18 +92,23 @@ enum ProtenixSizeGuard {
     }
 
     /// Refuse, caution, or proceed. `nil`-free: every outcome is a case.
+    ///
+    /// `availableBytes` is what the machine has; the fold is sized against
+    /// `min(budgetBytes, availableBytes)`, so a smaller machine is still protected by its
+    /// own memory and a larger one is still bounded by the budget.
     static func decide(tokens: Int, availableBytes: Int) -> PredictSizeGuard.Decision {
+        let budget = min(budgetBytes, availableBytes)
         guard tokens <= maximumTokens else {
             return .refuse(maxFittingTokens: min(maximumTokens,
-                                                 largestFittingTokenCount(availableBytes)))
+                                                 largestFittingTokenCount(budget)))
         }
         let estimate = estimatedBytes(tokens: tokens)
-        let fraction = Double(estimate) / Double(max(availableBytes, 1))
+        let fraction = Double(estimate) / Double(max(budget, 1))
         if fraction <= okFraction { return .ok }
         if fraction <= warnFraction {
-            return .warn(estimatedBytes: estimate, availableBytes: availableBytes)
+            return .warn(estimatedBytes: estimate, availableBytes: budget)
         }
-        return .refuse(maxFittingTokens: largestFittingTokenCount(availableBytes))
+        return .refuse(maxFittingTokens: largestFittingTokenCount(budget))
     }
 
     /// The largest token count whose estimate stays inside the warn budget.

--- a/swiftui/PyMOLViewerTests/ProtenixRuntimeTests.swift
+++ b/swiftui/PyMOLViewerTests/ProtenixRuntimeTests.swift
@@ -1,0 +1,171 @@
+#if os(macOS)
+import XCTest
+
+@testable import RayMol
+
+/// The second inference runtime: its size guard, its MLX registration, and the routing
+/// that gets a `protenix` request to it instead of to Boltz.
+///
+/// The routing tests matter more than they look. A request whose `runtime` is absent is
+/// read as Boltz *deliberately*, so an older Python side keeps working — which means the
+/// failure mode for a mis-routed job is not an error but a Protenix sequence folded by
+/// Boltz's featurizer and weights, returning a confident wrong structure.
+final class ProtenixRuntimeTests: XCTestCase {
+
+    private var dir: URL!
+
+    override func setUp() {
+        super.setUp()
+        dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: dir)
+        super.tearDown()
+    }
+
+    private func writeRequest(job: String, chains: [(String, String)],
+                              runtime: String?) throws -> BoltzJobManager.Request {
+        let url = dir.appendingPathComponent("raymol_predict_req_\(job).json")
+        var payload: [String: Any] = [
+            "job_id": job,
+            "weights_dir": dir.path,
+            "chains": chains.map { ["chain": $0.0, "sequence": $0.1] },
+            "recycling_steps": 10,
+            "diffusion_steps": 200,
+            "seed": 0,
+            "out_path": dir.appendingPathComponent("out_\(job).pdb").path,
+            "status_path": dir.appendingPathComponent("st_\(job).json").path,
+        ]
+        if let runtime { payload["runtime"] = runtime }
+        try JSONSerialization.data(withJSONObject: payload).write(to: url)
+        return try BoltzJobManager.parseRequest(at: url)
+    }
+
+    // MARK: - Wire format
+
+    func testRequestCarriesItsRuntime() throws {
+        let request = try writeRequest(job: "p1", chains: [("A", "ACDEF")],
+                                       runtime: "protenix")
+        XCTAssertEqual(request.runtime, ProtenixJobManager.runtimeName)
+    }
+
+    func testAnAbsentRuntimeStillDecodes() throws {
+        // Optional on purpose: a Python side that predates the field must not produce
+        // "malformed prediction request", it must fall back to Boltz.
+        let request = try writeRequest(job: "p2", chains: [("A", "ACDEF")], runtime: nil)
+        XCTAssertNil(request.runtime)
+        XCTAssertNil(BoltzJobManager.preflight(request),
+                     "an absent runtime means boltz, which must still be accepted")
+    }
+
+    func testBoltzRefusesARuntimeNothingImplements() throws {
+        let request = try writeRequest(job: "p3", chains: [("A", "ACDEF")],
+                                       runtime: "no-such-runtime")
+        let status = BoltzJobManager.preflight(request)
+        XCTAssertEqual(status?.state, "failed")
+        XCTAssertTrue(status?.error?.contains("no-such-runtime") == true,
+                      "the refusal must name the runtime, not just decline")
+    }
+
+    // MARK: - Size guard
+
+    func testEveryMeasuredPointIsReproducedExactly() {
+        // Interpolation must pass through its own data. A guard that smooths its
+        // measurements is a fit, and a fit is the thing this type exists to avoid.
+        for point in ProtenixSizeGuard.measured where point.tokens <= 700 {
+            XCTAssertEqual(ProtenixSizeGuard.estimatedPeakMiB(tokens: point.tokens),
+                           point.peakMiB, "at \(point.tokens) residues")
+        }
+    }
+
+    func testEstimateRisesWithSize() {
+        var last = 0
+        for tokens in stride(from: 10, through: 400, by: 10) {
+            let estimate = ProtenixSizeGuard.estimatedPeakMiB(tokens: tokens)
+            XCTAssertGreaterThanOrEqual(estimate, last, "at \(tokens) residues")
+            last = estimate
+        }
+    }
+
+    func testSmallInputsStillPayForTheWeightPack() {
+        // ~500 MiB of the smallest measurement is the pack itself, which a 4-residue
+        // peptide pays in full. Scaling linearly to zero would promise a free fold.
+        XCTAssertEqual(ProtenixSizeGuard.estimatedPeakMiB(tokens: 4),
+                       ProtenixSizeGuard.measured[0].peakMiB)
+    }
+
+    func testTheCapIsRefusedEvenOnAHugeMachine() {
+        let huge = 512 * 1024 * 1024 * 1024  // 512 GB
+        let decision = ProtenixSizeGuard.decide(
+            tokens: ProtenixSizeGuard.maximumTokens + 1, availableBytes: huge)
+        guard case .refuse = decision else {
+            return XCTFail("above the cap must refuse regardless of memory, got \(decision)")
+        }
+    }
+
+    func testTheCapAgreesWithThePythonSide() {
+        // Both ends enforce it: Python refuses before the 214 MB download, this refuses
+        // before the tensors. They disagreeing means one of them is decoration.
+        XCTAssertEqual(ProtenixSizeGuard.maximumTokens, 400,
+                       "keep in step with pymol.predictors.protenix.MAX_RESIDUES")
+    }
+
+    func testAModestFoldIsAccepted() {
+        let decision = ProtenixSizeGuard.decide(tokens: 60,
+                                                availableBytes: 36 * 1024 * 1024 * 1024)
+        XCTAssertEqual(decision, .ok)
+    }
+
+    func testATinyMachineRefusesAndSaysWhatWouldFit() {
+        let decision = ProtenixSizeGuard.decide(tokens: 400,
+                                                availableBytes: 2 * 1024 * 1024 * 1024)
+        guard case .refuse(let fitting) = decision else {
+            return XCTFail("2 GB cannot hold a 400-residue fold, got \(decision)")
+        }
+        XCTAssertLessThan(fitting, 400)
+    }
+
+    func testBoltzsGuardIsUntouched() {
+        // The two guards are separate types precisely so Protenix's numbers cannot move
+        // Boltz's. This pins that.
+        XCTAssertEqual(PredictSizeGuard.maximumTokens, 900)
+        XCTAssertNotEqual(PredictSizeGuard.maximumTokens, ProtenixSizeGuard.maximumTokens)
+    }
+
+    // MARK: - MLX arbitration
+
+    func testEachRuntimeRegistersUnderItsOwnName() {
+        // Registering under one name would overwrite rather than arbitrate, and whichever
+        // ran last would win — silently, by call order.
+        XCTAssertNotEqual(ProtenixRuntime.cacheLimitOwner, BoltzRuntime.cacheLimitOwner)
+    }
+
+    func testTheConservativeCeilingStillWins() {
+        // Protenix asks for more than Boltz; MLXRuntime must resolve DOWNWARD to the most
+        // conservative requirement, or Design mode's 96 MB ceiling could be raised by a
+        // prediction and the app jetsam-killed.
+        XCTAssertGreaterThan(ProtenixRuntime.cacheLimitBytes, BoltzRuntime.cacheLimitBytes)
+        ProtenixRuntime.configureOnce()
+        BoltzRuntime.configureOnce()
+        let asks = MLXRuntime.cacheLimitRequirements
+        XCTAssertEqual(asks[ProtenixRuntime.cacheLimitOwner],
+                       ProtenixRuntime.cacheLimitBytes)
+        XCTAssertEqual(asks[BoltzRuntime.cacheLimitOwner], BoltzRuntime.cacheLimitBytes)
+        // Both asks are on the register, so arbitration can see them; what MLX actually
+        // runs with is never above the smallest of them.
+        XCTAssertLessThanOrEqual(MLXRuntime.activeCacheLimitBytes,
+                                 asks.values.min() ?? Int.max)
+    }
+
+    // MARK: - Cancellation bookkeeping
+
+    func testCancellingAJobThisManagerNeverSawIsHarmless() {
+        // Cancels are broadcast to every manager, because the marker carries only a job
+        // id and there is nothing in it to route on.
+        ProtenixJobManager.shared.cancel(jobID: "never-existed")
+    }
+}
+#endif

--- a/swiftui/PyMOLViewerTests/ProtenixRuntimeTests.swift
+++ b/swiftui/PyMOLViewerTests/ProtenixRuntimeTests.swift
@@ -107,10 +107,43 @@ final class ProtenixRuntimeTests: XCTestCase {
     }
 
     func testTheCapAgreesWithThePythonSide() {
-        // Both ends enforce it: Python refuses before the 214 MB download, this refuses
-        // before the tensors. They disagreeing means one of them is decoration.
-        XCTAssertEqual(ProtenixSizeGuard.maximumTokens, 400,
+        // Both ends enforce it: Python refuses before the download, this refuses before
+        // the tensors. They disagreeing means one of them is decoration.
+        XCTAssertEqual(ProtenixSizeGuard.maximumTokens, 700,
                        "keep in step with pymol.predictors.protenix.MAX_RESIDUES")
+    }
+
+    func testTheCapIsTheLargestMeasuredPointAndNotBeyondIt() {
+        // The one invariant that survives raising the cap: it may reach the data and no
+        // further. PredictSizeGuard's docstring records three occasions where a fit past
+        // its measurements ran optimistic.
+        let largest = ProtenixSizeGuard.measured.map(\.tokens).max() ?? 0
+        XCTAssertLessThanOrEqual(ProtenixSizeGuard.maximumTokens, largest)
+    }
+
+    func testTheBudgetIsWhatBoundsAFoldOnALargeMachine() {
+        // 32 GB by request. A machine with more RAM than that is still held to it.
+        let huge = 512 * 1024 * 1024 * 1024
+        let decision = ProtenixSizeGuard.decide(tokens: 700, availableBytes: huge)
+        XCTAssertEqual(decision, .ok, "8.6 GB against a 32 GB budget is comfortable")
+        XCTAssertEqual(ProtenixSizeGuard.budgetBytes, 32 * 1024 * 1024 * 1024)
+    }
+
+    func testASmallMachineIsStillProtectedByItsOwnMemory() {
+        // The budget is a ceiling, not a promise: an 8 GB Mac is sized against 8 GB.
+        let decision = ProtenixSizeGuard.decide(tokens: 700,
+                                                availableBytes: 8 * 1024 * 1024 * 1024)
+        guard case .refuse = decision else {
+            return XCTFail("8.6 GB cannot fit in 8 GB, got \(decision)")
+        }
+    }
+
+    func testTheLengthThatPromptedThisFits() {
+        // 532 residues, the input that hit the old 400 cap. Interpolates to ~6 GB, which
+        // is measured territory: 550 was swept at 6303 MiB.
+        XCTAssertEqual(ProtenixSizeGuard.decide(tokens: 532,
+                                                availableBytes: 32 * 1024 * 1024 * 1024),
+                       .ok)
     }
 
     func testAModestFoldIsAccepted() {

--- a/swiftui/project.yml
+++ b/swiftui/project.yml
@@ -59,7 +59,11 @@ packages:
     # defaults (step_scale_eta 1.0, gamma0 0.0) instead of the pack's own 1.5 / 0.8, which
     # produced folds whose CA-CA distances averaged 3.27 A against an ideal 3.80. Anything
     # below it folds plausible-looking structures with bad local chemistry.
-    from: 0.1.2
+    #
+    # 0.1.3 makes the protenix-v2 packs loadable at all: the confidence head hardcoded 4
+    # triangle-attention heads, and v2's 256-wide pair track needs 8, so all three v2
+    # packs died on load. Required for the v2 predictors registered here.
+    from: 0.1.3
   # Sparkle auto-update framework. macOS-only — linked into the macOS slice of the
   # shared PyMOLViewer target via a platformFilter dependency; never the iOS slice.
   # RAYMOL_SPARKLE_BEGIN — stripped for the Mac App Store build by archive_appstore.sh

--- a/swiftui/project.yml
+++ b/swiftui/project.yml
@@ -40,6 +40,26 @@ packages:
     # an artifact manifest declares no quantization block, which is what the
     # boltz2-bf16 predictor's pack does.
     from: 0.2.0
+  # protenix-mlx: on-device Protenix (AlphaFold3-class) structure prediction (#309).
+  # macOS only, for the same reasons boltz-mlx is: MLX cannot run in the iOS Simulator,
+  # and Protenix is heavier than Boltz at equal length -- 3.9 GB peak at 400 residues.
+  #
+  # It featurizes in Swift, so unlike boltz-mlx it also carries a resource bundle (the
+  # canonical-20 reference conformers, ~90 KB of JSON).
+  #
+  # Pins mlx-swift as a RANGE rather than exactly, so it composes with BoltzMLX's exact
+  # 0.31.6 instead of deadlocking against it.
+  ProtenixMLX:
+    url: https://github.com/javierbq/protenix-mlx.git
+    # 0.1.1 adds the progress/cancellation hook fold() needs to be driveable: without it
+    # predict_cancel would do nothing for up to six minutes, and there is no fraction to
+    # report. See FoldProgress.
+    #
+    # 0.1.2 fixes systematically compressed geometry -- the sampler was using struct
+    # defaults (step_scale_eta 1.0, gamma0 0.0) instead of the pack's own 1.5 / 0.8, which
+    # produced folds whose CA-CA distances averaged 3.27 A against an ideal 3.80. Anything
+    # below it folds plausible-looking structures with bad local chemistry.
+    from: 0.1.2
   # Sparkle auto-update framework. macOS-only — linked into the macOS slice of the
   # shared PyMOLViewer target via a platformFilter dependency; never the iOS slice.
   # RAYMOL_SPARKLE_BEGIN — stripped for the Mac App Store build by archive_appstore.sh
@@ -551,6 +571,12 @@ targets:
       - package: BoltzMLX
         product: BoltzMLX
         platforms: [macOS]
+      # protenix-mlx: the second inference runtime (#309). Same macOS-only filter and
+      # the same reasoning as BoltzMLX above, and likewise outside the Sparkle markers
+      # so archive_appstore.sh does not strip prediction out of the MAS build.
+      - package: ProtenixMLX
+        product: ProtenixMLX
+        platforms: [macOS]
 # RAYMOL_SPARKLE_BEGIN — stripped for the Mac App Store build (see archive_appstore.sh)
       # macOS-only: Sparkle has no iOS slice, so the platforms filter keeps it
       # out of the iOS build. All Swift usage is additionally guarded by
@@ -588,6 +614,9 @@ targets:
       # own `platform: macOS`, so no platformFilter is needed.
       - package: BoltzMLX
         product: BoltzMLX
+      # ProtenixMLX: same, for ProtenixJobManager.swift.
+      - package: ProtenixMLX
+        product: ProtenixMLX
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: io.raymol.RayMol.tests

--- a/testing/tests/predict/predict_completion.py
+++ b/testing/tests/predict/predict_completion.py
@@ -33,14 +33,17 @@ class TestPredictCompletion(testing.PyMOLTestCase):
         self.assertEqual(cmd._parser.complete('predict boltz2-'),
                          'predict boltz2-bf16, ')
 
-    def testAnIdSharingNoPrefixCompletesInOneStep(self):
-        """The payoff for NOT naming it `protenix`: 'p' identifies it uniquely.
+    def testProtenixCompletesToItsCommonPrefixThenBranches(self):
+        """Nine protenix packs share `protenix-`, so 'p' gets you that far and no further.
 
-        Had a second Protenix pack shipped as `protenix`, this would stop at the bare
-        `protenix` with no separator -- the dead end `boltz2` already creates above.
+        The payoff for giving every id a precision suffix is the step AFTER this one:
+        because no id is a prefix of another, `protenix-base-i` resolves to a runnable
+        command with its separator, rather than stopping dead the way `boltz2` does for
+        `boltz2-bf16`.
         """
-        self.assertEqual(cmd._parser.complete('predict p'),
-                         'predict protenix-base, ')
+        self.assertEqual(cmd._parser.complete('predict p'), 'predict protenix-')
+        self.assertEqual(cmd._parser.complete('predict protenix-base-i'),
+                         'predict protenix-base-int8, ')
 
     def testPredictWeightsAlsoOffersPredictors(self):
         self.assertEqual(cmd._parser.complete('predict_weights b'),

--- a/testing/tests/predict/predict_completion.py
+++ b/testing/tests/predict/predict_completion.py
@@ -12,8 +12,16 @@ from pymol import cmd, testing
 
 class TestPredictCompletion(testing.PyMOLTestCase):
 
-    def testPredictOffersRegisteredPredictors(self):
-        self.assertEqual(cmd._parser.complete('predict '), 'predict boltz2')
+    def testPredictCompletesNothingWhenTheIdsShareNoPrefix(self):
+        """Tab extends the line to the LONGEST COMMON PREFIX, or not at all.
+
+        With `boltz2`, `boltz2-bf16` and `protenix-base` registered there is no common
+        prefix, so an empty argument completes to nothing and the parser returns None.
+        The candidate list is still shown -- that is `complete`'s side effect, not its
+        return value. This assertion is about the registry's contents, so it moves every
+        time a predictor whose id starts with a new letter is added.
+        """
+        self.assertIsNone(cmd._parser.complete('predict '))
 
     def testPartialPredictorNameCompletesAsFarAsItIsUnambiguous(self):
         """'boltz2' is a PREFIX of 'boltz2-bf16', so Tab stops there with no separator.
@@ -25,9 +33,19 @@ class TestPredictCompletion(testing.PyMOLTestCase):
         self.assertEqual(cmd._parser.complete('predict boltz2-'),
                          'predict boltz2-bf16, ')
 
+    def testAnIdSharingNoPrefixCompletesInOneStep(self):
+        """The payoff for NOT naming it `protenix`: 'p' identifies it uniquely.
+
+        Had a second Protenix pack shipped as `protenix`, this would stop at the bare
+        `protenix` with no separator -- the dead end `boltz2` already creates above.
+        """
+        self.assertEqual(cmd._parser.complete('predict p'),
+                         'predict protenix-base, ')
+
     def testPredictWeightsAlsoOffersPredictors(self):
-        self.assertEqual(cmd._parser.complete('predict_weights '),
+        self.assertEqual(cmd._parser.complete('predict_weights b'),
                          'predict_weights boltz2')
+        self.assertIsNone(cmd._parser.complete('predict_weights '))
 
     def testCommandNameItselfStillCompletes(self):
         self.assertEqual(cmd._parser.complete('predic'), 'predict')

--- a/testing/tests/predict/predict_protenix.py
+++ b/testing/tests/predict/predict_protenix.py
@@ -168,6 +168,11 @@ class TestResidueValidation(testing.PyMOLTestCase):
         self.assertRaises(PredictionInputError,
                           self.predictor().parse_spec, 'A' * (MAX_RESIDUES + 1))
 
+    def testTheLengthThatPromptedTheRaiseIsAccepted(self):
+        """532 residues hit the old 400 cap. 550 is measured, at 6.3 GB."""
+        spec = self.predictor().parse_spec('A' * 532)
+        self.assertEqual(len(spec.chains[0][1]), 532)
+
     def testAtTheLimitAccepted(self):
         spec = self.predictor().parse_spec('A' * MAX_RESIDUES)
         self.assertEqual(len(spec.chains[0][1]), MAX_RESIDUES)
@@ -286,14 +291,26 @@ class TestEveryPackIsAPredictor(testing.PyMOLTestCase):
         from pymol.predictors import registry
         return [i for i in registry.available() if i.startswith('protenix-')]
 
-    def testAllTwelvePacksAreRegistered(self):
-        self.assertEqual(len(self.ids()), 12)
+    def testAllSixPacksAreRegistered(self):
+        self.assertEqual(len(self.ids()), 6)
 
-    def testEveryVariantAndPrecisionIsOffered(self):
+    def testEveryOfferedVariantAndPrecision(self):
         expected = {'protenix-%s-%s' % (v, p)
-                    for v in ('tiny', 'mini', 'base', 'v2')
+                    for v in ('base', 'v2')
                     for p in ('int8', 'fp16', 'bf16')}
         self.assertEqual(set(self.ids()), expected)
+
+    def testTinyAndMiniAreNotOffered(self):
+        """Published upstream, deliberately not registered here.
+
+        Five diffusion steps does not converge the geometry: at a fixed seed tiny gives
+        CA-CA 3.26 A against base's 3.67 and an ideal 3.80, loose enough that DSSP stops
+        calling helices. Fast is not a virtue on its own -- a fold nobody should trust is
+        not worth 11 seconds either, and offering it invites exactly that.
+        """
+        for variant in ('tiny', 'mini'):
+            for precision in ('int8', 'fp16', 'bf16'):
+                self.assertNotIn('protenix-%s-%s' % (variant, precision), self.ids())
 
     def testV2SaysItIsMirrorSourcedWhereAUserWouldSeeIt(self):
         """Its official checkpoint has answered 403 since April 2026.
@@ -361,17 +378,17 @@ class TestEveryPackIsAPredictor(testing.PyMOLTestCase):
             # A real sha256 has no long runs; a hand-padded one usually does.
             self.assertNotIn('a0a0a0a0a0a0', sha, pid)
 
-    def testTinyAndMiniUseTheirOwnShorterSchedule(self):
-        """v0.5.0 models were trained at 4 recycles / 5 steps.
+    def testEveryOfferedPackUsesTheFullSchedule(self):
+        """base and v2 are both 10 recycles / 200 steps, from their own config.json.
 
-        Running them at base's 10 / 200 would spend forty times the compute on a model
-        that was not trained to use it -- and quietly, since nothing would fail.
+        The shorter 4 / 5 schedule belonged to the v0.5.0 models that are no longer
+        offered; nothing here should silently inherit it.
         """
         from pymol.predictors import registry
-        for pid in ('protenix-tiny-int8', 'protenix-mini-bf16'):
+        for pid in self.ids():
             defaults = registry.get(pid).option_defaults
-            self.assertEqual(defaults['recycling_steps'], 4, pid)
-            self.assertEqual(defaults['diffusion_steps'], 5, pid)
+            self.assertEqual(defaults['recycling_steps'], 10, pid)
+            self.assertEqual(defaults['diffusion_steps'], 200, pid)
 
     def testBaseUsesTheReleasedOperatingPoint(self):
         from pymol.predictors import registry
@@ -391,7 +408,7 @@ class TestEveryPackIsAPredictor(testing.PyMOLTestCase):
     def testTheDensePacksAreLargerThanTheQuantisedOne(self):
         """Sanity on the transcription: fp16 is about twice int8, per variant."""
         from pymol.predictors import registry
-        for variant in ('tiny', 'mini', 'base', 'v2'):
+        for variant in ('base', 'v2'):
             small = registry.get('protenix-%s-int8' % variant).weight_bundle.size
             dense = registry.get('protenix-%s-fp16' % variant).weight_bundle.size
             self.assertGreater(dense, small * 1.5, variant)
@@ -512,8 +529,8 @@ class TestBulkPrefetchSkipsWhatCannotRun(HostEnvTestCase):
         out = cmd.predict_weights(download=1, async_=1)
         self.assertTrue(out['protenix-base-int8']['cached']
                         or 'protenix-base-mlx-int8' in self.started)
-        # And the OTHER packs, which no fold has cached, are genuinely fetched.
-        self.assertIn('protenix-tiny-mlx-int8', self.started)
+        # And the other packs, which no fold has cached, are genuinely fetched.
+        self.assertIn('protenix-v2-mlx-int8', self.started)
 
     def testItIsStillReportedEvenWhenNotFetched(self):
         """Skipping the download must not hide the predictor from the report."""

--- a/testing/tests/predict/predict_protenix.py
+++ b/testing/tests/predict/predict_protenix.py
@@ -1,0 +1,411 @@
+"""protenix-base predictor: availability, what it accepts, and what it puts on the wire.
+No Swift and no network -- the host is simulated by the env vars it sets.
+
+    pymol -ckqy testing/testing.py --run testing/tests/predict/predict_protenix.py
+"""
+import io
+import json
+import os
+from contextlib import redirect_stdout
+
+from pymol import cmd, predicting, testing
+from pymol.predictors import host
+from pymol.predictors.errors import (PredictionInputError, PredictionOptionError,
+                                     PredictorUnavailable)
+from pymol.predictors.protenix import MAX_RESIDUES, ProtenixBasePredictor
+
+
+class HostEnvTestCase(testing.PyMOLTestCase):
+    """Restores both host variables, so one test cannot leak into the next."""
+
+    def setUp(self):
+        testing.PyMOLTestCase.setUp(self)
+        self._saved = {name: os.environ.get(name)
+                       for name in (host.HOST_ENV, host.RUNTIMES_ENV)}
+
+    def tearDown(self):
+        for name, value in self._saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        testing.PyMOLTestCase.tearDown(self)
+
+    def declareHost(self, runtimes):
+        os.environ[host.HOST_ENV] = '1'
+        os.environ[host.RUNTIMES_ENV] = runtimes
+
+
+class TestAvailability(HostEnvTestCase):
+
+    def testUnavailableWithoutAHost(self):
+        os.environ.pop(host.HOST_ENV, None)
+        os.environ.pop(host.RUNTIMES_ENV, None)
+        self.assertRaises(PredictorUnavailable,
+                          ProtenixBasePredictor().check_available)
+
+    def testNoHostIsReportedAsNoHostEvenWhenTheRuntimeIsAlsoMissing(self):
+        """Order matters: the two failures have different remedies."""
+        os.environ.pop(host.HOST_ENV, None)
+        os.environ.pop(host.RUNTIMES_ENV, None)
+        try:
+            ProtenixBasePredictor().check_available()
+        except PredictorUnavailable as error:
+            self.assertIn('application host', str(error))
+        else:
+            self.fail('expected PredictorUnavailable')
+
+    def testRefusedOnAHostThatCarriesOnlyBoltz(self):
+        """This is today's state: no build carries the protenix runtime yet."""
+        self.declareHost('boltz')
+        try:
+            ProtenixBasePredictor().check_available()
+        except PredictorUnavailable as error:
+            self.assertIn('protenix-base', str(error))
+            self.assertIn('does not carry', str(error))
+        else:
+            self.fail('expected PredictorUnavailable')
+
+    def testRefusalNamesWhatTheBuildDoesCarry(self):
+        """So the user can tell "wrong build" from "wrong predictor name"."""
+        self.declareHost('boltz,mystery')
+        try:
+            ProtenixBasePredictor().check_available()
+        except PredictorUnavailable as error:
+            self.assertIn('boltz', str(error))
+        else:
+            self.fail('expected PredictorUnavailable')
+
+    def testAvailableOnAHostCarryingProtenix(self):
+        self.declareHost('boltz,protenix')
+        self.assertIsNone(ProtenixBasePredictor().check_available())
+
+    def testAHostDeclaringNothingIsAssumedBoltzOnly(self):
+        os.environ[host.HOST_ENV] = '1'
+        os.environ.pop(host.RUNTIMES_ENV, None)
+        self.assertRaises(PredictorUnavailable,
+                          ProtenixBasePredictor().check_available)
+
+
+class TestComplexesAreAccepted(testing.PyMOLTestCase):
+    """Protenix genuinely models a complex, so a multimer is accepted.
+
+    The port's featurizer groups chains into entities and builds the cross-chain pair
+    features, so refusing a multimer here would withhold something the method does. A
+    method that CANNOT model one must refuse instead: folding the concatenation would
+    emit a PDB nothing downstream could distinguish from a real prediction.
+    """
+
+    def predictor(self):
+        return ProtenixBasePredictor()
+
+    def testOneChainIsAccepted(self):
+        spec = self.predictor().parse_spec('ACDEFGHIK', 'p')
+        self.assertEqual(spec.chains, (('A', 'ACDEFGHIK'),))
+
+    def testTwoTypedChainsAccepted(self):
+        spec = self.predictor().parse_spec('ACDEF/GHIKL')
+        self.assertEqual(spec.chains, (('A', 'ACDEF'), ('B', 'GHIKL')))
+
+    def testAHomodimerIsAccepted(self):
+        """Identical sequences are the case the featurizer groups into one entity."""
+        spec = self.predictor().parse_spec('ACDEF/ACDEF')
+        self.assertEqual(spec.chains, (('A', 'ACDEF'), ('B', 'ACDEF')))
+
+    def testAMultiChainSelectionIsAccepted(self):
+        cmd.fab('ACDEFG', 'one')
+        cmd.fab('GHIKL', 'two')
+        resolved = predicting.resolve_sequence('one or two')
+        self.assertEqual(resolved, 'ACDEFG/GHIKL')
+        spec = self.predictor().parse_spec(resolved)
+        self.assertEqual(len(spec.chains), 2)
+
+    def testTheLimitIsOnTheTotalNotPerChain(self):
+        """Peak memory is ~N^2 in TOTAL tokens, so the cap has to be on the sum."""
+        half = 'A' * (MAX_RESIDUES // 2 + 1)
+        self.assertRaises(PredictionInputError,
+                          self.predictor().parse_spec, '%s/%s' % (half, half))
+
+
+class TestResidueValidation(testing.PyMOLTestCase):
+
+    def predictor(self):
+        return ProtenixBasePredictor()
+
+    def testNonCanonicalRejectedRatherThanSubstituted(self):
+        for sequence in ('ACDEFX', 'ACDEFU', 'ACDEFB', 'ACDEFZ'):
+            self.assertRaises(PredictionInputError,
+                              self.predictor().parse_spec, sequence)
+
+    def testTheOffendingLetterIsNamed(self):
+        try:
+            self.predictor().parse_spec('ACDEFJ')
+        except PredictionInputError as error:
+            self.assertIn('J', str(error))
+        else:
+            self.fail('expected PredictionInputError')
+
+    def testTheChainIsNamedToo(self):
+        """With a complex, "there is a bad residue" is not actionable on its own."""
+        try:
+            self.predictor().parse_spec('ACDEF/GHIKX')
+        except PredictionInputError as error:
+            self.assertIn('chain B', str(error))
+        else:
+            self.fail('expected PredictionInputError')
+
+    def testTheRefusalSaysWhyRatherThanJustNo(self):
+        """The reason is the remedy: this runtime carries no CCD, so no ligands."""
+        try:
+            self.predictor().parse_spec('ACDEFX')
+        except PredictionInputError as error:
+            self.assertIn('canonical 20', str(error))
+        else:
+            self.fail('expected PredictionInputError')
+
+    def testTooLongRejected(self):
+        self.assertRaises(PredictionInputError,
+                          self.predictor().parse_spec, 'A' * (MAX_RESIDUES + 1))
+
+    def testAtTheLimitAccepted(self):
+        spec = self.predictor().parse_spec('A' * MAX_RESIDUES)
+        self.assertEqual(len(spec.chains[0][1]), MAX_RESIDUES)
+
+    def testTheLimitSaysItIsMeasuredRatherThanIntrinsic(self):
+        try:
+            self.predictor().parse_spec('A' * (MAX_RESIDUES + 1))
+        except PredictionInputError as error:
+            self.assertIn('measured', str(error))
+        else:
+            self.fail('expected PredictionInputError')
+
+
+class TestOptions(testing.PyMOLTestCase):
+    """Protenix recycles a trunk and runs reverse diffusion, so it takes Boltz's knobs."""
+
+    def predictor(self):
+        return ProtenixBasePredictor()
+
+    def testTheReleasedOperatingPointIsTheDefault(self):
+        options = self.predictor().validate_options({})
+        self.assertEqual(options.recycling_steps, 10)
+        self.assertEqual(options.diffusion_steps, 200)
+
+    def testBothKnobsAreHonoured(self):
+        options = self.predictor().validate_options(
+            {'recycling_steps': 3, 'diffusion_steps': 50})
+        self.assertEqual(options.recycling_steps, 3)
+        self.assertEqual(options.diffusion_steps, 50)
+
+    def testMsaDepthRejectedByName(self):
+        """There is no alignment to have a depth."""
+        try:
+            self.predictor().validate_options({'msa_depth': 64})
+        except PredictionOptionError as error:
+            self.assertIn('msa_depth', str(error))
+        else:
+            self.fail('expected msa_depth to be rejected by name')
+
+    def testKnobsAreStillBounded(self):
+        for bad in ({'recycling_steps': -1}, {'diffusion_steps': 0}, {'seed': -1}):
+            self.assertRaises(PredictionOptionError,
+                              self.predictor().validate_options, bad)
+
+
+class TestAlignmentsRefused(testing.PyMOLTestCase):
+    """supports_msa is False, so an alignment is refused BY NAME rather than dropped."""
+
+    def testAnAlignmentIsRefused(self):
+        predictor = ProtenixBasePredictor()
+        spec = predictor.parse_spec('ACDEFG')
+
+        class FakeMSA:
+            name = 'aln'
+            query = 'ACDEFG'
+            depth = 32
+
+        try:
+            predictor.bind_alignments(spec, {'A': FakeMSA()})
+        except PredictionInputError as error:
+            self.assertIn('cannot use a multiple-sequence alignment', str(error))
+        else:
+            self.fail('expected PredictionInputError')
+
+    def testNoAlignmentIsFine(self):
+        predictor = ProtenixBasePredictor()
+        spec = predictor.parse_spec('ACDEFG')
+        self.assertEqual(predictor.bind_alignments(spec, {}).alignments, {})
+
+
+class TestWireFormat(testing.PyMOLTestCase):
+    """What reaches the Swift host: its runtime, and only its own knobs."""
+
+    def submit(self, sequence='ACDEFG', options=None):
+        predictor = ProtenixBasePredictor()
+        spec = predictor.parse_spec(sequence, 'pred')
+        options = predictor.validate_options(options or {})
+        with redirect_stdout(io.StringIO()) as buf:
+            job = predictor.submit(spec, options, '/tmp/weights')
+        with open(job.request_path) as handle:
+            request = json.load(handle)
+        os.unlink(job.request_path)
+        return job, request, buf.getvalue()
+
+    def testRequestNamesTheProtenixRuntime(self):
+        _, request, _ = self.submit()
+        self.assertEqual(request['runtime'], 'protenix')
+
+    def testRequestCarriesItsOwnKnobs(self):
+        _, request, _ = self.submit(
+            options={'recycling_steps': 4, 'diffusion_steps': 20, 'seed': 7})
+        self.assertEqual(request['recycling_steps'], 4)
+        self.assertEqual(request['diffusion_steps'], 20)
+        self.assertEqual(request['seed'], 7)
+
+    def testRequestOmitsKnobsProtenixDoesNotHave(self):
+        _, request, _ = self.submit()
+        for absent in ('msa_depth',):
+            self.assertNotIn(absent, request)
+
+    def testAComplexReachesTheWireAsBothChains(self):
+        _, request, _ = self.submit('ACDEF/GHIKL')
+        self.assertEqual(request['chains'],
+                         [{'chain': 'A', 'sequence': 'ACDEF'},
+                          {'chain': 'B', 'sequence': 'GHIKL'}])
+
+    def testMarkerIsPrinted(self):
+        job, _, out = self.submit()
+        self.assertIn('PREDICT:submit:%s' % job.job_id, out)
+
+
+class TestRegistration(testing.PyMOLTestCase):
+
+    def testRegisteredUnderItsId(self):
+        from pymol.predictors import registry
+        self.assertIn('protenix-base', registry.available())
+        self.assertEqual(registry.get('protenix-base').id, 'protenix-base')
+
+    def testIdIsNotAPrefixExtensionOfAnother(self):
+        """docs/predictors.md step 1: a shared prefix breaks tab completion.
+
+        This is why the id is `protenix-base` and not `protenix` -- a later
+        `protenix-v2` would otherwise stop `predict protenix<Tab>` at a bare
+        `protenix` that names no runnable predictor.
+        """
+        from pymol.predictors import registry
+        for other in (i for i in registry.available() if i != 'protenix-base'):
+            self.assertFalse('protenix-base'.startswith(other))
+            self.assertFalse(other.startswith('protenix-base'))
+
+    def testWeightBundleIsDeclaredWithARealDigest(self):
+        bundle = ProtenixBasePredictor().weight_bundle
+        self.assertEqual(len(bundle.sha256), 64)
+        self.assertNotEqual(set(bundle.sha256), {'0'})
+        self.assertGreater(bundle.size, 0)
+        self.assertEqual(bundle.members,
+                         ('config.json', 'manifest.json', 'model.safetensors'))
+
+    def testConfigJsonIsAMandatoryMember(self):
+        """A Protenix checkpoint carries no architecture, so the pack must."""
+        self.assertIn('config.json', ProtenixBasePredictor().weight_bundle.members)
+
+
+class TestCommandSurface(HostEnvTestCase):
+    """cmd.predict's own layer, at quiet=0 as well as the default.
+
+    parsing.py sets quiet=0 for any command-line invocation, so a suite that only
+    exercises quiet=1 never takes a single message-emitting branch.
+    """
+
+    def testAnUnknownPredictorNamesThisOneAmongTheAlternatives(self):
+        """The registry's own error is how a user discovers the id."""
+        from pymol.predictors import registry
+        from pymol.predictors.errors import PredictorNotFound
+        try:
+            registry.get('protenix')
+        except PredictorNotFound as error:
+            self.assertIn('protenix-base', str(error))
+        else:
+            self.fail('expected a bare "protenix" to be unknown')
+
+    def testRefusalIsReportedAtBothVerbosities(self):
+        self.declareHost('boltz')
+        for quiet in (0, 1):
+            with redirect_stdout(io.StringIO()):
+                self.assertRaises(PredictorUnavailable, cmd.predict,
+                                  'protenix-base', 'ACDEFG', quiet=quiet)
+
+    def testWeightsSurfaceReportsTheBundleWithoutFetchingIt(self):
+        """predict_weights iterates EVERY predictor, so this must not download."""
+        for quiet in (0, 1):
+            out = cmd.predict_weights('protenix-base', download=0, quiet=quiet)
+            self.assertEqual(out['protenix-base']['bundle'],
+                             'protenix-base-mlx-int8')
+
+
+class TestBulkPrefetchSkipsWhatCannotRun(HostEnvTestCase):
+    """`predict_weights download=1` with no id must not fetch an unusable pack.
+
+    It iterates every registered predictor, and protenix-base is 214 MB whose runtime
+    no shipping build carries yet -- so without a filter, a command aimed at the
+    predictors that DO work pulls it down anyway. Naming it explicitly still fetches:
+    that is someone deliberately pre-warming, possibly for a build they do not have.
+    """
+
+    def setUp(self):
+        HostEnvTestCase.setUp(self)
+        self.started = []
+        from pymol.predictors import fetching
+        self._real_start = fetching.start
+        fetching.start = lambda bundle, cache, **kw: self.started.append(bundle.id)
+
+    def tearDown(self):
+        from pymol.predictors import fetching
+        fetching.start = self._real_start
+        HostEnvTestCase.tearDown(self)
+
+    def testBulkFetchSkipsAPredictorWhoseRuntimeIsAbsent(self):
+        self.declareHost('boltz')
+        cmd.predict_weights(download=1, async_=1)
+        self.assertNotIn('protenix-base-mlx-int8', self.started)
+
+    def testBulkFetchStillTakesTheOnesThatWork(self):
+        """Asserted as "fetched OR already cached", not "fetched".
+
+        Whether a bundle downloads depends on the machine's cache, so asserting a
+        download makes the test pass or fail on local state rather than on the filter.
+        """
+        self.declareHost('boltz')
+        out = cmd.predict_weights(download=1, async_=1)
+        self.assertTrue(out['boltz2']['cached']
+                        or 'boltz2-mlx-int8' in self.started)
+
+    def testNamingItExplicitlyStillFetches(self):
+        self.declareHost('boltz')
+        cmd.predict_weights('protenix-base', download=1, async_=1)
+        self.assertIn('protenix-base-mlx-int8', self.started)
+
+    def testBulkFetchTakesItOnceTheRuntimeIsThere(self):
+        self.declareHost('boltz,protenix')
+        cmd.predict_weights(download=1, async_=1)
+        self.assertIn('protenix-base-mlx-int8', self.started)
+
+    def testItIsStillReportedEvenWhenNotFetched(self):
+        """Skipping the download must not hide the predictor from the report."""
+        self.declareHost('boltz')
+        out = cmd.predict_weights(download=1, async_=1)
+        self.assertIn('protenix-base', out)
+        self.assertEqual(out['protenix-base']['bundle'], 'protenix-base-mlx-int8')
+
+    def testTheSkipIsExplainedAtQuietZero(self):
+        self.declareHost('boltz')
+        with redirect_stdout(io.StringIO()) as buf:
+            cmd.predict_weights(download=1, async_=1, quiet=0)
+        self.assertIn('cannot run in this build', buf.getvalue())
+
+    def testNoKnobHadToBeAddedToTheSignature(self):
+        """Every knob it declares already existed, so cmd.predict is untouched."""
+        import inspect
+        parameters = inspect.signature(predicting.predict).parameters
+        for knob in ProtenixBasePredictor().option_defaults:
+            self.assertIn(knob, parameters)

--- a/testing/tests/predict/predict_protenix.py
+++ b/testing/tests/predict/predict_protenix.py
@@ -12,7 +12,8 @@ from pymol import cmd, predicting, testing
 from pymol.predictors import host
 from pymol.predictors.errors import (PredictionInputError, PredictionOptionError,
                                      PredictorUnavailable)
-from pymol.predictors.protenix import MAX_RESIDUES, ProtenixBasePredictor
+from pymol.predictors import registry
+from pymol.predictors.protenix import MAX_RESIDUES, PREDICTORS
 
 
 class HostEnvTestCase(testing.PyMOLTestCase):
@@ -42,14 +43,14 @@ class TestAvailability(HostEnvTestCase):
         os.environ.pop(host.HOST_ENV, None)
         os.environ.pop(host.RUNTIMES_ENV, None)
         self.assertRaises(PredictorUnavailable,
-                          ProtenixBasePredictor().check_available)
+                          registry.get('protenix-base-int8').check_available)
 
     def testNoHostIsReportedAsNoHostEvenWhenTheRuntimeIsAlsoMissing(self):
         """Order matters: the two failures have different remedies."""
         os.environ.pop(host.HOST_ENV, None)
         os.environ.pop(host.RUNTIMES_ENV, None)
         try:
-            ProtenixBasePredictor().check_available()
+            registry.get('protenix-base-int8').check_available()
         except PredictorUnavailable as error:
             self.assertIn('application host', str(error))
         else:
@@ -59,9 +60,9 @@ class TestAvailability(HostEnvTestCase):
         """This is today's state: no build carries the protenix runtime yet."""
         self.declareHost('boltz')
         try:
-            ProtenixBasePredictor().check_available()
+            registry.get('protenix-base-int8').check_available()
         except PredictorUnavailable as error:
-            self.assertIn('protenix-base', str(error))
+            self.assertIn('protenix-base-int8', str(error))
             self.assertIn('does not carry', str(error))
         else:
             self.fail('expected PredictorUnavailable')
@@ -70,7 +71,7 @@ class TestAvailability(HostEnvTestCase):
         """So the user can tell "wrong build" from "wrong predictor name"."""
         self.declareHost('boltz,mystery')
         try:
-            ProtenixBasePredictor().check_available()
+            registry.get('protenix-base-int8').check_available()
         except PredictorUnavailable as error:
             self.assertIn('boltz', str(error))
         else:
@@ -78,13 +79,13 @@ class TestAvailability(HostEnvTestCase):
 
     def testAvailableOnAHostCarryingProtenix(self):
         self.declareHost('boltz,protenix')
-        self.assertIsNone(ProtenixBasePredictor().check_available())
+        self.assertIsNone(registry.get('protenix-base-int8').check_available())
 
     def testAHostDeclaringNothingIsAssumedBoltzOnly(self):
         os.environ[host.HOST_ENV] = '1'
         os.environ.pop(host.RUNTIMES_ENV, None)
         self.assertRaises(PredictorUnavailable,
-                          ProtenixBasePredictor().check_available)
+                          registry.get('protenix-base-int8').check_available)
 
 
 class TestComplexesAreAccepted(testing.PyMOLTestCase):
@@ -97,7 +98,7 @@ class TestComplexesAreAccepted(testing.PyMOLTestCase):
     """
 
     def predictor(self):
-        return ProtenixBasePredictor()
+        return registry.get('protenix-base-int8')
 
     def testOneChainIsAccepted(self):
         spec = self.predictor().parse_spec('ACDEFGHIK', 'p')
@@ -130,7 +131,7 @@ class TestComplexesAreAccepted(testing.PyMOLTestCase):
 class TestResidueValidation(testing.PyMOLTestCase):
 
     def predictor(self):
-        return ProtenixBasePredictor()
+        return registry.get('protenix-base-int8')
 
     def testNonCanonicalRejectedRatherThanSubstituted(self):
         for sequence in ('ACDEFX', 'ACDEFU', 'ACDEFB', 'ACDEFZ'):
@@ -184,7 +185,7 @@ class TestOptions(testing.PyMOLTestCase):
     """Protenix recycles a trunk and runs reverse diffusion, so it takes Boltz's knobs."""
 
     def predictor(self):
-        return ProtenixBasePredictor()
+        return registry.get('protenix-base-int8')
 
     def testTheReleasedOperatingPointIsTheDefault(self):
         options = self.predictor().validate_options({})
@@ -216,7 +217,7 @@ class TestAlignmentsRefused(testing.PyMOLTestCase):
     """supports_msa is False, so an alignment is refused BY NAME rather than dropped."""
 
     def testAnAlignmentIsRefused(self):
-        predictor = ProtenixBasePredictor()
+        predictor = registry.get('protenix-base-int8')
         spec = predictor.parse_spec('ACDEFG')
 
         class FakeMSA:
@@ -232,7 +233,7 @@ class TestAlignmentsRefused(testing.PyMOLTestCase):
             self.fail('expected PredictionInputError')
 
     def testNoAlignmentIsFine(self):
-        predictor = ProtenixBasePredictor()
+        predictor = registry.get('protenix-base-int8')
         spec = predictor.parse_spec('ACDEFG')
         self.assertEqual(predictor.bind_alignments(spec, {}).alignments, {})
 
@@ -241,7 +242,7 @@ class TestWireFormat(testing.PyMOLTestCase):
     """What reaches the Swift host: its runtime, and only its own knobs."""
 
     def submit(self, sequence='ACDEFG', options=None):
-        predictor = ProtenixBasePredictor()
+        predictor = registry.get('protenix-base-int8')
         spec = predictor.parse_spec(sequence, 'pred')
         options = predictor.validate_options(options or {})
         with redirect_stdout(io.StringIO()) as buf:
@@ -278,12 +279,130 @@ class TestWireFormat(testing.PyMOLTestCase):
         self.assertIn('PREDICT:submit:%s' % job.job_id, out)
 
 
+class TestEveryPackIsAPredictor(testing.PyMOLTestCase):
+    """One id per published pack, and every one of them fetchable and distinct."""
+
+    def ids(self):
+        from pymol.predictors import registry
+        return [i for i in registry.available() if i.startswith('protenix-')]
+
+    def testAllTwelvePacksAreRegistered(self):
+        self.assertEqual(len(self.ids()), 12)
+
+    def testEveryVariantAndPrecisionIsOffered(self):
+        expected = {'protenix-%s-%s' % (v, p)
+                    for v in ('tiny', 'mini', 'base', 'v2')
+                    for p in ('int8', 'fp16', 'bf16')}
+        self.assertEqual(set(self.ids()), expected)
+
+    def testV2SaysItIsMirrorSourcedWhereAUserWouldSeeIt(self):
+        """Its official checkpoint has answered 403 since April 2026.
+
+        These packs come from a Hugging Face mirror whose uploader states no affiliation.
+        The file audits clean structurally and is pinned by digest, but no official
+        checksum exists for ANY Protenix checkpoint, so nothing authoritative confirms the
+        weight values. That belongs in the NAME, not only in a comment.
+        """
+        from pymol.predictors import registry
+        for precision in ('int8', 'fp16', 'bf16'):
+            name = registry.get('protenix-v2-%s' % precision).name
+            self.assertIn('mirror', name.lower(), precision)
+
+    def testV2IsCappedLowerBecauseItIsMeasuredLess(self):
+        from pymol.predictors import registry
+        from pymol.predictors.protenix import MAX_RESIDUES, V2_MAX_RESIDUES
+        self.assertLess(V2_MAX_RESIDUES, MAX_RESIDUES)
+        self.assertEqual(registry.get('protenix-v2-int8').max_residues, V2_MAX_RESIDUES)
+        self.assertEqual(registry.get('protenix-base-int8').max_residues, MAX_RESIDUES)
+
+    def testV2RefusesAboveItsOwnCapNotBases(self):
+        from pymol.predictors import registry
+        from pymol.predictors.protenix import V2_MAX_RESIDUES
+        sequence = 'A' * (V2_MAX_RESIDUES + 1)
+        # Fine for base, refused for v2 -- the cap is per pack, not per method.
+        registry.get('protenix-base-int8').parse_spec(sequence)
+        try:
+            registry.get('protenix-v2-int8').parse_spec(sequence)
+        except PredictionInputError as error:
+            self.assertIn('protenix-v2-int8', str(error))
+        else:
+            self.fail('expected v2 to refuse above its own cap')
+
+    def testNoIdIsAPrefixOfAnother(self):
+        """docs/predictors.md step 1: a shared prefix is a tab-completion dead end.
+
+        With nine ids this stops being a nicety. Every one ends in a precision suffix of
+        the same shape, so `predict protenix-b<Tab>` can always make progress.
+        """
+        for one in self.ids():
+            for other in self.ids():
+                if one != other:
+                    self.assertFalse(other.startswith(one), '%s / %s' % (one, other))
+
+    def testEveryPackHasItsOwnDigestAndSize(self):
+        """Nine bundles copied by hand is nine chances to paste the wrong digest."""
+        from pymol.predictors import registry
+        seen = {}
+        for pid in self.ids():
+            bundle = registry.get(pid).weight_bundle
+            self.assertEqual(len(bundle.sha256), 64, pid)
+            self.assertNotIn(bundle.sha256, seen,
+                             '%s and %s share a digest' % (pid, seen.get(bundle.sha256)))
+            seen[bundle.sha256] = pid
+            self.assertGreater(bundle.size, 1_000_000, pid)
+
+    def testDigestsAreRealHex(self):
+        """A padded or placeholder digest is the failure mode this guards."""
+        from pymol.predictors import registry
+        for pid in self.ids():
+            sha = registry.get(pid).weight_bundle.sha256
+            self.assertRegex(sha, r'^[0-9a-f]{64}$', pid)
+            self.assertNotEqual(sha, '0' * 64, pid)
+            # A real sha256 has no long runs; a hand-padded one usually does.
+            self.assertNotIn('a0a0a0a0a0a0', sha, pid)
+
+    def testTinyAndMiniUseTheirOwnShorterSchedule(self):
+        """v0.5.0 models were trained at 4 recycles / 5 steps.
+
+        Running them at base's 10 / 200 would spend forty times the compute on a model
+        that was not trained to use it -- and quietly, since nothing would fail.
+        """
+        from pymol.predictors import registry
+        for pid in ('protenix-tiny-int8', 'protenix-mini-bf16'):
+            defaults = registry.get(pid).option_defaults
+            self.assertEqual(defaults['recycling_steps'], 4, pid)
+            self.assertEqual(defaults['diffusion_steps'], 5, pid)
+
+    def testBaseUsesTheReleasedOperatingPoint(self):
+        from pymol.predictors import registry
+        defaults = registry.get('protenix-base-fp16').option_defaults
+        self.assertEqual(defaults['recycling_steps'], 10)
+        self.assertEqual(defaults['diffusion_steps'], 200)
+
+    def testEveryPackSharesTheOneRuntime(self):
+        """Nine tools, one backend -- the boltz2 / boltz2-bf16 pattern."""
+        from pymol.predictors.protenix import RUNTIME
+        from pymol.predictors import registry
+        for pid in self.ids():
+            self.assertEqual(registry.get(pid).submit.__self__.__class__.__mro__[1].__name__,
+                             'ProtenixPredictor', pid)
+        self.assertEqual(RUNTIME, 'protenix')
+
+    def testTheDensePacksAreLargerThanTheQuantisedOne(self):
+        """Sanity on the transcription: fp16 is about twice int8, per variant."""
+        from pymol.predictors import registry
+        for variant in ('tiny', 'mini', 'base', 'v2'):
+            small = registry.get('protenix-%s-int8' % variant).weight_bundle.size
+            dense = registry.get('protenix-%s-fp16' % variant).weight_bundle.size
+            self.assertGreater(dense, small * 1.5, variant)
+
+
 class TestRegistration(testing.PyMOLTestCase):
 
     def testRegisteredUnderItsId(self):
         from pymol.predictors import registry
-        self.assertIn('protenix-base', registry.available())
-        self.assertEqual(registry.get('protenix-base').id, 'protenix-base')
+        self.assertIn('protenix-base-int8', registry.available())
+        self.assertEqual(registry.get('protenix-base-int8').id, 'protenix-base-int8')
 
     def testIdIsNotAPrefixExtensionOfAnother(self):
         """docs/predictors.md step 1: a shared prefix breaks tab completion.
@@ -293,12 +412,12 @@ class TestRegistration(testing.PyMOLTestCase):
         `protenix` that names no runnable predictor.
         """
         from pymol.predictors import registry
-        for other in (i for i in registry.available() if i != 'protenix-base'):
-            self.assertFalse('protenix-base'.startswith(other))
-            self.assertFalse(other.startswith('protenix-base'))
+        for other in (i for i in registry.available() if i != 'protenix-base-int8'):
+            self.assertFalse('protenix-base-int8'.startswith(other))
+            self.assertFalse(other.startswith('protenix-base-int8'))
 
     def testWeightBundleIsDeclaredWithARealDigest(self):
-        bundle = ProtenixBasePredictor().weight_bundle
+        bundle = registry.get('protenix-base-int8').weight_bundle
         self.assertEqual(len(bundle.sha256), 64)
         self.assertNotEqual(set(bundle.sha256), {'0'})
         self.assertGreater(bundle.size, 0)
@@ -307,7 +426,7 @@ class TestRegistration(testing.PyMOLTestCase):
 
     def testConfigJsonIsAMandatoryMember(self):
         """A Protenix checkpoint carries no architecture, so the pack must."""
-        self.assertIn('config.json', ProtenixBasePredictor().weight_bundle.members)
+        self.assertIn('config.json', registry.get('protenix-base-int8').weight_bundle.members)
 
 
 class TestCommandSurface(HostEnvTestCase):
@@ -324,7 +443,7 @@ class TestCommandSurface(HostEnvTestCase):
         try:
             registry.get('protenix')
         except PredictorNotFound as error:
-            self.assertIn('protenix-base', str(error))
+            self.assertIn('protenix-base-int8', str(error))
         else:
             self.fail('expected a bare "protenix" to be unknown')
 
@@ -333,13 +452,13 @@ class TestCommandSurface(HostEnvTestCase):
         for quiet in (0, 1):
             with redirect_stdout(io.StringIO()):
                 self.assertRaises(PredictorUnavailable, cmd.predict,
-                                  'protenix-base', 'ACDEFG', quiet=quiet)
+                                  'protenix-base-int8', 'ACDEFG', quiet=quiet)
 
     def testWeightsSurfaceReportsTheBundleWithoutFetchingIt(self):
         """predict_weights iterates EVERY predictor, so this must not download."""
         for quiet in (0, 1):
-            out = cmd.predict_weights('protenix-base', download=0, quiet=quiet)
-            self.assertEqual(out['protenix-base']['bundle'],
+            out = cmd.predict_weights('protenix-base-int8', download=0, quiet=quiet)
+            self.assertEqual(out['protenix-base-int8']['bundle'],
                              'protenix-base-mlx-int8')
 
 
@@ -381,21 +500,27 @@ class TestBulkPrefetchSkipsWhatCannotRun(HostEnvTestCase):
                         or 'boltz2-mlx-int8' in self.started)
 
     def testNamingItExplicitlyStillFetches(self):
+        """Asserted as "fetched OR already cached" -- a machine that has run a fold has
+        the pack, so asserting a download tests local state rather than the filter."""
         self.declareHost('boltz')
-        cmd.predict_weights('protenix-base', download=1, async_=1)
-        self.assertIn('protenix-base-mlx-int8', self.started)
+        out = cmd.predict_weights('protenix-base-int8', download=1, async_=1)
+        self.assertTrue(out['protenix-base-int8']['cached']
+                        or 'protenix-base-mlx-int8' in self.started)
 
     def testBulkFetchTakesItOnceTheRuntimeIsThere(self):
         self.declareHost('boltz,protenix')
-        cmd.predict_weights(download=1, async_=1)
-        self.assertIn('protenix-base-mlx-int8', self.started)
+        out = cmd.predict_weights(download=1, async_=1)
+        self.assertTrue(out['protenix-base-int8']['cached']
+                        or 'protenix-base-mlx-int8' in self.started)
+        # And the OTHER packs, which no fold has cached, are genuinely fetched.
+        self.assertIn('protenix-tiny-mlx-int8', self.started)
 
     def testItIsStillReportedEvenWhenNotFetched(self):
         """Skipping the download must not hide the predictor from the report."""
         self.declareHost('boltz')
         out = cmd.predict_weights(download=1, async_=1)
-        self.assertIn('protenix-base', out)
-        self.assertEqual(out['protenix-base']['bundle'], 'protenix-base-mlx-int8')
+        self.assertIn('protenix-base-int8', out)
+        self.assertEqual(out['protenix-base-int8']['bundle'], 'protenix-base-mlx-int8')
 
     def testTheSkipIsExplainedAtQuietZero(self):
         self.declareHost('boltz')
@@ -407,5 +532,5 @@ class TestBulkPrefetchSkipsWhatCannotRun(HostEnvTestCase):
         """Every knob it declares already existed, so cmd.predict is untouched."""
         import inspect
         parameters = inspect.signature(predicting.predict).parameters
-        for knob in ProtenixBasePredictor().option_defaults:
+        for knob in registry.get('protenix-base-int8').option_defaults:
             self.assertIn(knob, parameters)

--- a/testing/tests/predict/predict_runtime.py
+++ b/testing/tests/predict/predict_runtime.py
@@ -109,7 +109,7 @@ class TestRequestNamesItsRuntime(testing.PyMOLTestCase):
         self.assertEqual(self.submit('boltz2-bf16')['runtime'], 'boltz')
 
     def testProtenixRequestSaysProtenix(self):
-        self.assertEqual(self.submit('protenix-base')['runtime'], 'protenix')
+        self.assertEqual(self.submit('protenix-base-int8')['runtime'], 'protenix')
 
     def testEveryRegisteredPredictorNamesARuntime(self):
         """A request with no runtime is read as BOLTZ at the far end, deliberately.
@@ -144,7 +144,7 @@ class TestOnlyDeclaredKnobsReachTheWire(testing.PyMOLTestCase):
 
     def testAMethodWithNoAlignmentSendsNoDepth(self):
         """msa_depth on the wire would record a run as having used an alignment."""
-        self.assertNotIn('msa_depth', self.submit('protenix-base'))
+        self.assertNotIn('msa_depth', self.submit('protenix-base-int8'))
 
     def testKnobsDefaultToEveryOptionWhenUnspecified(self):
         """An explicit `knobs=None` keeps the pre-seam behaviour for any caller."""

--- a/testing/tests/predict/predict_runtime.py
+++ b/testing/tests/predict/predict_runtime.py
@@ -1,0 +1,165 @@
+"""The runtime seam: a request names the backend that must run it.
+
+Before a second method existed, every prediction was Boltz and the request said nothing
+about which backend it was for. It does now, because weights and featurizer are
+method-specific: a request that reached the wrong backend would not fail, it would
+featurize with the wrong tokenizer and return a confident wrong structure. So a predictor
+declares its runtime, the host declares what it linked, and the mismatch is refused twice
+-- once in check_available before any download, once in the Swift preflight.
+
+Tested here rather than only through one predictor because the mechanism is shared, and
+because its back-compatibility properties (absent means boltz, on both sides) are exactly
+the kind of thing that rots silently.
+
+    pymol -ckqy testing/testing.py --run testing/tests/predict/predict_runtime.py
+"""
+import io
+import json
+import os
+from contextlib import redirect_stdout
+
+from pymol import testing
+from pymol.predictors import host, registry
+from pymol.predictors.errors import PredictorUnavailable
+
+
+class RuntimeEnvTestCase(testing.PyMOLTestCase):
+
+    def setUp(self):
+        testing.PyMOLTestCase.setUp(self)
+        self._saved = {name: os.environ.get(name)
+                       for name in (host.HOST_ENV, host.RUNTIMES_ENV)}
+
+    def tearDown(self):
+        for name, value in self._saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        testing.PyMOLTestCase.tearDown(self)
+
+
+class TestSupportedRuntimes(RuntimeEnvTestCase):
+
+    def testAHostDeclaringNothingIsAssumedBoltzOnly(self):
+        """Every build before this variable existed had exactly the Boltz runtime."""
+        os.environ[host.HOST_ENV] = '1'
+        os.environ.pop(host.RUNTIMES_ENV, None)
+        self.assertEqual(host.supported_runtimes(), ('boltz',))
+
+    def testAnEmptyDeclarationIsTreatedAsUndeclared(self):
+        """setenv with an empty value must not read as "no runtimes at all"."""
+        os.environ[host.RUNTIMES_ENV] = ''
+        self.assertEqual(host.supported_runtimes(), ('boltz',))
+
+    def testDeclarationIsSplitAndStripped(self):
+        os.environ[host.RUNTIMES_ENV] = ' boltz , protenix '
+        self.assertEqual(host.supported_runtimes(), ('boltz', 'protenix'))
+
+    def testTrailingSeparatorsAreIgnored(self):
+        os.environ[host.RUNTIMES_ENV] = 'boltz,,'
+        self.assertEqual(host.supported_runtimes(), ('boltz',))
+
+
+class TestRequireRuntime(RuntimeEnvTestCase):
+
+    def testPassesWhenDeclared(self):
+        os.environ[host.HOST_ENV] = '1'
+        os.environ[host.RUNTIMES_ENV] = 'boltz,protenix'
+        self.assertIsNone(host.require_runtime('some-predictor', 'protenix'))
+
+    def testRaisesWhenAbsent(self):
+        os.environ[host.HOST_ENV] = '1'
+        os.environ[host.RUNTIMES_ENV] = 'boltz'
+        self.assertRaises(PredictorUnavailable,
+                          host.require_runtime, 'some-predictor', 'protenix')
+
+    def testTheErrorNamesBothTheWantedAndTheAvailable(self):
+        """"Not available" is unactionable; "you have boltz, this needs protenix" is not."""
+        os.environ[host.HOST_ENV] = '1'
+        os.environ[host.RUNTIMES_ENV] = 'boltz'
+        try:
+            host.require_runtime('some-predictor', 'protenix')
+        except PredictorUnavailable as error:
+            self.assertIn('protenix', str(error))
+            self.assertIn('boltz', str(error))
+            self.assertIn('some-predictor', str(error))
+        else:
+            self.fail('expected PredictorUnavailable')
+
+
+class TestRequestNamesItsRuntime(testing.PyMOLTestCase):
+
+    def submit(self, predictor_id, sequence='ACDEFG'):
+        predictor = registry.get(predictor_id)
+        spec = predictor.parse_spec(sequence, 'pred')
+        options = predictor.validate_options({})
+        with redirect_stdout(io.StringIO()):
+            job = predictor.submit(spec, options, '/tmp/weights')
+        with open(job.request_path) as handle:
+            request = json.load(handle)
+        os.unlink(job.request_path)
+        return request
+
+    def testBoltzRequestSaysBoltz(self):
+        self.assertEqual(self.submit('boltz2')['runtime'], 'boltz')
+
+    def testTheDenseVariantIsTheSameRuntime(self):
+        """boltz2-bf16 is one runtime and two tools: same backend, different weights."""
+        self.assertEqual(self.submit('boltz2-bf16')['runtime'], 'boltz')
+
+    def testProtenixRequestSaysProtenix(self):
+        self.assertEqual(self.submit('protenix-base')['runtime'], 'protenix')
+
+    def testEveryRegisteredPredictorNamesARuntime(self):
+        """A request with no runtime is read as BOLTZ at the far end, deliberately.
+
+        That default is what keeps an older Python side working, and it is also the trap:
+        a new predictor that forgets to pass one is silently dispatched to Boltz's
+        featurizer and weights. So every registered predictor is checked.
+        """
+        for pid in registry.available():
+            self.assertIn('runtime', self.submit(pid), pid)
+
+
+class TestOnlyDeclaredKnobsReachTheWire(testing.PyMOLTestCase):
+    """A knob on the wire reads as one the method honours."""
+
+    def submit(self, predictor_id):
+        predictor = registry.get(predictor_id)
+        spec = predictor.parse_spec('ACDEFG', 'pred')
+        options = predictor.validate_options({})
+        with redirect_stdout(io.StringIO()):
+            job = predictor.submit(spec, options, '/tmp/weights')
+        with open(job.request_path) as handle:
+            request = json.load(handle)
+        os.unlink(job.request_path)
+        return request
+
+    def testBoltzStillSendsEverythingItHonours(self):
+        request = self.submit('boltz2')
+        self.assertEqual(request['recycling_steps'], 3)
+        self.assertEqual(request['diffusion_steps'], 200)
+        self.assertEqual(request['msa_depth'], 16384)
+
+    def testAMethodWithNoAlignmentSendsNoDepth(self):
+        """msa_depth on the wire would record a run as having used an alignment."""
+        self.assertNotIn('msa_depth', self.submit('protenix-base'))
+
+    def testKnobsDefaultToEveryOptionWhenUnspecified(self):
+        """An explicit `knobs=None` keeps the pre-seam behaviour for any caller."""
+        predictor = registry.get('boltz2')
+        spec = predictor.parse_spec('ACDEFG', 'pred')
+        options = predictor.validate_options({})
+        with redirect_stdout(io.StringIO()):
+            job = host.submit(spec, options, '/tmp/weights')
+        with open(job.request_path) as handle:
+            request = json.load(handle)
+        os.unlink(job.request_path)
+        from pymol.predictors.base import PredictionOptions
+        for knob in PredictionOptions.__slots__:
+            self.assertIn(knob, request)
+
+    def testTheDefaultRuntimeIsBoltz(self):
+        """host.submit's own default, for a caller that names no runtime."""
+        self.assertEqual(host.DEFAULT_RUNTIME, 'boltz')


### PR DESCRIPTION
Adds **Protenix** — ByteDance's AlphaFold3-class predictor — to `cmd.predict`, via
[`protenix-mlx`](https://github.com/javierbq/protenix-mlx), and with it the seam a request
needs to name which backend runs it. Closes #309.

`predict protenix-base-int8, <sequence>` folds on-device and loads the scored structure.

> Supersedes #312, which is fully contained here — this PR now targets `master` directly.
> #307's runtime seam is included rather than depended on, since that PR is not landing.

## Verified in the app, not only in tests

- The 225 MB pack downloads through RayMol's own `WeightCache` in 17 s, digest and member
  set checked on the way in.
- A 35-residue sequence folds in **34.7 s at 490 MiB peak** and loads with per-residue
  pLDDT in the B-factor column.
- At a fixed seed the coordinates are **bit-identical to `ProtenixMLXCLI`** from the same
  pack — max deviation 0.0000 Å across 289 atoms. That is what says the integration adds
  nothing and corrupts nothing.

## The runtime seam

Protenix is the first method that is not Boltz, so the request has to say so. Weights and
featurizer are method-specific: a Protenix request reaching the Boltz backend would not
fail, it would tokenize with the wrong featurizer and return a confident wrong structure.

- **`Request.runtime`**, optional on the Swift side, absent meaning `boltz` — a required
  field would turn Python/Swift skew into "malformed prediction request" instead of a
  refusal that names the runtime.
- **`preflight` refuses an unknown runtime first**, before the size model, which is fitted
  to Boltz's peaks and would be meaningless applied elsewhere.
- **`RAYMOL_PREDICT_RUNTIMES`** advertises what is linked, so `check_available` refuses
  before a download rather than after.
- **`host.submit(knobs=)`** puts only the knobs a method declared on the wire; Protenix has
  no alignment, and `msa_depth` there would record a run as having used one.

The job shell is `BoltzJobManager`'s, reused rather than reimplemented. Routing lives in
`handle(marker:)` only because it owns the marker; a third runtime should lift that into a
dispatcher, and the code says so.

## Three upstream releases this needed

**0.1.1 — progress and cancellation.** `fold()` was synchronous with no hook, so
`predict_cancel` would have done nothing for up to six minutes. Now a handler fires per
trunk recycle and per diffusion step; returning `false` throws. Finer than the Boltz path,
whose trunk has no cancellation points at all.

**0.1.2 — a real bug, found by measuring output.** The sampler used struct defaults
(`step_scale_eta` 1.0, `gamma0` 0.0) instead of the pack's own 1.5 / 0.8 — values every
`config.json` has carried all along. Folds did not crash; they came out plausible and
systematically compressed, while pLDDT still read 87, because the confidence head predicts
error in the structure it is given rather than auditing its chemistry.

| | before | after | ideal |
|---|---|---|---|
| CA–CA mean | 3.27 Å | **3.67 Å** | 3.80 |
| CA–CA spread | 2.46–3.89 | **3.59–3.75** | — |
| helical CA | 5 | **16** | — |

No parity fixture could have caught it: those constants are not weights, and the sampler
draws its own noise so it has no fixture. It took folding something and measuring the bonds.

**0.1.3 — v2 would not load.** All three v2 packs died with
`Shapes (1,N,4,N,N) and (1,1,8,N,N) cannot be broadcast` after downloading up to 610 MB.
v2 is the only variant with `hidden_scale_up`, under which upstream recomputes pair heads
as `c_z / 32` — 8 for its 256-wide track. The trunk derived that correctly; the confidence
head hardcoded 4.

## Six packs

| id | size | cap | notes |
|---|---|---|---|
| `protenix-base-{int8,fp16,bf16}` | 225 / 469 / 418 MB | 700 | `int8` is the default choice |
| `protenix-v2-{int8,fp16,bf16}` | 299 / 610 / 561 MB | 250 | **mirror-sourced**, said in the `name` |

Generated from protenix-mlx's `WEIGHTS.md` rather than transcribed — writing it by hand, I
padded five 16-character prefixes from that file's display table into fake digests, which
would have failed only on a user's machine after a download. A test now asserts every
digest is real hex, unique, and free of the runs a padded one has.

`tiny` and `mini` are published upstream and **deliberately not registered**: 5 diffusion
steps does not converge the geometry (CA–CA 3.26 Å against base's 3.67), and a fold nobody
should trust is not worth its 11 seconds either. A test pins their absence.

v2 is capped at 250 because its memory is measured only at the short end and its pair track
is twice as wide, so base's curve *understates* it — the direction that gets a session
killed.

## Memory, measured

`ProtenixSizeGuard` is a separate type from `PredictSizeGuard`, not a parameterisation:
that guard's constants are Boltz-fitted and its docstring records three occasions where
extrapolating past its data ran optimistic. This one interpolates between measured points
and refuses beyond them.

| residues | 60 | 250 | 400 | 550 | 700 | 900 |
|---|---|---|---|---|---|---|
| peak (MiB) | 547 | 2279 | 3868 | 6303 | 8622 | 16513 |
| wall clock | — | 64 s | 150 s | 217 s | 377 s | **9054 s** |

The cap is **700**, and 900 is the reason it is not higher: 900 *fits* (16.1 GB against a
32 GB budget) and takes **2.5 hours** — 24× the wall clock for 1.3× the length, as the fold
stops being compute-bound and starts paging — for a structure whose own confidence is 26.4.
So the ceiling is "where the time stops being worth it", which is a judgement, not "where
the data runs out". The budget is 32 GB, applied as `min(budget, physical)`.

## What single-sequence folding is worth

Mean pLDDT on **complete domains**: villin 35aa 94.8, ubiquitin 76aa 67.5, barnase 110aa
58.9, lysozyme 129aa 37.0, ~26 from 400 up. Expected for an AF3-class model with no
alignment — the same pack scores villin 94.8 against poly-alanine 78.4 at equal length —
and it means this earns its time on small domains until #274.

## Also here

One unrelated commit, easy to drop: `RAYMOL_MCP_PORT`, because a dev build and an installed
RayMol cannot both bind 51737 and the second comes up with no MCP server at all. It is what
made the in-app verification above possible.

## Testing

299 predict tests, 274 Swift tests, 127 MSA tests. macOS builds. The iOS slice is untouched
— both new Swift files are inside `#if os(macOS)`, and its pre-existing `AppIcon` failure
reproduces identically on `master`.

## Deliberately not here

`metric_specs` is empty pending #308/#310: the runtime computes pLDDT, PAE, PDE and
resolved (verified to 2e-4), but a per-residue array needs the metric store to land in, and
declaring keys with nowhere to write them would put numbers in the schema that never
arrive. pLDDT still reaches the viewer through the B-factor column. Real MSAs (#274),
templates, ligands and nucleic acids remain unimplemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
