### PR TITLE
docs(skills): add port-predictor-to-mlx engineering playbook

### DIFF
--- a/.claude/skills/port-predictor-to-mlx/SKILL.md
+++ b/.claude/skills/port-predictor-to-mlx/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: port-predictor-to-mlx
+description: Engineering playbook for porting a PyTorch biomolecular predictor network — structure predictors (Boltz-2, AlphaFold-style), diffusion models (RFdiffusion3), or inverse-folding nets (ProteinMPNN) — to a native Swift + MLX implementation that RayMol runs on iOS / iPadOS / macOS. Covers the feasibility/science gate, int8 weight export, layer-by-layer MLX-Swift translation, numerical parity, structural/accuracy ("is int8 lossless?") validation, on-device benchmarking, and RayMol integration + open-source publishing. Use this whenever the user wants to port / bring / run a folding, docking, diffusion, or sequence-design network natively / on-device / on iPhone / in MLX / in Swift for RayMol, quantize a model to int8 for the app, validate an MLX port against fp32, or asks how a boltz-mlx-style port is structured — even if they only name the model (Boltz, RFD3, MPNN) and not the words "MLX" or "port".
+---
+
+# Port a predictor network to Swift + MLX for RayMol
+
+This is the repeatable process for taking a PyTorch biomolecular predictor and making it run
+**natively inside RayMol** on Apple silicon — trunk + head reimplemented in
+[mlx-swift](https://github.com/ml-explore/mlx-swift), weights quantized to int8, features
+computed in Swift, and the whole thing validated hard enough that you can trust its output.
+
+The reference implementation this skill is distilled from is **`javierbq/boltz-mlx`** (Boltz-2
+structure prediction, shipped in RayMol via `cmd.predict`). Read it alongside this skill — it is
+the concrete shape of every abstract instruction here. Its layout is the deliverable template
+(see "The deliverable" below).
+
+## Read this first — two truths that reshape the whole project
+
+Most of the risk in a predictor port is *not* the matmuls. Internalize these before scoping:
+
+1. **Featurization is usually the schedule, not the network.** Embedding upstream Python
+   featurization on-device is a dead end — it drags in torch + rdkit (62 `.so`) + scipy + numba
+   (LLVM JIT) against RayMol's embedded interpreter that has only numpy + biopython. For Boltz,
+   upstream featurization measured **~915 s for one 401-token complex** vs ~7 s for the forward
+   pass. The win is that a **Swift** featurizer is tractable and *small* (Boltz's 2.1 GB `~/.boltz`
+   cache collapses to ~20 KB of reference-atom constants for canonical-20 proteins). Budget the
+   featurizer as a first-class subproject with its own parity harness — see
+   `references/swift-mlx-port.md`.
+
+2. **The science gate comes before the engineering.** A folding/scoring network is only worth
+   porting if its *output metric actually discriminates* on the inputs RayMol will feed it. Boltz
+   confidence had **never** scored a real two-chain de-novo complex when the port began (every
+   fixture was a monomer, so ipTM ≡ 0 by the chain-mask). Prove the metric works in Python at the
+   **production regime** (recycling 3 / 200 steps — not the fast 20-step default that scores a
+   3 Å-wrong structure) *before* committing engineering weeks. This is **Phase 0** and it can
+   fail the project cheaply.
+
+## The deliverable — "a Swift-MLX port suitable for RayMol"
+
+A self-contained, MIT-compatible SPM package mirroring `boltz-mlx`:
+
+```
+<net>-mlx/
+├── Package.swift                     # SPM package, repo ROOT (SPM has no subdir support)
+├── Sources/
+│   ├── <Net>MLX/                     # the MLX inference library: quantized layers,
+│   │                                 #   trunk, head/sampler, and the Swift featurizer
+│   └── <Net>MLXCLI/                  # a macOS command-line runner (predict from a feature bundle)
+├── src/
+│   ├── <net>_mlx_export/             # Python exporter: export-model / export-features / make-fixtures
+│   └── <upstream>/                   # vendored upstream package (for export + parity), license kept
+├── tests/                            # Swift parity + unit tests
+├── validation/{benchmark,quality,device}/   # int8-vs-fp32 parity, accuracy, on-device speed/memory
+└── README.md, LICENSE                # crediting upstream, MIT
+```
+
+Plus the two things that make it *RayMol's*, which live outside this package:
+
+- **A tagged release + a weights release asset.** RayMol consumes the package by
+  `url:` + `from: <tag>` in `swiftui/project.yml` (never a local `path:` — that is the recurring
+  un-mergeable trap). The quantized weights ship as a **GitHub release asset**, not in git,
+  fetched at runtime and **sha256-verified**.
+- **A RayMol predictor plugin** in `modules/pymol/predictors/` reachable via `cmd.predict`, plus a
+  CI entry so its Python tests actually run.
+
+See `references/raymol-integration.md` for both.
+
+## The seven phases
+
+Work them roughly in order, but Phase 0 gates everything and parity (Phase 3) is developed
+*alongside* the port (Phase 2), not after. Each reference file is loaded only when you reach that
+phase — keep them closed until then.
+
+| # | Phase | What you produce | Reference |
+|---|-------|------------------|-----------|
+| 0 | **Feasibility & science gate** | A go/no-go: does the metric discriminate at production settings? What is the peak-memory model? Do the SPM deps resolve? | this file, below |
+| 1 | **Weight export (Python)** | An exporter that turns a checkpoint into an int8 MLX artifact + manifest, plus feature bundles and module-boundary fixtures | `references/weight-export.md` |
+| 2 | **Swift-MLX port** | The trunk + head + sampler + featurizer in mlx-swift, quantization-aware from day one | `references/swift-mlx-port.md` |
+| 3 | **Numerical parity** | Every module boundary matches upstream PyTorch to the quantization floor (r ≥ 0.9997); deterministic tensors pinned bitwise | `references/numerical-parity.md` |
+| 4 | **Accuracy validation** | The "is int8 lossless?" benchmark: matched-noise RMSD vs the fp32 self-variance floor, at production step counts, against ground truth | `references/accuracy-validation.md` |
+| 5 | **Perf & size benchmarks** | Tokens×atoms scaling, peak RSS, model size per precision, on-device (iPhone) run | `references/accuracy-validation.md` |
+| 6 | **RayMol integration + publish** | Tagged package, weights asset, `cmd.predict` plugin, CI wiring, curated public repo | `references/raymol-integration.md` |
+
+## Phase 0 — feasibility & science gate (do this before any Swift)
+
+Cheap work that can kill or reshape the project. Produce a short written gate doc.
+
+- **Prove the metric discriminates.** Run the *upstream* model in Python on a labelled set at the
+  **production regime** and compute the actual figure of merit (e.g. AUC of `min_ipsae` for binder
+  triage, lDDT/TM vs ground truth for folding). If it does not separate signal from noise here, no
+  port will save it. Do not skip because "the paper says it works" — the paper's regime is rarely
+  RayMol's.
+- **Model peak memory as a function of input size**, and fit it *conservatively*. The failure mode
+  is a fit that sits **below** measurement and licenses a run that OOMs. Two hard-won facts:
+  peak is often **sub-linear in tokens** once the weight pack dominates (a quadratic-heavy fit
+  guesses low), and an MLX OOM thrown from a Metal completion handler is **`std::terminate` →
+  uncatchable** — you cannot try/catch your way out, so the model must **pre-flight refuse**
+  oversized inputs (an atom/token cap) or run under XPC. Keep a test asserting the fit never falls
+  under a measured point.
+- **Check SPM consumability now.** mlx-swift pins are tight (one usable tag, `exact:` has no
+  consumer override). Confirm `Package.swift` is at the **repo root** and every dependency has a
+  real tag before you build anything on top.
+- **Establish the precision default.** int8 group-64 is the right default: ~3.75× smaller than
+  fp32 and *faster* (quantized matmul beats dense fp16 on these memory-bound ops). Dense fp16/bf16
+  packs exist but cost 2× disk, +63% RAM, +22% time — build them only if a validation demands it.
+  Note the checkpoint's true dtype: "bf16-trained" nets are usually stored **fp32** on disk, so
+  "full precision" is a narrowing choice, not a free upgrade.
+
+Gate output: metric-discriminates verdict + memory model + dep-resolution proof + precision choice.
+Only then start Phase 1.
+
+## Non-negotiables (each cost real debugging time)
+
+- **No CI compiles iOS.** RayMol's shared Swift boundary breaks in *both* directions and only
+  surfaces when you compile the iOS slice by hand. Compile **both** macOS and iOS targets locally
+  before claiming a Swift change is done.
+- **Never merge a local `path:` dependency.** Developing against `path: ../../../<net>-mlx` is
+  fine; shipping it is the recurring un-mergeable defect. Flip to `url:` + `from: <tag>` and pin
+  `Package.resolved` before the PR.
+- **Weights are release assets, sha256-verified — never in git.** Verify the hash of the *served*
+  asset by downloading it back and re-hashing, not the local file you uploaded.
+- **Validate the *runtime*, not the source.** A Debug macOS build runs from
+  `Contents/MacOS/RayMol.debug.dylib` (72 MB), not the 58 KB stub; `strings` the dylib.
+  Release DMGs have silently shipped stale code — verify the binary you actually built.
+- **Same-seed or it's not a comparison.** `cmd.predict` randomizes the seed per call unless you
+  pass one. Two "identical" predictions are two different samples; matched-noise is the only way to
+  attribute a difference to precision (Phase 4).
+
+## Worked example & prior art
+
+- **`javierbq/boltz-mlx`** — the canonical port. Read `README.md`, `Sources/BoltzMLX/`,
+  `src/boltz_mlx_export/`, and `validation/` before starting your own.
+- **RayMol memory** (recall these): `raymol-224-predict-backend-state` (end-to-end integration +
+  traps), `boltz-swift-msa-featurizer` (featurizer parity landmines), `boltz-dense-precision-pack`
+  (precision A/B), `raymol-ondevice-design-funnel` (feasibility math, OOM uncatchability, the
+  science gate). RFD3 and ProteinMPNN are separate ports with their own divergences (RFD3's EMA
+  shadow weights genuinely differ; MPNN already ships) — the process is the same, the constants are
+  not.

--- a/.claude/skills/port-predictor-to-mlx/references/accuracy-validation.md
+++ b/.claude/skills/port-predictor-to-mlx/references/accuracy-validation.md
@@ -1,0 +1,94 @@
+# Phases 4 & 5 — accuracy validation and benchmarking
+
+Parity (Phase 3) proves the port is the same *computation*. This phase proves the **int8 model is
+good enough to trust** and measures what it costs. The headline question is usually *"is int8
+lossless?"* — and the first job is to reframe it honestly.
+
+## "Lossless" needs redefining before you can test it
+
+int8 is **not** bit-lossless — 8-bit weights can't be. The defensible, testable claim is:
+
+> **int8 causes no *meaningful* loss vs fp32** — the int8-vs-fp32 difference is no larger than the
+> model's own fp32 **run-to-run variance**, AND int8's accuracy against ground truth is
+> statistically equivalent to fp32's.
+
+The trap that makes naïve benchmarks worthless: structure prediction is **stochastic**, so the
+yardstick is not zero — it's the fp32 self-variance. A single-seed int8-vs-fp32 RMSD is meaningless
+because two fp32 runs at different seeds already differ. On Boltz, int8-vs-bf16 at the same seed is
+**3.10 Å**, but int8-vs-itself across seeds is **4.9–7.0 Å** — the precision delta sits *below* the
+sampling noise, so that A/B **cannot rank the packs at all.** Never let a single-seed number
+masquerade as an accuracy result.
+
+## Two comparison modes
+
+1. **Matched-noise (deterministic — isolates quantization).** Feed *identical* injected
+   initial/step noise + identity augmentation to both precisions, then Kabsch-superpose the two
+   outputs over identical atom order → per-target RMSD/lDDT/TM. This is the *only* way a difference
+   is attributable to precision rather than to two different valid conformations. Boltz matched-noise
+   int8-vs-fp32 is **sub-Ångström for 5 of 6 sizes** (0.22–1.82 Å, all under a 2.0 Å gate).
+2. **Free-sampling ensemble (the real-world test).** K seeds per target per precision → the fp32
+   seed-to-seed spread *is* the noise floor that int8-vs-fp32 must fall within. Report distributions,
+   not point estimates.
+
+## Run at the production regime, or the numbers lie
+
+Low diffusion-step counts inflate differences: Boltz's `prot_no_msa` was **3.19 Å at 20 steps but
+0.64 Å at 50**, and the confidence metric's own quality gate *fails* at 20 steps. Validate at the
+regime the network was **trained** for (Boltz: recycling 3 / 200 steps), plus a {20, 50, 200} sweep
+to show convergence. Every speed number quoted from a fast-default regime is scoring a wrong
+structure.
+
+## Dataset — the biggest lever
+
+~30–50 **real, diverse targets** with MSAs and experimental structures, ideally **post-dating the
+training cutoff** to avoid memorization (a slice of recent CAMEO/CASP or a curated PDB set). Well-
+determined targets (real MSAs) have low sampler variance, so any residual int8 gap is attributable
+to quantization rather than chaos — toy truncations of one no-MSA protein are under-determined and
+produce the 1.8–3 Å outliers that mean nothing. Mix sizes; add complexes / protein–ligand only if
+those paths and their memory envelopes are validated.
+
+## Metrics and the pre-registered verdict
+
+- **int8 vs fp32:** all-atom RMSD, Cα-lDDT, TM-score (+ DockQ for complexes; ligand-RMSD /
+  PoseBusters for ligands).
+- **vs ground truth (the one that matters):** lDDT / TM for *both* precisions → paired
+  **Δaccuracy = acc(int8) − acc(fp32)** per target.
+- **confidence preservation:** correlation of predicted pLDDT / PAE (int8 vs fp32) and top-model
+  ranking agreement.
+- **Verdict (fix the margin *before* running):** both of — (a) mean matched-noise int8-vs-fp32 RMSD
+  ≤ fp32 seed-to-seed RMSD; (b) a **TOST equivalence test** on Δ(lDDT-to-truth) with a margin set
+  in advance (e.g. ±1 lDDT point, or ± the measured fp32 self-variance). Report per-target and
+  aggregate (mean ± 95% CI), paired across targets.
+
+## Compute
+
+fp32 × 200 steps × ~40 targets × K seeds is heavy for a Mac — run the **fp32 reference on the SLURM
+cluster** (there's a `smith:boltz-predict` path) and keep the Mac for the int8 candidate. For binder
+triage the interface metric is cheap: `min_ipsae` needs only the PAE matrix + two chain lengths
+(~40 lines of Swift); `agent-smith`'s `compute_ipsae.py` + its test fixtures are the reference. Do
+**not** anchor a threshold to an unsourced number — an ipSAE cutoff from a different `d0`
+normalization moves the operating point in the permissive direction on the one number a design run
+gates on. Leave calibration to the user's labelled set.
+
+## Phase 5 — performance & size benchmarks
+
+Report these so the on-device viability is legible, all with **model load excluded** and the model
+loaded once:
+
+- **Speed vs a real baseline.** Boltz int8-MLX beats PyTorch-fp32-MPS **3.2× → 1.2×** across
+  40→384 tokens — biggest exactly where it matters (small proteins, the on-device regime, where MPS
+  pays per-step dispatch + a CPU-fallback SVD). At large sizes both go compute-bound and converge.
+  Be honest that part of the win is int8 vs fp32, not MLX vs MPS.
+- **Model size per precision** (same weights): int8 529 MB / fp16 ~992 MB / fp32 ~1.85 GB — the
+  ~3.75× shrink is what makes the phone budget work (int8 is the constant memory floor; activations
+  add ~0.6–1.4 GB peak).
+- **On-device run.** Actually run it on the target iPhone and record wall time + peak RSS at the
+  shipping operating point. Boltz: ~3–13 s per small protein at ~0.6–1.4 GB on an iPhone 15 Pro,
+  inside the 8 GB budget. Note DEBUG builds are an upper bound (materially slower than release).
+- **Precision A/B, if you built dense packs.** Boltz bf16-dense is **slower** (+22% wall, +63% RSS,
+  2× disk) and its accuracy delta vs int8 sits below sampling noise — i.e. dense is not worth it
+  here. Measure before assuming "full precision" is an upgrade.
+
+Land all of this as `validation/{quality,benchmark,device}/report.md` + raw JSON assets, mirroring
+`boltz-mlx/validation/`. The reports are part of the deliverable — they are what lets the next
+person (and RayMol review) trust the port.

--- a/.claude/skills/port-predictor-to-mlx/references/numerical-parity.md
+++ b/.claude/skills/port-predictor-to-mlx/references/numerical-parity.md
@@ -1,0 +1,64 @@
+# Phase 3 — numerical parity (developed alongside Phase 2)
+
+Parity is how you know the port is the *same network*, not a plausible-looking different one. Two
+tiers, and you need both:
+
+- **Tensor/boundary parity** — each ported module's output matches upstream PyTorch on the same
+  input. This is where bugs are localizable and cheap to fix.
+- **End-to-end golden** — a fixed (seed, input) produces the same final structure through both the
+  Swift path and a byte-identical reference, guarding against drift the per-boundary checks miss.
+
+## What "match" means, tier by tier
+
+- **Deterministic-at-inference tensors: pin bitwise.** Features with no RNG (MSA, profile,
+  res-type one-hots) must match **exactly** (max abs diff 0.000). If they don't, you have a real
+  bug (ordering, off-by-one, a "corrected" upstream quirk) — not quantization noise. Boltz pins
+  **7/7** MSA tensors bitwise on a 249×384 monomer *and* on a gap-expanding binder+target fixture.
+- **Quantized module boundaries: match to the quantization floor.** int8 group-64 sets a hard
+  ceiling; `boltz-mlx` reports every module boundary at **Pearson r ≥ 0.9997**. Record that
+  number as *the* acceptance bar and treat any boundary below it as a bug in that module.
+- **Randomly-augmented tensors: distribution-check only** (e.g. `ref_pos`). You cannot pin these;
+  assert shape + summary statistics, not values.
+
+## Module-boundary fixtures (`make-fixtures`)
+
+The exporter records, from a real forward pass, the input and output tensor of each module
+boundary. The Swift test loads the input, runs its ported module, and compares to the recorded
+output. Gate the fixtures behind an env var (`BOLTZ_MSA_REF_DIR`, `BOLTZ_CONF_MODEL`, …) so the
+suite runs without the (large, gitignored) fixtures in CI, and skips cleanly when they're absent.
+
+**A skipped test that looks green is the trap here.** Boltz has a pre-existing
+`swift test` "failure" where an XCTSkip sits *inside* an `XCTAssertEqual` for a missing env-gated
+fixture — it neither runs nor is obviously skipped. Make skips explicit and loud, and periodically
+run the suite *with* fixtures present so you know the parity tests actually execute.
+
+## Parity arithmetic that bites
+
+- **Reduction order changes the low bits.** A sum done in a different order passes at 1e-7 on one
+  fixture and drifts over hundreds of evals. When a boundary is *close* but not bit-identical on a
+  deterministic tensor, suspect accumulation order before suspecting a real difference.
+- **Set the error budget from the actual path, not a round number.** For RFD3 the binder `dm.X_L`
+  path's honest budget is **1.34e-5**, not the 6.9e-6 an unconditional-50 fixture suggests (at
+  I=50 a k=128 mask is all-True, so that fixture exercises nothing). A pass that is an `OR` over a
+  loose threshold hides compounding drift — pick the tightest defensible bound for the path you
+  actually ship.
+- **Fixture representativeness matters more than fixture count.** RFD3's committed fixtures have
+  motif sparsity **47.97%** vs production **0.136%** (169× off, exactly where the optimization you
+  want to verify helps *least*); the other fixture has zero motif atoms. A fixture that doesn't
+  resemble production traffic can pass while the shipped path is wrong.
+
+## End-to-end golden through byte-identical copies
+
+When the same source files exist in two places (e.g. RayMol vendors a copy of the Swift core), a
+fix must land in **both**, and the golden must run through **both**. RFD3 shares 12 files between
+`swift/Sources/RFD3Core/` and `RFD3Kit/Sources/RFD3Kit/`; the gate before *any* numerical change
+is a `designBinder`-level golden — fixed seed + target ⇒ exact output sequence + coordinate hash —
+run through both copies. Diverging copies is how a fix silently reaches only one target.
+
+## Confidence/scoring-head parity is usually cheap
+
+If the head reuses trunk blocks (Boltz confidence = the same pairformer, 8 blocks vs 64), it ports
+1:1 and quantizes almost losslessly: int8 round-trip on Boltz confidence moved ipTM by **2.2e-4**
+and kept PAE Pearson **0.999959** — no separate fp16 pack needed, +25 MiB. But still export the
+head's feeder modules (the distogram) and its full config (Phase 1 traps), or the head runs on
+garbage.

--- a/.claude/skills/port-predictor-to-mlx/references/raymol-integration.md
+++ b/.claude/skills/port-predictor-to-mlx/references/raymol-integration.md
@@ -1,0 +1,83 @@
+# Phase 6 — RayMol integration + publishing
+
+Two halves: **wire the package into RayMol** so `cmd.predict` reaches it, and (if open-sourcing)
+**publish a curated public repo** + weights. The `boltz-mlx` + RayMol `#224` work is the template.
+
+## Wiring the SPM package into RayMol
+
+- **Consume by `url:` + `from: <tag>`, never `path:`.** `swiftui/project.yml` points `<Net>MLX` at
+  `url: https://github.com/javierbq/<net>-mlx.git`, `from: <tag>`; `project.pbxproj` uses an
+  `XCRemoteSwiftPackageReference`; `Package.resolved` pins the tag + commit. Developing against a
+  local `path: ../../../<net>-mlx` is fine, but shipping it is **the** recurring un-mergeable
+  defect (hit on #269 and again on #293). Flip it back before every PR and grep the diff to be
+  sure.
+- **Compile both slices by hand.** No CI compiles iOS. Build `PyMOLViewer_macOS` *and* the iOS
+  target locally; the shared Swift boundary breaks in both directions and only shows up here.
+  `xcodebuild` needs `-skipPackagePluginValidation` for the MLX plugin packages.
+- **Two-stage macOS build.** Build the C++ core first, *then* `xcodebuild` — `xcodebuild` alone
+  silently links a stale `libpymol_core.a`. Verify the **runtime** dylib (`RayMol.debug.dylib`),
+  not the source.
+
+## Weights as a verified release asset
+
+The quantized pack is too big for git and must be fetched at runtime:
+
+- Publish `<net>-mlx-int8-v1.zip` as a **GitHub release asset** on the package repo. Record its
+  exact byte size and **sha256 computed from the *served* asset** (download it back, re-hash — do
+  not trust the local file's hash).
+- The Swift/Python weight cache downloads, verifies sha256, extracts, then writes a sentinel
+  (`.ok`) **last** and atomically (`os.replace`). Pin the expected hash in the predictor.
+- Adding a second precision is a new predictor id that overrides only `weight_bundle` and a new
+  release asset — one Swift runtime serves both packs (`host.submit` passes `weights_dir` per job).
+- Budget an hour for a cold fetch — the release CDN has run at **0.5–1 MB/s** for a ~1 GB asset;
+  don't read a long download as a hang.
+
+## The `cmd.predict` predictor plugin (Python side)
+
+Mirror `modules/pymol/predictors/`: `errors, base, registry, weights, host, <net>, _template`.
+The Swift bridge and embedded-interpreter traps that cost real debugging:
+
+- **`setenv` from C must precede `Py_InitializeFromConfig`.** Python snapshots `os.environ` once at
+  startup; a later C `setenv` is visible to C `getenv` but **invisible to `os.environ`**. Set
+  `RAYMOL_PREDICT_HOST` (and any config the Python layer reads) *before* init.
+- **Do long work on a Swift queue, not a Python thread.** A background Python thread is
+  GIL-starved in the embedded app (~364 KB/s zip extraction, ~1000× too slow) because the main
+  thread holds the GIL persistently. `cmd.predict`'s synchronous `ensure()` is fine; anything
+  concurrent must be Swift.
+- **Cancel must actually interrupt inference.** If `predict()` runs in a detached `Task{}` that is
+  never `.cancel()`d, the model's `Task.checkCancellation()` can't fire and "cancel" is a no-op —
+  a confirmed HIGH defect on #269. Thread the cancellation through.
+- **The first uncached call blocks on a ~500 MB download.** If `predict()` is documented "returns
+  immediately" but synchronously runs `WeightCache.ensure()`, it blocks the main thread silently
+  under `quiet=1`. Make the download explicitly asynchronous / surfaced.
+- **Feedback is invisible while the main thread is blocked** — surface progress off the blocked
+  thread, or the user sees a frozen app during a legitimate long run.
+
+## Wire the CI so the Python tests actually run
+
+RayMol's CI lists test files **by hand**, so a new `testing/tests/predict/` silently never runs
+unless you add it. Add the **directory** to `raymol-embedded-tests.yml` (the one variant that
+can't re-orphan files) and confirm the full list runs green locally. Python-layer test traps that
+passed-while-broken: `colorprinting` has **no `info`** (only error/warning/suggest/parrot) and
+`quiet=0` is the *default* command path — a suite testing only `quiet=1` can be 48/48 green while
+every message branch raises `AttributeError`. Test both, and assert reflectively that every
+`colorprinting.X` a module calls exists. A knob you intend to *reject* still needs to be a named
+parameter or Python raises `TypeError` before your validation runs.
+
+## Publishing a curated public repo (if open-sourcing)
+
+A public repo is effectively permanent (scraped/cached even if deleted) — do a safety pass first
+and get explicit sign-off before pushing:
+
+- **Scan for and strip:** internal hostnames (e.g. `*.accipiterbio.internal`), Apple team IDs,
+  device UDIDs, personal/work emails, company bundle ids / namespaces, and any company-internal
+  validation work. A scrub-in-place is not enough — identifiers persist in `git log`.
+- **Push a fresh, squashed history** (orphan commit) authored as the **public** identity
+  (`javierbq@gmail.com`), so nothing leaks via `git log`.
+- **Keep the upstream LICENSE + attribution** (Boltz is MIT); add a README describing the port.
+- **Exclude weights** — keep `.artifacts/` gitignored; users export their own from a checkpoint
+  they supply, per the README quick-start.
+- Verify the **remote** is clean (0 sensitive matches) after pushing, not just the local tree.
+
+Sending anything to a public host is outward-facing and irreversible — confirm with the user before
+the first push, and prefer HTTPS if their `~/.ssh/config` is broken (don't edit their ssh config).

--- a/.claude/skills/port-predictor-to-mlx/references/swift-mlx-port.md
+++ b/.claude/skills/port-predictor-to-mlx/references/swift-mlx-port.md
@@ -1,0 +1,87 @@
+# Phase 2 — the Swift + MLX port
+
+Reimplement the network in mlx-swift: the **trunk** (embeddings, template, MSA, Pairformer-style
+blocks), the **head/sampler** (diffusion score model + sampler, or the confidence/scoring head),
+and the **featurizer**. Build it **quantization-aware from the first layer** and develop parity
+(Phase 3) in lockstep — never "port everything, then check."
+
+## Translate module-by-module, verifying each boundary
+
+Port one PyTorch module at a time and immediately check its output against a recorded fixture
+(Phase 3). This keeps drift localized: when boundary *k* matches and *k+1* doesn't, the bug is in
+*k+1*. Reuse blocks: Boltz's trunk and confidence pairformer blocks are **tensor-identical** (same
+53 keys per block), so one `Pairformer.swift` serves both — look for this before writing a second
+copy of anything.
+
+## One quantization seam, not 122 call sites
+
+Make quantization a storage detail *inside* the linear/embedding types, not a branch at every use.
+`boltz-mlx` puts a `MatrixStorage` enum inside the existing `AffineLinear` / `AffineEmbedding`
+(with an `init(denseWeight:)` alongside the quantized init), so adding the dense path touched
+**zero** of the 122 sites that name those types. The weight store (`BoltzWeightStore`) branches
+once on `manifest.quantization == nil` and hands each layer the right storage. Consequences:
+
+- Adding fp16/bf16 later is a storage variant, not a rewrite.
+- Layers read shapes from the manifest, never re-derive them.
+- A whole pack is single-dtype; don't mix within a pack.
+
+## The featurizer is a first-class subproject
+
+You cannot embed upstream Python featurization on-device (torch + rdkit + scipy + numba vs
+RayMol's numpy-only embedded interpreter; and it is ~130× slower than the forward pass anyway).
+Write it in Swift, **MLX-free where possible** so it is pure and testable, and give it its own
+parity harness against the `export-features` bundles. Real landmines from the Boltz MSA featurizer
+(`Sources/BoltzMLX/Featurize/`):
+
+- **Reproduce upstream bugs deliberately, and document them.** Boltz's deletion features
+  (`deletion_value` / `has_deletion` / `deletion_mean`) are **identically zero** — not because
+  alignments lack insertions, but because `construct_paired_msa` slices an empty query array inside
+  its per-sequence loop. Emit zeros to match; park the parsed insertion counts as a seam if
+  upstream ever fixes it. A "more correct" featurizer that emits real deletions **fails parity**.
+- **Count then divide once.** `profile = one_hot(msa).float().mean(dim=0)` is an integer-valued sum
+  with a single division. Accumulating `1/depth` per row drifts ~2e-6 at depth 249 and breaks
+  bitwise parity — the only one of Boltz's 7 MSA tensors that failed first try.
+- **Throw where upstream silently degrades.** A length-mismatched MSA, a taxonomy-less local a3m
+  (kills all cross-chain pairing) — upstream limps on and mislabels; the Swift side should refuse,
+  because the downstream score reads *plausible* while being of the wrong complex.
+- **Share one vocabulary.** Gap/canonical/UNK/pad indexing must be identical between the MSA
+  one-hot and the residue-type one-hot, or they silently disagree. Reuse a single residue-template
+  table for both.
+
+## Memory planning — the model must refuse what it cannot fit
+
+An MLX OOM is uncatchable (`std::terminate` from a Metal completion handler). So capacity is a
+**pre-flight** decision, not an exception to handle:
+
+- Ship an **input-limits** type with distinct phone and desktop profiles (Boltz:
+  `BoltzInputLimits.desktop` = 1024 tok / 16384 atoms / 16384 MSA rows; the `MemoryPlanner`
+  default is phone-sized at 256 tok / 1024 rows and will refuse a real alignment). The **atom cap
+  usually binds before the token cap** — size on atoms.
+- Report the *true* input size to the planner. Boltz once hardcoded `msaDepth = 1`, so the planner
+  under-counted a real MSA until `metadata.msaDepth` reported the real depth.
+- **Arbitrate the MLX cache limit under a lock, and re-arbitrate after every run.**
+  `MemoryPlanner.cacheLimit` defaults to 64 MiB and `apply()` re-assigns it on *every* predict,
+  silently overwriting whatever the shared `MLXRuntime` arbitrated — so a later run (e.g. Design
+  mode) can inherit a larger ceiling and get jetsam-killed. Construct with
+  `cacheLimit: MLXRuntime.activeCacheLimitBytes` and re-call `configureOnce()` after each
+  prediction. Assign the global `MLX.Memory.cacheLimit` *inside* the lock (an outside-the-lock
+  assign is a lost-update race).
+- Save-and-restore `memoryLimit` with `defer`; don't leave a 6 GB ceiling installed. On Boltz,
+  `memoryLimit` is load-bearing (it gates a `gpu::finalize` + drain) — use ~4 GB, and going below
+  4 GB buys nothing while costing ~40% wall time.
+
+## Zero-work opportunities hide in "always zero outside a mask" tensors
+
+Before optimizing matmuls, look for large intermediates that are **identically zero outside a
+sparse mask**. RFD3's `SinusoidalDistEmbed` builds an `[A,A,64]` fp32 tensor (256 B/atom²) whose
+output is zero everywhere except the motif block — at 555 tokens **99.86%** of that work is
+multiplied by zero. Row-blocking it to the nonzero rows was **bit-identical** (max abs diff 0.0)
+and cut peak from 995 → 62 B/atom². These wins are safe *because* they're bit-identical — prove
+that with a fixture, don't assume it.
+
+## Build/run gotchas
+
+- The debug CLI dies with "Failed to load the default metallib" — only `.build/release/` has
+  `mlx.metallib` beside the binary. Build `-c release` to actually run the CLI.
+- SourceKit reports **"No such module 'MLX'"** in these packages even when `swift build` is clean.
+  Trust the compiler, not the editor squiggle.

--- a/.claude/skills/port-predictor-to-mlx/references/weight-export.md
+++ b/.claude/skills/port-predictor-to-mlx/references/weight-export.md
@@ -1,0 +1,89 @@
+# Phase 1 — Weight export (the Python side)
+
+Goal: a small, reproducible exporter that turns an upstream checkpoint into an **MLX artifact**
+(quantized weights + a manifest) plus the **feature bundles** and **module-boundary fixtures** the
+Swift side needs. In `boltz-mlx` this is `src/boltz_mlx_export/` with three CLI verbs:
+
+```bash
+boltz-mlx export-model    --checkpoint <ckpt> --output <dir> [--precision int8|float16|bfloat16]
+boltz-mlx export-features <input.yaml>        --output <dir>
+boltz-mlx make-fixtures   ...                 # PyTorch module-boundary tensors for parity tests
+```
+
+Modules to mirror: `cli.py` (verbs), `model_export.py` (weights), `feature_export.py` (features),
+`fixtures.py` (parity references), `names.py` (name mapping), `quantization.py`, `schema.py`
+(manifest), `tensor_io.py`. Vendor the upstream package under `src/<upstream>/` so export and
+parity run against the real thing.
+
+## The exporter contract
+
+Write **safetensors** + a JSON **manifest**. The manifest is the seam between Python and Swift —
+Swift branches on it and never re-derives shapes. For an int8 pack, each tensor carries packed
+8-bit weights + fp16 `scales`/`biases` + `logical`/`physical` shape (physical is padded to the
+quantization group size). A dense pack sets `quantization: null` and carries **no** scales/biases
+and **no** logical/physical shape (padding only exists for quantization). A pack must be
+**single-dtype** — MLX promotes a mixed fp16/bf16 op to fp32.
+
+Default precision is **int8, group-64**. It is smaller *and* faster than dense (quantized matmul
+wins on memory-bound ops); build dense fp16/bf16 only when a validation explicitly needs it.
+
+## Landmines — every one shipped a silently-wrong model at least once
+
+- **Know the checkpoint's true dtype.** "bf16-trained" networks are stored **fp32** on disk
+  (Boltz: 5102 tensors, all `torch.float32`). The `bfloat16` branch in an exporter is usually
+  defensive, not load-bearing. So exporting fp16 is *closer* to source than bf16 at equal size
+  (10-bit vs 7-bit mantissa); bf16 is "faithful" only in the sense the net was trained in it.
+
+- **EMA shadow weights — check whether the head uses them.** Diffusion/score models often keep an
+  exponential-moving-average shadow of the parameters that is what actually gets used at inference.
+  You **must** verify per-network: Boltz confidence has **0 of 5102** tensors differing from the
+  EMA shadow (safe to ignore), but **RFD3 has 392 of 400 differing by up to 55%** — exporting the
+  raw weights there ships a wrong model. Diff raw-vs-EMA before you trust either.
+
+- **Name-prefix omissions silently drop a submodule.** Export code that filters by a
+  `STRUCTURE_PREFIXES`-style allow-list will happily omit a head you need. Boltz's list omits
+  **both** `confidence_module` and `distogram_module` — and the distogram *feeds* confidence via
+  `pred_distogram_logits`, so adding only the first ships an unrunnable head. Enumerate what the
+  forward pass actually reads, not what the prefix list happens to name.
+
+- **`from_hparams`-style config loaders drop args and build a *different* model.** Boltz's
+  `ModelConfiguration.from_hparams` silently drops `confidence_model_args`
+  (`add_s_to_z_prod` / `add_s_input_to_s` / `add_z_input_to_z` / `use_separate_heads`, all True) —
+  the defaults construct a subtly wrong head that still runs and still produces plausible numbers.
+  Assert the reconstructed config equals the checkpoint's hparams field-by-field.
+
+- **numpy has no bf16 dtype.** Write bf16/fp16 dense packs via `safetensors.torch`, not numpy.
+
+- **Guard your CLI entrypoint.** `python -m <exporter>.cli` **silently exits 0 doing nothing** if
+  the module has no `__main__` guard. Use the installed console script (`boltz-mlx …`) and add a
+  smoke test that the artifact is non-empty.
+
+## Feature bundles (`export-features`)
+
+Emit the exact tensors the Swift featurizer must reproduce, from a small human-readable input
+(a YAML naming sequences / MSAs / ligands). These bundles are *also* the parity reference for the
+Swift featurizer (Phase 3). Two properties make bundles pinnable **bitwise**:
+
+- **The inference feature path is deterministic** when training-only randomness is off. Boltz's
+  `process()` sets `max_seqs_batch = max_seqs` and `msa_sampling = training and msa_sampling` with
+  `training=False` — no RNG, so the MSA/profile tensors can be pinned exactly. The exception is
+  anything randomly augmented per instance (e.g. `ref_pos`) — those cannot be pinned, only
+  distribution-checked.
+- **A mismatched input degrades silently upstream.** Boltz's `construct_paired_msa` compares only
+  the *first* sequence's length, prints a warning, and continues at `msa_depth 1`. The Swift side
+  should **throw** on the mismatch instead — losing the target's alignment means every downstream
+  score is of the wrong complex with nothing in the output saying so.
+
+## Rebuilding the Python side (it gets deleted / lives in a scratch venv)
+
+The exporter's venv and vendored upstream are heavy and disposable. Record the exact rebuild:
+
+```bash
+uv venv .venv --python 3.12 && uv pip install -e . safetensors mlx
+# plus any upstream data cache (Boltz: ~/.boltz/{mols,ccd.pkl}, ~1.8 GB, survives)
+boltz-mlx export-model    --checkpoint <ckpt> --output <dir>   # regenerates the pack
+boltz-mlx export-features <yaml> --output <dir>                # note --output is a required FLAG
+```
+
+Publish the artifact as a release asset (Phase 6); never commit it. Keep the export *command* in
+the repo so anyone can regenerate byte-identical weights from a checkpoint they supply.


### PR DESCRIPTION
## What

Adds a new project skill, **`port-predictor-to-mlx`**, under `.claude/skills/` — a repeatable engineering playbook for porting a PyTorch biomolecular predictor network to a native **Swift + MLX** implementation that RayMol runs on iOS / iPadOS / macOS.

It is documentation only (no code changes); nothing in the app or build is touched.

## Why

We've now done this port several times (Boltz-2 → `boltz-mlx`, plus the RFD3 and ProteinMPNN work), and the hard-won process — the science gate, int8 export traps, parity methodology, the honest "is int8 lossless?" validation, and the RayMol integration/publishing steps — lived only in session history and auto-memory. This captures it as a first-class skill so the next port (and the next person) doesn't re-learn it from scratch.

## Structure

```
.claude/skills/port-predictor-to-mlx/
├── SKILL.md                    hub: 7-phase workflow, Phase-0 gate, deliverable spec, non-negotiables
└── references/
    ├── weight-export.md        dtype truth, EMA shadow, name-prefix drops, int8 vs dense, manifest
    ├── swift-mlx-port.md       one quantization seam, featurizer-as-subproject, memory pre-flight
    ├── numerical-parity.md     module-boundary fixtures, bitwise vs r>=0.9997, golden coord hash
    ├── accuracy-validation.md  "is int8 lossless?" benchmark (fp32 self-variance floor, TOST) + perf/size
    └── raymol-integration.md   SPM url-not-path, weights-as-asset+sha256, cmd.predict plugin, CI, publishing
```

Progressive disclosure: `SKILL.md` is 139 lines; each reference is loaded only when its phase is reached.

## Notes for reviewers

- The skill is written **general** (structure / diffusion / inverse-folding predictors) with `boltz-mlx` as the worked example and RFD3 / ProteinMPNN called out as cross-referenced divergences (e.g. RFD3's EMA shadow weights genuinely differ; Boltz's don't).
- RFD3/MPNN constants were pulled from auto-memory (~2–3 weeks old). Happy to verify them against the actual `rfd3-ios` / `proteinmpnn-mlx` repos before merge if you'd like them treated as authoritative.
- No functional risk: adds files under `.claude/skills/` only.
