### PR TITLE
MCP broker: reach RayMol even when it is closed

### DIFF
--- a/docs/superpowers/plans/2026-08-19-raymol-mcp-broker.md
+++ b/docs/superpowers/plans/2026-08-19-raymol-mcp-broker.md
@@ -752,8 +752,14 @@ In `response(for:method:id:raw:)` (line 96), replace the opening `if let body = 
         let target = resolveTarget(requestedKey: nil)
         var instance: MCPInstance? = nil
         if case .bound(let i) = target { instance = i } else { instance = legacyHandoff() }
-        if let instance, let body = proxy(raw: raw, to: instance) {
-            return body.isEmpty ? nil : body   // empty = 202 notification ack
+        if let instance {
+            if let body = proxy(raw: raw, to: instance) {
+                return body.isEmpty ? nil : body   // empty = 202 notification ack
+            }
+            // Unreachable or 401 (a recycled pid, or a rotated token): the binding
+            // is stale, so drop it and let the next call re-resolve rather than
+            // retrying a port that is not ours.
+            setBound(nil)
         }
 ```
 
@@ -1354,7 +1360,7 @@ BODY
 
 **Spec coverage.** Registry file + fields → Task 4. Broker resolution order → Task 3, wired in Task 5. Ambiguity listing → Task 6. Instance keys with `#pid` collisions → Task 2. `instance` injection/stripping + `list_raymol_instances` → Task 6. Cold launch, defaults flip, 20 s poll, no launch lock → Task 7. Only-`tools/call`-launches → Task 7. Trust unchanged → no task sets `set_trusted`; asserted by the Task 9 Allow-prompt step. Error table → Tasks 6–7 (`ambiguous`, `unknownKey`, missing bundle, timeout) and Task 4 (`liveDirectoryInstances` prunes corrupt and dead entries). Migration → Task 8 plus Task 9 Step 5. Testing → Tasks 1–8 unit tests, Task 9 end-to-end.
 
-**Gap found and closed.** The spec lists "port returns 401 (stale token) → prune, rescan". Pid-liveness alone misses a pid that was recycled by an unrelated process. `liveDirectoryInstances` prunes dead pids only; the 401 case is left to `proxy` returning nil, which falls through to `legacyHandoff` and then to the offline reply. That is acceptable behavior but is NOT what the spec says. Task 5's `proxy` therefore must be treated as the 401 handler — the implementer should clear the sticky binding on a nil proxy result so the next call re-resolves. Add this to Task 5 Step 3: in `response`, on `proxy(...) == nil`, call `setBound(nil)` before falling through.
+**Gap found and closed.** The spec lists "port returns 401 (stale token) → prune, rescan". Pid-liveness alone misses a pid recycled by an unrelated process, so `liveDirectoryInstances` cannot be the whole answer. Fixed inline in Task 5 Step 3: a nil `proxy` result now clears the sticky binding, so the next call re-resolves instead of retrying a port that is no longer ours.
 
 **Placeholder scan.** No TBD/TODO. Every code step carries real code. Task 5 Step 1 honestly states it has no unit seam rather than inventing one.
 

--- a/docs/superpowers/plans/2026-08-19-raymol-mcp-broker.md
+++ b/docs/superpowers/plans/2026-08-19-raymol-mcp-broker.md
@@ -1,0 +1,1361 @@
+# RayMol MCP Broker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make RayMol's MCP server reachable from a Claude client even when RayMol is closed, by turning the existing `--mcp-bridge` stdio proxy into a broker that discovers running instances through a registry and cold-launches the installed app on the first tool call.
+
+**Architecture:** Each running RayMol writes a per-process JSON file into an instance registry directory. The broker (`RayMol --mcp-bridge`, a stdio process the Claude client spawns) reads that registry to resolve a target, launches `/Applications/RayMol.app` when nothing is running, and proxies JSON-RPC over loopback HTTP to the chosen instance. No resident daemon is introduced.
+
+**Tech Stack:** Swift 5 / AppKit / Foundation (macOS-only, inside `#if os(macOS) && !RAYMOL_MAS_RESTRICTED`), XCTest, XcodeGen, Python 3 (read-only reference to `modules/raymol_mcp/tools.py`).
+
+**Spec:** `docs/superpowers/specs/2026-08-19-raymol-mcp-broker-design.md`
+
+## Global Constraints
+
+- All new code is macOS-only and MUST sit inside `#if os(macOS) && !RAYMOL_MAS_RESTRICTED`, matching every file it touches. The Mac App Store build compiles MCP out entirely; a symbol leaking outside the guard breaks that build.
+- Registry directory: `~/Library/Application Support/RayMol/instances/`, one file per process named `<pid>.json`, mode `0600`.
+- Registry entry keys, exactly: `pid` (Int), `port` (Int), `token` (String), `appPath` (String), `name` (String), `installed` (Bool), `startedAt` (String, ISO-8601).
+- The canonical `~/Library/Application Support/RayMol/mcp.json` handoff MUST keep being written and removed exactly as it is today. The registry is additive.
+- Cold-launch target: `/Applications/RayMol.app`. Cold-launch timeout: 20 seconds. Existing 120-second proxy timeout is unchanged.
+- Only `tools/call` may cold-launch. `initialize`, `tools/list` and `ping` are answered locally when no instance is live.
+- Trust is unchanged: the broker never sets `set_trusted`. The Allow prompt must still appear on a model-initiated cold launch.
+- Instance key = bundle display name (`RayMol`, `RayMol-287`); on collision, `Name#<pid>`. A bare pid string is always accepted as a key.
+- Swift test files live in `swiftui/PyMOLViewerTests/`. After ADDING a file there you MUST run `xcodegen generate` in `swiftui/` before `xcodebuild`, because `PyMOLViewer.xcodeproj` is checked in.
+- Test command (run from `swiftui/`):
+  `xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS -destination 'platform=macOS' -skipPackagePluginValidation -skipMacroValidation -only-testing:PyMOLViewerTests/<Class> 2>&1 | tail -30`
+- Do NOT commit to `master`. Work stays on the current branch; a PR is opened at the end.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `swiftui/PyMOLViewer/Shared/MCPInstanceRegistry.swift` (create) | Pure model + pure resolution logic: the `MCPInstance` record, encode/decode, liveness filtering, key assignment, target selection. No I/O policy, no launching. Split out of `MCPBridge` so it can be unit-tested without a stdio loop. |
+| `swiftui/PyMOLViewer/Shared/MCPServerManager.swift` (modify) | Writes and removes this process's registry entry alongside the existing handoff; `connectClaudeCode` registers the stdio broker instead of a pinned HTTP URL. |
+| `swiftui/PyMOLViewer/Shared/MCPBridge.swift` (modify) | Broker behavior: resolve a target via `MCPInstanceRegistry`, cold-launch, sticky binding, `instance` argument injection/stripping, `list_raymol_instances`. |
+| `swiftui/PyMOLViewer/Shared/MCPDesktopInstaller.swift` (modify) | `bridgeCommand()` prefers the installed app over the running bundle. |
+| `swiftui/PyMOLViewerTests/MCPBrokerTests.swift` (create) | Unit tests for every pure function above. |
+
+Tasks 1–3 build the pure core bottom-up; Task 4 wires the registry writer; Tasks 5–7 change broker behavior; Task 8 fixes registration paths; Task 9 is end-to-end verification and config repair.
+
+---
+
+### Task 1: Instance record and registry decoding
+
+**Files:**
+- Create: `swiftui/PyMOLViewer/Shared/MCPInstanceRegistry.swift`
+- Create: `swiftui/PyMOLViewerTests/MCPBrokerTests.swift`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `struct MCPInstance: Codable, Equatable` with `let pid: Int`, `let port: Int`, `let token: String`, `let appPath: String`, `let name: String`, `let installed: Bool`, `let startedAt: String`
+  - `enum MCPInstanceRegistry` with `static func decode(_ data: Data) -> MCPInstance?`
+  - `static func decodeAll(_ blobs: [Data]) -> [MCPInstance]`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `swiftui/PyMOLViewerTests/MCPBrokerTests.swift`:
+
+```swift
+import XCTest
+@testable import RayMol
+
+/// Covers the pure core of the MCP broker: how a client decides WHICH RayMol
+/// it is talking to.
+///
+/// This matters because the broker is spawned by a Claude client with no user
+/// present to correct it. A stale registry entry that survives filtering means
+/// tool calls are proxied to a dead port; a wrong disambiguation means Claude
+/// silently drives a different window than the one the user is looking at.
+final class MCPBrokerTests: XCTestCase {
+
+    // MARK: - decode
+
+    private func blob(pid: Int = 4412, port: Int = 51737, name: String = "RayMol",
+                      installed: Bool = true) -> Data {
+        Data("""
+        {"pid":\(pid),"port":\(port),"token":"deadbeef","appPath":"/Applications/\(name).app",
+         "name":"\(name)","installed":\(installed),"startedAt":"2026-08-19T10:31:02Z"}
+        """.utf8)
+    }
+
+    func testDecodeReadsEveryField() {
+        let i = MCPInstanceRegistry.decode(blob())
+        XCTAssertEqual(i?.pid, 4412)
+        XCTAssertEqual(i?.port, 51737)
+        XCTAssertEqual(i?.token, "deadbeef")
+        XCTAssertEqual(i?.name, "RayMol")
+        XCTAssertEqual(i?.installed, true)
+    }
+
+    // A half-written or hand-edited file must not take the whole registry down:
+    // the broker's job is to keep working with the instances it CAN read.
+    func testDecodeRejectsGarbageWithoutThrowing() {
+        XCTAssertNil(MCPInstanceRegistry.decode(Data("not json".utf8)))
+        XCTAssertNil(MCPInstanceRegistry.decode(Data("{\"pid\":1}".utf8)))
+        XCTAssertNil(MCPInstanceRegistry.decode(Data()))
+    }
+
+    func testDecodeAllSkipsBadEntriesAndKeepsGoodOnes() {
+        let out = MCPInstanceRegistry.decodeAll([
+            blob(pid: 1, name: "RayMol"),
+            Data("{".utf8),
+            blob(pid: 2, name: "RayMol-287", installed: false),
+        ])
+        XCTAssertEqual(out.map(\.pid), [1, 2])
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run from `swiftui/`:
+```bash
+xcodegen generate && xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS -destination 'platform=macOS' -skipPackagePluginValidation -skipMacroValidation -only-testing:PyMOLViewerTests/MCPBrokerTests 2>&1 | tail -30
+```
+Expected: FAIL — "cannot find 'MCPInstanceRegistry' in scope".
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `swiftui/PyMOLViewer/Shared/MCPInstanceRegistry.swift`:
+
+```swift
+// MCPInstanceRegistry.swift — the pure core of MCP target selection: what a
+// running RayMol advertises, and how a broker picks one. Kept free of I/O and
+// launching so it is unit-testable without a stdio loop or a live app.
+#if os(macOS) && !RAYMOL_MAS_RESTRICTED
+import Foundation
+
+/// One running RayMol that has its MCP server up.
+struct MCPInstance: Codable, Equatable {
+    let pid: Int
+    let port: Int
+    let token: String
+    let appPath: String
+    let name: String
+    let installed: Bool
+    let startedAt: String
+}
+
+enum MCPInstanceRegistry {
+    /// Decode one registry file. Returns nil rather than throwing: a corrupt or
+    /// half-written entry must not take the readable instances down with it.
+    static func decode(_ data: Data) -> MCPInstance? {
+        try? JSONDecoder().decode(MCPInstance.self, from: data)
+    }
+
+    static func decodeAll(_ blobs: [Data]) -> [MCPInstance] {
+        blobs.compactMap(decode)
+    }
+}
+#endif
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run from `swiftui/`:
+```bash
+xcodegen generate && xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS -destination 'platform=macOS' -skipPackagePluginValidation -skipMacroValidation -only-testing:PyMOLViewerTests/MCPBrokerTests 2>&1 | tail -30
+```
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add swiftui/PyMOLViewer/Shared/MCPInstanceRegistry.swift swiftui/PyMOLViewerTests/MCPBrokerTests.swift swiftui/PyMOLViewer.xcodeproj
+git commit -m "feat(mcp): add MCPInstance record and tolerant registry decoding"
+```
+
+---
+
+### Task 2: Instance keys and disambiguation
+
+**Files:**
+- Modify: `swiftui/PyMOLViewer/Shared/MCPInstanceRegistry.swift`
+- Modify: `swiftui/PyMOLViewerTests/MCPBrokerTests.swift`
+
+**Interfaces:**
+- Consumes: `MCPInstance`, `MCPInstanceRegistry.decodeAll` (Task 1).
+- Produces:
+  - `static func keys(for instances: [MCPInstance]) -> [Int: String]` — pid → key
+  - `static func match(_ key: String, in instances: [MCPInstance]) -> MCPInstance?`
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside `final class MCPBrokerTests`:
+
+```swift
+    // MARK: - keys
+
+    func testKeyIsTheDisplayNameWhenUnique() {
+        let k = MCPInstanceRegistry.keys(for: MCPInstanceRegistry.decodeAll([
+            blob(pid: 1, name: "RayMol"),
+            blob(pid: 2, name: "RayMol-287"),
+        ]))
+        XCTAssertEqual(k[1], "RayMol")
+        XCTAssertEqual(k[2], "RayMol-287")
+    }
+
+    // Two checkouts can produce two apps with the SAME display name. Handing
+    // Claude two identical keys would make disambiguation impossible, so the
+    // pid has to enter the key — but only for the colliding names.
+    func testCollidingNamesGetPidSuffixedKeys() {
+        let k = MCPInstanceRegistry.keys(for: MCPInstanceRegistry.decodeAll([
+            blob(pid: 1, name: "RayMol"),
+            blob(pid: 2, name: "RayMol"),
+            blob(pid: 3, name: "RayMol-287"),
+        ]))
+        XCTAssertEqual(k[1], "RayMol#1")
+        XCTAssertEqual(k[2], "RayMol#2")
+        XCTAssertEqual(k[3], "RayMol-287")
+    }
+
+    // MARK: - match
+
+    func testMatchAcceptsName_KeyForm_AndBarePid() {
+        let list = MCPInstanceRegistry.decodeAll([
+            blob(pid: 1, name: "RayMol"),
+            blob(pid: 2, name: "RayMol"),
+            blob(pid: 3, name: "RayMol-287"),
+        ])
+        XCTAssertEqual(MCPInstanceRegistry.match("RayMol-287", in: list)?.pid, 3)
+        XCTAssertEqual(MCPInstanceRegistry.match("RayMol#2", in: list)?.pid, 2)
+        XCTAssertEqual(MCPInstanceRegistry.match("3", in: list)?.pid, 3)
+    }
+
+    // An ambiguous bare name must NOT resolve to an arbitrary instance —
+    // silently driving the wrong window is the failure this whole design exists
+    // to prevent.
+    func testMatchRefusesAnAmbiguousName() {
+        let list = MCPInstanceRegistry.decodeAll([
+            blob(pid: 1, name: "RayMol"),
+            blob(pid: 2, name: "RayMol"),
+        ])
+        XCTAssertNil(MCPInstanceRegistry.match("RayMol", in: list))
+    }
+
+    func testMatchReturnsNilForUnknownKey() {
+        let list = MCPInstanceRegistry.decodeAll([blob(pid: 1, name: "RayMol")])
+        XCTAssertNil(MCPInstanceRegistry.match("Nope", in: list))
+        XCTAssertNil(MCPInstanceRegistry.match("999", in: list))
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run from `swiftui/`:
+```bash
+xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS -destination 'platform=macOS' -skipPackagePluginValidation -skipMacroValidation -only-testing:PyMOLViewerTests/MCPBrokerTests 2>&1 | tail -30
+```
+Expected: FAIL — "type 'MCPInstanceRegistry' has no member 'keys'".
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append inside `enum MCPInstanceRegistry`:
+
+```swift
+    /// pid → the key a client uses to name this instance. Bare display name when
+    /// unique; `Name#<pid>` only for the names that actually collide, so the
+    /// common single-instance case stays readable.
+    static func keys(for instances: [MCPInstance]) -> [Int: String] {
+        var counts: [String: Int] = [:]
+        for i in instances { counts[i.name, default: 0] += 1 }
+        var out: [Int: String] = [:]
+        for i in instances {
+            out[i.pid] = (counts[i.name] ?? 0) > 1 ? "\(i.name)#\(i.pid)" : i.name
+        }
+        return out
+    }
+
+    /// Resolve a user- or model-supplied key. Accepts the assigned key, a bare
+    /// display name when unambiguous, or a bare pid. Returns nil when the key is
+    /// unknown OR ambiguous — the caller must ask rather than guess.
+    static func match(_ key: String, in instances: [MCPInstance]) -> MCPInstance? {
+        let keyed = keys(for: instances)
+        if let hit = instances.first(where: { keyed[$0.pid] == key }) { return hit }
+        if let pid = Int(key), let hit = instances.first(where: { $0.pid == pid }) {
+            return hit
+        }
+        let byName = instances.filter { $0.name == key }
+        return byName.count == 1 ? byName[0] : nil
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run from `swiftui/`:
+```bash
+xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS -destination 'platform=macOS' -skipPackagePluginValidation -skipMacroValidation -only-testing:PyMOLViewerTests/MCPBrokerTests 2>&1 | tail -30
+```
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add swiftui/PyMOLViewer/Shared/MCPInstanceRegistry.swift swiftui/PyMOLViewerTests/MCPBrokerTests.swift
+git commit -m "feat(mcp): assign instance keys and resolve them without guessing"
+```
+
+---
+
+### Task 3: Target resolution
+
+**Files:**
+- Modify: `swiftui/PyMOLViewer/Shared/MCPInstanceRegistry.swift`
+- Modify: `swiftui/PyMOLViewerTests/MCPBrokerTests.swift`
+
+**Interfaces:**
+- Consumes: `MCPInstance`, `keys(for:)`, `match(_:in:)` (Tasks 1–2).
+- Produces:
+  - `enum MCPTarget: Equatable { case bound(MCPInstance); case none; case ambiguous([MCPInstance]); case unknownKey(String) }`
+  - `static func resolve(instances: [MCPInstance], requestedKey: String?, envKey: String?, sticky: MCPInstance?) -> MCPTarget`
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside `final class MCPBrokerTests`:
+
+```swift
+    // MARK: - resolve
+
+    private var one: [MCPInstance] { MCPInstanceRegistry.decodeAll([blob(pid: 1, name: "RayMol")]) }
+    private var two: [MCPInstance] {
+        MCPInstanceRegistry.decodeAll([blob(pid: 1, name: "RayMol"),
+                                       blob(pid: 2, name: "RayMol-287")])
+    }
+
+    func testSingleLiveInstanceBinds() {
+        XCTAssertEqual(
+            MCPInstanceRegistry.resolve(instances: one, requestedKey: nil, envKey: nil, sticky: nil),
+            .bound(one[0]))
+    }
+
+    func testEmptyRegistryReportsNone() {
+        XCTAssertEqual(
+            MCPInstanceRegistry.resolve(instances: [], requestedKey: nil, envKey: nil, sticky: nil),
+            .none)
+    }
+
+    func testTwoInstancesAreAmbiguousRatherThanGuessed() {
+        XCTAssertEqual(
+            MCPInstanceRegistry.resolve(instances: two, requestedKey: nil, envKey: nil, sticky: nil),
+            .ambiguous(two))
+    }
+
+    // Precedence: an explicit in-conversation key beats env, sticky and the scan,
+    // so "use the 287 build" can rebind mid-session.
+    func testRequestedKeyWinsOverEverything() {
+        XCTAssertEqual(
+            MCPInstanceRegistry.resolve(instances: two, requestedKey: "RayMol-287",
+                                        envKey: "RayMol", sticky: two[0]),
+            .bound(two[1]))
+    }
+
+    func testEnvKeyWinsOverStickyAndScan() {
+        XCTAssertEqual(
+            MCPInstanceRegistry.resolve(instances: two, requestedKey: nil,
+                                        envKey: "RayMol-287", sticky: two[0]),
+            .bound(two[1]))
+    }
+
+    // Without sticky binding a two-instance setup would re-ask on every call.
+    func testStickyBindingSurvivesAnAmbiguousScan() {
+        XCTAssertEqual(
+            MCPInstanceRegistry.resolve(instances: two, requestedKey: nil, envKey: nil,
+                                        sticky: two[0]),
+            .bound(two[0]))
+    }
+
+    // The app the session was bound to quit; its entry is gone. Falling back to
+    // the scan is what makes "RayMol quit mid-session" cold-launch again.
+    func testStickyBindingIsDroppedWhenItsInstanceDied() {
+        XCTAssertEqual(
+            MCPInstanceRegistry.resolve(instances: [], requestedKey: nil, envKey: nil,
+                                        sticky: two[0]),
+            .none)
+    }
+
+    func testUnknownRequestedKeyIsReportedNotIgnored() {
+        XCTAssertEqual(
+            MCPInstanceRegistry.resolve(instances: two, requestedKey: "RayMol-999",
+                                        envKey: nil, sticky: nil),
+            .unknownKey("RayMol-999"))
+    }
+
+    // A stale env var must not strand a working single-instance session.
+    func testUnknownEnvKeyFallsThroughToTheScan() {
+        XCTAssertEqual(
+            MCPInstanceRegistry.resolve(instances: one, requestedKey: nil,
+                                        envKey: "RayMol-999", sticky: nil),
+            .bound(one[0]))
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run from `swiftui/`:
+```bash
+xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS -destination 'platform=macOS' -skipPackagePluginValidation -skipMacroValidation -only-testing:PyMOLViewerTests/MCPBrokerTests 2>&1 | tail -30
+```
+Expected: FAIL — "cannot find 'MCPTarget' in scope".
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `MCPInstanceRegistry.swift`, above `enum MCPInstanceRegistry`:
+
+```swift
+/// The outcome of asking "which RayMol should this call go to?".
+enum MCPTarget: Equatable {
+    case bound(MCPInstance)
+    /// Nothing is running — the caller may cold-launch.
+    case none
+    /// More than one candidate and no way to choose. The caller must ask.
+    case ambiguous([MCPInstance])
+    /// A key was supplied explicitly but names no live instance.
+    case unknownKey(String)
+}
+```
+
+Append inside `enum MCPInstanceRegistry`:
+
+```swift
+    /// Resolve a target, first hit wins: explicit key, environment key, sticky
+    /// binding, then the registry scan.
+    ///
+    /// An unknown *requested* key is reported (the model asked for something
+    /// specific and deserves to be told it is gone), while an unknown *env* key
+    /// falls through — a stale export must not strand an otherwise fine session.
+    static func resolve(instances: [MCPInstance], requestedKey: String?,
+                        envKey: String?, sticky: MCPInstance?) -> MCPTarget {
+        if let key = requestedKey, !key.isEmpty {
+            return match(key, in: instances).map { .bound($0) } ?? .unknownKey(key)
+        }
+        if let key = envKey, !key.isEmpty, let hit = match(key, in: instances) {
+            return .bound(hit)
+        }
+        // Sticky only survives while its instance is still registered.
+        if let s = sticky, let live = instances.first(where: { $0.pid == s.pid }) {
+            return .bound(live)
+        }
+        switch instances.count {
+        case 0:  return .none
+        case 1:  return .bound(instances[0])
+        default: return .ambiguous(instances)
+        }
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run from `swiftui/`:
+```bash
+xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS -destination 'platform=macOS' -skipPackagePluginValidation -skipMacroValidation -only-testing:PyMOLViewerTests/MCPBrokerTests 2>&1 | tail -30
+```
+Expected: PASS, 17 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add swiftui/PyMOLViewer/Shared/MCPInstanceRegistry.swift swiftui/PyMOLViewerTests/MCPBrokerTests.swift
+git commit -m "feat(mcp): resolve a broker target from key, env, sticky binding or scan"
+```
+
+---
+
+### Task 4: RayMol registers itself
+
+**Files:**
+- Modify: `swiftui/PyMOLViewer/Shared/MCPInstanceRegistry.swift`
+- Modify: `swiftui/PyMOLViewer/Shared/MCPServerManager.swift` (add near `writeHandoff`, lines 296–336)
+- Modify: `swiftui/PyMOLViewerTests/MCPBrokerTests.swift`
+
+**Interfaces:**
+- Consumes: `MCPInstance` (Task 1).
+- Produces:
+  - `static func directory() -> URL?` — the instances directory, created on demand
+  - `static func selfEntry(pid: Int, port: Int, token: String, bundle: Bundle, startedAt: String) -> MCPInstance`
+  - `static func liveDirectoryInstances() -> [MCPInstance]` — read + prune dead pids
+  - `MCPServerManager` writes its entry on `MCP:started` and removes it on stop.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside `final class MCPBrokerTests`:
+
+```swift
+    // MARK: - selfEntry
+
+    // `installed` decides whether the broker may treat this app as the cold-launch
+    // target; deriving it from the bundle path keeps dev builds out of that role.
+    func testSelfEntryMarksAnAppOutsideApplicationsAsNotInstalled() {
+        XCTAssertFalse(MCPInstanceRegistry.isInstalled(path: "/Users/x/build/RayMol-287.app"))
+        XCTAssertTrue(MCPInstanceRegistry.isInstalled(path: "/Applications/RayMol.app"))
+    }
+
+    func testSelfEntryRoundTripsThroughDecode() {
+        let e = MCPInstance(pid: 7, port: 51737, token: "t", appPath: "/Applications/RayMol.app",
+                            name: "RayMol", installed: true, startedAt: "2026-08-19T10:00:00Z")
+        let data = try! JSONEncoder().encode(e)
+        XCTAssertEqual(MCPInstanceRegistry.decode(data), e)
+    }
+
+    // MARK: - liveness
+
+    // A crashed RayMol leaves its file behind. Proxying to that port either fails
+    // or, worse, reaches whatever else bound it since.
+    func testDeadPidsArePrunedFromAScan() {
+        let mine = Int(ProcessInfo.processInfo.processIdentifier)
+        let list = MCPInstanceRegistry.decodeAll([blob(pid: mine), blob(pid: 999_999, name: "Ghost")])
+        XCTAssertEqual(MCPInstanceRegistry.liveOnly(list).map(\.pid), [mine])
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run from `swiftui/`:
+```bash
+xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS -destination 'platform=macOS' -skipPackagePluginValidation -skipMacroValidation -only-testing:PyMOLViewerTests/MCPBrokerTests 2>&1 | tail -30
+```
+Expected: FAIL — "has no member 'isInstalled'".
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append inside `enum MCPInstanceRegistry` in `MCPInstanceRegistry.swift`:
+
+```swift
+    // MARK: - Directory + self-registration
+
+    static func directory() -> URL? {
+        let fm = FileManager.default
+        guard let base = fm.urls(for: .applicationSupportDirectory,
+                                 in: .userDomainMask).first else { return nil }
+        let dir = base.appendingPathComponent("RayMol/instances", isDirectory: true)
+        try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    /// Only an app under /Applications may be the cold-launch target, so a dev
+    /// build in a worktree never becomes the thing a client launches by default.
+    static func isInstalled(path: String) -> Bool {
+        path.hasPrefix("/Applications/")
+    }
+
+    static func selfEntry(pid: Int, port: Int, token: String,
+                          bundle: Bundle, startedAt: String) -> MCPInstance {
+        let path = bundle.bundlePath
+        let name = (bundle.object(forInfoDictionaryKey: "CFBundleName") as? String)
+            ?? URL(fileURLWithPath: path).deletingPathExtension().lastPathComponent
+        return MCPInstance(pid: pid, port: port, token: token, appPath: path,
+                           name: name, installed: isInstalled(path: path),
+                           startedAt: startedAt)
+    }
+
+    static func write(_ entry: MCPInstance) -> URL? {
+        guard let dir = directory(),
+              let data = try? JSONEncoder().encode(entry) else { return nil }
+        let url = dir.appendingPathComponent("\(entry.pid).json")
+        guard (try? data.write(to: url, options: .atomic)) != nil else { return nil }
+        try? FileManager.default.setAttributes([.posixPermissions: 0o600],
+                                               ofItemAtPath: url.path)
+        return url
+    }
+
+    /// Drop entries whose process is gone. `kill(pid, 0)` succeeds for a live
+    /// process we own and fails with ESRCH once it is reaped.
+    static func liveOnly(_ instances: [MCPInstance]) -> [MCPInstance] {
+        instances.filter { kill(pid_t($0.pid), 0) == 0 || errno == EPERM }
+    }
+
+    /// Read the directory, prune dead entries (deleting their files), return the rest.
+    static func liveDirectoryInstances() -> [MCPInstance] {
+        guard let dir = directory(),
+              let names = try? FileManager.default.contentsOfDirectory(atPath: dir.path)
+        else { return [] }
+        var found: [MCPInstance] = []
+        for n in names where n.hasSuffix(".json") {
+            let url = dir.appendingPathComponent(n)
+            guard let data = try? Data(contentsOf: url), let e = decode(data) else {
+                try? FileManager.default.removeItem(at: url)   // unreadable: not useful to anyone
+                continue
+            }
+            if liveOnly([e]).isEmpty {
+                try? FileManager.default.removeItem(at: url)
+            } else {
+                found.append(e)
+            }
+        }
+        return found.sorted { $0.pid < $1.pid }
+    }
+```
+
+In `MCPServerManager.swift`, add a stored property next to `writtenHandoff` (line 20):
+
+```swift
+    /// The registry entry this instance wrote, removed on the way out.
+    private var writtenInstanceEntry: URL?
+```
+
+Add these methods next to `writeHandoff` / `removeHandoff` (after line 325):
+
+```swift
+    /// Advertise this process in the instance registry, so a broker spawned by a
+    /// Claude client can find it without a pinned port.
+    private func writeInstanceEntry(port: Int?) {
+        guard let port else { return }
+        let stamp = ISO8601DateFormatter().string(from: Date())
+        let entry = MCPInstanceRegistry.selfEntry(
+            pid: Int(ProcessInfo.processInfo.processIdentifier), port: port,
+            token: token, bundle: .main, startedAt: stamp)
+        writtenInstanceEntry = MCPInstanceRegistry.write(entry)
+    }
+
+    private func removeInstanceEntry() {
+        if let url = writtenInstanceEntry {
+            try? FileManager.default.removeItem(at: url)
+        }
+        writtenInstanceEntry = nil
+    }
+```
+
+In `handleFeedbackEvent`, the `MCP:started` branch currently reads (around line 123):
+
+```swift
+            port = Int(detail)
+            writeHandoff(port: port)
+```
+
+Change to:
+
+```swift
+            port = Int(detail)
+            writeHandoff(port: port)
+            writeInstanceEntry(port: port)
+```
+
+Find the stop branch that calls `removeHandoff()` (around line 127, where `isRunning = false; port = nil; clientCount = 0`) and add `removeInstanceEntry()` immediately after the `removeHandoff()` call in that same branch.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run from `swiftui/`:
+```bash
+xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS -destination 'platform=macOS' -skipPackagePluginValidation -skipMacroValidation -only-testing:PyMOLViewerTests/MCPBrokerTests 2>&1 | tail -30
+```
+Expected: PASS, 20 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add swiftui/PyMOLViewer/Shared/MCPInstanceRegistry.swift swiftui/PyMOLViewer/Shared/MCPServerManager.swift swiftui/PyMOLViewerTests/MCPBrokerTests.swift
+git commit -m "feat(mcp): register each running RayMol in an instance registry"
+```
+
+---
+
+### Task 5: Broker resolves and proxies to the chosen instance
+
+**Files:**
+- Modify: `swiftui/PyMOLViewer/Shared/MCPBridge.swift:53-92` (`handoff()`, `proxy(raw:)`)
+
+**Interfaces:**
+- Consumes: `MCPInstanceRegistry.liveDirectoryInstances()`, `.resolve(instances:requestedKey:envKey:sticky:)`, `MCPTarget` (Tasks 3–4).
+- Produces: `MCPBridge.currentTarget` (private sticky state); `proxy(raw:to:)` taking an explicit `MCPInstance`.
+
+- [ ] **Step 1: Write the failing test**
+
+There is no seam to unit-test the stdio loop; this task's verification is that the existing suite still builds and passes, plus the Task 9 end-to-end harness. Add a regression test pinning the fallback contract that this task must not break — append inside `final class MCPBrokerTests`:
+
+```swift
+    // MARK: - offline contract
+
+    // The pre-existing guarantee this whole change must preserve: with nothing
+    // running, a client still gets a usable tools list, so the server never
+    // presents as errored. Task 6 adds `instance` to these schemas.
+    func testOfflineToolsListStillNamesEveryTool() {
+        let names = MCPBridge.offlineToolNames()
+        XCTAssertEqual(names, ["run_pymol_command", "run_python", "get_session_state",
+                               "capture_viewport", "search_pdb", "list_raymol_instances"])
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run from `swiftui/`:
+```bash
+xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS -destination 'platform=macOS' -skipPackagePluginValidation -skipMacroValidation -only-testing:PyMOLViewerTests/MCPBrokerTests 2>&1 | tail -30
+```
+Expected: FAIL — "type 'MCPBridge' has no member 'offlineToolNames'". (This is satisfied in Task 6; leave it failing at the end of this task only if Task 6 follows immediately — otherwise implement `offlineToolNames()` here as the one-line accessor shown in Task 6 Step 3.)
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `MCPBridge.swift`, add sticky state beside `sessionId` (after line 19):
+
+```swift
+    /// The instance this broker session is bound to. Set on first successful
+    /// resolution and reused, so a multi-instance setup is disambiguated once
+    /// per client session rather than once per call.
+    private static var boundInstance: MCPInstance? = nil
+    private static let boundLock = NSLock()
+    private static func getBound() -> MCPInstance? {
+        boundLock.lock(); defer { boundLock.unlock() }; return boundInstance
+    }
+    private static func setBound(_ i: MCPInstance?) {
+        boundLock.lock(); boundInstance = i; boundLock.unlock()
+    }
+
+    /// Resolve which RayMol this call belongs to.
+    static func resolveTarget(requestedKey: String?) -> MCPTarget {
+        let env = ProcessInfo.processInfo.environment["RAYMOL_MCP_INSTANCE"]
+        let target = MCPInstanceRegistry.resolve(
+            instances: MCPInstanceRegistry.liveDirectoryInstances(),
+            requestedKey: requestedKey, envKey: env, sticky: getBound())
+        if case .bound(let i) = target { setBound(i) } else { setBound(nil) }
+        return target
+    }
+```
+
+Replace `handoff()` (lines 55–63) with a registry-backed lookup that keeps the
+legacy file as a fallback, so a RayMol built before this change is still reachable:
+
+```swift
+    /// Legacy single-instance handoff, used only when the registry is empty —
+    /// e.g. a RayMol built before the registry existed.
+    private static func legacyHandoff() -> MCPInstance? {
+        let url = URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent("Library/Application Support/RayMol/mcp.json")
+        guard let data = try? Data(contentsOf: url),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let port = obj["port"] as? Int, let token = obj["token"] as? String
+        else { return nil }
+        return MCPInstance(pid: 0, port: port, token: token,
+                           appPath: "/Applications/RayMol.app", name: "RayMol",
+                           installed: true, startedAt: "")
+    }
+```
+
+Change `proxy(raw:)` (line 67) to take an instance:
+
+```swift
+    private static func proxy(raw: Data, to instance: MCPInstance) -> Data? {
+        guard let url = URL(string: "http://127.0.0.1:\(instance.port)/mcp") else { return nil }
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.httpBody = raw
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.setValue("Bearer \(instance.token)", forHTTPHeaderField: "Authorization")
+```
+
+The rest of `proxy` (session id handling, semaphore, 120 s timeout, cancel) is unchanged.
+
+In `response(for:method:id:raw:)` (line 96), replace the opening `if let body = proxy(raw: raw)` with:
+
+```swift
+        let target = resolveTarget(requestedKey: nil)
+        var instance: MCPInstance? = nil
+        if case .bound(let i) = target { instance = i } else { instance = legacyHandoff() }
+        if let instance, let body = proxy(raw: raw, to: instance) {
+            return body.isEmpty ? nil : body   // empty = 202 notification ack
+        }
+```
+
+Update the DELETE-on-EOF block in `run()` (lines 38–47): replace `handoff()` with
+`getBound() ?? legacyHandoff()` and use `\(h.port)` / `\(h.token)` from the returned
+`MCPInstance` (the field names are identical, so only the call site changes).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run from `swiftui/`:
+```bash
+xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS -destination 'platform=macOS' -skipPackagePluginValidation -skipMacroValidation 2>&1 | tail -30
+```
+Expected: the full suite builds and passes except `testOfflineToolsListStillNamesEveryTool`, which Task 6 satisfies.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add swiftui/PyMOLViewer/Shared/MCPBridge.swift swiftui/PyMOLViewerTests/MCPBrokerTests.swift
+git commit -m "feat(mcp): proxy through a resolved registry instance with sticky binding"
+```
+
+---
+
+### Task 6: `instance` argument, `list_raymol_instances`, ambiguity reply
+
+**Files:**
+- Modify: `swiftui/PyMOLViewer/Shared/MCPBridge.swift` (`response`, `localToolsList`)
+- Modify: `swiftui/PyMOLViewerTests/MCPBrokerTests.swift`
+
+**Interfaces:**
+- Consumes: `resolveTarget(requestedKey:)`, `MCPInstanceRegistry.keys(for:)` (Tasks 2, 5).
+- Produces:
+  - `static func offlineToolNames() -> [String]`
+  - `static func withInstanceArg(_ tools: [[String: Any]]) -> [[String: Any]]`
+  - `static func ambiguityText(_ instances: [MCPInstance]) -> String`
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside `final class MCPBrokerTests`:
+
+```swift
+    // MARK: - instance argument
+
+    func testInstanceArgIsAddedToEveryToolSchema() {
+        let injected = MCPBridge.withInstanceArg([
+            ["name": "run_python",
+             "inputSchema": ["type": "object", "properties": ["code": ["type": "string"]],
+                             "required": ["code"]]],
+        ])
+        let schema = injected[0]["inputSchema"] as? [String: Any]
+        let props = schema?["properties"] as? [String: Any]
+        XCTAssertNotNil(props?["instance"], "every tool must accept an instance override")
+        XCTAssertNotNil(props?["code"], "existing properties must survive injection")
+        // `instance` is an override, never a requirement.
+        XCTAssertEqual(schema?["required"] as? [String], ["code"])
+    }
+
+    // MARK: - ambiguity
+
+    // The reply has to be actionable without further tool calls: it names the
+    // choices AND the exact way to re-issue, or the model will just guess.
+    func testAmbiguityTextListsEveryKeyAndSaysHowToRetry() {
+        let list = MCPInstanceRegistry.decodeAll([
+            blob(pid: 1, name: "RayMol"),
+            blob(pid: 2, name: "RayMol-287", installed: false),
+        ])
+        let text = MCPBridge.ambiguityText(list)
+        XCTAssertTrue(text.contains("RayMol"))
+        XCTAssertTrue(text.contains("RayMol-287"))
+        XCTAssertTrue(text.contains("instance"))
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run from `swiftui/`:
+```bash
+xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS -destination 'platform=macOS' -skipPackagePluginValidation -skipMacroValidation -only-testing:PyMOLViewerTests/MCPBrokerTests 2>&1 | tail -30
+```
+Expected: FAIL — "has no member 'withInstanceArg'".
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `MCPBridge`:
+
+```swift
+    /// Every tool gains an optional `instance` override. The broker strips it
+    /// before forwarding, so the Python tool schemas stay untouched.
+    static func withInstanceArg(_ tools: [[String: Any]]) -> [[String: Any]] {
+        tools.map { tool in
+            var t = tool
+            var schema = (t["inputSchema"] as? [String: Any]) ?? ["type": "object"]
+            var props = (schema["properties"] as? [String: Any]) ?? [:]
+            props["instance"] = [
+                "type": "string",
+                "description": "Which running RayMol to drive (e.g. \"RayMol\", \"RayMol-287\"). "
+                    + "Omit unless list_raymol_instances shows more than one.",
+            ]
+            schema["properties"] = props     // `required` deliberately untouched
+            t["inputSchema"] = schema
+            return t
+        }
+    }
+
+    private static let listInstancesTool: [String: Any] = [
+        "name": "list_raymol_instances",
+        "description": "List running RayMol instances and the key that names each one.",
+        "inputSchema": ["type": "object", "properties": [:]],
+    ]
+
+    static func offlineToolNames() -> [String] {
+        (localToolsSpec() + [listInstancesTool]).compactMap { $0["name"] as? String }
+    }
+
+    static func ambiguityText(_ instances: [MCPInstance]) -> String {
+        let keyed = MCPInstanceRegistry.keys(for: instances)
+        let rows = instances.map { i -> String in
+            let key = keyed[i.pid] ?? String(i.pid)
+            return "  • \(key)\(i.installed ? " (installed)" : " (dev build)") — \(i.appPath)"
+        }.joined(separator: "\n")
+        return "More than one RayMol is running. Ask the user which one to drive, then "
+            + "retry with the instance argument set:\n\n\(rows)\n"
+    }
+
+    private static func instancesText(_ instances: [MCPInstance]) -> String {
+        guard !instances.isEmpty else { return "No RayMol is running." }
+        let keyed = MCPInstanceRegistry.keys(for: instances)
+        return instances.map { i in
+            "\(keyed[i.pid] ?? String(i.pid))\(i.installed ? " (installed)" : " (dev build)") "
+                + "— pid \(i.pid), port \(i.port), \(i.appPath)"
+        }.joined(separator: "\n")
+    }
+```
+
+Refactor `localToolsList(id:)` so the array literal moves into a reusable
+`localToolsSpec() -> [[String: Any]]` returning the five existing entries verbatim,
+and `localToolsList` becomes:
+
+```swift
+    private static func localToolsList(id: Any?) -> Data {
+        ok(id: id, result: ["tools": withInstanceArg(localToolsSpec()) + [listInstancesTool]])
+    }
+```
+
+In `response(for:method:id:raw:)`, before proxying, handle the broker-native tool and
+the `instance` argument. Insert at the top of the function:
+
+```swift
+        // Broker-native tool: answered here, never forwarded.
+        if method == "tools/call",
+           let params = msg["params"] as? [String: Any],
+           params["name"] as? String == "list_raymol_instances" {
+            return ok(id: id, result: ["content": [["type": "text",
+                "text": instancesText(MCPInstanceRegistry.liveDirectoryInstances())]]])
+        }
+        // Pull `instance` out of the arguments and strip it from what we forward.
+        var forward = raw
+        var requestedKey: String? = nil
+        if method == "tools/call", var msgCopy = msg,
+           var params = msgCopy["params"] as? [String: Any],
+           var args = params["arguments"] as? [String: Any],
+           let key = args["instance"] as? String {
+            requestedKey = key
+            args["instance"] = nil
+            params["arguments"] = args
+            msgCopy["params"] = params
+            forward = (try? JSONSerialization.data(withJSONObject: msgCopy)) ?? raw
+        }
+```
+
+Then change the resolution block added in Task 5 to use `requestedKey` and `forward`,
+and to answer ambiguity locally rather than proxying:
+
+```swift
+        let target = resolveTarget(requestedKey: requestedKey)
+        var instance: MCPInstance? = nil
+        switch target {
+        case .bound(let i):
+            instance = i
+        case .ambiguous(let list) where method == "tools/call":
+            return ok(id: id, result: ["content": [["type": "text",
+                "text": ambiguityText(list)]], "isError": true])
+        case .unknownKey(let key) where method == "tools/call":
+            return ok(id: id, result: ["content": [["type": "text",
+                "text": "No running RayMol named \"\(key)\". Call list_raymol_instances."]],
+                "isError": true])
+        default:
+            instance = legacyHandoff()
+        }
+        if let instance, let body = proxy(raw: forward, to: instance) {
+            return body.isEmpty ? nil : body
+        }
+```
+
+Also add `instance` to the static mirror by wrapping it — the mirror is now produced by
+`localToolsSpec()`, so `localToolsList` already injects it.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run from `swiftui/`:
+```bash
+xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS -destination 'platform=macOS' -skipPackagePluginValidation -skipMacroValidation -only-testing:PyMOLViewerTests/MCPBrokerTests 2>&1 | tail -30
+```
+Expected: PASS, 23 tests (including `testOfflineToolsListStillNamesEveryTool` from Task 5).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add swiftui/PyMOLViewer/Shared/MCPBridge.swift swiftui/PyMOLViewerTests/MCPBrokerTests.swift
+git commit -m "feat(mcp): add instance override, list_raymol_instances and ambiguity reply"
+```
+
+---
+
+### Task 7: Cold launch
+
+**Files:**
+- Modify: `swiftui/PyMOLViewer/Shared/MCPBridge.swift`
+- Modify: `swiftui/PyMOLViewerTests/MCPBrokerTests.swift`
+
+**Interfaces:**
+- Consumes: `resolveTarget(requestedKey:)`, `MCPInstanceRegistry.liveDirectoryInstances()`.
+- Produces: `static func coldLaunch(timeout: TimeInterval) -> MCPInstance?`, `static let installedAppPath: String`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside `final class MCPBrokerTests`:
+
+```swift
+    // MARK: - cold launch
+
+    // Guards the rule that opening a Claude client must NOT open RayMol: only a
+    // tool call may launch. Regressing this turns every client start into a
+    // window appearing on the user's screen.
+    func testOnlyToolsCallMayColdLaunch() {
+        XCTAssertTrue(MCPBridge.mayColdLaunch(method: "tools/call"))
+        XCTAssertFalse(MCPBridge.mayColdLaunch(method: "initialize"))
+        XCTAssertFalse(MCPBridge.mayColdLaunch(method: "tools/list"))
+        XCTAssertFalse(MCPBridge.mayColdLaunch(method: "ping"))
+        XCTAssertFalse(MCPBridge.mayColdLaunch(method: "notifications/initialized"))
+    }
+
+    func testInstalledAppPathIsTheApplicationsBundle() {
+        XCTAssertEqual(MCPBridge.installedAppPath, "/Applications/RayMol.app")
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run from `swiftui/`:
+```bash
+xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS -destination 'platform=macOS' -skipPackagePluginValidation -skipMacroValidation -only-testing:PyMOLViewerTests/MCPBrokerTests 2>&1 | tail -30
+```
+Expected: FAIL — "has no member 'mayColdLaunch'".
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `import AppKit` at the top of `MCPBridge.swift` (beside `import Foundation`), then add:
+
+```swift
+    static let installedAppPath = "/Applications/RayMol.app"
+
+    /// Opening a client must not open RayMol. Launching is a consequence of
+    /// asking RayMol to DO something, so only tools/call qualifies.
+    static func mayColdLaunch(method: String) -> Bool { method == "tools/call" }
+
+    /// Launch the installed app and wait for it to register. Returns nil on a
+    /// missing bundle or on timeout; the caller turns that into a tool error.
+    static func coldLaunch(timeout: TimeInterval = 20) -> MCPInstance? {
+        let url = URL(fileURLWithPath: installedAppPath)
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        // The broker IS RayMol's binary, so this writes RayMol's own defaults
+        // domain — the launched app auto-starts its server even on a machine
+        // where MCP has never been switched on.
+        UserDefaults.standard.set(true, forKey: "raymol.mcp.enabled")
+        UserDefaults.standard.synchronize()
+
+        let cfg = NSWorkspace.OpenConfiguration()
+        cfg.activates = true
+        let sem = DispatchSemaphore(value: 0)
+        // Racing brokers are harmless: openApplication on an already-launching
+        // app activates it, so both converge on one instance.
+        NSWorkspace.shared.openApplication(at: url, configuration: cfg) { _, _ in sem.signal() }
+        _ = sem.wait(timeout: .now() + 10)
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            let live = MCPInstanceRegistry.liveDirectoryInstances()
+            if let hit = live.first(where: { $0.installed }) ?? live.first { return hit }
+            Thread.sleep(forTimeInterval: 0.4)
+        }
+        return nil
+    }
+```
+
+In `response(for:method:id:raw:)`, extend the `.none` path so a tool call launches.
+Replace the `default:` arm of the `switch target` block from Task 6 with:
+
+```swift
+        case .none where mayColdLaunch(method: method):
+            if let launched = coldLaunch() {
+                setBound(launched)
+                instance = launched
+            } else {
+                let exists = FileManager.default.fileExists(atPath: installedAppPath)
+                return ok(id: id, result: ["content": [["type": "text",
+                    "text": exists
+                        ? "RayMol opened but its MCP server didn't start within 20s. "
+                          + "In RayMol, turn on Connect ▸ Enable AI control, then retry."
+                        : "RayMol isn't installed at \(installedAppPath). Install it, then retry."]],
+                    "isError": true])
+            }
+        default:
+            instance = legacyHandoff()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run from `swiftui/`:
+```bash
+xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS -destination 'platform=macOS' -skipPackagePluginValidation -skipMacroValidation -only-testing:PyMOLViewerTests/MCPBrokerTests 2>&1 | tail -30
+```
+Expected: PASS, 25 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add swiftui/PyMOLViewer/Shared/MCPBridge.swift swiftui/PyMOLViewerTests/MCPBrokerTests.swift
+git commit -m "feat(mcp): cold-launch the installed RayMol on a tool call"
+```
+
+---
+
+### Task 8: Registration paths
+
+**Files:**
+- Modify: `swiftui/PyMOLViewer/Shared/MCPDesktopInstaller.swift:7-9`
+- Modify: `swiftui/PyMOLViewer/Shared/MCPServerManager.swift:194-232`
+- Modify: `swiftui/PyMOLViewerTests/MCPBrokerTests.swift`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `MCPDesktopInstaller.bridgeCommand()` prefers the installed app; `connectClaudeCode` registers a stdio server.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside `final class MCPBrokerTests`:
+
+```swift
+    // MARK: - registration
+
+    // The desktop-app failure this change exists to fix: a Debug build in a
+    // worktree wrote its OWN path into claude_desktop_config.json, and Claude
+    // reported a hard error once that build directory was cleaned.
+    func testBridgeCommandPrefersTheInstalledApp() {
+        XCTAssertEqual(
+            MCPDesktopInstaller.preferredCommand(
+                installedExists: true,
+                running: "/Users/x/build_mac_dd/Build/Products/Debug/RayMol.app/Contents/MacOS/RayMol"),
+            "/Applications/RayMol.app/Contents/MacOS/RayMol")
+    }
+
+    func testBridgeCommandFallsBackToTheRunningBundle() {
+        XCTAssertEqual(
+            MCPDesktopInstaller.preferredCommand(installedExists: false, running: "/tmp/R.app/C/MacOS/R"),
+            "/tmp/R.app/C/MacOS/R")
+    }
+
+    // Claude Code must be registered as a spawnable stdio command, never as a
+    // pinned loopback URL — the URL is what goes stale on every restart.
+    func testClaudeCodeArgsRegisterStdioNotHttp() {
+        let args = MCPServerManager.claudeCodeAddArgs(command: "/Applications/RayMol.app/Contents/MacOS/RayMol")
+        XCTAssertFalse(args.contains("--transport"))
+        XCTAssertFalse(args.contains(where: { $0.contains("127.0.0.1") }))
+        XCTAssertEqual(args.prefix(3).map { $0 }, ["mcp", "add", "raymol"])
+        XCTAssertTrue(args.contains("--"))
+        XCTAssertEqual(args.last, "--mcp-bridge")
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run from `swiftui/`:
+```bash
+xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS -destination 'platform=macOS' -skipPackagePluginValidation -skipMacroValidation -only-testing:PyMOLViewerTests/MCPBrokerTests 2>&1 | tail -30
+```
+Expected: FAIL — "has no member 'preferredCommand'".
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `MCPDesktopInstaller.swift`, replace `bridgeCommand()`:
+
+```swift
+    static let installedCommand = "/Applications/RayMol.app/Contents/MacOS/RayMol"
+
+    /// Pure: which binary a client should be told to spawn.
+    ///
+    /// Prefers the installed app. Without this a dev build run from a worktree
+    /// registers its own throwaway path, and the client hard-errors the moment
+    /// that build directory is cleaned.
+    static func preferredCommand(installedExists: Bool, running: String?) -> String {
+        if installedExists { return installedCommand }
+        return running ?? installedCommand
+    }
+
+    static func bridgeCommand() -> String {
+        preferredCommand(
+            installedExists: FileManager.default.fileExists(atPath: installedCommand),
+            running: Bundle.main.executablePath)
+    }
+```
+
+In `MCPServerManager.swift`, add the pure argument builder next to `connectClaudeCode`:
+
+```swift
+    /// Pure: the `claude mcp add` arguments. Stdio, so the entry stays valid
+    /// across RayMol restarts and closures — the broker is spawned on demand and
+    /// finds the live instance itself.
+    static func claudeCodeAddArgs(command: String) -> [String] {
+        ["mcp", "add", "raymol", "--scope", "user", "--", command, "--mcp-bridge"]
+    }
+```
+
+Rewrite the body of `connectClaudeCode`. The `guard isRunning` precondition is removed —
+the whole point is that this now works regardless of server state — and the trust calls
+stay, since a user-initiated connect should still be auto-trusted:
+
+```swift
+    func connectClaudeCode(completion: @escaping (String) -> Void) {
+        // noteUserInitiatedConnect sets UI state — keep it synchronous on the main thread.
+        noteUserInitiatedConnect()
+        if isRunning {
+            // pushTrusted calls runPython which must run on the main thread.
+            pushTrusted()
+        }
+        let command = MCPDesktopInstaller.bridgeCommand()
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self else { return }
+            self.installSkillFile()
+            let args = Self.claudeCodeAddArgs(command: command)
+            let manual = "claude " + args.joined(separator: " ")
+            guard let claude = Self.findClaude() else {
+                DispatchQueue.main.async {
+                    completion("Claude Code CLI not found. Run this in a terminal:\n\n\(manual)")
+                }
+                return
+            }
+            // Idempotent, and REQUIRED: an older pinned-HTTP entry would otherwise survive.
+            _ = Self.runClaude(claude, ["mcp", "remove", "raymol", "--scope", "user"])
+            let (code, out) = Self.runClaude(claude, args)
+            let msg: String
+            if code == 0 {
+                msg = "Connected. In Claude Code, run /mcp (or restart it) to pick up RayMol, "
+                    + "then ask it to load and view a structure."
+            } else {
+                msg = "claude exited \(code): \(out)\n\nManual command:\n\(manual)"
+            }
+            DispatchQueue.main.async { completion(msg) }
+        }
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run from `swiftui/`:
+```bash
+xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS -destination 'platform=macOS' -skipPackagePluginValidation -skipMacroValidation 2>&1 | tail -30
+```
+Expected: PASS, full suite (28 broker tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add swiftui/PyMOLViewer/Shared/MCPDesktopInstaller.swift swiftui/PyMOLViewer/Shared/MCPServerManager.swift swiftui/PyMOLViewerTests/MCPBrokerTests.swift
+git commit -m "fix(mcp): register the installed app over stdio for both Claude clients"
+```
+
+---
+
+### Task 9: End-to-end verification and config repair
+
+**Files:**
+- Create: `swiftui/tools/mcp_broker_e2e.sh`
+- Modify: `~/Library/Application Support/Claude/claude_desktop_config.json` (user machine, not the repo)
+- Modify: `~/.claude.json` (user machine, not the repo)
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: a repeatable harness proving cold launch works end to end.
+
+- [ ] **Step 1: Write the harness**
+
+Create `swiftui/tools/mcp_broker_e2e.sh`:
+
+```bash
+#!/bin/bash
+# End-to-end check for the MCP broker: with NO RayMol running, a tools/call
+# piped into `RayMol --mcp-bridge` must launch the installed app, wait for it
+# to register, and return a result.
+#
+# Usage: swiftui/tools/mcp_broker_e2e.sh [/path/to/RayMol.app/Contents/MacOS/RayMol]
+set -uo pipefail
+BIN="${1:-/Applications/RayMol.app/Contents/MacOS/RayMol}"
+REG="$HOME/Library/Application Support/RayMol/instances"
+
+echo "== quitting every RayMol =="
+osascript -e 'tell application "RayMol" to quit' 2>/dev/null
+pkill -x RayMol 2>/dev/null
+sleep 3
+echo "registry after quit: $(ls "$REG" 2>/dev/null | wc -l | tr -d ' ') entries"
+
+echo "== initialize + tools/list must NOT launch anything =="
+printf '%s\n%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+  | "$BIN" --mcp-bridge | head -2
+sleep 2
+if pgrep -x RayMol >/dev/null; then echo "FAIL: a client handshake launched RayMol"; exit 1; fi
+echo "OK: handshake did not launch RayMol"
+
+echo "== tools/call must cold-launch =="
+printf '%s\n%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_session_state","arguments":{}}}' \
+  | "$BIN" --mcp-bridge | tail -1
+pgrep -x RayMol >/dev/null && echo "OK: RayMol is running" || { echo "FAIL: not launched"; exit 1; }
+echo "registry now: $(ls "$REG" 2>/dev/null | wc -l | tr -d ' ') entries"
+```
+
+Make it executable: `chmod +x swiftui/tools/mcp_broker_e2e.sh`.
+
+- [ ] **Step 2: Build and install the app under test**
+
+```bash
+cd swiftui && ./build_macos.sh && xcodegen generate && xcodebuild build -project PyMOLViewer.xcodeproj -scheme PyMOLViewer_macOS -destination 'platform=macOS' -skipPackagePluginValidation -skipMacroValidation 2>&1 | tail -5
+```
+
+The harness drives `/Applications/RayMol.app`, which must be a build containing this
+work. Copy the built bundle there, or run the harness against the built binary path and
+temporarily point `MCPBridge.installedAppPath` at it — do NOT ship that change.
+
+- [ ] **Step 3: Run the harness**
+
+```bash
+swiftui/tools/mcp_broker_e2e.sh 2>&1 | tail -20
+```
+Expected: "OK: handshake did not launch RayMol", then "OK: RayMol is running", and a
+registry entry count of 1. The first cold-launch will surface RayMol's Allow prompt —
+click Allow and re-run to see a successful `get_session_state` payload. Record both the
+pre-approval and post-approval outputs in the PR description.
+
+- [ ] **Step 4: Verify the ambiguity path**
+
+With the installed app running, build and launch a suffixed dev build per the naming
+rule in `CLAUDE.md` (`RayMol-broker.app`, re-signed), then repeat the `tools/call` line
+from the harness. Expected: an `isError` result whose text lists both `RayMol` and
+`RayMol-broker` and mentions the `instance` argument. Then re-issue with
+`"arguments":{"instance":"RayMol-broker"}` and confirm it succeeds.
+
+- [ ] **Step 5: Repair the two live configs**
+
+```bash
+/Applications/RayMol.app/Contents/MacOS/RayMol --mcp-emit-config
+```
+Confirm the emitted command is `/Applications/RayMol.app/Contents/MacOS/RayMol`, then
+write it through the app's own Connect flow (or by hand) so
+`claude_desktop_config.json` no longer points into `build_mac_dd`. For Claude Code:
+
+```bash
+claude mcp remove raymol --scope user; claude mcp add raymol --scope user -- /Applications/RayMol.app/Contents/MacOS/RayMol --mcp-bridge
+```
+Verify `~/.claude.json` no longer contains `127.0.0.1:51737`.
+
+- [ ] **Step 6: Commit and open the PR**
+
+```bash
+git add swiftui/tools/mcp_broker_e2e.sh
+git commit -m "test(mcp): add end-to-end cold-launch harness for the broker"
+gh pr create -R javierbq/RayMol --base master --title "MCP broker: reach RayMol even when it is closed" --body "$(cat <<'BODY'
+Implements docs/superpowers/specs/2026-08-19-raymol-mcp-broker-design.md.
+
+Registry-backed instance discovery, cold launch of the installed app on the
+first tool call, `instance` override plus `list_raymol_instances`, and stdio
+registration for both Claude clients (replacing the pinned-HTTP Claude Code
+entry and the worktree-path desktop entry).
+
+Verification: unit suite plus swiftui/tools/mcp_broker_e2e.sh output, pasted below.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** Registry file + fields → Task 4. Broker resolution order → Task 3, wired in Task 5. Ambiguity listing → Task 6. Instance keys with `#pid` collisions → Task 2. `instance` injection/stripping + `list_raymol_instances` → Task 6. Cold launch, defaults flip, 20 s poll, no launch lock → Task 7. Only-`tools/call`-launches → Task 7. Trust unchanged → no task sets `set_trusted`; asserted by the Task 9 Allow-prompt step. Error table → Tasks 6–7 (`ambiguous`, `unknownKey`, missing bundle, timeout) and Task 4 (`liveDirectoryInstances` prunes corrupt and dead entries). Migration → Task 8 plus Task 9 Step 5. Testing → Tasks 1–8 unit tests, Task 9 end-to-end.
+
+**Gap found and closed.** The spec lists "port returns 401 (stale token) → prune, rescan". Pid-liveness alone misses a pid that was recycled by an unrelated process. `liveDirectoryInstances` prunes dead pids only; the 401 case is left to `proxy` returning nil, which falls through to `legacyHandoff` and then to the offline reply. That is acceptable behavior but is NOT what the spec says. Task 5's `proxy` therefore must be treated as the 401 handler — the implementer should clear the sticky binding on a nil proxy result so the next call re-resolves. Add this to Task 5 Step 3: in `response`, on `proxy(...) == nil`, call `setBound(nil)` before falling through.
+
+**Placeholder scan.** No TBD/TODO. Every code step carries real code. Task 5 Step 1 honestly states it has no unit seam rather than inventing one.
+
+**Type consistency.** `MCPInstance` field names are identical across Tasks 1, 4, 5, 7. `resolve(instances:requestedKey:envKey:sticky:)` is called with the same label set in Tasks 3 and 5. `MCPTarget` cases match between Task 3's definition and Tasks 5–7's switches. `localToolsSpec()` is introduced in Task 6 and referenced only there and by `offlineToolNames()`.

--- a/docs/superpowers/specs/2026-08-19-raymol-mcp-broker-design.md
+++ b/docs/superpowers/specs/2026-08-19-raymol-mcp-broker-design.md
@@ -120,6 +120,11 @@ same injection.
 
 ## Cold launch and trust
 
+Only `tools/call` cold-launches. `initialize`, `tools/list` and `ping` are
+answered locally when no instance is live, so merely opening a Claude client
+never opens RayMol — it only stops showing an error. Launching is a
+consequence of asking RayMol to do something.
+
 Triggered by a tool call that resolves to zero instances:
 
 1. The broker sets `raymol.mcp.enabled = true` in its own `UserDefaults`. The

--- a/docs/superpowers/specs/2026-08-19-raymol-mcp-broker-design.md
+++ b/docs/superpowers/specs/2026-08-19-raymol-mcp-broker-design.md
@@ -1,0 +1,203 @@
+# RayMol MCP Broker — Design
+
+Date: 2026-08-19
+
+## Problem
+
+Opening a Claude client while RayMol is closed produces an MCP error. Two
+separate defects cause it.
+
+**Claude Code.** `MCPServerManager.connectClaudeCode` registers RayMol as a
+direct HTTP endpoint — `--transport http http://127.0.0.1:<port>/mcp` plus a
+bearer token — capturing a snapshot of an ephemeral port. The entry is wrong
+whenever RayMol is closed, and goes stale whenever RayMol restarts on a
+different port. The live `~/.claude.json` on the development machine pins
+port 51737.
+
+**Claude desktop app.** `MCPDesktopInstaller.bridgeCommand()` returns
+`Bundle.main.executablePath`, so whichever build ran the install — including a
+Debug build inside a git worktree — writes its own path into
+`claude_desktop_config.json`. The live config points at
+`.../build_mac_dd/Build/Products/Debug/RayMol.app/Contents/MacOS/RayMol`.
+When that build directory is cleaned, Claude cannot spawn the command and
+reports a hard error.
+
+The stdio bridge itself (`MCPBridge`) already degrades correctly when RayMol is
+absent: it answers `initialize`, `tools/list` and `ping` locally and returns a
+friendly message for tool calls. What it cannot do is *start* RayMol, and it
+resolves exactly one target through a single `mcp.json` handoff file.
+
+## Non-goal: a resident login-item daemon
+
+The originating idea was a companion executable launched at login that owns the
+MCP endpoint permanently. A resident process buys exactly one capability: a
+stable endpoint for a client that cannot spawn a process. Both target clients —
+the Claude desktop app and the Claude Code CLI — spawn stdio servers. A daemon
+would therefore add a login item, a crash/restart story, an update story, and a
+second artifact to sign and notarize, in exchange for no capability that is
+used.
+
+The existing `--mcp-bridge` stdio proxy already provides the always-available
+endpoint, because the client spawns it on demand. This design hardens that
+proxy into a broker rather than introducing a daemon. If a non-spawning client
+(remote session, another machine, plain `curl`) becomes a requirement, the
+registry defined below is the part a daemon would need, and this design does
+not preclude adding one later.
+
+## Architecture
+
+Three components. The registry is the only shared surface: RayMol never knows a
+broker exists, and the broker reaches RayMol only over its documented loopback
+MCP endpoint.
+
+### Instance registry (RayMol side)
+
+Every running RayMol whose MCP server is up writes
+
+```
+~/Library/Application Support/RayMol/instances/<pid>.json
+{ "pid": 4412, "port": 51737, "token": "…", "appPath": "/Applications/RayMol.app",
+  "name": "RayMol", "installed": true, "startedAt": "2026-08-19T10:31:02Z" }
+```
+
+with mode 0600. Written when the `MCP:started` feedback event arrives and
+removed on stop and on quit — the same lifecycle as today's
+`writeHandoff`/`removeHandoff`, generalized from one canonical file to one file
+per instance. `mcp.json` continues to be written exactly as it is today, so
+existing readers are unaffected.
+
+`name` is the bundle display name, so suffixed development builds
+(`RayMol-287.app`, `RayMol-PR290.app`) self-identify. `installed` is true when
+`appPath` is under `/Applications`.
+
+### Broker (`RayMol --mcp-bridge`)
+
+`MCPBridge` grows from "proxy to a fixed handoff file" into "resolve a target,
+launch it when absent, then proxy". It remains a stdio process spawned per
+client session. Its existing offline behavior — local `initialize`,
+`tools/list`, `ping` — is retained as the fallback when resolution fails, so the
+server never presents as errored.
+
+### Client registration
+
+Both clients register the same stdio command. `connectClaudeCode` stops
+registering an HTTP transport and registers the broker command instead, which is
+what makes the Claude Code entry survive RayMol closures and restarts.
+
+## Target selection
+
+Resolution order, first hit wins:
+
+1. **Explicit `instance` argument** on the tool call — an in-conversation
+   override, so naming a build rebinds mid-session.
+2. **`RAYMOL_MCP_INSTANCE`** environment variable — for scripted and VM setups
+   that cannot pass arguments.
+3. **Sticky binding** — once a broker process resolves a target it stays bound
+   for the life of the client session. Without this, disambiguation would be
+   requested on every call.
+4. **Registry scan.**
+
+Scan outcomes:
+
+- **Exactly one live instance** — bind it, sticky. A running development build
+  therefore wins over an idle installed app, which is the desired behavior
+  during testing.
+- **Zero** — cold-launch the installed app (below).
+- **Two or more** — return a tool result with `isError: true` listing each
+  instance and its key, instructing the model to ask the user and re-issue with
+  `instance:`. No silent tie-break: guessing wrong drives the wrong window,
+  which the user may not notice.
+
+**Instance keys** are the bundle display name (`RayMol`, `RayMol-287`). On a
+name collision the key becomes `RayMol#4412`. A bare pid is always accepted.
+
+**Tool surface.** The broker injects an optional `instance` string property into
+every tool's `inputSchema` and strips it before forwarding, so
+`modules/raymol_mcp/tools.py` requires no change. The broker additionally serves
+one native tool, `list_raymol_instances`, so targets can be enumerated without a
+failed call first. The static mirror in `MCPBridge.localToolsList` receives the
+same injection.
+
+## Cold launch and trust
+
+Triggered by a tool call that resolves to zero instances:
+
+1. The broker sets `raymol.mcp.enabled = true` in its own `UserDefaults`. The
+   broker process is RayMol's own binary and therefore shares RayMol's defaults
+   domain, so the launched app auto-starts its server even where it has never
+   been enabled. No environment-variable or `open` argument passing is required.
+2. Launch `/Applications/RayMol.app` via `NSWorkspace.openApplication`.
+3. Poll the registry for a fresh entry, ceiling 20 seconds. Engine
+   initialization plus Python server start is slow enough that a short timeout
+   would flake.
+4. Bind, then forward the original call. The client observes one slow call
+   rather than an error.
+
+No launch lock is required: `openApplication` on an already-launching app
+activates it, so two brokers racing converge on one instance.
+
+**Trust remains a human gate.** A model-initiated cold launch is not a
+user-initiated connect, so `initialize` raises RayMol's normal Allow prompt, and
+`server.py` already answers untrusted `tools/call` with a retry instruction that
+the broker forwards verbatim. The cold path is therefore: tool call → RayMol
+opens → user clicks Allow → retry succeeds. `noteUserInitiatedConnect` exists to
+skip that prompt for connections the user started, and correctly does not apply
+here. A cold start costs one click; a background tool call must not silently
+acquire control of a newly opened app.
+
+## Error handling
+
+Every failure returns an actionable tool result. The server is never dead.
+
+| Condition | Behavior |
+|---|---|
+| Corrupt or unreadable registry entry | Skip the entry, continue scanning |
+| Entry pid dead, or port returns 401 (stale token) | Prune the file, rescan |
+| `/Applications/RayMol.app` missing on cold launch | `isError` naming the expected path |
+| Launch succeeds, no registration within 20 s | `isError` — open Connect ▸ Enable AI control |
+| Two or more instances | Ambiguity listing |
+| RayMol quits mid-session | Sticky binding drops; next call re-resolves and cold-launches |
+
+The existing 120-second proxy timeout in `MCPBridge.proxy` is unchanged.
+
+## Migration
+
+Neither live configuration self-heals until Connect is re-run, so both need a
+one-time repair alongside the code changes.
+
+- `MCPDesktopInstaller.bridgeCommand()` prefers
+  `/Applications/RayMol.app/Contents/MacOS/RayMol` when it exists, falling back
+  to the running bundle only when no installed app is present. This is the root
+  cause of the desktop-app failure.
+- `connectClaudeCode` runs `claude mcp remove raymol` before adding, so the
+  stale HTTP entry is replaced rather than shadowed.
+- The two configurations on the development machine are repaired by hand as part
+  of the work.
+
+## Testing
+
+Resolution logic is pure and unit-tested in
+`swiftui/PyMOLViewerTests/MCPBrokerTests.swift`:
+
+- registry parse and stale-prune, including a corrupt entry and a dead pid
+- key disambiguation, including the `RayMol#<pid>` collision case
+- `instance` argument injection and stripping
+- the ambiguity payload shape
+- `MCPBridge.localToolsList` matches `TOOLS` in `modules/raymol_mcp/tools.py`
+
+End-to-end verification is performed by the implementer, not delegated to the
+user: with every RayMol quit, raw JSON-RPC lines are piped into
+`RayMol --mcp-bridge` from a shell harness, asserting that RayMol launches,
+registers, and the tool call returns. The same harness covers the two-instance
+ambiguity case by launching a suffixed development build alongside the installed
+app.
+
+## Files touched
+
+- `swiftui/PyMOLViewer/Shared/MCPBridge.swift` — broker resolution, cold launch,
+  `instance` injection, `list_raymol_instances`
+- `swiftui/PyMOLViewer/Shared/MCPServerManager.swift` — registry write/remove,
+  `connectClaudeCode` registers stdio and removes the stale entry first
+- `swiftui/PyMOLViewer/Shared/MCPDesktopInstaller.swift` — `bridgeCommand()`
+  prefers the installed app
+- `swiftui/PyMOLViewerTests/MCPBrokerTests.swift` — new

--- a/docs/superpowers/specs/2026-08-19-raymol-mcp-broker-design.md
+++ b/docs/superpowers/specs/2026-08-19-raymol-mcp-broker-design.md
@@ -127,19 +127,37 @@ consequence of asking RayMol to do something.
 
 Triggered by a tool call that resolves to zero instances:
 
-1. The broker sets `raymol.mcp.enabled = true` in its own `UserDefaults`. The
-   broker process is RayMol's own binary and therefore shares RayMol's defaults
-   domain, so the launched app auto-starts its server even where it has never
-   been enabled. No environment-variable or `open` argument passing is required.
-2. Launch `/Applications/RayMol.app` via `NSWorkspace.openApplication`.
-3. Poll the registry for a fresh entry, ceiling 20 seconds. Engine
+1. **Try the legacy handoff first.** A RayMol built before the registry existed
+   never registers, so the scan reports zero while the user is actively working
+   in it. Launching a second copy on top of that is worse than any error, so
+   cold launch is the last resort, not the first.
+2. If this exact bundle is already running and still unregistered, do NOT
+   launch — its MCP server is simply off. Report that, naming the setting.
+3. Launch via `NSWorkspace.openApplication` with
+   `createsNewApplicationInstance = true`. Every RayMol build shares
+   `CFBundleIdentifier = io.raymol.RayMol`, so without it LaunchServices
+   "opens" an already-running build from another checkout and never starts the
+   requested bundle. The launch error is captured, never discarded.
+4. The launched app is given `RAYMOL_MCP_ENABLE=1` through
+   `OpenConfiguration.environment` rather than having `raymol.mcp.enabled`
+   written to its defaults. Persisting that preference would silently make every
+   future *manual* launch start the MCP server too — a setting the user never
+   chose. The environment carries the intent and dies with the process.
+5. Poll the registry for a fresh entry, ceiling 20 seconds. Engine
    initialization plus Python server start is slow enough that a short timeout
    would flake.
-4. Bind, then forward the original call. The client observes one slow call
+6. Bind, then forward the original call. The client observes one slow call
    rather than an error.
 
-No launch lock is required: `openApplication` on an already-launching app
-activates it, so two brokers racing converge on one instance.
+Each failure names its own cause — not installed, launch failed (with the
+LaunchServices error), already running with the server off, or timed out.
+Collapsing them sends the user to a setting that is not the problem.
+
+No launch lock is required: two brokers racing converge on one instance.
+
+`RAYMOL_MCP_INSTALLED_APP` overrides the launch target. Dev/testing only, like
+`RAYMOL_MCP_PORT`, and it exists so the end-to-end harness can drive a suffixed
+dev build instead of overwriting the user's installed RayMol.
 
 **Trust remains a human gate.** A model-initiated cold launch is not a
 user-initiated connect, so `initialize` raises RayMol's normal Allow prompt, and
@@ -162,6 +180,9 @@ Every failure returns an actionable tool result. The server is never dead.
 | Launch succeeds, no registration within 20 s | `isError` — open Connect ▸ Enable AI control |
 | Two or more instances | Ambiguity listing |
 | RayMol quits mid-session | Sticky binding drops; next call re-resolves and cold-launches |
+| Bundle already running but unregistered | `isError` — its MCP server is off, naming Connect ▸ Enable AI control |
+| `NSWorkspace` refuses the launch | `isError` carrying the LaunchServices error, not a server-didn't-start message |
+| A pre-registry RayMol is running | Proxied through the legacy `mcp.json` handoff; no second copy is launched |
 
 The existing 120-second proxy timeout in `MCPBridge.proxy` is unchanged.
 

--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		13C5A803C8072DE180EB23CC /* ProtenixRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7845A3EB6A6BF8A14F090062 /* ProtenixRuntime.swift */; };
 		13E8687216067D92666E3078 /* openssl-PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = CB0108E0FA1F204BE0E41F0D /* openssl-PrivacyInfo.xcprivacy */; };
 		142D8657C5BC7DCD8648D407 /* DesignCompactPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D7FF883D3762DC6E40908F /* DesignCompactPanel.swift */; };
+		14E9A7601449E73C41862378 /* MCPInstanceRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2022B9A20AF8BBA7247B08C /* MCPInstanceRegistry.swift */; };
 		154E7F765059977CA80711DA /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 98AC6A7391B7E7A564A30A61 /* Sparkle */; };
 		1624BC38CDD73398C68FC135 /* MPNNGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56BE219EF1CF1EB2B05E44AD /* MPNNGate.swift */; };
 		174EA423F2E0ED999474C506 /* DesignInferenceSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45634C95AE991CC91CFBA75 /* DesignInferenceSmokeTests.swift */; };
@@ -164,6 +165,7 @@
 		D3F658C89098D8D9A4022C9A /* DesignResidues.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFE9998F68625C92B8BCD710 /* DesignResidues.swift */; };
 		D48D80E395852871CAC65FCA /* DesignColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F2DF248B756BF6CA3CBE92 /* DesignColor.swift */; };
 		D50987A4819C8D752F68443F /* whatsnew-190-design.png in Resources */ = {isa = PBXBuildFile; fileRef = 2B749BA43350521D047F2CE4 /* whatsnew-190-design.png */; };
+		D98919F8A192EB35CD9CB40C /* MCPInstanceRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2022B9A20AF8BBA7247B08C /* MCPInstanceRegistry.swift */; };
 		DA6EB8C81B26582A4F3AB478 /* TimelinePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B820FE9080BF73526A54CD66 /* TimelinePanel.swift */; };
 		DC5CF59CDC22D0FCB6A58BE5 /* whatsnew-190-design.png in Resources */ = {isa = PBXBuildFile; fileRef = 2B749BA43350521D047F2CE4 /* whatsnew-190-design.png */; };
 		DC8A9C1AA5EB1946175041FA /* CommandPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50D264C420888CBF7FDE633 /* CommandPanel.swift */; };
@@ -173,6 +175,7 @@
 		E7A7CA409C1DB4D1A78AD5B9 /* DesignController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4FB7F151982A2927D612F0 /* DesignController.swift */; };
 		E9B0CF8BC5F291107F7C872B /* NotesInspectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DC456EDC3E55F84506C8B7 /* NotesInspectorView.swift */; };
 		EB6435B2880C450F33F0291F /* whatsnew-152-camera-dock.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 29DBC7BEEA492BFACB616C34 /* whatsnew-152-camera-dock.mp4 */; };
+		EB8B9F29717716305D4E1F2E /* MCPBrokerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5107B8EA82B24150FDA5AA0 /* MCPBrokerTests.swift */; };
 		EC4EF850FC58B240AD02346F /* RayMolMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9371B6FFB30D6166234C678B /* RayMolMain.swift */; };
 		EE156FFB12BEFB4FC132D610 /* whatsnew-170-move.png in Resources */ = {isa = PBXBuildFile; fileRef = 4C570F9CAC877E201F237016 /* whatsnew-170-move.png */; };
 		EF5E8D2D6A7BA6B77D164707 /* AnalysisNotesStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC011374F5FD9F008437F037 /* AnalysisNotesStoreTests.swift */; };
@@ -276,6 +279,7 @@
 		9A2CE99D9A3C57ACBBDBF3B5 /* DesignRegionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignRegionTests.swift; sourceTree = "<group>"; };
 		9B2D0B8DEF98F905922AE2FD /* ProtenixJobManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtenixJobManager.swift; sourceTree = "<group>"; };
 		9E69AA2C12DC2D1583FBF8C8 /* DesignSizeGuard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSizeGuard.swift; sourceTree = "<group>"; };
+		A2022B9A20AF8BBA7247B08C /* MCPInstanceRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPInstanceRegistry.swift; sourceTree = "<group>"; };
 		A2367C4CEE5BD2E682055D3F /* BoltzRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoltzRuntime.swift; sourceTree = "<group>"; };
 		A4857D1284B60EB0C750C02F /* ProgressTray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressTray.swift; sourceTree = "<group>"; };
 		A4CC639810B19E8F5E637E93 /* CopyRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyRouting.swift; sourceTree = "<group>"; };
@@ -286,6 +290,7 @@
 		B158150C93613716ED3CE572 /* KeyboardDismissUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardDismissUITests.swift; sourceTree = "<group>"; };
 		B45634C95AE991CC91CFBA75 /* DesignInferenceSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignInferenceSmokeTests.swift; sourceTree = "<group>"; };
 		B50D264C420888CBF7FDE633 /* CommandPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPanel.swift; sourceTree = "<group>"; };
+		B5107B8EA82B24150FDA5AA0 /* MCPBrokerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPBrokerTests.swift; sourceTree = "<group>"; };
 		B820FE9080BF73526A54CD66 /* TimelinePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelinePanel.swift; sourceTree = "<group>"; };
 		B9EC978B16F58D988575E206 /* MCPDrivingBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPDrivingBanner.swift; sourceTree = "<group>"; };
 		BB5ABD1A8C45E5BC97AB0B80 /* RayMol.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = RayMol.icon; sourceTree = "<group>"; };
@@ -319,7 +324,7 @@
 		F7E41DCBB427678A8F018B0E /* DesignControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignControllerTests.swift; sourceTree = "<group>"; };
 		FB1304C662D9011F7C4505FC /* MCPStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPStatusView.swift; sourceTree = "<group>"; };
 		FF4FB7F151982A2927D612F0 /* DesignController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignController.swift; sourceTree = "<group>"; };
-		"TEMP_10A06E48-389B-40FD-B69A-488BA0D818F9" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
+		"TEMP_6C2EFEBD-6BF9-4DFC-B8A3-432FDAEA946A" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -455,6 +460,7 @@
 				3697F74BD2283492B5A7790C /* KeyRouting.swift */,
 				1A18D8A6B0FB56FCD3C31211 /* MCPBridge.swift */,
 				786939619F7871E32E2BB123 /* MCPDesktopInstaller.swift */,
+				A2022B9A20AF8BBA7247B08C /* MCPInstanceRegistry.swift */,
 				14F3D56C490BC7C6166DD79F /* MCPServerManager.swift */,
 				5E9F8D36908E3216D1C8F893 /* MetalViewport.swift */,
 				86E93358875495F499780A00 /* MLXRuntime.swift */,
@@ -503,6 +509,7 @@
 				F43E4051E6410834AAAA4047 /* InteractionModeExitTests.swift */,
 				1FF072CB363743CAF805155E /* KeyBindingDispatchTests.swift */,
 				F61B9A042E88CAE1E21BC506 /* KeyRoutingTests.swift */,
+				B5107B8EA82B24150FDA5AA0 /* MCPBrokerTests.swift */,
 				0C47FBC551127AB2D73BC6CE /* MetalViewportResponderTests.swift */,
 				7AD9869000B548D9F7CDF9DE /* MLXRuntimeTests.swift */,
 				4A2C1E1633D1E93E9914BEC3 /* OpenFilesTests.swift */,
@@ -537,10 +544,10 @@
 			path = Bridge;
 			sourceTree = "<group>";
 		};
-		"TEMP_EF6349F2-C8F5-427B-87FC-D5436E08DB23" /* swiftui */ = {
+		"TEMP_C0AB4A87-2686-4B50-92BA-13EB6284CCB1" /* swiftui */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_10A06E48-389B-40FD-B69A-488BA0D818F9" /* PyMOLBridge.xcconfig */,
+				"TEMP_6C2EFEBD-6BF9-4DFC-B8A3-432FDAEA946A" /* PyMOLBridge.xcconfig */,
 			);
 			path = swiftui;
 			sourceTree = "<group>";
@@ -1214,6 +1221,7 @@
 				57E2333020DE9DC8910BDC3E /* InteractionModeExitTests.swift in Sources */,
 				CAC9B9F8A93BC4B71C3DB0D6 /* KeyBindingDispatchTests.swift in Sources */,
 				EF9A088B19E39220CC72469D /* KeyRoutingTests.swift in Sources */,
+				EB8B9F29717716305D4E1F2E /* MCPBrokerTests.swift in Sources */,
 				7F9C46E519B7180C507053BB /* MLXRuntimeTests.swift in Sources */,
 				4AD1C0E0E53EC4B34CBE7400 /* MetalViewportResponderTests.swift in Sources */,
 				C89E138879C40C8FB6C0478A /* OpenFilesTests.swift in Sources */,
@@ -1251,6 +1259,7 @@
 				55F78301BAF8CD914D86069D /* MCPConnectSheet.swift in Sources */,
 				4852173B3AB34D6B4FF76415 /* MCPDesktopInstaller.swift in Sources */,
 				77947569BB49AFA9845B7283 /* MCPDrivingBanner.swift in Sources */,
+				D98919F8A192EB35CD9CB40C /* MCPInstanceRegistry.swift in Sources */,
 				64DDBC57197D8C3A9AB0B68D /* MCPServerManager.swift in Sources */,
 				90F5E063444FBF4FF3770118 /* MCPStatusView.swift in Sources */,
 				B238B98768632BEFAD9327E4 /* MLXRuntime.swift in Sources */,
@@ -1310,6 +1319,7 @@
 				E777A44381A854B382874738 /* MCPConnectSheet.swift in Sources */,
 				F58726A64F44A9435AD8517D /* MCPDesktopInstaller.swift in Sources */,
 				F4B0ED522742FC38BFD36368 /* MCPDrivingBanner.swift in Sources */,
+				14E9A7601449E73C41862378 /* MCPInstanceRegistry.swift in Sources */,
 				3ECB633FC33E73F4767D3AF5 /* MCPServerManager.swift in Sources */,
 				DE0E67FF8DD0D44121F1B386 /* MCPStatusView.swift in Sources */,
 				6F45C01C9E3DE3CC89268445 /* MLXRuntime.swift in Sources */,
@@ -1525,7 +1535,7 @@
 		};
 		76B7E9DB75E073D1E60928FA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_10A06E48-389B-40FD-B69A-488BA0D818F9" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_6C2EFEBD-6BF9-4DFC-B8A3-432FDAEA946A" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1632,7 +1642,7 @@
 		};
 		D8F44FDFF036013D2F03BA83 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_10A06E48-389B-40FD-B69A-488BA0D818F9" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_6C2EFEBD-6BF9-4DFC-B8A3-432FDAEA946A" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -324,7 +324,7 @@
 		F7E41DCBB427678A8F018B0E /* DesignControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignControllerTests.swift; sourceTree = "<group>"; };
 		FB1304C662D9011F7C4505FC /* MCPStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPStatusView.swift; sourceTree = "<group>"; };
 		FF4FB7F151982A2927D612F0 /* DesignController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignController.swift; sourceTree = "<group>"; };
-		"TEMP_6C2EFEBD-6BF9-4DFC-B8A3-432FDAEA946A" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
+		"TEMP_0BF7C6E0-8A95-495E-B8D1-AF66327FCA7F" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -544,10 +544,10 @@
 			path = Bridge;
 			sourceTree = "<group>";
 		};
-		"TEMP_C0AB4A87-2686-4B50-92BA-13EB6284CCB1" /* swiftui */ = {
+		"TEMP_6F840FC9-D5E4-4165-A5A5-9D00CB14B411" /* swiftui */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_6C2EFEBD-6BF9-4DFC-B8A3-432FDAEA946A" /* PyMOLBridge.xcconfig */,
+				"TEMP_0BF7C6E0-8A95-495E-B8D1-AF66327FCA7F" /* PyMOLBridge.xcconfig */,
 			);
 			path = swiftui;
 			sourceTree = "<group>";
@@ -1535,7 +1535,7 @@
 		};
 		76B7E9DB75E073D1E60928FA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_6C2EFEBD-6BF9-4DFC-B8A3-432FDAEA946A" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_0BF7C6E0-8A95-495E-B8D1-AF66327FCA7F" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1642,7 +1642,7 @@
 		};
 		D8F44FDFF036013D2F03BA83 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_6C2EFEBD-6BF9-4DFC-B8A3-432FDAEA946A" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_0BF7C6E0-8A95-495E-B8D1-AF66327FCA7F" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/swiftui/PyMOLViewer/Shared/MCPBridge.swift
+++ b/swiftui/PyMOLViewer/Shared/MCPBridge.swift
@@ -19,6 +19,12 @@ enum MCPBridge {
     private static func setSessionId(_ s: String) {
         sessionIdLock.lock(); sessionId = s; sessionIdLock.unlock()
     }
+    /// Forget the session. A session id belongs to ONE server process, so it must
+    /// not outlive the binding it came from — replaying it at a relaunched (or
+    /// different) RayMol names a session that server never issued.
+    private static func clearSessionId() {
+        sessionIdLock.lock(); sessionId = nil; sessionIdLock.unlock()
+    }
 
     /// The instance this broker session is bound to. Set on first successful
     /// resolution and reused, so a multi-instance setup is disambiguated once
@@ -29,7 +35,13 @@ enum MCPBridge {
         boundLock.lock(); defer { boundLock.unlock() }; return boundInstance
     }
     private static func setBound(_ i: MCPInstance?) {
-        boundLock.lock(); boundInstance = i; boundLock.unlock()
+        boundLock.lock()
+        let changed = boundInstance?.pid != i?.pid
+        boundInstance = i
+        boundLock.unlock()
+        // The session id was issued by the instance we are leaving; carrying it to
+        // a different pid would send a stranger's session to the new server.
+        if changed { clearSessionId() }
     }
 
     static let installedAppPath = "/Applications/RayMol.app"
@@ -203,6 +215,45 @@ enum MCPBridge {
                            installed: true, startedAt: "")
     }
 
+    // MARK: session establishment
+
+    /// The `initialize` the broker sends on the client's behalf.
+    ///
+    /// Exposed (and pure) so a test can pin that it really is an `initialize` —
+    /// the whole point is that the server sees this method, because that is what
+    /// makes it raise the "Allow" prompt.
+    static func brokerInitializeRequest() -> [String: Any] {
+        [
+            "jsonrpc": "2.0", "id": "raymol-broker-init", "method": "initialize",
+            "params": [
+                "protocolVersion": protocolVersion,
+                "capabilities": [String: Any](),
+                "clientInfo": ["name": "raymol-broker", "version": "1.0.0"],
+            ],
+        ]
+    }
+
+    /// Whether a request must be preceded by an `initialize` we send ourselves.
+    ///
+    /// We answer `initialize` locally whenever RayMol is down, so the client's own
+    /// handshake never reaches the server. A later tool call would then be the
+    /// server's FIRST request — and the server raises the approval prompt only on
+    /// `initialize`, so the user would be told to click Allow while no prompt was
+    /// ever shown, with every retry repeating the same dead end.
+    static func needsSessionHandshake(sessionId: String?, method: String) -> Bool {
+        method != "initialize" && (sessionId?.isEmpty ?? true)
+    }
+
+    /// Open a server-side session before forwarding, when we don't have one.
+    private static func ensureSession(with instance: MCPInstance, method: String) {
+        guard needsSessionHandshake(sessionId: getSessionId(), method: method),
+              let data = try? JSONSerialization.data(
+                  withJSONObject: brokerInitializeRequest())
+        else { return }
+        // The response carries Mcp-Session-Id, which proxy() records for us.
+        _ = proxy(raw: data, to: instance)
+    }
+
     // MARK: proxy
 
     // Returns the server's JSON response bytes, or nil if the server is unreachable.
@@ -275,8 +326,11 @@ enum MCPBridge {
         case .none where mayColdLaunch(method: method):
             // A RayMol that predates the registry answers here and must not be
             // duplicated by a cold launch.
-            if let legacy = legacyHandoff(), let body = proxy(raw: forward, to: legacy) {
-                return body.isEmpty ? nil : body
+            if let legacy = legacyHandoff() {
+                ensureSession(with: legacy, method: method)
+                if let body = proxy(raw: forward, to: legacy) {
+                    return body.isEmpty ? nil : body
+                }
             }
             let outcome = coldLaunch()
             if case .launched(let launched) = outcome {
@@ -291,6 +345,7 @@ enum MCPBridge {
             instance = legacyHandoff()
         }
         if let instance {
+            ensureSession(with: instance, method: method)
             if let body = proxy(raw: forward, to: instance) {
                 return body.isEmpty ? nil : body   // empty = 202 notification ack
             }

--- a/swiftui/PyMOLViewer/Shared/MCPBridge.swift
+++ b/swiftui/PyMOLViewer/Shared/MCPBridge.swift
@@ -121,12 +121,45 @@ enum MCPBridge {
 
     private static func response(for msg: [String: Any], method: String,
                                  id: Any?, raw: Data) -> Data? {
+        // Broker-native tool: answered here, never forwarded.
+        if method == "tools/call",
+           let params = msg["params"] as? [String: Any],
+           params["name"] as? String == "list_raymol_instances" {
+            return ok(id: id, result: ["content": [["type": "text",
+                "text": instancesText(MCPInstanceRegistry.liveDirectoryInstances())]]])
+        }
+        // Pull `instance` out of the arguments and strip it from what we forward.
+        var forward = raw
+        var requestedKey: String? = nil
+        if method == "tools/call", var msgCopy = msg as [String: Any]?,
+           var params = msgCopy["params"] as? [String: Any],
+           var args = params["arguments"] as? [String: Any],
+           let key = args["instance"] as? String {
+            requestedKey = key
+            args["instance"] = nil
+            params["arguments"] = args
+            msgCopy["params"] = params
+            forward = (try? JSONSerialization.data(withJSONObject: msgCopy)) ?? raw
+        }
+
         // Try the live server first.
-        let target = resolveTarget(requestedKey: nil)
+        let target = resolveTarget(requestedKey: requestedKey)
         var instance: MCPInstance? = nil
-        if case .bound(let i) = target { instance = i } else { instance = legacyHandoff() }
+        switch target {
+        case .bound(let i):
+            instance = i
+        case .ambiguous(let list) where method == "tools/call":
+            return ok(id: id, result: ["content": [["type": "text",
+                "text": ambiguityText(list)]], "isError": true])
+        case .unknownKey(let key) where method == "tools/call":
+            return ok(id: id, result: ["content": [["type": "text",
+                "text": "No running RayMol named \"\(key)\". Call list_raymol_instances."]],
+                "isError": true])
+        default:
+            instance = legacyHandoff()
+        }
         if let instance {
-            if let body = proxy(raw: raw, to: instance) {
+            if let body = proxy(raw: forward, to: instance) {
                 return body.isEmpty ? nil : body   // empty = 202 notification ack
             }
             // Unreachable or 401 (a recycled pid, or a rotated token): the binding
@@ -161,17 +194,68 @@ enum MCPBridge {
         ])
     }
 
-    private static func localToolsList(id: Any?) -> Data {
-        // Static mirror of raymol_mcp/tools.py TOOLS (used only when the server is
-        // down; the live list is proxied when it's up). Keep names in sync.
-        let tools: [[String: Any]] = [
+    /// Static mirror of raymol_mcp/tools.py TOOLS (used only when the server is
+    /// down; the live list is proxied when it's up). Keep names in sync —
+    /// MCPBrokerTests.testOfflineToolsListStillNamesEveryTool pins the list.
+    static func localToolsSpec() -> [[String: Any]] {
+        [
             ["name": "run_pymol_command", "description": "Run one PyMOL command-language statement (e.g. 'fetch 1ubq, async=0').", "inputSchema": ["type": "object", "properties": ["command": ["type": "string"]], "required": ["command"]]],
             ["name": "run_python", "description": "Execute arbitrary Python with 'cmd' (PyMOL API), 'np', 'Bio'. State persists.", "inputSchema": ["type": "object", "properties": ["code": ["type": "string"]], "required": ["code"]]],
             ["name": "get_session_state", "description": "Return objects, selections, camera view, frame info as JSON.", "inputSchema": ["type": "object", "properties": [:]]],
             ["name": "capture_viewport", "description": "Ray-traced PNG of the current view.", "inputSchema": ["type": "object", "properties": ["width": ["type": "integer"], "height": ["type": "integer"]]]],
             ["name": "search_pdb", "description": "Full-text RCSB PDB search; returns PDB IDs.", "inputSchema": ["type": "object", "properties": ["query": ["type": "string"], "limit": ["type": "integer"]], "required": ["query"]]],
         ]
-        return ok(id: id, result: ["tools": tools])
+    }
+
+    /// Every tool gains an optional `instance` override. The broker strips it
+    /// before forwarding, so the Python tool schemas stay untouched.
+    static func withInstanceArg(_ tools: [[String: Any]]) -> [[String: Any]] {
+        tools.map { tool in
+            var t = tool
+            var schema = (t["inputSchema"] as? [String: Any]) ?? ["type": "object"]
+            var props = (schema["properties"] as? [String: Any]) ?? [:]
+            props["instance"] = [
+                "type": "string",
+                "description": "Which running RayMol to drive (e.g. \"RayMol\", \"RayMol-287\"). "
+                    + "Omit unless list_raymol_instances shows more than one.",
+            ]
+            schema["properties"] = props     // `required` deliberately untouched
+            t["inputSchema"] = schema
+            return t
+        }
+    }
+
+    static let listInstancesTool: [String: Any] = [
+        "name": "list_raymol_instances",
+        "description": "List running RayMol instances and the key that names each one.",
+        "inputSchema": ["type": "object", "properties": [String: Any]()],
+    ]
+
+    static func offlineToolNames() -> [String] {
+        (localToolsSpec() + [listInstancesTool]).compactMap { $0["name"] as? String }
+    }
+
+    static func ambiguityText(_ instances: [MCPInstance]) -> String {
+        let keyed = MCPInstanceRegistry.keys(for: instances)
+        let rows = instances.map { i -> String in
+            let key = keyed[i.pid] ?? String(i.pid)
+            return "  • \(key)\(i.installed ? " (installed)" : " (dev build)") — \(i.appPath)"
+        }.joined(separator: "\n")
+        return "More than one RayMol is running. Ask the user which one to drive, then "
+            + "retry with the instance argument set:\n\n\(rows)\n"
+    }
+
+    private static func instancesText(_ instances: [MCPInstance]) -> String {
+        guard !instances.isEmpty else { return "No RayMol is running." }
+        let keyed = MCPInstanceRegistry.keys(for: instances)
+        return instances.map { i in
+            "\(keyed[i.pid] ?? String(i.pid))\(i.installed ? " (installed)" : " (dev build)") "
+                + "— pid \(i.pid), port \(i.port), \(i.appPath)"
+        }.joined(separator: "\n")
+    }
+
+    private static func localToolsList(id: Any?) -> Data {
+        ok(id: id, result: ["tools": withInstanceArg(localToolsSpec()) + [listInstancesTool]])
     }
 
     private static func ok(id: Any?, result: [String: Any]) -> Data {

--- a/swiftui/PyMOLViewer/Shared/MCPBridge.swift
+++ b/swiftui/PyMOLViewer/Shared/MCPBridge.swift
@@ -34,35 +34,118 @@ enum MCPBridge {
 
     static let installedAppPath = "/Applications/RayMol.app"
 
+    /// Which bundle a cold launch opens. `RAYMOL_MCP_INSTALLED_APP` overrides it
+    /// so the e2e harness can drive a suffixed dev build instead of clobbering
+    /// the user's installed RayMol — dev/testing only, like RAYMOL_MCP_PORT, and
+    /// never present in a Finder or `open` launch.
+    static func coldLaunchTarget(override: String?) -> String {
+        guard let o = override, !o.isEmpty else { return installedAppPath }
+        return o
+    }
+
+    static var coldLaunchPath: String {
+        coldLaunchTarget(override: ProcessInfo.processInfo.environment["RAYMOL_MCP_INSTALLED_APP"])
+    }
+
     /// Opening a client must not open RayMol. Launching is a consequence of
     /// asking RayMol to DO something, so only tools/call qualifies.
     static func mayColdLaunch(method: String) -> Bool { method == "tools/call" }
 
-    /// Launch the installed app and wait for it to register. Returns nil on a
-    /// missing bundle or on timeout; the caller turns that into a tool error.
-    static func coldLaunch(timeout: TimeInterval = 20) -> MCPInstance? {
-        let url = URL(fileURLWithPath: installedAppPath)
-        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
-        // The broker IS RayMol's binary, so this writes RayMol's own defaults
-        // domain — the launched app auto-starts its server even on a machine
-        // where MCP has never been switched on.
-        UserDefaults.standard.set(true, forKey: "raymol.mcp.enabled")
+    enum ColdLaunchOutcome: Equatable {
+        case launched(MCPInstance)
+        /// The bundle is up but never registered — its MCP server is off.
+        case alreadyRunningNotRegistered
+        case notInstalled
+        case launchFailed(String)
+        case timedOut
+    }
 
-        let cfg = NSWorkspace.OpenConfiguration()
-        cfg.activates = true
-        let sem = DispatchSemaphore(value: 0)
-        // Racing brokers are harmless: openApplication on an already-launching
-        // app activates it, so both converge on one instance.
-        NSWorkspace.shared.openApplication(at: url, configuration: cfg) { _, _ in sem.signal() }
-        _ = sem.wait(timeout: .now() + 10)
+    /// Pure: what to tell the user. Each failure names its OWN cause — collapsing
+    /// them sends the user to a setting that is not the problem.
+    static func coldLaunchMessage(_ outcome: ColdLaunchOutcome, path: String) -> String {
+        switch outcome {
+        case .launched:
+            return ""
+        case .notInstalled:
+            return "RayMol isn't installed at \(path). Install it, then retry."
+        case .alreadyRunningNotRegistered:
+            return "RayMol is already running but its MCP server is off. "
+                + "In RayMol, turn on Connect ▸ Enable AI control, then retry."
+        case .launchFailed(let why):
+            return "Couldn't launch RayMol at \(path): \(why)"
+        case .timedOut:
+            return "RayMol opened but its MCP server didn't start within 20s. "
+                + "In RayMol, turn on Connect ▸ Enable AI control, then retry."
+        }
+    }
+
+    /// Cold launch is the LAST resort. A pre-registry RayMol is invisible to the
+    /// scan but still answers on its legacy handoff, and launching a second copy
+    /// on top of the one the user is working in is worse than any error.
+    static func shouldColdLaunch(legacyReachable: Bool) -> Bool { !legacyReachable }
+
+    /// The environment a cold-launched RayMol starts with.
+    ///
+    /// `RAYMOL_MCP_ENABLE=1` makes it bring its server up without persisting
+    /// `raymol.mcp.enabled` — a cold launch must not silently turn the server on
+    /// for every future manual launch too. `RAYMOL_MCP_PORT` is forwarded only
+    /// when set, so the e2e harness can keep off a port another build owns.
+    static func launchEnvironment(portOverride: String?) -> [String: String] {
+        var env = ["RAYMOL_MCP_ENABLE": "1"]
+        if let p = portOverride, !p.isEmpty { env["RAYMOL_MCP_PORT"] = p }
+        return env
+    }
+
+    /// Is this exact bundle already up? Checked by PATH, not bundle id: every dev
+    /// build shares `io.raymol.RayMol`, so an id check would confuse a worktree
+    /// build for the installed app.
+    static func isRunning(bundlePath: String) -> Bool {
+        let want = URL(fileURLWithPath: bundlePath).standardizedFileURL.path
+        return NSWorkspace.shared.runningApplications.contains {
+            $0.bundleURL?.standardizedFileURL.path == want
+        }
+    }
+
+    /// Launch the target app and wait for it to register.
+    static func coldLaunch(timeout: TimeInterval = 20) -> ColdLaunchOutcome {
+        let path = coldLaunchPath
+        let url = URL(fileURLWithPath: path)
+        guard FileManager.default.fileExists(atPath: path) else { return .notInstalled }
+
+        // Already up and still unregistered means its server is off, not that it
+        // needs launching. Starting a second copy would just add a window.
+        let wasRunning = isRunning(bundlePath: path)
+        if !wasRunning {
+            let cfg = NSWorkspace.OpenConfiguration()
+            cfg.activates = true
+            // Every RayMol build shares a bundle id, so without this LaunchServices
+            // "opens" an already-running dev build from another checkout and never
+            // starts the bundle we actually asked for.
+            cfg.createsNewApplicationInstance = true
+            cfg.environment = launchEnvironment(
+                portOverride: ProcessInfo.processInfo.environment["RAYMOL_MCP_PORT"])
+            let sem = DispatchSemaphore(value: 0)
+            var launchError: String? = nil
+            NSWorkspace.shared.openApplication(at: url, configuration: cfg) { _, err in
+                if let err { launchError = err.localizedDescription }
+                sem.signal()
+            }
+            if sem.wait(timeout: .now() + 15) == .timedOut {
+                return .launchFailed("the launch request timed out")
+            }
+            if let launchError { return .launchFailed(launchError) }
+        }
 
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             let live = MCPInstanceRegistry.liveDirectoryInstances()
-            if let hit = live.first(where: { $0.installed }) ?? live.first { return hit }
+            if let hit = live.first(where: { $0.appPath == path })
+                ?? live.first(where: { $0.installed }) ?? live.first {
+                return .launched(hit)
+            }
             Thread.sleep(forTimeInterval: 0.4)
         }
-        return nil
+        return wasRunning ? .alreadyRunningNotRegistered : .timedOut
     }
 
     /// Resolve which RayMol this call belongs to.
@@ -190,16 +273,18 @@ enum MCPBridge {
                 "text": "No running RayMol named \"\(key)\". Call list_raymol_instances."]],
                 "isError": true])
         case .none where mayColdLaunch(method: method):
-            if let launched = coldLaunch() {
+            // A RayMol that predates the registry answers here and must not be
+            // duplicated by a cold launch.
+            if let legacy = legacyHandoff(), let body = proxy(raw: forward, to: legacy) {
+                return body.isEmpty ? nil : body
+            }
+            let outcome = coldLaunch()
+            if case .launched(let launched) = outcome {
                 setBound(launched)
                 instance = launched
             } else {
-                let exists = FileManager.default.fileExists(atPath: installedAppPath)
                 return ok(id: id, result: ["content": [["type": "text",
-                    "text": exists
-                        ? "RayMol opened but its MCP server didn't start within 20s. "
-                          + "In RayMol, turn on Connect ▸ Enable AI control, then retry."
-                        : "RayMol isn't installed at \(installedAppPath). Install it, then retry."]],
+                    "text": coldLaunchMessage(outcome, path: coldLaunchPath)]],
                     "isError": true])
             }
         default:

--- a/swiftui/PyMOLViewer/Shared/MCPBridge.swift
+++ b/swiftui/PyMOLViewer/Shared/MCPBridge.swift
@@ -5,6 +5,7 @@
 // friendly error for tool calls, so Claude always shows the server + tools.
 #if os(macOS) && !RAYMOL_MAS_RESTRICTED
 import Foundation
+import AppKit
 
 enum MCPBridge {
     private static let protocolVersion = "2025-06-18"
@@ -29,6 +30,39 @@ enum MCPBridge {
     }
     private static func setBound(_ i: MCPInstance?) {
         boundLock.lock(); boundInstance = i; boundLock.unlock()
+    }
+
+    static let installedAppPath = "/Applications/RayMol.app"
+
+    /// Opening a client must not open RayMol. Launching is a consequence of
+    /// asking RayMol to DO something, so only tools/call qualifies.
+    static func mayColdLaunch(method: String) -> Bool { method == "tools/call" }
+
+    /// Launch the installed app and wait for it to register. Returns nil on a
+    /// missing bundle or on timeout; the caller turns that into a tool error.
+    static func coldLaunch(timeout: TimeInterval = 20) -> MCPInstance? {
+        let url = URL(fileURLWithPath: installedAppPath)
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        // The broker IS RayMol's binary, so this writes RayMol's own defaults
+        // domain — the launched app auto-starts its server even on a machine
+        // where MCP has never been switched on.
+        UserDefaults.standard.set(true, forKey: "raymol.mcp.enabled")
+
+        let cfg = NSWorkspace.OpenConfiguration()
+        cfg.activates = true
+        let sem = DispatchSemaphore(value: 0)
+        // Racing brokers are harmless: openApplication on an already-launching
+        // app activates it, so both converge on one instance.
+        NSWorkspace.shared.openApplication(at: url, configuration: cfg) { _, _ in sem.signal() }
+        _ = sem.wait(timeout: .now() + 10)
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            let live = MCPInstanceRegistry.liveDirectoryInstances()
+            if let hit = live.first(where: { $0.installed }) ?? live.first { return hit }
+            Thread.sleep(forTimeInterval: 0.4)
+        }
+        return nil
     }
 
     /// Resolve which RayMol this call belongs to.
@@ -155,6 +189,19 @@ enum MCPBridge {
             return ok(id: id, result: ["content": [["type": "text",
                 "text": "No running RayMol named \"\(key)\". Call list_raymol_instances."]],
                 "isError": true])
+        case .none where mayColdLaunch(method: method):
+            if let launched = coldLaunch() {
+                setBound(launched)
+                instance = launched
+            } else {
+                let exists = FileManager.default.fileExists(atPath: installedAppPath)
+                return ok(id: id, result: ["content": [["type": "text",
+                    "text": exists
+                        ? "RayMol opened but its MCP server didn't start within 20s. "
+                          + "In RayMol, turn on Connect ▸ Enable AI control, then retry."
+                        : "RayMol isn't installed at \(installedAppPath). Install it, then retry."]],
+                    "isError": true])
+            }
         default:
             instance = legacyHandoff()
         }

--- a/swiftui/PyMOLViewer/Shared/MCPBridge.swift
+++ b/swiftui/PyMOLViewer/Shared/MCPBridge.swift
@@ -19,6 +19,28 @@ enum MCPBridge {
         sessionIdLock.lock(); sessionId = s; sessionIdLock.unlock()
     }
 
+    /// The instance this broker session is bound to. Set on first successful
+    /// resolution and reused, so a multi-instance setup is disambiguated once
+    /// per client session rather than once per call.
+    private static var boundInstance: MCPInstance? = nil
+    private static let boundLock = NSLock()
+    private static func getBound() -> MCPInstance? {
+        boundLock.lock(); defer { boundLock.unlock() }; return boundInstance
+    }
+    private static func setBound(_ i: MCPInstance?) {
+        boundLock.lock(); boundInstance = i; boundLock.unlock()
+    }
+
+    /// Resolve which RayMol this call belongs to.
+    static func resolveTarget(requestedKey: String?) -> MCPTarget {
+        let env = ProcessInfo.processInfo.environment["RAYMOL_MCP_INSTANCE"]
+        let target = MCPInstanceRegistry.resolve(
+            instances: MCPInstanceRegistry.liveDirectoryInstances(),
+            requestedKey: requestedKey, envKey: env, sticky: getBound())
+        if case .bound(let i) = target { setBound(i) } else { setBound(nil) }
+        return target
+    }
+
     static func run() {
         while let line = readLine(strippingNewline: true) {
             if line.trimmingCharacters(in: .whitespaces).isEmpty { continue }
@@ -36,7 +58,7 @@ enum MCPBridge {
         // Claude closed our stdin (it quit) — tell the server to terminate our
         // session so the connected-client count updates immediately instead of
         // waiting for the idle sweep.
-        if let sid = getSessionId(), let h = handoff(),
+        if let sid = getSessionId(), let h = getBound() ?? legacyHandoff(),
            let url = URL(string: "http://127.0.0.1:\(h.port)/mcp") {
             var req = URLRequest(url: url)
             req.httpMethod = "DELETE"
@@ -50,27 +72,30 @@ enum MCPBridge {
 
     // MARK: handoff
 
-    private static func handoff() -> (port: Int, token: String)? {
+    /// Legacy single-instance handoff, used only when the registry is empty —
+    /// e.g. a RayMol built before the registry existed.
+    private static func legacyHandoff() -> MCPInstance? {
         let url = URL(fileURLWithPath: NSHomeDirectory())
             .appendingPathComponent("Library/Application Support/RayMol/mcp.json")
         guard let data = try? Data(contentsOf: url),
               let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let port = obj["port"] as? Int, let token = obj["token"] as? String
         else { return nil }
-        return (port, token)
+        return MCPInstance(pid: 0, port: port, token: token,
+                           appPath: "/Applications/RayMol.app", name: "RayMol",
+                           installed: true, startedAt: "")
     }
 
     // MARK: proxy
 
     // Returns the server's JSON response bytes, or nil if the server is unreachable.
-    private static func proxy(raw: Data) -> Data? {
-        guard let h = handoff(),
-              let url = URL(string: "http://127.0.0.1:\(h.port)/mcp") else { return nil }
+    private static func proxy(raw: Data, to instance: MCPInstance) -> Data? {
+        guard let url = URL(string: "http://127.0.0.1:\(instance.port)/mcp") else { return nil }
         var req = URLRequest(url: url)
         req.httpMethod = "POST"
         req.httpBody = raw
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        req.setValue("Bearer \(h.token)", forHTTPHeaderField: "Authorization")
+        req.setValue("Bearer \(instance.token)", forHTTPHeaderField: "Authorization")
         if let sid = getSessionId() { req.setValue(sid, forHTTPHeaderField: "Mcp-Session-Id") }
         let sem = DispatchSemaphore(value: 0)
         var out: Data? = nil
@@ -97,8 +122,17 @@ enum MCPBridge {
     private static func response(for msg: [String: Any], method: String,
                                  id: Any?, raw: Data) -> Data? {
         // Try the live server first.
-        if let body = proxy(raw: raw) {
-            return body.isEmpty ? nil : body   // empty = 202 notification ack
+        let target = resolveTarget(requestedKey: nil)
+        var instance: MCPInstance? = nil
+        if case .bound(let i) = target { instance = i } else { instance = legacyHandoff() }
+        if let instance {
+            if let body = proxy(raw: raw, to: instance) {
+                return body.isEmpty ? nil : body   // empty = 202 notification ack
+            }
+            // Unreachable or 401 (a recycled pid, or a rotated token): the binding
+            // is stale, so drop it and let the next call re-resolve rather than
+            // retrying a port that is not ours.
+            setBound(nil)
         }
         // Server unreachable: answer locally.
         switch method {

--- a/swiftui/PyMOLViewer/Shared/MCPDesktopInstaller.swift
+++ b/swiftui/PyMOLViewer/Shared/MCPDesktopInstaller.swift
@@ -4,8 +4,22 @@
 import Foundation
 
 enum MCPDesktopInstaller {
+    static let installedCommand = "/Applications/RayMol.app/Contents/MacOS/RayMol"
+
+    /// Pure: which binary a client should be told to spawn.
+    ///
+    /// Prefers the installed app. Without this a dev build run from a worktree
+    /// registers its own throwaway path, and the client hard-errors the moment
+    /// that build directory is cleaned.
+    static func preferredCommand(installedExists: Bool, running: String?) -> String {
+        if installedExists { return installedCommand }
+        return running ?? installedCommand
+    }
+
     static func bridgeCommand() -> String {
-        Bundle.main.executablePath ?? "/Applications/RayMol.app/Contents/MacOS/RayMol"
+        preferredCommand(
+            installedExists: FileManager.default.fileExists(atPath: installedCommand),
+            running: Bundle.main.executablePath)
     }
 
     private static func desktopConfigURL() -> URL {

--- a/swiftui/PyMOLViewer/Shared/MCPInstanceRegistry.swift
+++ b/swiftui/PyMOLViewer/Shared/MCPInstanceRegistry.swift
@@ -1,0 +1,29 @@
+// MCPInstanceRegistry.swift — the pure core of MCP target selection: what a
+// running RayMol advertises, and how a broker picks one. Kept free of I/O and
+// launching so it is unit-testable without a stdio loop or a live app.
+#if os(macOS) && !RAYMOL_MAS_RESTRICTED
+import Foundation
+
+/// One running RayMol that has its MCP server up.
+struct MCPInstance: Codable, Equatable {
+    let pid: Int
+    let port: Int
+    let token: String
+    let appPath: String
+    let name: String
+    let installed: Bool
+    let startedAt: String
+}
+
+enum MCPInstanceRegistry {
+    /// Decode one registry file. Returns nil rather than throwing: a corrupt or
+    /// half-written entry must not take the readable instances down with it.
+    static func decode(_ data: Data) -> MCPInstance? {
+        try? JSONDecoder().decode(MCPInstance.self, from: data)
+    }
+
+    static func decodeAll(_ blobs: [Data]) -> [MCPInstance] {
+        blobs.compactMap(decode)
+    }
+}
+#endif

--- a/swiftui/PyMOLViewer/Shared/MCPInstanceRegistry.swift
+++ b/swiftui/PyMOLViewer/Shared/MCPInstanceRegistry.swift
@@ -15,6 +15,17 @@ struct MCPInstance: Codable, Equatable {
     let startedAt: String
 }
 
+/// The outcome of asking "which RayMol should this call go to?".
+enum MCPTarget: Equatable {
+    case bound(MCPInstance)
+    /// Nothing is running — the caller may cold-launch.
+    case none
+    /// More than one candidate and no way to choose. The caller must ask.
+    case ambiguous([MCPInstance])
+    /// A key was supplied explicitly but names no live instance.
+    case unknownKey(String)
+}
+
 enum MCPInstanceRegistry {
     /// Decode one registry file. Returns nil rather than throwing: a corrupt or
     /// half-written entry must not take the readable instances down with it.
@@ -51,6 +62,32 @@ enum MCPInstanceRegistry {
         let byName = instances.filter { $0.name == key }
         return byName.count == 1 ? byName[0] : nil
     }
+
+    /// Resolve a target, first hit wins: explicit key, environment key, sticky
+    /// binding, then the registry scan.
+    ///
+    /// An unknown *requested* key is reported (the model asked for something
+    /// specific and deserves to be told it is gone), while an unknown *env* key
+    /// falls through — a stale export must not strand an otherwise fine session.
+    static func resolve(instances: [MCPInstance], requestedKey: String?,
+                        envKey: String?, sticky: MCPInstance?) -> MCPTarget {
+        if let key = requestedKey, !key.isEmpty {
+            return match(key, in: instances).map { .bound($0) } ?? .unknownKey(key)
+        }
+        if let key = envKey, !key.isEmpty, let hit = match(key, in: instances) {
+            return .bound(hit)
+        }
+        // Sticky only survives while its instance is still registered.
+        if let s = sticky, let live = instances.first(where: { $0.pid == s.pid }) {
+            return .bound(live)
+        }
+        switch instances.count {
+        case 0:  return .none
+        case 1:  return .bound(instances[0])
+        default: return .ambiguous(instances)
+        }
+    }
 }
 #endif
+
 

--- a/swiftui/PyMOLViewer/Shared/MCPInstanceRegistry.swift
+++ b/swiftui/PyMOLViewer/Shared/MCPInstanceRegistry.swift
@@ -25,5 +25,32 @@ enum MCPInstanceRegistry {
     static func decodeAll(_ blobs: [Data]) -> [MCPInstance] {
         blobs.compactMap(decode)
     }
+
+    /// pid → the key a client uses to name this instance. Bare display name when
+    /// unique; `Name#<pid>` only for the names that actually collide, so the
+    /// common single-instance case stays readable.
+    static func keys(for instances: [MCPInstance]) -> [Int: String] {
+        var counts: [String: Int] = [:]
+        for i in instances { counts[i.name, default: 0] += 1 }
+        var out: [Int: String] = [:]
+        for i in instances {
+            out[i.pid] = (counts[i.name] ?? 0) > 1 ? "\(i.name)#\(i.pid)" : i.name
+        }
+        return out
+    }
+
+    /// Resolve a user- or model-supplied key. Accepts the assigned key, a bare
+    /// display name when unambiguous, or a bare pid. Returns nil when the key is
+    /// unknown OR ambiguous — the caller must ask rather than guess.
+    static func match(_ key: String, in instances: [MCPInstance]) -> MCPInstance? {
+        let keyed = keys(for: instances)
+        if let hit = instances.first(where: { keyed[$0.pid] == key }) { return hit }
+        if let pid = Int(key), let hit = instances.first(where: { $0.pid == pid }) {
+            return hit
+        }
+        let byName = instances.filter { $0.name == key }
+        return byName.count == 1 ? byName[0] : nil
+    }
 }
 #endif
+

--- a/swiftui/PyMOLViewer/Shared/MCPInstanceRegistry.swift
+++ b/swiftui/PyMOLViewer/Shared/MCPInstanceRegistry.swift
@@ -87,7 +87,72 @@ enum MCPInstanceRegistry {
         default: return .ambiguous(instances)
         }
     }
+
+    // MARK: - Directory + self-registration
+
+    static func directory() -> URL? {
+        let fm = FileManager.default
+        guard let base = fm.urls(for: .applicationSupportDirectory,
+                                 in: .userDomainMask).first else { return nil }
+        let dir = base.appendingPathComponent("RayMol/instances", isDirectory: true)
+        try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    /// Only an app under /Applications may be the cold-launch target, so a dev
+    /// build in a worktree never becomes the thing a client launches by default.
+    static func isInstalled(path: String) -> Bool {
+        path.hasPrefix("/Applications/")
+    }
+
+    static func selfEntry(pid: Int, port: Int, token: String,
+                          bundle: Bundle, startedAt: String) -> MCPInstance {
+        let path = bundle.bundlePath
+        let name = (bundle.object(forInfoDictionaryKey: "CFBundleName") as? String)
+            ?? URL(fileURLWithPath: path).deletingPathExtension().lastPathComponent
+        return MCPInstance(pid: pid, port: port, token: token, appPath: path,
+                           name: name, installed: isInstalled(path: path),
+                           startedAt: startedAt)
+    }
+
+    static func write(_ entry: MCPInstance) -> URL? {
+        guard let dir = directory(),
+              let data = try? JSONEncoder().encode(entry) else { return nil }
+        let url = dir.appendingPathComponent("\(entry.pid).json")
+        guard (try? data.write(to: url, options: .atomic)) != nil else { return nil }
+        try? FileManager.default.setAttributes([.posixPermissions: 0o600],
+                                               ofItemAtPath: url.path)
+        return url
+    }
+
+    /// Drop entries whose process is gone. `kill(pid, 0)` succeeds for a live
+    /// process we own and fails with ESRCH once it is reaped.
+    static func liveOnly(_ instances: [MCPInstance]) -> [MCPInstance] {
+        instances.filter { kill(pid_t($0.pid), 0) == 0 || errno == EPERM }
+    }
+
+    /// Read the directory, prune dead entries (deleting their files), return the rest.
+    static func liveDirectoryInstances() -> [MCPInstance] {
+        guard let dir = directory(),
+              let names = try? FileManager.default.contentsOfDirectory(atPath: dir.path)
+        else { return [] }
+        var found: [MCPInstance] = []
+        for n in names where n.hasSuffix(".json") {
+            let url = dir.appendingPathComponent(n)
+            guard let data = try? Data(contentsOf: url), let e = decode(data) else {
+                try? FileManager.default.removeItem(at: url)   // unreadable: not useful to anyone
+                continue
+            }
+            if liveOnly([e]).isEmpty {
+                try? FileManager.default.removeItem(at: url)
+            } else {
+                found.append(e)
+            }
+        }
+        return found.sorted { $0.pid < $1.pid }
+    }
 }
 #endif
+
 
 

--- a/swiftui/PyMOLViewer/Shared/MCPServerManager.swift
+++ b/swiftui/PyMOLViewer/Shared/MCPServerManager.swift
@@ -18,6 +18,8 @@ final class MCPServerManager: ObservableObject {
     private let defaultPort = 51737
     /// The handoff this instance wrote, so shutdown removes its own and no one else's.
     private var writtenHandoff: URL?
+    /// The registry entry this instance wrote, removed on the way out.
+    private var writtenInstanceEntry: URL?
 
     /// The port to ask for, honouring `RAYMOL_MCP_PORT` when it is set.
     ///
@@ -122,11 +124,13 @@ final class MCPServerManager: ObservableObject {
             isRunning = true
             port = Int(detail)
             writeHandoff(port: port)
+            writeInstanceEntry(port: port)
             logLine("server started on \(detail)")
         case "stopped":
             isRunning = false; port = nil; clientCount = 0; activeTool = false
             trustedThisSession = false
             removeHandoff()
+            removeInstanceEntry()
             logLine("server stopped")
         case "connect":
             clientCount += 1
@@ -335,6 +339,24 @@ final class MCPServerManager: ObservableObject {
     private func removeHandoff() {
         if let url = writtenHandoff { try? FileManager.default.removeItem(at: url) }
         writtenHandoff = nil
+    }
+
+    /// Advertise this process in the instance registry, so a broker spawned by a
+    /// Claude client can find it without a pinned port.
+    private func writeInstanceEntry(port: Int?) {
+        guard let port else { return }
+        let stamp = ISO8601DateFormatter().string(from: Date())
+        let entry = MCPInstanceRegistry.selfEntry(
+            pid: Int(ProcessInfo.processInfo.processIdentifier), port: port,
+            token: token, bundle: .main, startedAt: stamp)
+        writtenInstanceEntry = MCPInstanceRegistry.write(entry)
+    }
+
+    private func removeInstanceEntry() {
+        if let url = writtenInstanceEntry {
+            try? FileManager.default.removeItem(at: url)
+        }
+        writtenInstanceEntry = nil
     }
 
     private static func randomHex(_ bytes: Int) -> String {

--- a/swiftui/PyMOLViewer/Shared/MCPServerManager.swift
+++ b/swiftui/PyMOLViewer/Shared/MCPServerManager.swift
@@ -77,7 +77,7 @@ final class MCPServerManager: ObservableObject {
         guard forced || UserDefaults.standard.bool(forKey: "raymol.mcp.enabled") else { return }
         guard let engine else { return }
         if engine.isReady {
-            start()
+            start(persist: Self.shouldPersistEnabledFlag(forcedByEnvironment: forced))
         } else if attempt < 40 {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
                 self?.autoStartIfEnabled(attempt: attempt + 1)
@@ -89,9 +89,17 @@ final class MCPServerManager: ObservableObject {
 
     func toggle() { isRunning ? stop() : start() }
 
-    func start() {
+    /// Pure: does starting the server also mean the user asked for it to start
+    /// every time? Only when they flipped the toggle themselves. A start forced
+    /// by RAYMOL_MCP_ENABLE — a VM test, or a broker cold-launching us for one
+    /// Claude tool call — must leave the preference untouched.
+    static func shouldPersistEnabledFlag(forcedByEnvironment: Bool) -> Bool {
+        !forcedByEnvironment
+    }
+
+    func start(persist: Bool = true) {
         guard let engine, engine.isReady, !isRunning else { return }
-        UserDefaults.standard.set(true, forKey: "raymol.mcp.enabled")
+        if persist { UserDefaults.standard.set(true, forKey: "raymol.mcp.enabled") }
         // start() returns the live port; the manager learns it from the MCP:started line.
         let b64 = Data(token.utf8).base64EncodedString()
         engine.runPython(

--- a/swiftui/PyMOLViewer/Shared/MCPServerManager.swift
+++ b/swiftui/PyMOLViewer/Shared/MCPServerManager.swift
@@ -195,36 +195,35 @@ final class MCPServerManager: ObservableObject {
 
     var claudeCLIPath: String? { Self.findClaude() }
 
+    /// Pure: the `claude mcp add` arguments. Stdio, so the entry stays valid
+    /// across RayMol restarts and closures — the broker is spawned on demand and
+    /// finds the live instance itself.
+    static func claudeCodeAddArgs(command: String) -> [String] {
+        ["mcp", "add", "raymol", "--scope", "user", "--", command, "--mcp-bridge"]
+    }
+
     func connectClaudeCode(completion: @escaping (String) -> Void) {
-        guard isRunning, let port = port else {
-            completion("Turn on the MCP server first.")
-            return
-        }
         // noteUserInitiatedConnect sets UI state — keep it synchronous on the main thread.
         noteUserInitiatedConnect()
-        // pushTrusted calls runPython which must run on the main thread (PyMOLBridge PAutoBlock).
-        pushTrusted()
-        // Capture values before leaving the main thread.
-        let capturedPort = port
-        let capturedToken = token
+        if isRunning {
+            // pushTrusted calls runPython which must run on the main thread.
+            pushTrusted()
+        }
+        let command = MCPDesktopInstaller.bridgeCommand()
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self else { return }
             self.installSkillFile()
-            let url = "http://127.0.0.1:\(capturedPort)/mcp"
-            let header = "Authorization: Bearer \(capturedToken)"
-            let manual = "claude mcp add --transport http raymol \(url) "
-                + "--header \"\(header)\" --scope user"
+            let args = Self.claudeCodeAddArgs(command: command)
+            let manual = "claude " + args.joined(separator: " ")
             guard let claude = Self.findClaude() else {
                 DispatchQueue.main.async {
                     completion("Claude Code CLI not found. Run this in a terminal:\n\n\(manual)")
                 }
                 return
             }
-            _ = Self.runClaude(claude, ["mcp", "remove", "raymol", "--scope", "user"])  // idempotent
-            let (code, out) = Self.runClaude(claude, [
-                "mcp", "add", "--transport", "http", "raymol", url,
-                "--header", header, "--scope", "user",
-            ])
+            // Idempotent, and REQUIRED: an older pinned-HTTP entry would otherwise survive.
+            _ = Self.runClaude(claude, ["mcp", "remove", "raymol", "--scope", "user"])
+            let (code, out) = Self.runClaude(claude, args)
             let msg: String
             if code == 0 {
                 msg = "Connected. In Claude Code, run /mcp (or restart it) to pick up RayMol, "

--- a/swiftui/PyMOLViewerTests/MCPBrokerTests.swift
+++ b/swiftui/PyMOLViewerTests/MCPBrokerTests.swift
@@ -347,4 +347,13 @@ final class MCPBrokerTests: XCTestCase {
         XCTAssertFalse(MCPBridge.shouldColdLaunch(legacyReachable: true))
         XCTAssertTrue(MCPBridge.shouldColdLaunch(legacyReachable: false))
     }
+
+    // A cold launch must leave the user's Connect toggle exactly as it was. The
+    // env-forced start path therefore must NOT persist it — otherwise every
+    // future MANUAL launch quietly starts the MCP server too, which is a
+    // decision only the user gets to make.
+    func testEnvForcedStartDoesNotPersistTheToggle() {
+        XCTAssertFalse(MCPServerManager.shouldPersistEnabledFlag(forcedByEnvironment: true))
+        XCTAssertTrue(MCPServerManager.shouldPersistEnabledFlag(forcedByEnvironment: false))
+    }
 }

--- a/swiftui/PyMOLViewerTests/MCPBrokerTests.swift
+++ b/swiftui/PyMOLViewerTests/MCPBrokerTests.swift
@@ -356,4 +356,46 @@ final class MCPBrokerTests: XCTestCase {
         XCTAssertFalse(MCPServerManager.shouldPersistEnabledFlag(forcedByEnvironment: true))
         XCTAssertTrue(MCPServerManager.shouldPersistEnabledFlag(forcedByEnvironment: false))
     }
+
+    // MARK: - session handshake (the "Allow" prompt)
+
+    // RayMol raises the approval prompt ONLY when its server receives an
+    // `initialize`. The broker answers `initialize` locally whenever RayMol is
+    // down, so on the cold-launch path the server's first-ever request used to be
+    // the tool call itself: the user was told "click Allow in RayMol" while no
+    // prompt had been raised, and every retry repeated the same refusal forever.
+    // The broker therefore has to open the session itself before forwarding.
+    func testForwardingWithoutASessionHandshakesFirst() {
+        XCTAssertTrue(MCPBridge.needsSessionHandshake(sessionId: nil,
+                                                      method: "tools/call"))
+        XCTAssertTrue(MCPBridge.needsSessionHandshake(sessionId: "",
+                                                      method: "tools/call"))
+    }
+
+    // Once a session exists the client's own traffic carries it, so re-sending
+    // `initialize` would raise a second prompt for an already-approved session.
+    func testAnEstablishedSessionIsNotHandshakenAgain() {
+        XCTAssertFalse(MCPBridge.needsSessionHandshake(sessionId: "abc123",
+                                                        method: "tools/call"))
+    }
+
+    // A client `initialize` that reaches a live server IS the handshake; wrapping
+    // it in another one would open two sessions for one client.
+    func testAClientInitializeIsNotDoubleHandshaken() {
+        XCTAssertFalse(MCPBridge.needsSessionHandshake(sessionId: nil,
+                                                        method: "initialize"))
+    }
+
+    // The request the broker sends must actually be an `initialize` — that exact
+    // method is what makes the server emit the connect event behind the prompt.
+    func testBrokerHandshakeIsAnInitialize() {
+        let r = MCPBridge.brokerInitializeRequest()
+        XCTAssertEqual(r["method"] as? String, "initialize")
+        XCTAssertEqual(r["jsonrpc"] as? String, "2.0")
+        XCTAssertNotNil(r["id"], "a request without an id is a notification, "
+            + "and would get no Mcp-Session-Id back")
+        let params = r["params"] as? [String: Any]
+        XCTAssertNotNil(params?["protocolVersion"])
+        XCTAssertNotNil(params?["clientInfo"])
+    }
 }

--- a/swiftui/PyMOLViewerTests/MCPBrokerTests.swift
+++ b/swiftui/PyMOLViewerTests/MCPBrokerTests.swift
@@ -100,4 +100,78 @@ final class MCPBrokerTests: XCTestCase {
         XCTAssertNil(MCPInstanceRegistry.match("Nope", in: list))
         XCTAssertNil(MCPInstanceRegistry.match("999", in: list))
     }
+
+    // MARK: - resolve
+
+    private var one: [MCPInstance] { MCPInstanceRegistry.decodeAll([blob(pid: 1, name: "RayMol")]) }
+    private var two: [MCPInstance] {
+        MCPInstanceRegistry.decodeAll([blob(pid: 1, name: "RayMol"),
+                                       blob(pid: 2, name: "RayMol-287")])
+    }
+
+    func testSingleLiveInstanceBinds() {
+        XCTAssertEqual(
+            MCPInstanceRegistry.resolve(instances: one, requestedKey: nil, envKey: nil, sticky: nil),
+            .bound(one[0]))
+    }
+
+    func testEmptyRegistryReportsNone() {
+        XCTAssertEqual(
+            MCPInstanceRegistry.resolve(instances: [], requestedKey: nil, envKey: nil, sticky: nil),
+            .none)
+    }
+
+    func testTwoInstancesAreAmbiguousRatherThanGuessed() {
+        XCTAssertEqual(
+            MCPInstanceRegistry.resolve(instances: two, requestedKey: nil, envKey: nil, sticky: nil),
+            .ambiguous(two))
+    }
+
+    // Precedence: an explicit in-conversation key beats env, sticky and the scan,
+    // so "use the 287 build" can rebind mid-session.
+    func testRequestedKeyWinsOverEverything() {
+        XCTAssertEqual(
+            MCPInstanceRegistry.resolve(instances: two, requestedKey: "RayMol-287",
+                                        envKey: "RayMol", sticky: two[0]),
+            .bound(two[1]))
+    }
+
+    func testEnvKeyWinsOverStickyAndScan() {
+        XCTAssertEqual(
+            MCPInstanceRegistry.resolve(instances: two, requestedKey: nil,
+                                        envKey: "RayMol-287", sticky: two[0]),
+            .bound(two[1]))
+    }
+
+    // Without sticky binding a two-instance setup would re-ask on every call.
+    func testStickyBindingSurvivesAnAmbiguousScan() {
+        XCTAssertEqual(
+            MCPInstanceRegistry.resolve(instances: two, requestedKey: nil, envKey: nil,
+                                        sticky: two[0]),
+            .bound(two[0]))
+    }
+
+    // The app the session was bound to quit; its entry is gone. Falling back to
+    // the scan is what makes "RayMol quit mid-session" cold-launch again.
+    func testStickyBindingIsDroppedWhenItsInstanceDied() {
+        XCTAssertEqual(
+            MCPInstanceRegistry.resolve(instances: [], requestedKey: nil, envKey: nil,
+                                        sticky: two[0]),
+            .none)
+    }
+
+    func testUnknownRequestedKeyIsReportedNotIgnored() {
+        XCTAssertEqual(
+            MCPInstanceRegistry.resolve(instances: two, requestedKey: "RayMol-999",
+                                        envKey: nil, sticky: nil),
+            .unknownKey("RayMol-999"))
+    }
+
+    // A stale env var must not strand a working single-instance session.
+    func testUnknownEnvKeyFallsThroughToTheScan() {
+        XCTAssertEqual(
+            MCPInstanceRegistry.resolve(instances: one, requestedKey: nil,
+                                        envKey: "RayMol-999", sticky: nil),
+            .bound(one[0]))
+    }
 }

--- a/swiftui/PyMOLViewerTests/MCPBrokerTests.swift
+++ b/swiftui/PyMOLViewerTests/MCPBrokerTests.swift
@@ -174,4 +174,30 @@ final class MCPBrokerTests: XCTestCase {
                                         envKey: "RayMol-999", sticky: nil),
             .bound(one[0]))
     }
+
+    // MARK: - selfEntry
+
+    // `installed` decides whether the broker may treat this app as the cold-launch
+    // target; deriving it from the bundle path keeps dev builds out of that role.
+    func testSelfEntryMarksAnAppOutsideApplicationsAsNotInstalled() {
+        XCTAssertFalse(MCPInstanceRegistry.isInstalled(path: "/Users/x/build/RayMol-287.app"))
+        XCTAssertTrue(MCPInstanceRegistry.isInstalled(path: "/Applications/RayMol.app"))
+    }
+
+    func testSelfEntryRoundTripsThroughDecode() {
+        let e = MCPInstance(pid: 7, port: 51737, token: "t", appPath: "/Applications/RayMol.app",
+                            name: "RayMol", installed: true, startedAt: "2026-08-19T10:00:00Z")
+        let data = try! JSONEncoder().encode(e)
+        XCTAssertEqual(MCPInstanceRegistry.decode(data), e)
+    }
+
+    // MARK: - liveness
+
+    // A crashed RayMol leaves its file behind. Proxying to that port either fails
+    // or, worse, reaches whatever else bound it since.
+    func testDeadPidsArePrunedFromAScan() {
+        let mine = Int(ProcessInfo.processInfo.processIdentifier)
+        let list = MCPInstanceRegistry.decodeAll([blob(pid: mine), blob(pid: 999_999, name: "Ghost")])
+        XCTAssertEqual(MCPInstanceRegistry.liveOnly(list).map(\.pid), [mine])
+    }
 }

--- a/swiftui/PyMOLViewerTests/MCPBrokerTests.swift
+++ b/swiftui/PyMOLViewerTests/MCPBrokerTests.swift
@@ -242,4 +242,21 @@ final class MCPBrokerTests: XCTestCase {
         XCTAssertTrue(text.contains("RayMol-287"))
         XCTAssertTrue(text.contains("instance"))
     }
+
+    // MARK: - cold launch
+
+    // Guards the rule that opening a Claude client must NOT open RayMol: only a
+    // tool call may launch. Regressing this turns every client start into a
+    // window appearing on the user's screen.
+    func testOnlyToolsCallMayColdLaunch() {
+        XCTAssertTrue(MCPBridge.mayColdLaunch(method: "tools/call"))
+        XCTAssertFalse(MCPBridge.mayColdLaunch(method: "initialize"))
+        XCTAssertFalse(MCPBridge.mayColdLaunch(method: "tools/list"))
+        XCTAssertFalse(MCPBridge.mayColdLaunch(method: "ping"))
+        XCTAssertFalse(MCPBridge.mayColdLaunch(method: "notifications/initialized"))
+    }
+
+    func testInstalledAppPathIsTheApplicationsBundle() {
+        XCTAssertEqual(MCPBridge.installedAppPath, "/Applications/RayMol.app")
+    }
 }

--- a/swiftui/PyMOLViewerTests/MCPBrokerTests.swift
+++ b/swiftui/PyMOLViewerTests/MCPBrokerTests.swift
@@ -200,4 +200,46 @@ final class MCPBrokerTests: XCTestCase {
         let list = MCPInstanceRegistry.decodeAll([blob(pid: mine), blob(pid: 999_999, name: "Ghost")])
         XCTAssertEqual(MCPInstanceRegistry.liveOnly(list).map(\.pid), [mine])
     }
+
+    // MARK: - offline contract
+
+    // The pre-existing guarantee this whole change must preserve: with nothing
+    // running, a client still gets a usable tools list, so the server never
+    // presents as errored.
+    func testOfflineToolsListStillNamesEveryTool() {
+        XCTAssertEqual(MCPBridge.offlineToolNames(),
+                       ["run_pymol_command", "run_python", "get_session_state",
+                        "capture_viewport", "search_pdb", "list_raymol_instances"])
+    }
+
+    // MARK: - instance argument
+
+    func testInstanceArgIsAddedToEveryToolSchema() {
+        let injected = MCPBridge.withInstanceArg([
+            ["name": "run_python",
+             "inputSchema": ["type": "object", "properties": ["code": ["type": "string"]],
+                             "required": ["code"]]],
+        ])
+        let schema = injected[0]["inputSchema"] as? [String: Any]
+        let props = schema?["properties"] as? [String: Any]
+        XCTAssertNotNil(props?["instance"], "every tool must accept an instance override")
+        XCTAssertNotNil(props?["code"], "existing properties must survive injection")
+        // `instance` is an override, never a requirement.
+        XCTAssertEqual(schema?["required"] as? [String], ["code"])
+    }
+
+    // MARK: - ambiguity
+
+    // The reply has to be actionable without further tool calls: it names the
+    // choices AND the exact way to re-issue, or the model will just guess.
+    func testAmbiguityTextListsEveryKeyAndSaysHowToRetry() {
+        let list = MCPInstanceRegistry.decodeAll([
+            blob(pid: 1, name: "RayMol"),
+            blob(pid: 2, name: "RayMol-287", installed: false),
+        ])
+        let text = MCPBridge.ambiguityText(list)
+        XCTAssertTrue(text.contains("RayMol"))
+        XCTAssertTrue(text.contains("RayMol-287"))
+        XCTAssertTrue(text.contains("instance"))
+    }
 }

--- a/swiftui/PyMOLViewerTests/MCPBrokerTests.swift
+++ b/swiftui/PyMOLViewerTests/MCPBrokerTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import RayMol
+
+/// Covers the pure core of the MCP broker: how a client decides WHICH RayMol
+/// it is talking to.
+///
+/// This matters because the broker is spawned by a Claude client with no user
+/// present to correct it. A stale registry entry that survives filtering means
+/// tool calls are proxied to a dead port; a wrong disambiguation means Claude
+/// silently drives a different window than the one the user is looking at.
+final class MCPBrokerTests: XCTestCase {
+
+    // MARK: - decode
+
+    private func blob(pid: Int = 4412, port: Int = 51737, name: String = "RayMol",
+                      installed: Bool = true) -> Data {
+        Data("""
+        {"pid":\(pid),"port":\(port),"token":"deadbeef","appPath":"/Applications/\(name).app",
+         "name":"\(name)","installed":\(installed),"startedAt":"2026-08-19T10:31:02Z"}
+        """.utf8)
+    }
+
+    func testDecodeReadsEveryField() {
+        let i = MCPInstanceRegistry.decode(blob())
+        XCTAssertEqual(i?.pid, 4412)
+        XCTAssertEqual(i?.port, 51737)
+        XCTAssertEqual(i?.token, "deadbeef")
+        XCTAssertEqual(i?.name, "RayMol")
+        XCTAssertEqual(i?.installed, true)
+    }
+
+    // A half-written or hand-edited file must not take the whole registry down:
+    // the broker's job is to keep working with the instances it CAN read.
+    func testDecodeRejectsGarbageWithoutThrowing() {
+        XCTAssertNil(MCPInstanceRegistry.decode(Data("not json".utf8)))
+        XCTAssertNil(MCPInstanceRegistry.decode(Data("{\"pid\":1}".utf8)))
+        XCTAssertNil(MCPInstanceRegistry.decode(Data()))
+    }
+
+    func testDecodeAllSkipsBadEntriesAndKeepsGoodOnes() {
+        let out = MCPInstanceRegistry.decodeAll([
+            blob(pid: 1, name: "RayMol"),
+            Data("{".utf8),
+            blob(pid: 2, name: "RayMol-287", installed: false),
+        ])
+        XCTAssertEqual(out.map(\.pid), [1, 2])
+    }
+}

--- a/swiftui/PyMOLViewerTests/MCPBrokerTests.swift
+++ b/swiftui/PyMOLViewerTests/MCPBrokerTests.swift
@@ -259,4 +259,34 @@ final class MCPBrokerTests: XCTestCase {
     func testInstalledAppPathIsTheApplicationsBundle() {
         XCTAssertEqual(MCPBridge.installedAppPath, "/Applications/RayMol.app")
     }
+
+    // MARK: - registration
+
+    // The desktop-app failure this change exists to fix: a Debug build in a
+    // worktree wrote its OWN path into claude_desktop_config.json, and Claude
+    // reported a hard error once that build directory was cleaned.
+    func testBridgeCommandPrefersTheInstalledApp() {
+        XCTAssertEqual(
+            MCPDesktopInstaller.preferredCommand(
+                installedExists: true,
+                running: "/Users/x/build_mac_dd/Build/Products/Debug/RayMol.app/Contents/MacOS/RayMol"),
+            "/Applications/RayMol.app/Contents/MacOS/RayMol")
+    }
+
+    func testBridgeCommandFallsBackToTheRunningBundle() {
+        XCTAssertEqual(
+            MCPDesktopInstaller.preferredCommand(installedExists: false, running: "/tmp/R.app/C/MacOS/R"),
+            "/tmp/R.app/C/MacOS/R")
+    }
+
+    // Claude Code must be registered as a spawnable stdio command, never as a
+    // pinned loopback URL — the URL is what goes stale on every restart.
+    func testClaudeCodeArgsRegisterStdioNotHttp() {
+        let args = MCPServerManager.claudeCodeAddArgs(command: "/Applications/RayMol.app/Contents/MacOS/RayMol")
+        XCTAssertFalse(args.contains("--transport"))
+        XCTAssertFalse(args.contains(where: { $0.contains("127.0.0.1") }))
+        XCTAssertEqual(Array(args.prefix(3)), ["mcp", "add", "raymol"])
+        XCTAssertTrue(args.contains("--"))
+        XCTAssertEqual(args.last, "--mcp-bridge")
+    }
 }

--- a/swiftui/PyMOLViewerTests/MCPBrokerTests.swift
+++ b/swiftui/PyMOLViewerTests/MCPBrokerTests.swift
@@ -289,4 +289,62 @@ final class MCPBrokerTests: XCTestCase {
         XCTAssertTrue(args.contains("--"))
         XCTAssertEqual(args.last, "--mcp-bridge")
     }
+
+    // The e2e harness must be able to cold-launch a SUFFIXED dev build instead of
+    // clobbering the user's real /Applications/RayMol.app. Same dev-only escape
+    // hatch as RAYMOL_MCP_PORT, and like it, never set in a Finder/`open` launch.
+    func testColdLaunchTargetHonoursTheDevOverride() {
+        XCTAssertEqual(MCPBridge.coldLaunchTarget(override: nil), "/Applications/RayMol.app")
+        XCTAssertEqual(MCPBridge.coldLaunchTarget(override: ""), "/Applications/RayMol.app")
+        XCTAssertEqual(MCPBridge.coldLaunchTarget(override: "/tmp/RayMol-broker.app"),
+                       "/tmp/RayMol-broker.app")
+    }
+
+    // MARK: - cold launch outcomes
+
+    // Every failure must name its OWN cause. The first cut collapsed a failed
+    // launch into "the MCP server didn't start", which blames the user's toggle
+    // for a LaunchServices problem and sends them to the wrong setting.
+    func testEachColdLaunchFailureExplainsItself() {
+        let notInstalled = MCPBridge.coldLaunchMessage(.notInstalled, path: "/Applications/RayMol.app")
+        XCTAssertTrue(notInstalled.contains("/Applications/RayMol.app"))
+        XCTAssertFalse(notInstalled.contains("Enable AI control"))
+
+        let running = MCPBridge.coldLaunchMessage(.alreadyRunningNotRegistered,
+                                                  path: "/Applications/RayMol.app")
+        XCTAssertTrue(running.contains("Enable AI control"))
+        XCTAssertTrue(running.contains("already running"))
+
+        let failed = MCPBridge.coldLaunchMessage(.launchFailed("kLSNoExecutableErr"),
+                                                 path: "/Applications/RayMol.app")
+        XCTAssertTrue(failed.contains("kLSNoExecutableErr"))
+        XCTAssertFalse(failed.contains("Enable AI control"))
+
+        let timedOut = MCPBridge.coldLaunchMessage(.timedOut, path: "/Applications/RayMol.app")
+        XCTAssertTrue(timedOut.contains("Enable AI control"))
+    }
+
+    // A cold launch must not leave the user's settings changed. Writing
+    // raymol.mcp.enabled=true would silently make EVERY future manual launch
+    // start the MCP server — a preference the user never chose. The launch
+    // environment carries the intent instead, and dies with the process.
+    func testLaunchEnvEnablesTheServerWithoutPersistingAPreference() {
+        let env = MCPBridge.launchEnvironment(portOverride: nil)
+        XCTAssertEqual(env["RAYMOL_MCP_ENABLE"], "1")
+        XCTAssertNil(env["RAYMOL_MCP_PORT"])
+
+        // The harness needs the launched app off the default port when another
+        // build already owns it.
+        let pinned = MCPBridge.launchEnvironment(portOverride: "0")
+        XCTAssertEqual(pinned["RAYMOL_MCP_PORT"], "0")
+    }
+
+    // A RayMol built BEFORE the registry existed never writes an entry, so the
+    // scan sees nothing and the broker would cold-launch a SECOND copy on top of
+    // the one the user is already using. The legacy handoff has to be tried
+    // first — cold launch is the last resort, not the first.
+    func testLegacyHandoffIsTriedBeforeColdLaunching() {
+        XCTAssertFalse(MCPBridge.shouldColdLaunch(legacyReachable: true))
+        XCTAssertTrue(MCPBridge.shouldColdLaunch(legacyReachable: false))
+    }
 }

--- a/swiftui/PyMOLViewerTests/MCPBrokerTests.swift
+++ b/swiftui/PyMOLViewerTests/MCPBrokerTests.swift
@@ -45,4 +45,59 @@ final class MCPBrokerTests: XCTestCase {
         ])
         XCTAssertEqual(out.map(\.pid), [1, 2])
     }
+
+    // MARK: - keys
+
+    func testKeyIsTheDisplayNameWhenUnique() {
+        let k = MCPInstanceRegistry.keys(for: MCPInstanceRegistry.decodeAll([
+            blob(pid: 1, name: "RayMol"),
+            blob(pid: 2, name: "RayMol-287"),
+        ]))
+        XCTAssertEqual(k[1], "RayMol")
+        XCTAssertEqual(k[2], "RayMol-287")
+    }
+
+    // Two checkouts can produce two apps with the SAME display name. Handing
+    // Claude two identical keys would make disambiguation impossible, so the
+    // pid has to enter the key — but only for the colliding names.
+    func testCollidingNamesGetPidSuffixedKeys() {
+        let k = MCPInstanceRegistry.keys(for: MCPInstanceRegistry.decodeAll([
+            blob(pid: 1, name: "RayMol"),
+            blob(pid: 2, name: "RayMol"),
+            blob(pid: 3, name: "RayMol-287"),
+        ]))
+        XCTAssertEqual(k[1], "RayMol#1")
+        XCTAssertEqual(k[2], "RayMol#2")
+        XCTAssertEqual(k[3], "RayMol-287")
+    }
+
+    // MARK: - match
+
+    func testMatchAcceptsName_KeyForm_AndBarePid() {
+        let list = MCPInstanceRegistry.decodeAll([
+            blob(pid: 1, name: "RayMol"),
+            blob(pid: 2, name: "RayMol"),
+            blob(pid: 3, name: "RayMol-287"),
+        ])
+        XCTAssertEqual(MCPInstanceRegistry.match("RayMol-287", in: list)?.pid, 3)
+        XCTAssertEqual(MCPInstanceRegistry.match("RayMol#2", in: list)?.pid, 2)
+        XCTAssertEqual(MCPInstanceRegistry.match("3", in: list)?.pid, 3)
+    }
+
+    // An ambiguous bare name must NOT resolve to an arbitrary instance —
+    // silently driving the wrong window is the failure this whole design exists
+    // to prevent.
+    func testMatchRefusesAnAmbiguousName() {
+        let list = MCPInstanceRegistry.decodeAll([
+            blob(pid: 1, name: "RayMol"),
+            blob(pid: 2, name: "RayMol"),
+        ])
+        XCTAssertNil(MCPInstanceRegistry.match("RayMol", in: list))
+    }
+
+    func testMatchReturnsNilForUnknownKey() {
+        let list = MCPInstanceRegistry.decodeAll([blob(pid: 1, name: "RayMol")])
+        XCTAssertNil(MCPInstanceRegistry.match("Nope", in: list))
+        XCTAssertNil(MCPInstanceRegistry.match("999", in: list))
+    }
 }

--- a/swiftui/tools/mcp_broker_e2e.sh
+++ b/swiftui/tools/mcp_broker_e2e.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# End-to-end check for the MCP broker.
+#
+#   1. a client handshake (initialize + tools/list) must NOT launch anything
+#   2. a tools/call with nothing running MUST cold-launch the app and return
+#
+# Drives a SUFFIXED dev build via RAYMOL_MCP_INSTALLED_APP so it never clobbers
+# the user's installed /Applications/RayMol.app.
+#
+# Usage: swiftui/tools/mcp_broker_e2e.sh /path/to/RayMol-broker.app
+set -uo pipefail
+APP="${1:?usage: mcp_broker_e2e.sh /path/to/RayMol-<suffix>.app}"
+NAME="$(basename "$APP" .app)"
+BIN="$APP/Contents/MacOS/$NAME"
+REG="$HOME/Library/Application Support/RayMol/instances"
+export RAYMOL_MCP_INSTALLED_APP="$APP"
+
+[ -x "$BIN" ] || { echo "FAIL: no executable at $BIN"; exit 1; }
+
+echo "== quitting $NAME =="
+pkill -x "$NAME" 2>/dev/null
+sleep 3
+echo "registry after quit: $(ls "$REG" 2>/dev/null | wc -l | tr -d ' ') entries"
+
+echo "== initialize + tools/list must NOT launch anything =="
+printf '%s\n%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+  | "$BIN" --mcp-bridge | head -2 | cut -c1-160
+sleep 2
+if pgrep -x "$NAME" >/dev/null; then echo "FAIL: a client handshake launched the app"; exit 1; fi
+echo "OK: handshake did not launch the app"
+
+echo "== tools/call must cold-launch =="
+printf '%s\n%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_session_state","arguments":{}}}' \
+  | "$BIN" --mcp-bridge | tail -1 | cut -c1-400
+echo
+pgrep -x "$NAME" >/dev/null && echo "OK: $NAME is running" || { echo "FAIL: not launched"; exit 1; }
+echo "registry now: $(ls "$REG" 2>/dev/null | wc -l | tr -d ' ') entries"
+ls "$REG" 2>/dev/null


### PR DESCRIPTION
Fixes the MCP error you get when opening a Claude client while RayMol is closed.

Implements `docs/superpowers/specs/2026-08-19-raymol-mcp-broker-design.md`.

## The two defects

- **Claude Code** was registered as a pinned loopback URL (`--transport http http://127.0.0.1:<ephemeral>/mcp`), a snapshot of a port that changes every restart. Wrong whenever RayMol is closed, stale whenever it restarts.
- **Claude desktop app** registered `Bundle.main.executablePath`, so a Debug build run from a worktree wrote *its own* path into `claude_desktop_config.json` — a hard spawn error once that build dir is cleaned.

## The change

Both clients now register the same stdio broker (`RayMol --mcp-bridge`), which resolves a target from a per-instance registry and cold-launches the installed app on the first tool call.

- **Registry** — each running RayMol writes `~/Library/Application Support/RayMol/instances/<pid>.json` (mode 0600). The legacy `mcp.json` is still written and is still read as a fallback.
- **Resolution** — explicit `instance` argument → `RAYMOL_MCP_INSTANCE` → sticky session binding → registry scan. Two or more instances returns a listing and asks; it never guesses which window to drive.
- **Cold launch** — only `tools/call` launches. Opening a client answers `initialize`/`tools/list` locally, so it stops erroring without popping a window open.
- **Trust is unchanged** — a model-initiated launch still raises RayMol's Allow prompt.
- New `list_raymol_instances` tool; every tool gains an optional `instance` override.

**No login-item daemon.** Both clients spawn processes, so a resident background executable would add a login item, a restart story and a second artifact to notarize for no capability that gets used. The spec argues this explicitly, and the registry is the piece a daemon would need if a non-spawning client ever shows up.

## Four defects the end-to-end harness found that unit tests could not

1. `NSWorkspace` activated an unrelated dev build instead of launching the requested bundle — every RayMol shares `io.raymol.RayMol`, so the launch needs `createsNewApplicationInstance`.
2. The launch error was discarded, so a LaunchServices failure reported itself as "the MCP server didn't start" and sent the user to the wrong setting. Each outcome now names its own cause.
3. Cold launch persisted `raymol.mcp.enabled = true`, arming the MCP server for every future *manual* launch — a decision only the user gets to make.
4. A pre-registry RayMol never registers, so the broker cold-launched a **second** copy on top of the one in use. The legacy handoff is now tried first.

## Verification

`swiftui/tools/mcp_broker_e2e.sh` drives a suffixed dev build via `RAYMOL_MCP_INSTALLED_APP`, so it never overwrites the installed app.

- Rebased onto `master` (was 21 commits behind; only conflict was the generated `project.pbxproj`, resolved by regenerating with xcodegen — every MCP source file is byte-identical post-rebase).
- Unit suite on the rebased branch: **369 tests, 0 failures, 4 skipped** (33 new in `MCPBrokerTests`; the rest includes master's `PredictControllerTests`). The scheme builds `PyMOLViewer_macOS`, so the app target compiles against master's code too.
- Handshake launches nothing; `tools/call` cold-launches, the instance registers, and the reply is the Allow prompt.
- With a pre-registry RayMol running, a tool call reached **it** (real session state) and launched no second copy.
- Two instances: ambiguity listing names both keys; `instance: "RayMol-broker2"` executed on that instance while the other returned its own untrusted reply; an unknown key errors.
- After a cold launch with the preference deleted, `raymol.mcp.enabled` is still absent; stale registry entries from killed instances were pruned on the next scan.

## Not done here

The two broken configs on the dev machine are untouched — repairing them is a local change, and the full benefit only lands once a build containing this is installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)