### PR TITLE
test(predict): stop asserting the v2 int8 pack downloads

### DIFF
--- a/testing/tests/predict/predict_protenix.py
+++ b/testing/tests/predict/predict_protenix.py
@@ -543,12 +543,16 @@ class TestBulkPrefetchSkipsWhatCannotRun(HostEnvTestCase):
                         or 'protenix-base-mlx-int8' in self.started)
 
     def testBulkFetchTakesItOnceTheRuntimeIsThere(self):
+        """Both asserted as "fetched OR already cached" -- a machine that has run a fold,
+        or a prior bulk prefetch, has the pack, so asserting a download tests local state
+        rather than the filter."""
         self.declareHost('boltz,protenix')
         out = cmd.predict_weights(download=1, async_=1)
         self.assertTrue(out['protenix-base-int8']['cached']
                         or 'protenix-base-mlx-int8' in self.started)
-        # And the other packs, which no fold has cached, are genuinely fetched.
-        self.assertIn('protenix-v2-mlx-int8', self.started)
+        # And the other packs, no longer filtered out, are reached as well.
+        self.assertTrue(out['protenix-v2-int8']['cached']
+                        or 'protenix-v2-mlx-int8' in self.started)
 
     def testItIsStillReportedEvenWhenNotFetched(self):
         """Skipping the download must not hide the predictor from the report."""


### PR DESCRIPTION
## Problem

`TestBulkPrefetchSkipsWhatCannotRun.testBulkFetchTakesItOnceTheRuntimeIsThere` in `testing/tests/predict/predict_protenix.py` failed on any machine where the `protenix-v2-int8` weight pack was already cached — that is, any machine that had run a v2 fold or a prior bulk prefetch.

The last line was:

```python
self.assertIn('protenix-v2-mlx-int8', self.started)
```

`self.started` only records bundles actually handed to `fetching.start`, and `predict_weights` skips a bundle already present in `~/Library/Application Support/RayMol/weights/`. So on a machine with the pack, the assertion failed:

```
AssertionError: 'protenix-v2-mlx-int8' not found in ['boltz2-mlx-bf16',
'protenix-base-mlx-bfloat16', 'protenix-base-mlx-float16',
'protenix-v2-mlx-bfloat16', 'protenix-v2-mlx-float16']
```

The test exists to check the *runtime filter* — that declaring the protenix runtime stops the pack from being filtered out of a bulk prefetch. Asserting a download instead made it pass or fail on local cache state.

## Fix

Assert "started OR reported cached", the pattern the two assertions directly above it and the sibling tests `testBulkFetchStillTakesTheOnesThatWork` / `testNamingItExplicitlyStillFetches` already use, with docstrings explaining why. This one line had not been converted.

Both branches stay meaningful: `predict_weights` recomputes `cached` *after* calling `fetching.start`, and the test stubs `start` out to a recorder, so nothing reaches disk during the test — `cached` is true only when the pack was already there.

## Verification

Verified on a machine that reproduces the failure (`protenix-v2-mlx-int8` present in the weights cache).

Before, on that machine:

```
testBulkFetchTakesItOnceTheRuntimeIsThere ... FAIL
AssertionError: 'protenix-v2-mlx-int8' not found in [...]
FAILED (failures=1)
```

After:

```
Ran 59 tests in 0.100s

OK
```

via `pymol -ckq testing/testing.py --run testing/tests/predict/predict_protenix.py`.

Pre-existing and unrelated to #316; noticed while working on that issue. Test-only change — no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)