### PR TITLE
feat(ios): port the Predict tool to iPhone (Boltz int8, on-device)

### DIFF
--- a/modules/pymol/appkit_predict.py
+++ b/modules/pymol/appkit_predict.py
@@ -16,7 +16,25 @@ from pymol import cmd
 
 
 def _predictors():
-    """[{'id': str, 'msa': bool}] for every registered predictor, sorted by id.
+    """[{'id': str, 'msa': bool}] for every registered predictor that can ACTUALLY RUN
+    on this host, sorted by id.
+
+    Filtered by each predictor's own `check_available()`, not merely by what is
+    registered. The registry is the same on every platform -- it is built by
+    `_register_builtins()` with no per-OS branches -- so an unfiltered list offers
+    methods the host cannot run: on iOS the app advertises the `boltz` runtime alone
+    (see PyMOLBridge.mm's RAYMOL_PREDICT_RUNTIMES), which makes all six Protenix packs
+    refuse at submit time. Listing them anyway turns a clear "not on this platform"
+    into a menu entry that fails after the user has typed a sequence and hit Run.
+
+    An empty list is a meaningful answer, not a bug to paper over: under headless
+    `pymol -c` nothing consumes the PREDICT: marker, so every predictor is genuinely
+    unavailable and the bar must offer nothing rather than something that would hang.
+
+    Never raises: `check_available` is a predictor's own code, and one bad method must
+    not empty the whole menu. A predictor that throws anything other than a refusal is
+    treated as unavailable -- the conservative direction, since the alternative is
+    offering a method whose availability we could not establish.
 
     `msa` is the method's own `supports_msa`: the bar disables the MSA controls for
     a method (e.g. protenix) that would refuse an alignment.
@@ -26,6 +44,13 @@ def _predictors():
     for pid in registry.available():
         try:
             p = registry.get(pid)
+        except Exception:
+            continue
+        try:
+            p.check_available()
+        except Exception:
+            continue
+        try:
             supports = bool(getattr(p, 'supports_msa', False))
         except Exception:
             supports = False

--- a/modules/pymol/predictors/boltz2_bf16.py
+++ b/modules/pymol/predictors/boltz2_bf16.py
@@ -25,7 +25,10 @@ would be a strictly closer one at identical size. Both are exportable
 (`boltz-mlx export-model --precision`); bfloat16 is offered because it is the
 width Boltz was trained in.
 """
+import sys
+
 from .boltz2 import Boltz2Predictor
+from .errors import PredictorUnavailable
 from .weights import WeightBundle
 
 
@@ -47,3 +50,37 @@ class Boltz2BF16Predictor(Boltz2Predictor):
         size=1_044_050_191,
         members=('config.json', 'manifest.json', 'model.safetensors'),
     )
+
+    def check_available(self):
+        """Available wherever Boltz is -- EXCEPT iOS.
+
+        Not a capability limit: the bf16 runtime is the same Swift `boltz` runtime the
+        int8 pack uses, so this method would load and run on a phone. It is refused
+        because the iOS memory guard cannot honestly admit it.
+
+        `PredictSizeGuard.decide` takes tokens, MSA depth and available bytes -- it does
+        NOT take a predictor, so there is one fitted curve for all Boltz packs, and that
+        curve was fitted to MEASURED int8 peak `phys_footprint` on an iPhone 15 Pro. The
+        dense pack needs materially more than int8 at the same token count (bigger
+        resident weights: 1.04 GB against 529 MB, plus wider activations). Feeding it
+        through the int8 curve therefore produces an estimate BELOW the real cost, which
+        is the one direction this guard must never err in: the failure mode is a jetsam
+        SIGKILL that no Swift handler can catch and that takes the unsaved session with
+        it. The guard's own doc comment records it having been wrong optimistically twice.
+
+        The rule that follows from that is "never let a fit sit below a measurement", and
+        no bf16 run has been measured on device. So the pack is refused rather than
+        guessed at. Lifting this needs a device sweep of bf16 peak footprints and a
+        predictor-aware `decide`, not a scaled-up int8 number.
+
+        macOS is unaffected: `availableBytes` there is real physical memory with a desktop
+        headroom budget, and the desktop has no jetsam.
+        """
+        super().check_available()
+        if sys.platform == 'ios':
+            raise PredictorUnavailable(
+                '%s is not available on iOS: the dense bfloat16 pack needs more memory '
+                'than the int8 pack the on-device size guard is calibrated against, and '
+                'no bfloat16 run has been measured on device. Use boltz2 (int8).'
+                % self.id
+            )

--- a/modules/pymol/predictors/weights.py
+++ b/modules/pymol/predictors/weights.py
@@ -135,8 +135,24 @@ class WeightCache:
     def default_root(platform=None, home=None):
         platform = sys.platform if platform is None else platform
         home = os.path.expanduser('~') if home is None else home
-        if platform == 'darwin':
+        if platform in ('darwin', 'ios'):
             # Under the App Sandbox this same path resolves inside the container.
+            #
+            # 'ios' is NOT cosmetic. CPython reports sys.platform == 'ios' there, not
+            # 'darwin', so an iPhone used to fall through to the ~/.raymol branch below --
+            # and on iOS $HOME is the app's DATA CONTAINER ROOT, which is readable but not
+            # writable. The download failed at the first mkdir with
+            #   [Errno 1] Operation not permitted:
+            #   /var/mobile/Containers/Data/Application/<uuid>/.raymol
+            # after the user had already asked for a 529 MB fetch. Only Documents/,
+            # Library/ and tmp/ are writable inside the container, so the same
+            # Library/Application Support path the sandboxed Mac build uses is both the
+            # correct location here and already covered by this branch.
+            #
+            # Library/Application Support rather than Documents/ on purpose: weights are
+            # a reproducible cache, not user data, and Documents/ is surfaced in the Files
+            # app (UIFileSharingEnabled) where half a gigabyte of model shards would sit
+            # among the user's own structures inviting deletion.
             return os.path.join(home, 'Library', 'Application Support',
                                 'RayMol', 'weights')
         return os.path.join(home, '.raymol', 'weights')

--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		047FD10B437F95938AB4B3B0 /* WeightsFetchStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C4E3216DAFC42C515FD0C3E /* WeightsFetchStateTests.swift */; };
 		057F3C59DACA26AAC603702E /* AppBuildInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AE160C6EB58F631604002E6 /* AppBuildInfoTests.swift */; };
 		0C0E67D9436CC6DF29DE983C /* DesignEditingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05E6ECE945556A6D1FAE98F9 /* DesignEditingTests.swift */; };
+		0C7AFC549798A22C0FE22112 /* PredictCompactPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2C2F36B9B6E660DD0256EC2 /* PredictCompactPanel.swift */; };
 		0DDA865CB0C8ACAC1BFD0FE9 /* NotesInspectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DC456EDC3E55F84506C8B7 /* NotesInspectorView.swift */; };
 		0F6C6BD0DB9B077E51D1EFAF /* WhatsNewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5377EE69A856479317FD61 /* WhatsNewModel.swift */; };
 		0FFCBEB460CD541E932326AB /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3E805AC2D63B01AB7EE29C /* Theme.swift */; };
@@ -34,6 +35,7 @@
 		272C379DFEE54E979E9A15D2 /* whatsnew-190-scenes.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 6A0950CBB18F3934DDA02CBE /* whatsnew-190-scenes.mp4 */; };
 		2B6E59F50398ACB89A0BB029 /* DesignModeStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E47D8905CF71AF7BDF4BE074 /* DesignModeStateTests.swift */; };
 		2C2D4B24DF4807FA1407582D /* KeyRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3697F74BD2283492B5A7790C /* KeyRouting.swift */; };
+		2D3D69F7B73F3F499AD0894F /* PredictAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5AA1A4BFA5787E1B83D100 /* PredictAvailability.swift */; };
 		2E559E9581421DDC00C8BBB8 /* DesignScoreCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC5AE545F97DF175BFE0462 /* DesignScoreCache.swift */; };
 		300656C47AD9A9C18C129C42 /* SequencePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474D18A43D0D9A6BDD69EEFD /* SequencePanel.swift */; };
 		303210F410E1AD9DBCCF57F3 /* BoltzJobManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4B5DB2F82A55E25041FE28 /* BoltzJobManager.swift */; };
@@ -43,6 +45,7 @@
 		34985FCB3C0FBC450384D4C9 /* ProtenixSizeGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EE8A26A41F551AB296B2F8E /* ProtenixSizeGuard.swift */; };
 		36D99340CCDDAD7C67680476 /* whatsnew-161-hover.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 6E2FC2AD1A8FEE912986DF9D /* whatsnew-161-hover.mp4 */; };
 		3A8107D094C920B600681B74 /* ThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC5E722722DEF7FBB1D649F /* ThemeManager.swift */; };
+		3B4F843E2515C36E517E8FD7 /* PredictSizeGuardIOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4A62DDBB48F5166D118F32 /* PredictSizeGuardIOSTests.swift */; };
 		3D6FE0218915810960306973 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 589928DEEE69075B965DB9F2 /* Assets.xcassets */; };
 		3E6C34959A3934D2DE3E080F /* RayMolUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = F607D204A410CA38B84223BE /* RayMolUpdater.swift */; };
 		3ECB633FC33E73F4767D3AF5 /* MCPServerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F3D56C490BC7C6166DD79F /* MCPServerManager.swift */; };
@@ -68,10 +71,12 @@
 		55F78301BAF8CD914D86069D /* MCPConnectSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE692F1547C53D28B5F9A9AD /* MCPConnectSheet.swift */; };
 		56CC6A9A8A95D5B1B8D92688 /* PyMOLEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33D6A753E4525628B96C259C /* PyMOLEngine.swift */; };
 		575E4E4792DE4C46A70ECE01 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 10CCAA289EA2934B267C337A /* PrivacyInfo.xcprivacy */; };
+		57B2D711FAEB98EBCAD11CBC /* PredictScreenAwake.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4847B7F5C09AD3E9412C3EB /* PredictScreenAwake.swift */; };
 		57E2333020DE9DC8910BDC3E /* InteractionModeExitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43E4051E6410834AAAA4047 /* InteractionModeExitTests.swift */; };
 		598C60D5EA54B317DA845A5D /* PredictControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60E5CB80464F5616064A91C /* PredictControllerTests.swift */; };
 		5992346BC7D06026A673BA71 /* ObjectPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A73267D4D7B506E647B7A995 /* ObjectPanel.swift */; };
 		5A20A6D21AA3CFAE2394BAB4 /* dylib-Info-template.plist in Resources */ = {isa = PBXBuildFile; fileRef = 57E9E81F5C4757D03AAF7ABD /* dylib-Info-template.plist */; };
+		5B31EBD069B506D6B0C4DEEA /* PredictCompactPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2C2F36B9B6E660DD0256EC2 /* PredictCompactPanel.swift */; };
 		5C923361D76329D2A466FFA9 /* PyMOLApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D965CB609C447033E5DB0046 /* PyMOLApp.swift */; };
 		5CAB662574D238626A8F4D68 /* SmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F4F52D951CF1F96606F41C /* SmokeTests.swift */; };
 		5CEF96397383F4A7F731F9A0 /* ThemeStudioPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85B66833BF167209A47B9C15 /* ThemeStudioPanel.swift */; };
@@ -105,6 +110,7 @@
 		7B6E4F8683D469C6984163AA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 589928DEEE69075B965DB9F2 /* Assets.xcassets */; };
 		7B9C53449F7557047170D008 /* MovieExportSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FE79EC8844C681A41A1E54A /* MovieExportSheet.swift */; };
 		7F9C46E519B7180C507053BB /* MLXRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AD9869000B548D9F7CDF9DE /* MLXRuntimeTests.swift */; };
+		809165FC9A0F411860956BD6 /* PredictAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0825BFE369DAF40A6F3AA5D4 /* PredictAvailabilityTests.swift */; };
 		8471766417221874246F5252 /* WhatsNewLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3753EB4AA7EC91E685E36B84 /* WhatsNewLogic.swift */; };
 		848682B247E00ECDD720FF73 /* DesignResidues.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFE9998F68625C92B8BCD710 /* DesignResidues.swift */; };
 		86F8E58F4BAA9E8B03380DBB /* TransportBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C562306A5AD1EEDDBA931B98 /* TransportBar.swift */; };
@@ -124,7 +130,9 @@
 		9E056CF2985B57F6BF968798 /* ProtenixMLX in Frameworks */ = {isa = PBXBuildFile; productRef = 90EE4E4414E8FBDC2271BEA2 /* ProtenixMLX */; };
 		9FDA615BBA4A6BBDF131EF7F /* ProtenixRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56746569540D202277F2B47F /* ProtenixRuntimeTests.swift */; };
 		9FE703EF6FD7C97884C299DF /* RayMol.icon in Resources */ = {isa = PBXBuildFile; fileRef = BB5ABD1A8C45E5BC97AB0B80 /* RayMol.icon */; };
+		A39EA05FAD0B4D18957DA517 /* PredictAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5AA1A4BFA5787E1B83D100 /* PredictAvailability.swift */; };
 		A4E8C9619C9B7F0C169BFAFF /* BoltzMLX in Frameworks */ = {isa = PBXBuildFile; productRef = B20D95BF3CA7BA300F0AF09F /* BoltzMLX */; };
+		A653B70A6B824D1F48549503 /* BoltzMLX in Frameworks */ = {isa = PBXBuildFile; productRef = 0BD76B8E1C781556992E4D28 /* BoltzMLX */; };
 		A76B8F620DCFED6F7AD69FEE /* ProtenixRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7845A3EB6A6BF8A14F090062 /* ProtenixRuntime.swift */; };
 		AA00B9355E30A51B8F4C207B /* AppBuildInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525F338CAB2EE18987CD1701 /* AppBuildInfo.swift */; };
 		AA36D034CEC68207CFC82340 /* WhatsNewModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4D170B35BCCF683A6B3D655 /* WhatsNewModal.swift */; };
@@ -169,6 +177,7 @@
 		DC8A9C1AA5EB1946175041FA /* CommandPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50D264C420888CBF7FDE633 /* CommandPanel.swift */; };
 		DE0E67FF8DD0D44121F1B386 /* MCPStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1304C662D9011F7C4505FC /* MCPStatusView.swift */; };
 		E08AF23E9A696D29B94CA999 /* dylib-Info-template.plist in Resources */ = {isa = PBXBuildFile; fileRef = 57E9E81F5C4757D03AAF7ABD /* dylib-Info-template.plist */; };
+		E51EFBE3A58396C4934721ED /* PredictScreenAwake.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4847B7F5C09AD3E9412C3EB /* PredictScreenAwake.swift */; };
 		E777A44381A854B382874738 /* MCPConnectSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE692F1547C53D28B5F9A9AD /* MCPConnectSheet.swift */; };
 		E7A7CA409C1DB4D1A78AD5B9 /* DesignController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4FB7F151982A2927D612F0 /* DesignController.swift */; };
 		E9B0CF8BC5F291107F7C872B /* NotesInspectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DC456EDC3E55F84506C8B7 /* NotesInspectorView.swift */; };
@@ -186,6 +195,7 @@
 		F5F9A2124F71FDC7541A6BF8 /* 1ubq.cif in Resources */ = {isa = PBXBuildFile; fileRef = 1A55383922D69D691CA1BAB1 /* 1ubq.cif */; };
 		F619DEB3EA3D691634AE8268 /* MousePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221117550FAD97CF81924E05 /* MousePanel.swift */; };
 		F6C4DEEFED66EB440E6359AF /* PyMOLApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D965CB609C447033E5DB0046 /* PyMOLApp.swift */; };
+		F96DF6C063C742C64F3C221C /* PredictScreenAwakeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA9F6B00A6FC98E37CB26EC /* PredictScreenAwakeTests.swift */; };
 		FC8808FCB845C7543244AC94 /* MovieExportSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FE79EC8844C681A41A1E54A /* MovieExportSheet.swift */; };
 		FCB5A40892C6D7239E49791A /* DesignControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7E41DCBB427678A8F018B0E /* DesignControllerTests.swift */; };
 		FCE3C0AD3EC5319F8F2E144E /* DesignEditInferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6A959CC1590FC60333582B /* DesignEditInferenceTests.swift */; };
@@ -209,8 +219,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		02F1DF5E9689EFF422BE279A /* RayMolIOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RayMolIOS.entitlements; sourceTree = "<group>"; };
 		05C388F2E8B5A99F3CBFFC7E /* PyMOLViewer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PyMOLViewer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		05E6ECE945556A6D1FAE98F9 /* DesignEditingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignEditingTests.swift; sourceTree = "<group>"; };
+		0825BFE369DAF40A6F3AA5D4 /* PredictAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictAvailabilityTests.swift; sourceTree = "<group>"; };
 		0C3FB5B53174F8E55104705A /* whatsnew-170-homebrew.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "whatsnew-170-homebrew.png"; sourceTree = "<group>"; };
 		0C47FBC551127AB2D73BC6CE /* MetalViewportResponderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalViewportResponderTests.swift; sourceTree = "<group>"; };
 		0C4E3216DAFC42C515FD0C3E /* WeightsFetchStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightsFetchStateTests.swift; sourceTree = "<group>"; };
@@ -223,12 +235,14 @@
 		1A18D8A6B0FB56FCD3C31211 /* MCPBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPBridge.swift; sourceTree = "<group>"; };
 		1A55383922D69D691CA1BAB1 /* 1ubq.cif */ = {isa = PBXFileReference; path = 1ubq.cif; sourceTree = "<group>"; };
 		1A75842F74BFC453CE7BA777 /* BoltzJobManagerMSATests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoltzJobManagerMSATests.swift; sourceTree = "<group>"; };
+		1AA9F6B00A6FC98E37CB26EC /* PredictScreenAwakeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictScreenAwakeTests.swift; sourceTree = "<group>"; };
 		1B045EA1D04163863BD9DA94 /* DesignColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignColorTests.swift; sourceTree = "<group>"; };
 		1FF072CB363743CAF805155E /* KeyBindingDispatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyBindingDispatchTests.swift; sourceTree = "<group>"; };
 		221117550FAD97CF81924E05 /* MousePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MousePanel.swift; sourceTree = "<group>"; };
 		2345D7E2703CF29D4A2AA277 /* DesignAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignAvailabilityTests.swift; sourceTree = "<group>"; };
 		29DBC7BEEA492BFACB616C34 /* whatsnew-152-camera-dock.mp4 */ = {isa = PBXFileReference; path = "whatsnew-152-camera-dock.mp4"; sourceTree = "<group>"; };
 		2B749BA43350521D047F2CE4 /* whatsnew-190-design.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "whatsnew-190-design.png"; sourceTree = "<group>"; };
+		2E5AA1A4BFA5787E1B83D100 /* PredictAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictAvailability.swift; sourceTree = "<group>"; };
 		33D6A753E4525628B96C259C /* PyMOLEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PyMOLEngine.swift; sourceTree = "<group>"; };
 		356FC561FA1515B3D15A26E2 /* PyMOLBridge.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PyMOLBridge.mm; sourceTree = "<group>"; };
 		35DC456EDC3E55F84506C8B7 /* NotesInspectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesInspectorView.swift; sourceTree = "<group>"; };
@@ -290,6 +304,7 @@
 		B9EC978B16F58D988575E206 /* MCPDrivingBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPDrivingBanner.swift; sourceTree = "<group>"; };
 		BB5ABD1A8C45E5BC97AB0B80 /* RayMol.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = RayMol.icon; sourceTree = "<group>"; };
 		BF0B47016374F32C7BB13017 /* CopyRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyRoutingTests.swift; sourceTree = "<group>"; };
+		C2C2F36B9B6E660DD0256EC2 /* PredictCompactPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictCompactPanel.swift; sourceTree = "<group>"; };
 		C3F3410F7C0D3C85783B985F /* AppVersionFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionFooter.swift; sourceTree = "<group>"; };
 		C562306A5AD1EEDDBA931B98 /* TransportBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportBar.swift; sourceTree = "<group>"; };
 		C5F2DF248B756BF6CA3CBE92 /* DesignColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignColor.swift; sourceTree = "<group>"; };
@@ -301,8 +316,10 @@
 		D0BCB2A867C3554FB56A7299 /* DesignScoreCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignScoreCacheTests.swift; sourceTree = "<group>"; };
 		D177C9A043AE57844A9AEB95 /* PredictSizeGuardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictSizeGuardTests.swift; sourceTree = "<group>"; };
 		D1D7FF883D3762DC6E40908F /* DesignCompactPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignCompactPanel.swift; sourceTree = "<group>"; };
+		D4847B7F5C09AD3E9412C3EB /* PredictScreenAwake.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictScreenAwake.swift; sourceTree = "<group>"; };
 		D60E5CB80464F5616064A91C /* PredictControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictControllerTests.swift; sourceTree = "<group>"; };
 		D965CB609C447033E5DB0046 /* PyMOLApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PyMOLApp.swift; sourceTree = "<group>"; };
+		DA4A62DDBB48F5166D118F32 /* PredictSizeGuardIOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictSizeGuardIOSTests.swift; sourceTree = "<group>"; };
 		E2D0BB6A1E7959881767F049 /* MPNNRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPNNRuntime.swift; sourceTree = "<group>"; };
 		E47D8905CF71AF7BDF4BE074 /* DesignModeStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignModeStateTests.swift; sourceTree = "<group>"; };
 		E8EE6573045A81CF52A9CDF5 /* PyMOLGestureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PyMOLGestureUITests.swift; sourceTree = "<group>"; };
@@ -319,7 +336,7 @@
 		F7E41DCBB427678A8F018B0E /* DesignControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignControllerTests.swift; sourceTree = "<group>"; };
 		FB1304C662D9011F7C4505FC /* MCPStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPStatusView.swift; sourceTree = "<group>"; };
 		FF4FB7F151982A2927D612F0 /* DesignController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignController.swift; sourceTree = "<group>"; };
-		"TEMP_10A06E48-389B-40FD-B69A-488BA0D818F9" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
+		"TEMP_F1DCB80A-1B5A-49BB-B343-8211418995E6" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -351,6 +368,7 @@
 			files = (
 				54D986046911571938A3CF13 /* MPNNKit in Frameworks */,
 				C97C087311C3D159E74FA96A /* MLX in Frameworks */,
+				A653B70A6B824D1F48549503 /* BoltzMLX in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -426,6 +444,7 @@
 			children = (
 				10CCAA289EA2934B267C337A /* PrivacyInfo.xcprivacy */,
 				F2078076B68D28457409F7A5 /* RayMol.entitlements */,
+				02F1DF5E9689EFF422BE279A /* RayMolIOS.entitlements */,
 				A63406B360384F3C62E511E1 /* RayMolPython.entitlements */,
 				F5456D006DB0002CB809CACF /* Bridge */,
 				1A65998EE1F4B509B9B62F00 /* Panels */,
@@ -460,8 +479,11 @@
 				86E93358875495F499780A00 /* MLXRuntime.swift */,
 				56BE219EF1CF1EB2B05E44AD /* MPNNGate.swift */,
 				E2D0BB6A1E7959881767F049 /* MPNNRuntime.swift */,
+				2E5AA1A4BFA5787E1B83D100 /* PredictAvailability.swift */,
 				F14E7328C4421ADC9E81417D /* PredictBar.swift */,
+				C2C2F36B9B6E660DD0256EC2 /* PredictCompactPanel.swift */,
 				8B0D207800BE2DDAF04598C1 /* PredictController.swift */,
+				D4847B7F5C09AD3E9412C3EB /* PredictScreenAwake.swift */,
 				6C07F661E0541060409A09F7 /* PredictSizeGuard.swift */,
 				A4857D1284B60EB0C750C02F /* ProgressTray.swift */,
 				9B2D0B8DEF98F905922AE2FD /* ProtenixJobManager.swift */,
@@ -507,8 +529,11 @@
 				7AD9869000B548D9F7CDF9DE /* MLXRuntimeTests.swift */,
 				4A2C1E1633D1E93E9914BEC3 /* OpenFilesTests.swift */,
 				7DEAB18A89F026148528C71E /* PendingJobTests.swift */,
+				0825BFE369DAF40A6F3AA5D4 /* PredictAvailabilityTests.swift */,
 				D60E5CB80464F5616064A91C /* PredictControllerTests.swift */,
 				48793845CB95A609CD9F37BF /* PredictMSAMemorySweepTests.swift */,
+				1AA9F6B00A6FC98E37CB26EC /* PredictScreenAwakeTests.swift */,
+				DA4A62DDBB48F5166D118F32 /* PredictSizeGuardIOSTests.swift */,
 				D177C9A043AE57844A9AEB95 /* PredictSizeGuardTests.swift */,
 				56746569540D202277F2B47F /* ProtenixRuntimeTests.swift */,
 				55F4F52D951CF1F96606F41C /* SmokeTests.swift */,
@@ -537,10 +562,10 @@
 			path = Bridge;
 			sourceTree = "<group>";
 		};
-		"TEMP_EF6349F2-C8F5-427B-87FC-D5436E08DB23" /* swiftui */ = {
+		"TEMP_95B39CCF-CC5D-4F9A-82B9-FAD7B922A496" /* swiftui */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_10A06E48-389B-40FD-B69A-488BA0D818F9" /* PyMOLBridge.xcconfig */,
+				"TEMP_F1DCB80A-1B5A-49BB-B343-8211418995E6" /* PyMOLBridge.xcconfig */,
 			);
 			path = swiftui;
 			sourceTree = "<group>";
@@ -610,6 +635,7 @@
 			packageProductDependencies = (
 				80B2210B207942EBB65BAF59 /* MPNNKit */,
 				69935BE3EFD2F08B88D4AEE9 /* MLX */,
+				0BD76B8E1C781556992E4D28 /* BoltzMLX */,
 			);
 			productName = PyMOLViewer_iOS;
 			productReference = C78CBBCC3AFAD0E62BBAA884 /* PyMOLViewer.app */;
@@ -1218,8 +1244,11 @@
 				4AD1C0E0E53EC4B34CBE7400 /* MetalViewportResponderTests.swift in Sources */,
 				C89E138879C40C8FB6C0478A /* OpenFilesTests.swift in Sources */,
 				CFBEE2172EC92121700639E7 /* PendingJobTests.swift in Sources */,
+				809165FC9A0F411860956BD6 /* PredictAvailabilityTests.swift in Sources */,
 				598C60D5EA54B317DA845A5D /* PredictControllerTests.swift in Sources */,
 				615CCED824D7A973408A6CBD /* PredictMSAMemorySweepTests.swift in Sources */,
+				F96DF6C063C742C64F3C221C /* PredictScreenAwakeTests.swift in Sources */,
+				3B4F843E2515C36E517E8FD7 /* PredictSizeGuardIOSTests.swift in Sources */,
 				D1A6B8D3D1B74B4D1142ADE5 /* PredictSizeGuardTests.swift in Sources */,
 				9FDA615BBA4A6BBDF131EF7F /* ProtenixRuntimeTests.swift in Sources */,
 				5CAB662574D238626A8F4D68 /* SmokeTests.swift in Sources */,
@@ -1262,8 +1291,11 @@
 				FC8808FCB845C7543244AC94 /* MovieExportSheet.swift in Sources */,
 				0DDA865CB0C8ACAC1BFD0FE9 /* NotesInspectorView.swift in Sources */,
 				4679E36960C9AE8AAE3B1F7D /* ObjectPanel.swift in Sources */,
+				2D3D69F7B73F3F499AD0894F /* PredictAvailability.swift in Sources */,
 				D31F1B51A22EDBE0B05005AE /* PredictBar.swift in Sources */,
+				5B31EBD069B506D6B0C4DEEA /* PredictCompactPanel.swift in Sources */,
 				4328A7D903B06B6115075B3B /* PredictController.swift in Sources */,
+				57B2D711FAEB98EBCAD11CBC /* PredictScreenAwake.swift in Sources */,
 				3494764DF6FC43A45FB259AF /* PredictSizeGuard.swift in Sources */,
 				AF7D82103248D30E0CD32311 /* ProgressTray.swift in Sources */,
 				783033ED2463B78CD831611D /* ProtenixJobManager.swift in Sources */,
@@ -1321,8 +1353,11 @@
 				7B9C53449F7557047170D008 /* MovieExportSheet.swift in Sources */,
 				E9B0CF8BC5F291107F7C872B /* NotesInspectorView.swift in Sources */,
 				5992346BC7D06026A673BA71 /* ObjectPanel.swift in Sources */,
+				A39EA05FAD0B4D18957DA517 /* PredictAvailability.swift in Sources */,
 				5D0883E6462ADA97AEAA823D /* PredictBar.swift in Sources */,
+				0C7AFC549798A22C0FE22112 /* PredictCompactPanel.swift in Sources */,
 				6D67CAB3F655837D48E68AF3 /* PredictController.swift in Sources */,
+				E51EFBE3A58396C4934721ED /* PredictScreenAwake.swift in Sources */,
 				F5BEB7A4A5B270B0A64476D2 /* PredictSizeGuard.swift in Sources */,
 				BDF58C2A00D4BFACD41D6462 /* ProgressTray.swift in Sources */,
 				BAF51FE61B64C23C51DF4AAF /* ProtenixJobManager.swift in Sources */,
@@ -1525,7 +1560,7 @@
 		};
 		76B7E9DB75E073D1E60928FA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_10A06E48-389B-40FD-B69A-488BA0D818F9" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_F1DCB80A-1B5A-49BB-B343-8211418995E6" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1632,7 +1667,7 @@
 		};
 		D8F44FDFF036013D2F03BA83 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_10A06E48-389B-40FD-B69A-488BA0D818F9" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_F1DCB80A-1B5A-49BB-B343-8211418995E6" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1804,6 +1839,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		0BD76B8E1C781556992E4D28 /* BoltzMLX */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C2A63CE2513FB93FA639FB61 /* XCRemoteSwiftPackageReference "boltz-mlx" */;
+			productName = BoltzMLX;
+		};
 		69935BE3EFD2F08B88D4AEE9 /* MLX */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 59736E03D73BFCCFF74027FA /* XCRemoteSwiftPackageReference "mlx-swift" */;

--- a/swiftui/PyMOLViewer/Bridge/PyMOLBridge.mm
+++ b/swiftui/PyMOLViewer/Bridge/PyMOLBridge.mm
@@ -97,7 +97,14 @@ void PyMOLBridge_InitPython(PyMOLHandle h, const char *resourcePath)
     PyConfig_SetBytesString(&config, &config.program_name, "PyMOL");
     PyConfig_SetBytesString(&config, &config.home, [pythonHome UTF8String]);
 
-#if TARGET_OS_OSX
+// macOS, and iOS on real hardware. The iOS SIMULATOR is deliberately excluded: MLX
+// cannot run there at all (MTLSimDevice forbids the private-storage heaps MLX's
+// allocator builds — see MLXRuntime.deviceConfigured), so a simulator that claimed a
+// host would let cmd.predict submit a job whose only possible outcome is an abort.
+// Leaving the variable unset makes host.available() False, and the predictor refuses
+// with the accurate "needs the RayMol application host" message instead. This mirrors
+// PredictAvailability on the Swift side; the two must agree.
+#if TARGET_OS_OSX || (TARGET_OS_IOS && !TARGET_OS_SIMULATOR)
     // Tells modules/pymol/predictors/host.py that a host is listening for PREDICT:
     // markers on the feedback line. There is no Python->Swift call path, so this
     // variable IS how Python knows inference is reachable; absent under headless
@@ -117,7 +124,17 @@ void PyMOLBridge_InitPython(PyMOLHandle h, const char *resourcePath)
     // waited out a weight download. Keep in step with BoltzJobManager.boltzRuntime and
     // ProtenixJobManager.runtimeName; add a name here only when its runtime actually
     // ships, because check_available trusts this list to decide what can run.
+    // iOS carries the Boltz runtime ONLY. Protenix is deliberately not ported: it
+    // peaks near 3.9 GB at 400 residues (modules/pymol/predictors/protenix.py), which
+    // is past an iPhone's jetsam ceiling, and ProtenixJobManager/ProtenixSizeGuard stay
+    // behind `#if os(macOS)`. Advertising "protenix" here would let check_available
+    // green-light a predictor whose Swift half does not exist in this binary, and the
+    // user would only find out after waiting out a weight download.
+#if TARGET_OS_OSX
     setenv("RAYMOL_PREDICT_RUNTIMES", "boltz,protenix", 1);
+#else
+    setenv("RAYMOL_PREDICT_RUNTIMES", "boltz", 1);
+#endif
 #endif
 
     PyStatus status = Py_InitializeFromConfig(&config);

--- a/swiftui/PyMOLViewer/RayMolIOS.entitlements
+++ b/swiftui/PyMOLViewer/RayMolIOS.entitlements
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- iOS-only entitlements. Deliberately a SEPARATE file from RayMol.entitlements
+         (macOS: App Sandbox + network + user-selected files + keychain): the sandbox keys
+         there are macOS concepts, and increased-memory-limit below is an iOS one. Merging
+         them into one file would put an iOS-only key into the Mac App Store submission,
+         which is exactly the kind of thing App Review rejects for.
+
+         com.apple.developer.kernel.increased-memory-limit raises this app's jetsam
+         ceiling on devices that have the RAM to spare. It is what makes on-device folding
+         viable at a useful size: without it an iPhone 15 Pro app budget sits near 2.5 GB,
+         against which PredictSizeGuard refuses anything past ~120 residues — inside the
+         100-150 residue range this port exists to serve. It requires no capability in the
+         developer portal and no review; Apple documents it for exactly this case (large
+         on-device ML working sets).
+
+         It is a REQUEST, not a guarantee: the kernel may decline it, and it raises the
+         ceiling rather than removing it. So it changes the number PredictSizeGuard reads
+         from os_proc_available_memory() and changes nothing about the guard's logic — the
+         guard still refuses when the estimate does not fit whatever budget is actually
+         granted. Never treat this entitlement as licence to loosen the guard. -->
+    <key>com.apple.developer.kernel.increased-memory-limit</key>
+    <true/>
+</dict>
+</plist>

--- a/swiftui/PyMOLViewer/Shared/BoltzJobManager.swift
+++ b/swiftui/PyMOLViewer/Shared/BoltzJobManager.swift
@@ -169,6 +169,25 @@ final class BoltzJobManager {
         /// growth against a multi-GB actual -- so this is the only honest instrument, and
         /// it is what `PredictSizeGuard`'s constants must be fitted against.
         let peakBytes: Int?
+        /// The MAXIMUM `phys_footprint` this process reached during the run, in bytes,
+        /// sampled every 200 ms (see ``FootprintSampler``). Nil until the run finishes.
+        ///
+        /// **Not a duplicate of ``peakBytes``, and the difference is the point.** MLX's
+        /// high-water mark EXCLUDES its own buffer cache
+        /// (mlx-swift/Source/MLX/Memory.swift:171-178), so it under-reports what the
+        /// system sees. `phys_footprint` is the quantity **jetsam kills on** and the one
+        /// `os_proc_available_memory()` is denominated in — so on iOS it, not `peakBytes`,
+        /// is what ``PredictSizeGuard``'s estimate is actually racing.
+        ///
+        /// The comment above about RSS being useless refers to `resident_size`, which
+        /// omits compressed and IOKit-mapped pages and therefore misses Metal allocations
+        /// entirely. `phys_footprint` includes them; the two are different instruments and
+        /// only one of them was tried.
+        ///
+        /// Recorded rather than derived because the gap between the two is not a constant:
+        /// it is whatever the cache happens to be holding, which is exactly the thing a
+        /// fitted model cannot know.
+        var footprintBytes: Int? = nil
         /// Wall time for the inference itself, excluding the one-time model load.
         let elapsedSeconds: Double?
         /// Steps completed within the CURRENT phase, and that phase's total --
@@ -185,7 +204,8 @@ final class BoltzJobManager {
 
         enum CodingKeys: String, CodingKey {
             case state, phase, fraction, error, resultPath = "result_path"
-            case peakBytes = "peak_bytes", elapsedSeconds = "elapsed_s"
+            case peakBytes = "peak_bytes", footprintBytes = "footprint_bytes"
+            case elapsedSeconds = "elapsed_s"
             case step, totalSteps = "total_steps"
         }
     }
@@ -601,12 +621,14 @@ final class BoltzJobManager {
         let statusURL = URL(fileURLWithPath: request.statusPath)
         // Captured by report() below; filled in once inference completes.
         var peak: Int? = nil
+        var footprint: Int? = nil
         var elapsed: Double? = nil
         func report(_ state: String, _ phase: String, _ fraction: Double,
                     error: String? = nil, result: String? = nil) {
             try? Self.writeStatus(Status(state: state, phase: phase, fraction: fraction,
                                          error: error, resultPath: result,
-                                         peakBytes: peak, elapsedSeconds: elapsed),
+                                         peakBytes: peak, footprintBytes: footprint,
+                                         elapsedSeconds: elapsed),
                                   to: statusURL)
         }
         func isCancelled() -> Bool {
@@ -616,13 +638,16 @@ final class BoltzJobManager {
             Self.settle(request,
                         Status(state: state, phase: phase, fraction: 0,
                                error: error, resultPath: nil,
-                               peakBytes: peak, elapsedSeconds: elapsed),
+                               peakBytes: peak, footprintBytes: footprint,
+                               elapsedSeconds: elapsed),
                         to: statusURL)
         }
 
         report("running", "featurize", 0.0)
         Self.logMemory("start", jobID: request.jobID)
-        defer { Self.logMemory("end", jobID: request.jobID) }
+        let sampler = Self.FootprintSampler()
+        sampler.start()
+        defer { sampler.stop(); Self.logMemory("end", jobID: request.jobID) }
         do {
             BoltzRuntime.configureOnce()
 
@@ -737,6 +762,9 @@ final class BoltzJobManager {
             }
             elapsed = Date().timeIntervalSince(started)
             peak = Self.awaitSyncValue { await predictor.memorySnapshot().peakMemory }
+            // Read at the same moment as the MLX peak, before anything is released, so
+            // the two describe the same instant.
+            footprint = max(sampler.peak, MLXRuntime.currentFootprintBytes)
 
             if isCancelled() {
                 settle("cancelled", "inference"); return
@@ -873,6 +901,45 @@ final class BoltzJobManager {
         Task { out = await body(); done.signal() }
         done.wait()
         return out
+    }
+
+    /// Samples `phys_footprint` on a timer and keeps the maximum seen.
+    ///
+    /// Exists because neither number recorded before it is the peak the OS kills on.
+    /// MLX's own high-water mark excludes its buffer cache, and a single `phys_footprint`
+    /// read taken after `memorySnapshot()` is a POST-RELEASE reading — measured at 1.05 GB
+    /// for both a 110- and a 164-residue fold whose MLX peaks were 1.38 and 2.00 GB, which
+    /// is how you can tell it is not measuring the peak of anything. Only sampling
+    /// throughout gives the quantity `os_proc_available_memory()` is denominated in, and
+    /// therefore the only quantity ``PredictSizeGuard``'s budget comparison is actually
+    /// about.
+    ///
+    /// 200 ms and a plain background thread: inference runs tens of seconds, so a few
+    /// hundred samples is ample resolution, and a `task_info` call is a syscall costing
+    /// microseconds. Deliberately not a DispatchSourceTimer on the shared queue — the
+    /// point is to keep sampling while that queue is saturated by inference.
+    final class FootprintSampler {
+        private let lock = NSLock()
+        private var _peak = 0
+        private var running = true
+
+        var peak: Int { lock.lock(); defer { lock.unlock() }; return _peak }
+
+        func start() {
+            Thread.detachNewThread { [weak self] in
+                while true {
+                    guard let self else { return }
+                    self.lock.lock()
+                    let go = self.running
+                    if go { self._peak = max(self._peak, MLXRuntime.currentFootprintBytes) }
+                    self.lock.unlock()
+                    if !go { return }
+                    Thread.sleep(forTimeInterval: 0.2)
+                }
+            }
+        }
+
+        func stop() { lock.lock(); running = false; lock.unlock() }
     }
 
     /// Record the memory position around a fold, on the `com.raymol.predict` subsystem.

--- a/swiftui/PyMOLViewer/Shared/BoltzJobManager.swift
+++ b/swiftui/PyMOLViewer/Shared/BoltzJobManager.swift
@@ -1,4 +1,4 @@
-#if os(macOS)
+#if os(macOS) || os(iOS)
 import BoltzMLX
 import Foundation
 
@@ -295,8 +295,11 @@ final class BoltzJobManager {
             }
             // Broadcast: a cancel marker carries only a job id, so there is nothing in it
             // to route on. Every manager keeps only its own ids, and a cancel for a job
-            // this one never had is a no-op.
+            // this one never had is a no-op. macOS only because Protenix is: iOS links
+            // no second manager, so there is nothing to broadcast to.
+            #if os(macOS)
             ProtenixJobManager.shared.cancel(jobID: marker.jobID)
+            #endif
         case .submit:
             let url = URL(fileURLWithPath: NSTemporaryDirectory())
                 .appendingPathComponent("raymol_predict_req_\(marker.jobID).json")
@@ -323,10 +326,18 @@ final class BoltzJobManager {
             // This manager owns the marker only because it was here first. When a third
             // runtime lands, lift the parse-and-route out into a dispatcher rather than
             // adding another branch here.
+            //
+            // macOS only, and the iOS arm needs no fallback branch: PyMOLBridge.mm
+            // advertises "boltz" alone there, so host.require_runtime refuses a protenix
+            // request in Python before any marker is printed. If one somehow arrived, it
+            // would fall through to Self.preflight below, whose runtime check refuses
+            // exactly this case with an accurate message.
+            #if os(macOS)
             if request.runtime == ProtenixJobManager.runtimeName {
                 ProtenixJobManager.shared.submit(request)
                 return
             }
+            #endif
             if let failure = Self.preflight(request) {
                 // Refused before any work: the placeholder Python just created will never
                 // be filled, so drop it rather than leaving an empty stub behind.
@@ -861,19 +872,49 @@ final class BoltzJobManager {
         return out
     }
 
+    /// The memory plan handed to `BoltzPredictor`, per platform.
+    ///
+    /// In both arms `cacheLimit` is pinned to whatever ``MLXRuntime`` has arbitrated,
+    /// because `MemoryPlanner.apply()` assigns `MLX.Memory.cacheLimit` on **every**
+    /// predict call. Passing the arbitrated value makes that assignment re-assert the
+    /// agreed ceiling rather than substitute boltz-mlx's own default and quietly
+    /// out-vote the min-wins registry.
+    ///
+    /// **macOS — `.desktop` limits.** boltz-mlx's default preset is phone-sized (256
+    /// tokens, 2 048 atoms, 1 024 MSA rows) and would refuse anything real on a Mac.
+    ///
+    /// **iOS — the phone preset, explicitly.** `BoltzInputLimits` has no `.phone`
+    /// static; the phone numbers ARE `MemoryPlanner`'s defaults, so they are written out
+    /// here rather than obtained by omitting arguments — an upstream change to those
+    /// defaults should be a visible diff, not a silent change to what an iPhone will
+    /// accept. 2 048 atoms is the binding limit in practice, not the 256 tokens: a
+    /// single-chain protein runs about 7.7 atoms per residue, so ~265 residues reaches
+    /// the atom cap first. Both sit above ``PredictSizeGuard/iOSMaximumTokens``, which is
+    /// the gate that actually decides, and this is the belt to its braces — it refuses
+    /// inside the runtime if anything ever reaches here ungated.
+    ///
+    /// `memoryLimit` is the substantive iOS change: see
+    /// ``BoltzRuntime/memoryLimitBytes`` for why a 6 GB default cannot fire on a phone.
+    private static var memoryPlanner: MemoryPlanner {
+        #if os(iOS)
+        return MemoryPlanner(
+            limits: BoltzInputLimits(maximumTokens: 256, maximumAtoms: 2_048,
+                                     maximumMSADepth: 1_024),
+            memoryLimit: BoltzRuntime.memoryLimitBytes,
+            cacheLimit: MLXRuntime.activeCacheLimitBytes)
+        #else
+        return MemoryPlanner(limits: .desktop,
+                             cacheLimit: MLXRuntime.activeCacheLimitBytes)
+        #endif
+    }
+
     /// Reuses the loaded predictor when the weights directory is unchanged.
     private func loadedPredictor(directory: String) throws -> BoltzPredictor {
         try stateQueue.sync {
             if let existing = predictor, predictorDirectory == directory { return existing }
             let built = try BoltzRuntime.withMLXErrorsAsThrows {
-                try BoltzPredictor(
-                    modelDirectory: URL(fileURLWithPath: directory),
-                    // The default preset is phone-sized (256 tokens) and would refuse
-                    // anything real. cacheLimit is pinned to whatever MLXRuntime has
-                    // arbitrated so this planner's apply() re-asserts the agreed
-                    // ceiling instead of substituting its own 64 MiB default.
-                    memoryPlanner: MemoryPlanner(limits: .desktop,
-                                                 cacheLimit: MLXRuntime.activeCacheLimitBytes))
+                try BoltzPredictor(modelDirectory: URL(fileURLWithPath: directory),
+                                   memoryPlanner: Self.memoryPlanner)
             }
             predictor = built
             predictorDirectory = directory

--- a/swiftui/PyMOLViewer/Shared/BoltzJobManager.swift
+++ b/swiftui/PyMOLViewer/Shared/BoltzJobManager.swift
@@ -647,7 +647,16 @@ final class BoltzJobManager {
         Self.logMemory("start", jobID: request.jobID)
         let sampler = Self.FootprintSampler()
         sampler.start()
-        defer { sampler.stop(); Self.logMemory("end", jobID: request.jobID) }
+        // Pin the display for the whole run, taken HERE rather than left to the view
+        // layer: the view learns about a job only through the ~500 ms object-panel poll,
+        // and a fold has been observed freezing at diffusion step 42 because the phone
+        // locked inside that window. See PredictScreenAwake.setJobActive.
+        PredictScreenAwake.setJobActive(true)
+        defer {
+            PredictScreenAwake.setJobActive(false)
+            sampler.stop()
+            Self.logMemory("end", jobID: request.jobID)
+        }
         do {
             BoltzRuntime.configureOnce()
 

--- a/swiftui/PyMOLViewer/Shared/BoltzJobManager.swift
+++ b/swiftui/PyMOLViewer/Shared/BoltzJobManager.swift
@@ -1,6 +1,7 @@
 #if os(macOS) || os(iOS)
 import BoltzMLX
 import Foundation
+import os
 
 /// Runs Boltz predictions on behalf of Python.
 ///
@@ -620,6 +621,8 @@ final class BoltzJobManager {
         }
 
         report("running", "featurize", 0.0)
+        Self.logMemory("start", jobID: request.jobID)
+        defer { Self.logMemory("end", jobID: request.jobID) }
         do {
             BoltzRuntime.configureOnce()
 
@@ -870,6 +873,31 @@ final class BoltzJobManager {
         Task { out = await body(); done.signal() }
         done.wait()
         return out
+    }
+
+    /// Record the memory position around a fold, on the `com.raymol.predict` subsystem.
+    ///
+    /// Exists because the numbers this feature is governed by cannot be obtained any other
+    /// way on a phone. `PredictSizeGuard`'s whole iOS fit is reasoned against what
+    /// `os_proc_available_memory()` actually reports on the device, and the way that
+    /// question gets answered wrongly is by nobody ever asking it — the guard's three
+    /// recorded failures were all fits nobody checked against a measurement. A jetsam kill
+    /// also leaves no crash log worth reading, so the LAST line logged before a
+    /// disappearance is frequently the only evidence of what the run was asking for.
+    ///
+    /// Logged rather than asserted: this is diagnostic, it must never change behaviour,
+    /// and `os_log` survives the process being killed where a `print` to a detached
+    /// stdout does not. Cheap enough to leave in shipping builds — twice per fold.
+    static func logMemory(_ marker: String, jobID: String) {
+        let footprint = MLXRuntime.currentFootprintBytes
+        #if os(iOS)
+        let available = os_proc_available_memory()
+        #else
+        let available = 0
+        #endif
+        let mb = { (b: Int) in b / (1024 * 1024) }
+        Logger(subsystem: "com.raymol.predict", category: "memory")
+            .log("predict \(marker, privacy: .public) job=\(jobID, privacy: .public) footprint=\(mb(footprint), privacy: .public)MiB available=\(mb(available), privacy: .public)MiB cacheLimit=\(mb(MLXRuntime.activeCacheLimitBytes), privacy: .public)MiB")
     }
 
     /// The memory plan handed to `BoltzPredictor`, per platform.

--- a/swiftui/PyMOLViewer/Shared/BoltzRuntime.swift
+++ b/swiftui/PyMOLViewer/Shared/BoltzRuntime.swift
@@ -1,5 +1,8 @@
-#if os(macOS)
+#if os(macOS) || os(iOS)
 import Foundation
+#if os(iOS)
+import os   // os_proc_available_memory()
+#endif
 
 /// Structure prediction's MLX policy. The process-wide MLX configuration itself lives
 /// in ``MLXRuntime``; this type contributes only the numbers prediction requires.
@@ -12,10 +15,70 @@ import Foundation
 /// silently and by call order.
 enum BoltzRuntime {
 
-    /// Larger than Design mode's ceiling: the trunk's pairwise tensors reuse big
-    /// buffers, and a Mac is not jetsam-constrained the way a phone is. This is a
-    /// *request*, not a claim — ``MLXRuntime`` resolves any disagreement downward.
-    static let cacheLimitBytes = 256 * 1024 * 1024
+    /// MLX buffer-cache ceiling this feature requests. A *request*, not a claim —
+    /// ``MLXRuntime`` resolves any disagreement downward (min-wins).
+    ///
+    /// **macOS — 256 MB.** Larger than Design mode's ceiling: the trunk's pairwise
+    /// tensors reuse big buffers, and a Mac is not jetsam-constrained the way a phone
+    /// is.
+    ///
+    /// **iOS — 64 MB.** Lower than Design mode's 96 MB, and lower on purpose. The cache
+    /// is retained memory that counts against `phys_footprint`, which is the number
+    /// jetsam kills on; a fold's own tensors already run to ~1.4 GB against an app
+    /// budget of roughly 2–3 GB, so cache is the cheapest gigabyte-fraction to give
+    /// back. The asymmetry documented on ``MLXRuntime/requireCacheLimit(_:owner:)``
+    /// applies directly: too low costs allocator churn — slower, never fatal — while too
+    /// high risks an uncatchable SIGKILL. 64 MB is also boltz-mlx's own phone default
+    /// (`MemoryPlanner.init`), so this asks for no more than upstream sized for a phone.
+    ///
+    /// Because arbitration is min-wins and process-global, on iOS this ALSO pulls Design
+    /// mode's effective ceiling from 96 MB to 64 MB whenever both are registered. That is
+    /// the intended direction and is safe by construction — a smaller cache cannot make
+    /// Design fail, only churn — but it is a real behaviour change on iOS and is called
+    /// out here rather than left to be discovered.
+    static var cacheLimitBytes: Int {
+        #if os(iOS)
+        return 64 * 1024 * 1024
+        #else
+        return 256 * 1024 * 1024
+        #endif
+    }
+
+    #if os(iOS)
+    /// The `MLX.Memory.memoryLimit` a phone run should install, in bytes.
+    ///
+    /// This exists to convert an *uncatchable* failure into a catchable one. Past this
+    /// ceiling MLX reports an allocation failure, which ``withMLXErrorsAsThrows(_:)``
+    /// turns into a Swift `throw` that ``BoltzJobManager`` can fail the job on; without
+    /// it the same overshoot arrives as a jetsam SIGKILL that kills the app and the
+    /// unsaved session. boltz-mlx's own default is 6 GB — a desktop number that on a
+    /// phone sits far above the point where the OS has already killed us, so it can
+    /// never fire.
+    ///
+    /// Set to the app's whole jetsam ceiling (`available + already used`) rather than to
+    /// this run's budget, and that choice is deliberate on two counts:
+    ///
+    /// - `MLX.Memory.memoryLimit` is **process-global and not arbitrated** by
+    ///   ``MLXRuntime`` (which mediates only `cacheLimit`). A ceiling sized to one Boltz
+    ///   run would outlive the run and clamp Design mode's next inference too. Sizing it
+    ///   to the device ceiling leaves every other MLX consumer exactly as it was, because
+    ///   nothing may legitimately exceed that number anyway.
+    /// - Per-input budgeting is ``PredictSizeGuard``'s job, and it runs *before* the job
+    ///   is submitted. This is the backstop underneath it, not a second opinion.
+    ///
+    /// Read live at configure time, not cached: `os_proc_available_memory()` moves with
+    /// whatever structures are loaded, and a value captured at launch would be stale by
+    /// the time a session has a target open in it.
+    static var memoryLimitBytes: Int {
+        let footprint = MLXRuntime.currentFootprintBytes
+        let available = os_proc_available_memory()
+        // Floor at 1 GB so a pathological reading (footprint unavailable, or a device
+        // already near its limit) cannot install a ceiling so low that MLX refuses to
+        // load the weights at all — that would turn a memory backstop into a hard
+        // "prediction is broken", which is a worse failure than the one it prevents.
+        return max(1024 * 1024 * 1024, available + footprint)
+    }
+    #endif
 
     /// Identifies this requirement in ``MLXRuntime/cacheLimitRequirements``.
     static let cacheLimitOwner = "Boltz"

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -272,7 +272,30 @@ struct ContentView: View {
                 }
             }
             #endif
+            #if os(iOS)
+            // Hold the screen awake while a fold or a weight download is in flight.
+            // Attached at the root, and to BOTH feeds, so it does not depend on the
+            // Predict panel still being on screen — the tool can be exited (or the mode
+            // switched) while the job it started keeps running, and that is exactly when
+            // a suspended app is easiest to cause and hardest to explain. See
+            // PredictScreenAwake for why this is load-bearing rather than polish.
+            .onChange(of: engine.predictionJobs) { _ in applyScreenAwake() }
+            .onChange(of: engine.weightsFetch) { _ in applyScreenAwake() }
+            .onDisappear {
+                // Never leave the idle timer disabled behind us — that would keep the
+                // display on for the rest of the app's life.
+                PredictScreenAwake.apply(false)
+            }
+            #endif
     }
+
+    #if os(iOS)
+    private func applyScreenAwake() {
+        PredictScreenAwake.apply(
+            PredictScreenAwake.shouldStayAwake(predictions: engine.predictionJobs,
+                                               weightsFetching: engine.weightsFetch != nil))
+    }
+    #endif
 
     @ViewBuilder private var layout: some View {
         #if os(macOS)
@@ -1761,7 +1784,7 @@ struct ContentView: View {
         let cTerm = showCommandPanel && !iosFullScreen
         let anyTop = !iosFullScreen && (cTerm || engine.sequenceVisible
             || engine.interactionMode == .move || engine.measureMode != nil
-            || engine.designMode)
+            || engine.designMode || engine.predictMode)
         VStack(spacing: 0) {
             // Top row, right under the status bar (nav bar is hidden on iPhone):
             // RayMol title on the left, Open/Save/Export on the right. It takes the
@@ -1791,6 +1814,7 @@ struct ContentView: View {
                 if engine.interactionMode == .move { moveOverlay }
                 else if engine.measureMode != nil { measureOverlay }
                 else if engine.designMode { designModeBar }
+                else if engine.predictMode { predictModeBar }
             }
             viewportView
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -1850,7 +1874,7 @@ struct ContentView: View {
         let cTerm = consoleBinding.wrappedValue && !iosFullScreen
         let anyTop = !iosFullScreen && (cTerm || engine.sequenceVisible
             || engine.interactionMode == .move || engine.measureMode != nil
-            || engine.designMode)
+            || engine.designMode || engine.predictMode)
         HStack(spacing: 0) {
             // Left: the molecular viewer (+ optional sequence strip), with the
             // toolbar buttons floating over its top edge. The 3D viewport bleeds
@@ -1874,6 +1898,7 @@ struct ContentView: View {
                     if engine.interactionMode == .move { moveOverlay }
                     else if engine.measureMode != nil { measureOverlay }
                     else if engine.designMode { designModeBar }
+                    else if engine.predictMode { predictModeBar }
                 }
                 viewportView
                     .overlay(alignment: .top) {
@@ -1986,7 +2011,7 @@ struct ContentView: View {
         // floats over the full-bleed viewport. Move & Measure share the bottom slot.
         let anyTop = cTerm || engine.sequenceVisible
             || engine.interactionMode == .move || engine.measureMode != nil
-            || engine.designMode
+            || engine.designMode || engine.predictMode
 
         if landscape {
             // LANDSCAPE (iPad + iPhone landscape): left stack (terminal/sequence/
@@ -2014,6 +2039,7 @@ struct ContentView: View {
                         if engine.interactionMode == .move { moveOverlay }
                         else if engine.measureMode != nil { measureOverlay }
                         else if engine.designMode { designModeBar }
+                        else if engine.predictMode { predictModeBar }
                     }
                     viewportView
                         // Collapsed: the rail floats over the full-bleed viewport.
@@ -2079,6 +2105,7 @@ struct ContentView: View {
                     if engine.interactionMode == .move { moveOverlay }
                     else if engine.measureMode != nil { measureOverlay }
                     else if engine.designMode { designModeBar }
+                    else if engine.predictMode { predictModeBar }
                 }
                 viewportView
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -2228,6 +2255,24 @@ struct ContentView: View {
         #else
         EmptyView()
         #endif
+    }
+
+    // Predict-mode docked bar for the iOS layouts, the peer of `designModeBar`.
+    //
+    // Unlike Design, this does NOT branch on `hSize`: PredictCompactPanel serves iPhone
+    // and iPad alike, because the wide alternative (`PredictBar`) is macOS-only at the
+    // API level — it uses `.toggleStyle(.checkbox)`, which does not exist on iOS — and
+    // the compact panel lays out correctly at iPad widths, it is simply roomier than it
+    // needs to be. If iPad ever earns a denser form, this is where the branch goes.
+    //
+    // No `#if` for the feature: prediction compiles on both platforms unconditionally.
+    // The runtime gate is PredictAvailability, applied at the Tools menu, so `predictMode`
+    // can never be true on a device where this would be unusable.
+    @ViewBuilder
+    private var predictModeBar: some View {
+        PredictCompactPanel(controller: engine.predictController,
+                            engine: engine,
+                            theme: themeManager)
     }
     #endif
 
@@ -3073,9 +3118,7 @@ struct ContentView: View {
         #if RAYMOL_MPNN
         if engine.designMode { return ("Design", "flask.fill", "wand.and.stars") }
         #endif
-        #if os(macOS)
         if engine.predictMode { return ("Predict", "atom", "atom") }
-        #endif
         return nil
     }
 
@@ -3127,28 +3170,36 @@ struct ContentView: View {
             .disabled(isDesignLocked)
         }
         #endif
-        #if os(macOS)
-        Button {
-            engine.setPredictMode(!engine.predictMode)
-        } label: {
-            if engine.predictMode {
-                Label("Predict", systemImage: "checkmark")
-            } else {
-                Text("Predict")
+        // Gated on PredictAvailability for the same reason Design is gated on
+        // DesignAvailability: on iOS the tool needs 18+ and cannot run in the Simulator
+        // at all, and an item you can never enable is worse in a menu than no item.
+        // Always true on macOS.
+        if PredictAvailability.isSupported {
+            Button {
+                engine.setPredictMode(!engine.predictMode)
+            } label: {
+                if engine.predictMode {
+                    Label("Predict", systemImage: "checkmark")
+                } else {
+                    Text("Predict")
+                }
             }
+            .disabled(isDesignLocked)
         }
-        .disabled(isDesignLocked)
-        #endif
     }
 
     /// Tooltip for the Tools menu. Names only the tools this build actually has —
-    /// Design is absent from non-MPNN builds, so it must not be advertised there.
+    /// Design is absent from non-MPNN builds, and Predict from an iOS device that
+    /// PredictAvailability rules out, so neither may be advertised there. Built by
+    /// appending rather than as fixed strings so the two conditions compose; the
+    /// hardcoded variants this replaced could not express "MPNN but no Predict".
     private var toolsMenuHelp: String {
+        var parts = ["Move objects", "Measure distances"]
         #if RAYMOL_MPNN
-        let tools = "Move objects · Measure distances · Design with MPNN · Predict structures"
-        #else
-        let tools = "Move objects · Measure distances · Predict structures"
+        if DesignAvailability.isSupported { parts.append("Design with MPNN") }
         #endif
+        if PredictAvailability.isSupported { parts.append("Predict structures") }
+        let tools = parts.joined(separator: " · ")
         guard let active = activeInteractionTool else { return "Tools: \(tools)" }
         return "\(active.name) mode is active — Tools: \(tools)"
     }

--- a/swiftui/PyMOLViewer/Shared/MLXRuntime.swift
+++ b/swiftui/PyMOLViewer/Shared/MLXRuntime.swift
@@ -1,4 +1,4 @@
-#if RAYMOL_MPNN || os(macOS)
+#if RAYMOL_MPNN || os(macOS) || os(iOS)
 import Foundation
 import MLX
 
@@ -15,9 +15,12 @@ import MLX
 ///   `MemoryPlanner.apply()` assigns `Memory.cacheLimit`/`memoryLimit` on **every**
 ///   predict call.
 ///
-/// The gate is `RAYMOL_MPNN || os(macOS)` rather than a dedicated compilation condition:
-/// structure prediction ships in every macOS build, so there is no flag to set, while the
-/// `RAYMOL_MPNN` arm keeps this type available to Design mode on iOS.
+/// The gate is `RAYMOL_MPNN || os(macOS) || os(iOS)` rather than a dedicated compilation
+/// condition: structure prediction ships unconditionally on BOTH platforms now, so there
+/// is no flag to set, and the `RAYMOL_MPNN` arm is kept only so a hypothetical
+/// third-platform Design build still gets this type. The `os(iOS)` arm is not redundant
+/// with it: `RAYMOL_MPNN` is a per-SDK build setting anyone could turn off for iOS, and
+/// prediction would then lose its MLX configuration with no compile error to say so.
 ///
 /// With both linked, whoever wrote last used to win — silently, by call order, with no
 /// way to observe or test the outcome. `MLXRuntime` arbitrates instead (see
@@ -134,6 +137,41 @@ enum MLXRuntime {
     static func resetCacheLimitRequirementsForTesting() {
         lock.lock(); defer { lock.unlock() }
         requirements.removeAll()
+    }
+
+    // MARK: – Process footprint
+
+    /// This process's `phys_footprint`, in bytes, or 0 when the kernel will not say.
+    ///
+    /// The SAME quantity jetsam kills on — deliberately not `resident_size`, which omits
+    /// compressed and IOKit-mapped pages and therefore reads low on exactly the
+    /// MLX/Metal allocations that matter here.
+    ///
+    /// Exists so `os_proc_available_memory()` (bytes *remaining*) can be turned back into
+    /// the app's absolute ceiling: `available + footprint`. See
+    /// ``BoltzRuntime/memoryLimitBytes``. Available on both platforms because
+    /// `TASK_VM_INFO` is, and because a Mac reading is useful for diagnostics even though
+    /// nothing gates on it there.
+    ///
+    /// Returns 0 rather than trapping if `task_info` fails: every caller treats 0 as
+    /// "unknown" and falls back, which is the right response to a kernel that declined to
+    /// answer.
+    static var currentFootprintBytes: Int {
+        var info = task_vm_info_data_t()
+        var count = mach_msg_type_number_t(MemoryLayout<task_vm_info_data_t>.size
+                                           / MemoryLayout<natural_t>.size)
+        let result = withUnsafeMutablePointer(to: &info) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), $0, &count)
+            }
+        }
+        // phys_footprint lives past the end of the older TASK_VM_INFO layout, so a short
+        // reply means the field was not populated and must not be read.
+        guard result == KERN_SUCCESS,
+              count >= mach_msg_type_number_t(MemoryLayout<task_vm_info_data_t>.size
+                                              / MemoryLayout<natural_t>.size)
+        else { return 0 }
+        return Int(info.phys_footprint)
     }
 
     // MARK: – Error handling

--- a/swiftui/PyMOLViewer/Shared/PredictAvailability.swift
+++ b/swiftui/PyMOLViewer/Shared/PredictAvailability.swift
@@ -1,0 +1,83 @@
+#if os(macOS) || os(iOS)
+import Foundation
+
+/// Whether the Predict tool may be offered on this build, OS, and environment.
+///
+/// The peer of ``DesignAvailability``, and deliberately a separate type: the two
+/// features answer to different constraints. Design's only question is the iOS
+/// version; Predict additionally has to refuse the iOS Simulator, and does so for a
+/// reason that is not a version at all.
+///
+/// Three gates, all of which must pass on iOS:
+///
+/// 1. **Not the Simulator.** MLX cannot run there — its allocator is Metal-backed
+///    regardless of the compute device, and `MTLSimDevice` rejects the private-storage
+///    heaps it builds (`MLXRuntime.deviceConfigured` documents the exact assertion and
+///    the two workarounds that were tried and did not help). A prediction started in
+///    the Simulator has no outcome except an abort, so the tool must be absent rather
+///    than dead-on-arrival. BoltzMLX is still LINKED for the Simulator so that slice
+///    keeps compiling — availability is the runtime gate, not the link.
+/// 2. **iOS 18+**, for the same reason `DesignAvailability` uses: mlx-swift's Metal
+///    path has only ever been validated on iOS 18 hardware, and SPM will happily
+///    resolve against the iOS 17 deployment target boltz-mlx declares.
+/// 3. Nothing else. Memory is NOT a gate here — that is ``PredictSizeGuard``'s job,
+///    per input, and it is why this type deliberately does not consult
+///    `os_proc_available_memory()`. A device-wide "is there enough RAM" answer would
+///    be wrong for both a 60-residue peptide and a 900-residue target.
+///
+/// `PyMOLBridge.mm` applies the SAME rule when it decides whether to export
+/// `RAYMOL_PREDICT_HOST`, so the Python half refuses in step with the UI. The two
+/// must agree: if this type said yes where the bridge said no, the Predict tool would
+/// open onto a form whose every Run reports the predictor unavailable.
+enum PredictAvailability {
+
+    enum Platform { case macOS, iOS }
+
+    /// Minimum iOS major version on which Predict is offered. Same floor, same
+    /// reasoning, as ``DesignAvailability/minimumIOSMajorVersion`` — but a separate
+    /// constant, because raising one of these should not silently raise the other.
+    static let minimumIOSMajorVersion = 18
+
+    /// Pure decision. `platform`, `osMajorVersion`, and `isSimulator` are parameters
+    /// rather than `#if` branches so the macOS test host can verify the iOS rules; a
+    /// compile-time branch would leave the iOS arms permanently untested.
+    static func isSupported(platform: Platform, osMajorVersion: Int,
+                            isSimulator: Bool) -> Bool {
+        switch platform {
+        case .macOS:
+            return true
+        case .iOS:
+            return !isSimulator && osMajorVersion >= minimumIOSMajorVersion
+        }
+    }
+
+    /// The platform this binary was compiled for.
+    static var current: Platform {
+        #if os(iOS)
+        return .iOS
+        #else
+        return .macOS
+        #endif
+    }
+
+    static var currentOSMajorVersion: Int {
+        ProcessInfo.processInfo.operatingSystemVersion.majorVersion
+    }
+
+    static var currentIsSimulator: Bool {
+        #if targetEnvironment(simulator)
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    /// True when the Predict tool should be offered. Callers must not build any
+    /// Predict entry point — Tools menu item, docked bar, keyboard path — when this
+    /// is false.
+    static var isSupported: Bool {
+        isSupported(platform: current, osMajorVersion: currentOSMajorVersion,
+                    isSimulator: currentIsSimulator)
+    }
+}
+#endif

--- a/swiftui/PyMOLViewer/Shared/PredictCompactPanel.swift
+++ b/swiftui/PyMOLViewer/Shared/PredictCompactPanel.swift
@@ -1,0 +1,367 @@
+#if os(iOS)
+import SwiftUI
+
+/// Compact Predict form for iPhone — the peer of ``DesignCompactPanel``, and the iOS
+/// counterpart of ``PredictBar``.
+///
+/// ``PredictBar`` is not reused here. It is a docked macOS form of up to four
+/// non-scrolling rows carrying two `Stepper`s, four `TextField`s, a `Picker`, and a
+/// `.checkbox` Toggle across roughly 700 pt of width; an iPhone has ~390, and
+/// `.toggleStyle(.checkbox)` does not exist on iOS at all. Shrinking it would produce a
+/// row of 20 pt hit targets.
+///
+/// So this keeps **two docked rows** — status, then input + predictor + Run — and moves
+/// every set-once control into a sheet, exactly the split `DesignCompactPanel` makes and
+/// for the same reason. What stays docked is what is touched per run; what moves to the
+/// sheet is what is set once per session.
+///
+/// The MSA chain row is docked but conditional, appearing only when the selected model
+/// supports alignments AND the user asked for them — on a phone the common case is the
+/// single-chain, no-MSA fold this port targets, and an always-present row would cost a
+/// third of the panel to show one disabled toggle.
+///
+/// iPad and macOS keep ``PredictBar``; see ContentView.predictModeBar.
+struct PredictCompactPanel: View {
+    @ObservedObject var controller: PredictController
+    @ObservedObject var engine: PyMOLEngine
+    @ObservedObject var theme: ThemeManager
+
+    @State private var showSettings = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            PredictBackgroundNotice(engine: engine, theme: theme)
+            statusRow
+            if let w = controller.pendingSizeWarning { sizeWarningRow(w) }
+            inputRow
+            if controller.useMSA && selectedSupportsMSA && !controller.chains.isEmpty {
+                Divider().opacity(0.3)
+                msaRow
+            }
+        }
+        .background(theme.active.panelBackground.color)
+        .tint(theme.active.accent.color)
+        .onChange(of: controller.inputText) { _ in controller.inputChanged() }
+        .sheet(isPresented: $showSettings) {
+            PredictSettingsSheet(controller: controller)
+        }
+    }
+
+    private var selectedSupportsMSA: Bool {
+        controller.availablePredictors.first { $0.id == controller.predictor }?.msa ?? false
+    }
+
+    // MARK: - Row 1: resolved chains / phase / errors
+
+    @ViewBuilder private var statusRow: some View {
+        HStack(spacing: 8) {
+            statusContent
+            Spacer(minLength: 0)
+            Button { showSettings = true } label: {
+                Image(systemName: "ellipsis.circle")
+                    .font(.system(size: 15))
+                    .foregroundColor(theme.active.panelText.color.opacity(0.7))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Predict settings")
+
+            Button { engine.setPredictMode(false) } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 15))
+                    .foregroundColor(theme.active.panelText.color.opacity(0.6))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Exit predict mode")
+        }
+        .padding(.horizontal, 12).padding(.vertical, 8)
+    }
+
+    @ViewBuilder private var statusContent: some View {
+        switch controller.phase {
+        case .idle:
+            if let e = controller.resolveError {
+                Label(e, systemImage: "exclamationmark.triangle")
+                    .font(.system(size: 11)).foregroundColor(.orange).lineLimit(2)
+            } else if !controller.chains.isEmpty {
+                // Chains AND the total, because the total is what PredictSizeGuard and
+                // the runtime's own token cap are both measured in — a user who has to
+                // add "A·64 B·71" in their head to know why a run was refused has been
+                // shown the wrong number.
+                Text(controller.chains.map { "\($0.id)·\($0.length)" }
+                        .joined(separator: "  ")
+                     + "  ·  \(totalResidues) res")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(theme.active.panelText.color.opacity(0.6))
+                    .lineLimit(1)
+            } else {
+                Text("Paste a sequence, or pick an object.")
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.active.panelText.color.opacity(0.5))
+            }
+        case .searching(let n):
+            ProgressView().scaleEffect(0.6)
+            Text("Building \(n) alignment\(n == 1 ? "" : "s")…").font(.system(size: 11))
+        case .predicting:
+            // Unreachable: submitPredict() returns the controller to .idle the moment a
+            // job is handed off, and the ProgressTray is the single source of truth for
+            // a running fold. Kept for switch exhaustiveness, rendering nothing.
+            EmptyView()
+        case .error(let m):
+            Label(m, systemImage: "xmark.octagon").font(.system(size: 11))
+                .foregroundColor(.red).lineLimit(3)
+        }
+    }
+
+    private var totalResidues: Int { controller.chains.reduce(0) { $0 + $1.length } }
+
+    // MARK: - Row 1b: size warning
+
+    @ViewBuilder
+    private func sizeWarningRow(_ w: PredictSizeWarning) -> some View {
+        let fmt: (Int) -> String = {
+            ByteCountFormatter.string(fromByteCount: Int64($0), countStyle: .memory)
+        }
+        VStack(alignment: .leading, spacing: 6) {
+            // Deliberately says "before iOS stops the app" rather than macOS's "this
+            // device's limit". On a Mac an over-large fold thrashes; on a phone it is a
+            // SIGKILL that takes the unsaved session, and the copy should not be milder
+            // than the consequence.
+            Text("Needs about \(fmt(w.estimatedBytes)) — this app has about "
+                 + "\(fmt(w.availableBytes)) left before iOS stops it. "
+                 + "Save your session first.")
+                .font(.system(size: 11))
+                .fixedSize(horizontal: false, vertical: true)
+            HStack(spacing: 16) {
+                Button("Run anyway") { controller.confirmPendingWarning() }
+                    .font(.system(size: 13, weight: .semibold)).buttonStyle(.plain)
+                Button("Cancel") { controller.cancelPendingWarning() }
+                    .font(.system(size: 13)).buttonStyle(.plain)
+                    .foregroundColor(theme.active.panelText.color.opacity(0.6))
+                Spacer(minLength: 0)
+            }
+        }
+        .padding(.horizontal, 12).padding(.vertical, 8)
+        .background(Color.orange.opacity(0.14))
+    }
+
+    // MARK: - Row 2: input · object picker · model · Run
+
+    private var inputRow: some View {
+        HStack(spacing: 8) {
+            TextField("sequence", text: $controller.inputText)
+                .textFieldStyle(.roundedBorder)
+                .font(.system(size: 13, design: .monospaced))
+                // A pasted sequence must survive verbatim: autocapitalisation would
+                // not hurt (parse_chains upper-cases anyway) but autocorrect and smart
+                // quotes rewrite residue letters, and the failure is silent — a
+                // corrected sequence still folds, into the wrong thing.
+                .textInputAutocapitalization(.characters)
+                .autocorrectionDisabled(true)
+                .submitLabel(.done)
+
+            Menu {
+                ForEach(engine.objects.filter { !$0.isSelection }, id: \.name) { o in
+                    Button(o.name) { controller.inputText = o.name }
+                }
+            } label: {
+                Image(systemName: "cube").font(.system(size: 15))
+                    .foregroundColor(theme.active.panelText.color.opacity(0.8))
+            }
+            .menuIndicator(.hidden)
+            .accessibilityLabel("Use a loaded object")
+
+            // One predictor is the norm on iOS (the host advertises "boltz" alone), so
+            // this is a menu rather than a segmented picker: it collapses to a single
+            // short label instead of reserving width for choices that are not there.
+            Menu {
+                ForEach(controller.availablePredictors) { p in
+                    Button {
+                        controller.predictor = p.id
+                    } label: {
+                        if p.id == controller.predictor {
+                            Label(p.id, systemImage: "checkmark")
+                        } else {
+                            Text(p.id)
+                        }
+                    }
+                }
+            } label: {
+                HStack(spacing: 3) {
+                    Text(controller.predictor.isEmpty ? "model" : controller.predictor)
+                        .font(.system(size: 12)).lineLimit(1)
+                    Image(systemName: "chevron.down").font(.system(size: 8))
+                }
+                .foregroundColor(theme.active.panelText.color)
+                .frame(maxWidth: 96)
+            }
+            .menuIndicator(.hidden)
+            .accessibilityLabel("Prediction model")
+
+            Button { controller.run() } label: {
+                Text("Run")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 14).padding(.vertical, 7)
+                    .background(canRun ? theme.active.accent.color
+                                       : theme.active.panelText.color.opacity(0.25),
+                                in: RoundedRectangle(cornerRadius: 7))
+            }
+            .buttonStyle(.plain)
+            .disabled(!canRun)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 6)
+    }
+
+    private var canRun: Bool {
+        !controller.predictor.isEmpty && !controller.chains.isEmpty
+            && controller.resolveError == nil
+            && controller.pendingSizeWarning == nil
+            && { switch controller.phase {
+                 case .searching, .predicting: return false
+                 default: return true
+                 } }()
+    }
+
+    // MARK: - Row 3: which chains get an MSA
+
+    private var msaRow: some View {
+        HStack(spacing: 8) {
+            Text("MSA:").font(.system(size: 11))
+                .foregroundColor(theme.active.panelText.color.opacity(0.7))
+            ForEach(controller.chains) { ch in
+                Toggle(ch.id, isOn: Binding(
+                    get: { controller.msaChains.contains(ch.id) },
+                    set: { on in
+                        if on { controller.msaChains.insert(ch.id) }
+                        else { controller.msaChains.remove(ch.id) }
+                    }))
+                    .toggleStyle(.button).controlSize(.small)
+            }
+            Spacer(minLength: 0)
+            Text("Sent to \(serverLabel).")
+                .font(.system(size: 10)).foregroundColor(.orange.opacity(0.9))
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 6)
+    }
+
+    private var serverLabel: String {
+        controller.server.isEmpty ? "the ColabFold server" : controller.server
+    }
+}
+
+// MARK: - Settings sheet
+
+/// The set-once half of the iPhone Predict form: everything ``PredictBar`` keeps in its
+/// Advanced row, plus the two controls (`MSA`, `×n models`) that are docked on macOS but
+/// do not fit a phone's main row.
+///
+/// Sectioned by what the setting COSTS rather than by what it configures, because on a
+/// phone that is the question actually being asked. "Sampling" trades time; "Alignment"
+/// trades both time and memory and sends the sequence off-device; "Output" is free.
+struct PredictSettingsSheet: View {
+    @ObservedObject var controller: PredictController
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                samplingSection
+                alignmentSection
+                outputSection
+            }
+            .navigationTitle("Predict settings")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+    }
+
+    private var selectedSupportsMSA: Bool {
+        controller.availablePredictors.first { $0.id == controller.predictor }?.msa ?? false
+    }
+
+    private var samplingSection: some View {
+        Section("Sampling") {
+            Stepper("Models  ×\(controller.nModels)",
+                    value: $controller.nModels, in: 1...20)
+            Stepper("Recycling  \(controller.recyclingSteps)",
+                    value: $controller.recyclingSteps, in: 1...10)
+            Stepper("Diffusion  \(controller.diffusionSteps)",
+                    value: $controller.diffusionSteps, in: 10...500, step: 10)
+            HStack {
+                Text("Seed")
+                Spacer()
+                TextField("auto", text: $controller.seedText)
+                    .multilineTextAlignment(.trailing)
+                    .keyboardType(.numberPad)
+                    .frame(width: 110)
+            }
+            Text("Each model is a separate fold. On a phone, one model with the "
+                 + "default steps is the fast path — every extra model costs the "
+                 + "same time again.")
+                .font(.footnote).foregroundStyle(.secondary)
+        }
+    }
+
+    private var alignmentSection: some View {
+        Section("Alignment") {
+            Toggle("Use MSA", isOn: $controller.useMSA)
+                .disabled(!selectedSupportsMSA)
+            if selectedSupportsMSA {
+                Picker("Mode", selection: $controller.msaMode) {
+                    ForEach(["env", "all", "env-nofilter", "nofilter"], id: \.self) {
+                        Text($0).tag($0)
+                    }
+                }
+                HStack {
+                    Text("Depth")
+                    Spacer()
+                    TextField("auto", text: $controller.msaDepthText)
+                        .multilineTextAlignment(.trailing)
+                        .keyboardType(.numberPad)
+                        .frame(width: 110)
+                }
+                HStack {
+                    Text("Server")
+                    Spacer()
+                    TextField("default", text: $controller.server)
+                        .multilineTextAlignment(.trailing)
+                        .autocorrectionDisabled(true)
+                        .textInputAutocapitalization(.never)
+                        .frame(width: 170)
+                }
+                // Not decoration. Depth is the dimension PredictSizeGuard's own history
+                // records it having failed to model — 3.6× optimistic at the ceiling —
+                // and on a phone that headroom does not exist to be wrong with.
+                Text("An alignment improves accuracy, but it is also the largest "
+                     + "single memory cost here and your sequence leaves the device "
+                     + "to build it. Single-sequence folding is the tested path on "
+                     + "iPhone.")
+                    .font(.footnote).foregroundStyle(.secondary)
+            } else {
+                Text("This model folds single-sequence.")
+                    .font(.footnote).foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var outputSection: some View {
+        Section("Output") {
+            HStack {
+                Text("Name")
+                Spacer()
+                TextField("auto", text: $controller.resultName)
+                    .multilineTextAlignment(.trailing)
+                    .autocorrectionDisabled(true)
+                    .textInputAutocapitalization(.never)
+                    .frame(width: 170)
+            }
+        }
+    }
+}
+#endif

--- a/swiftui/PyMOLViewer/Shared/PredictController.swift
+++ b/swiftui/PyMOLViewer/Shared/PredictController.swift
@@ -221,9 +221,17 @@ final class PredictController: ObservableObject {
         // The Protenix branch is macOS-only because ProtenixSizeGuard is (the runtime
         // was not ported to iOS — see PyMOLBridge.mm's RAYMOL_PREDICT_RUNTIMES). On iOS
         // the branch is also unreachable rather than merely absent: the host advertises
-        // "boltz" alone, so check_available refuses every protenix predictor and none
-        // ever reaches `availablePredictors`. Compiling it out is therefore removing
-        // dead code, not narrowing behaviour.
+        // "boltz" alone, so check_available refuses every protenix predictor, and
+        // appkit_predict._predictors() FILTERS the form list by check_available, so none
+        // reaches `availablePredictors`. Compiling it out removes dead code rather than
+        // narrowing behaviour — but note the filter is what makes that true. Before it
+        // existed the list was every REGISTERED predictor and Protenix ids did arrive
+        // here on iOS, where this branch was compiled out and they fell through to the
+        // Boltz curve: a Protenix job sized against Boltz's much smaller footprint.
+        //
+        // Also why boltz2-bf16 refuses on iOS (see Boltz2BF16Predictor.check_available):
+        // `decide` below takes no predictor, so every Boltz pack shares one curve, and
+        // that curve is fitted to measured int8 footprints.
         let decision: PredictSizeGuard.Decision
         #if os(macOS)
         if predictor.hasPrefix("protenix") {

--- a/swiftui/PyMOLViewer/Shared/PredictController.swift
+++ b/swiftui/PyMOLViewer/Shared/PredictController.swift
@@ -1,4 +1,4 @@
-#if os(macOS)
+#if os(macOS) || os(iOS)
 import Foundation
 
 // MARK: - Wire types (decoded from pymol_predict_<pid>.json; see appkit_predict.emit)
@@ -217,7 +217,15 @@ final class PredictController: ObservableObject {
         // widths and caps. Map the id → variant the same way ProtenixSizeGuard does —
         // explicitly base only for a "protenix-base*" pack, else the expensive v2
         // (which also covers the "protenix" alias for protenix-v2-int8).
+        //
+        // The Protenix branch is macOS-only because ProtenixSizeGuard is (the runtime
+        // was not ported to iOS — see PyMOLBridge.mm's RAYMOL_PREDICT_RUNTIMES). On iOS
+        // the branch is also unreachable rather than merely absent: the host advertises
+        // "boltz" alone, so check_available refuses every protenix predictor and none
+        // ever reaches `availablePredictors`. Compiling it out is therefore removing
+        // dead code, not narrowing behaviour.
         let decision: PredictSizeGuard.Decision
+        #if os(macOS)
         if predictor.hasPrefix("protenix") {
             let variant: ProtenixSizeGuard.Variant =
                 predictor.contains("protenix-base") ? .base : .v2
@@ -227,6 +235,10 @@ final class PredictController: ObservableObject {
             decision = PredictSizeGuard.decide(tokens: tokenCount, msaDepth: effectiveMSADepth,
                                                availableBytes: availableBytesProvider())
         }
+        #else
+        decision = PredictSizeGuard.decide(tokens: tokenCount, msaDepth: effectiveMSADepth,
+                                           availableBytes: availableBytesProvider())
+        #endif
         switch decision {
         case .ok:
             proceed()

--- a/swiftui/PyMOLViewer/Shared/PredictScreenAwake.swift
+++ b/swiftui/PyMOLViewer/Shared/PredictScreenAwake.swift
@@ -1,0 +1,92 @@
+#if os(macOS) || os(iOS)
+import SwiftUI
+#if os(iOS)
+import UIKit
+#endif
+
+/// Holds the screen awake while on-device work that iOS would otherwise interrupt is in
+/// flight — a structure prediction, or the weight download that precedes it.
+///
+/// **This is not a nicety.** A Boltz fold and a 529 MB weight download are both minutes
+/// of foreground-only work with no user input, which is precisely the shape iOS treats as
+/// idle. When the display sleeps the app is suspended shortly after; suspension revokes
+/// GPU access, and MLX work in flight does not survive it. `swiftui/project.yml` records
+/// the observed consequence: no boltz run above ~115 tokens had ever completed on a
+/// physical device, because iOS suspended the app mid-run. Nothing in RayMol set
+/// `isIdleTimerDisabled` before this type.
+///
+/// It does **not** make the app background-safe, and cannot: there is no background mode
+/// that grants Metal compute. Keeping the screen on removes the OS's own reason to
+/// suspend us; a user who switches apps or locks the phone by hand still ends the run,
+/// which is what ``PredictBackgroundNotice`` warns about.
+///
+/// The POLICY compiles on both platforms; only the side effect and the banner are
+/// iOS-only. That split is deliberate and copies ``DesignSizeGuard``: the unit-test
+/// bundle is a macOS target, so a rule written behind `#if os(iOS)` is a rule that can
+/// never be tested. ``apply(_:)`` is inert on macOS, which has no idle-timer concept and
+/// does not suspend an app for being quiet.
+enum PredictScreenAwake {
+
+    /// Whether the screen should be held awake, from the two job feeds.
+    ///
+    /// Pure and static so the policy is unit-testable without a `UIApplication` or a
+    /// live engine — the side effect below is the only untestable part, and it is one
+    /// line.
+    ///
+    /// A prediction counts while it is not terminal. `isError` already covers error,
+    /// failed, AND cancelled, so a job the user cancelled releases the screen
+    /// immediately rather than holding it until the card is dismissed. Completed jobs
+    /// leave `predictionJobs` entirely, so they need no case here.
+    static func shouldStayAwake(predictions: [PredictionJobState],
+                                weightsFetching: Bool) -> Bool {
+        weightsFetching || predictions.contains { !$0.isError }
+    }
+
+    /// Apply the decision. Idempotent — assigning the same value is free, so callers may
+    /// drive this from an `.onChange` without tracking the previous state themselves.
+    /// A no-op on macOS.
+    @MainActor
+    static func apply(_ stayAwake: Bool) {
+        #if os(iOS)
+        UIApplication.shared.isIdleTimerDisabled = stayAwake
+        #endif
+    }
+}
+
+#if os(iOS)
+
+/// The banner shown while a fold is running, telling the user the one thing that will
+/// lose it.
+///
+/// Separate from the progress tray on purpose. The tray reports *progress*, and it is
+/// shared with weight downloads and `ray` renders — all of which survive being
+/// backgrounded. This warns about a constraint that is specific to on-device inference,
+/// and it needs to be legible at a glance rather than parsed out of a progress card.
+struct PredictBackgroundNotice: View {
+    @ObservedObject var engine: PyMOLEngine
+    @ObservedObject var theme: ThemeManager
+
+    private var running: Bool {
+        PredictScreenAwake.shouldStayAwake(predictions: engine.predictionJobs,
+                                           weightsFetching: engine.weightsFetch != nil)
+    }
+
+    var body: some View {
+        if running {
+            HStack(spacing: 6) {
+                Image(systemName: "iphone.gen3.radiowaves.left.and.right")
+                    .font(.system(size: 11))
+                Text("Keep RayMol on screen — switching apps or locking the phone "
+                     + "ends the fold.")
+                    .font(.system(size: 11))
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer(minLength: 0)
+            }
+            .foregroundColor(.orange)
+            .padding(.horizontal, 12).padding(.vertical, 6)
+            .background(Color.orange.opacity(0.12))
+        }
+    }
+}
+#endif
+#endif

--- a/swiftui/PyMOLViewer/Shared/PredictScreenAwake.swift
+++ b/swiftui/PyMOLViewer/Shared/PredictScreenAwake.swift
@@ -45,8 +45,60 @@ enum PredictScreenAwake {
     /// Apply the decision. Idempotent — assigning the same value is free, so callers may
     /// drive this from an `.onChange` without tracking the previous state themselves.
     /// A no-op on macOS.
+    ///
+    /// Only ever RAISES the hold if a job is active (see ``setJobActive(_:)``): the
+    /// view-driven caller must not be able to release a hold the job owner still needs.
     @MainActor
     static func apply(_ stayAwake: Bool) {
+        install(stayAwake || jobActiveCount > 0)
+    }
+
+    // MARK: - Direct, job-owned hold
+
+    private static let jobLock = NSLock()
+    private static var jobActiveCount = 0
+
+    /// Take or release the hold directly from the code that runs the fold.
+    ///
+    /// **This is the authoritative path, and it exists because the view-driven one was
+    /// too slow.** `PredictBackgroundNotice` and ContentView's `.onChange` both key off
+    /// `engine.predictionJobs`, which is filled in by the ~500 ms OBJECT PANEL poll — a
+    /// UI-shaped feed that only learns a job exists after Python has written it and the
+    /// next tick has read it back. That leaves a window of up to a second or so between
+    /// submitting a fold and the display being pinned, and a phone whose idle timer is
+    /// already nearly expired locks inside it. Observed doing exactly that: a 110-residue
+    /// run froze at diffusion step 42 of 200 and never advanced, because iOS suspended the
+    /// app mid-inference.
+    ///
+    /// `BoltzJobManager` knows a job has started at the instant it starts one, so it takes
+    /// the hold itself. The view path is kept as well — it also covers the weight download,
+    /// which has no `BoltzJobManager` job — and the two compose through a count rather than
+    /// a boolean so neither can release the other's hold.
+    ///
+    /// Counted rather than a flag because `n_models > 1` and queued jobs mean folds can
+    /// overlap; the display must stay pinned until the LAST one finishes.
+    ///
+    /// Safe from any thread — the UIKit assignment is hopped to the main actor.
+    nonisolated static func setJobActive(_ active: Bool) {
+        jobLock.lock()
+        jobActiveCount = max(0, jobActiveCount + (active ? 1 : -1))
+        let held = jobActiveCount > 0
+        jobLock.unlock()
+        Task { @MainActor in install(held) }
+    }
+
+    /// Number of folds currently holding the display on. Exposed for tests.
+    static var activeJobHolds: Int {
+        jobLock.lock(); defer { jobLock.unlock() }; return jobActiveCount
+    }
+
+    /// Reset the counter so a test can assert from a known state.
+    static func resetJobHoldsForTesting() {
+        jobLock.lock(); jobActiveCount = 0; jobLock.unlock()
+    }
+
+    @MainActor
+    private static func install(_ stayAwake: Bool) {
         #if os(iOS)
         UIApplication.shared.isIdleTimerDisabled = stayAwake
         #endif

--- a/swiftui/PyMOLViewer/Shared/PredictSizeGuard.swift
+++ b/swiftui/PyMOLViewer/Shared/PredictSizeGuard.swift
@@ -66,46 +66,67 @@ import os   // os_proc_available_memory()
 /// - ``maximumTokens`` becomes ``iOSMaximumTokens``, the largest input actually folded
 ///   on device.
 ///
-/// and the three fitted terms take iOS values. **Reusing the Mac constants was tried
-/// first and is wrong** — not merely conservative, unusable: at 117 tokens the Mac fit
-/// estimates 2.25 GB, and against a realistic iPhone app budget near 2.5 GB that is 86%,
-/// which this guard REFUSES. The Mac curve would have made the 100–150-residue fold this
-/// port exists for impossible on the device it was ported to. A guard that refuses
-/// everything is not a safe guard, it is a broken feature wearing a safe guard's clothes.
+/// and the three fitted terms take iOS values. **Reusing the Mac constants is safe but
+/// over-conservative.** Measured against the device footprints below it over-predicts by
+/// 1.23–1.39×, so it would not have got anyone jetsam-killed — but it is cautious enough
+/// to REFUSE sizes that fold perfectly well: at 130 residues it estimates 2.52 GB against
+/// the measured 3.27 GB budget (77%, past ``warnFraction``) for a fold that actually
+/// peaked at 2.00 GB and finished in 64 s. The iOS terms buy back that headroom without
+/// giving up margin over any measurement.
 ///
 /// ### How the iOS constants were derived
 ///
-/// From the one iOS peak anyone has recorded: **iPhone 15 Pro, 117 tokens / 899 atoms,
-/// ~1.4 GB `phys_footprint`** (boltz-mlx `examples/BoltzMLXDemo/DEVICE_BENCHMARK.md`).
-/// That is already the jetsam-relevant process footprint, cache included — so unlike
-/// `DesignSizeGuard`, no correction is needed for MLX's peak excluding its buffer cache.
+/// From a device sweep on the target hardware — iPhone 15 Pro, iOS 26.6, Release build,
+/// single chain, no MSA, at the shipped operating point (3 recycles / 200 diffusion
+/// steps). **Peak `phys_footprint`, sampled every 200 ms throughout the run** by
+/// `BoltzJobManager.FootprintSampler`:
 ///
-/// The Mac curve's SHAPE is kept (a linear term plus a pairwise ~N² term). The intercept
-/// is set first and independently, to 700 MiB, as an envelope over the 529 MB int8 weight
-/// pack plus Metal and the interpreter; the linear and quadratic terms are then scaled
-/// together until the whole estimate clears the measurement with a reserve, which lands
-/// both at exactly half their Mac values. The result at the anchor is **1.75 GB against a
-/// measured 1.4 GB — a 19% reserve**, in the same spirit as the 25% `DesignSizeGuard`
-/// carries, though not the same number: the terms were rounded to halves rather than
-/// bent to hit a target reserve exactly, because a round mechanism is easier to re-derive
-/// later than a fitted constant nobody can reconstruct. That halving is a RESULT, not an assumption,
-/// and it is consistent with the mechanism: iOS runs boltz-mlx under a phone-sized
-/// `MemoryPlanner` — a 64 MiB MLX cache against the Mac's arbitrated 256 MB — so less is
-/// retained between steps.
+/// | residues | wall  | MLX peak | peak phys_footprint |
+/// |---------:|------:|---------:|--------------------:|
+/// | 110      |  39 s |  1.38 GB |          **1.72 GB** |
+/// | 130      |  64 s |  1.75 GB |          **2.00 GB** |
+/// | 164      | 250 s |  2.00 GB |          **2.35 GB** |
+///
+/// `os_proc_available_memory()` on that device, with a session open, solves to about
+/// **3.27 GB** (back-derived from the guard's own refusal of a 200-residue input naming
+/// 180 as the largest that fit).
+///
+/// ### The units correction, which is the whole story here
+///
+/// **These constants were first fitted against MLX's high-water mark, and that was
+/// wrong.** `MLX.Memory` excludes its own buffer cache
+/// (mlx-swift/Source/MLX/Memory.swift:171-178), so it under-reports the process by
+/// 300–350 MB at these sizes. The budget it gets compared against —
+/// `os_proc_available_memory()` — is denominated in `phys_footprint`, so comparing an
+/// MLX-peak estimate to it is comparing two different quantities and quietly favouring
+/// the optimistic one.
+///
+/// Fitted against MLX peak, this curve estimated 1.68 / 1.89 / 2.26 GB — **below the
+/// measured footprint at every single point**, i.e. precisely the failure the three
+/// numbered items above describe, for a fourth time and by a new mechanism. It was caught
+/// only because the footprint was sampled rather than assumed. A single `phys_footprint`
+/// read taken after inference does NOT catch it either: that is a post-release reading,
+/// and it returned 1.05 GB for both the 110- and the 164-residue run.
+///
+/// The shipped terms are refitted to the footprint column with an **11–15% reserve** at
+/// every measured point (1.15× / 1.11× / 1.15×). Modest on purpose: three real points
+/// across the range of interest justify far less padding than one point did, and
+/// `warnFraction` already withholds a further 25% on top.
+///
+/// Note the macOS arm still fits MLX peak against `physicalMemory` — the same mismatch,
+/// but harmless there because a Mac has swap and installed RAM is a soft wall. Left alone
+/// deliberately; changing shipped macOS behaviour is not this port's business.
 ///
 /// ### What this fit does NOT know
 ///
-/// **It is one point.** The Mac fit's three recorded failures were all extrapolation past
-/// its data, and this has far less data than the Mac fit had when it failed the first
-/// time. Two consequences, both deliberate:
+/// - ``bytesPerTokenMSARow`` is still NOT rescaled — see that constant. No MSA fold has
+///   been run on device, and inventing a measurement is what all four failures were.
+/// - ``iOSMaximumTokens`` is 164: the largest input actually folded to completion here.
+///   Not the 256 the runtime's phone preset allows, and not a round 200. Note the wall
+///   time at 164 was 250 s against 99 s for the same input in an earlier run — a 2.5×
+///   spread that suggests thermal or memory-pressure throttling and is itself a reason
+///   not to treat that size as comfortable.
 ///
-/// - ``iOSMaximumTokens`` is set to the measured size and nothing above it, so the fit is
-///   never asked a question outside its single anchor.
-/// - ``bytesPerTokenMSARow`` is NOT rescaled — see that constant.
-///
-/// When a device sweep exists, refit all of it together against the table, raise
-/// ``iOSMaximumTokens`` to the largest size that actually completed, and keep the rule
-/// that has held here throughout: **never let the fit sit below a measurement.**
 enum PredictSizeGuard {
 
     // MARK: - Tunable constants
@@ -113,12 +134,12 @@ enum PredictSizeGuard {
     /// Model-resident floor. Small, because the linear and quadratic terms now carry the
     /// curve across the whole measured range instead of the intercept papering over the
     /// small end.
-    static var fixedOverheadBytes: Int { isPhone ? 700 * 1024 * 1024 : 200 * 1024 * 1024 }
+    static var fixedOverheadBytes: Int { isPhone ? 850 * 1024 * 1024 : 200 * 1024 * 1024 }
     /// Linear term, bytes per token.
-    static var bytesPerToken: Int { isPhone ? 7_250_000 : 14_500_000 }
+    static var bytesPerToken: Int { isPhone ? 7_500_000 : 14_500_000 }
     /// Quadratic term, bytes per token² — the pairwise tensors. 12.5× the original value;
     /// see the type doc for the two successive under-predictions that produced it.
-    static var bytesPerTokenSquared: Int { isPhone ? 12_500 : 25_000 }
+    static var bytesPerTokenSquared: Int { isPhone ? 21_500 : 25_000 }
     /// Bilinear term, bytes per (token × alignment row beyond the first) — the MSA
     /// module's own tensors, which are depth × tokens wide.
     ///
@@ -175,7 +196,7 @@ enum PredictSizeGuard {
     ///
     /// Raise it to the largest size that has actually completed on device, and record
     /// the run. Nothing else licenses a change here.
-    static let iOSMaximumTokens = 117
+    static let iOSMaximumTokens = 164
     /// Hard ceiling on alignment depth: the deepest actually MEASURED, which is also
     /// upstream's `const.max_msa_seqs` and `BoltzInputLimits.desktop.maximumMSADepth`.
     /// The two agreeing is a coincidence of this sweep having reached the cap, not a

--- a/swiftui/PyMOLViewer/Shared/PredictSizeGuard.swift
+++ b/swiftui/PyMOLViewer/Shared/PredictSizeGuard.swift
@@ -1,5 +1,8 @@
-#if os(macOS)
+#if os(macOS) || os(iOS)
 import Foundation
+#if os(iOS)
+import os   // os_proc_available_memory()
+#endif
 
 /// Predicts the peak memory a Boltz run needs and decides whether to proceed, warn, or
 /// refuse.
@@ -53,6 +56,56 @@ import Foundation
 /// measurement** — that is what licenses a run which then gets jetsam-killed.
 /// `testEstimateNeverSitsBelowMeasurement` pins both tables for exactly this reason; an
 /// earlier version pinned only two points, which is how shortfall #1 survived.
+///
+/// ## iOS
+///
+/// Two things change on a phone, and only two:
+///
+/// - ``availableBytes`` becomes `os_proc_available_memory()` rather than
+///   `physicalMemory`. This is the change that matters. See that property.
+/// - ``maximumTokens`` becomes ``iOSMaximumTokens``, the largest input actually folded
+///   on device.
+///
+/// and the three fitted terms take iOS values. **Reusing the Mac constants was tried
+/// first and is wrong** — not merely conservative, unusable: at 117 tokens the Mac fit
+/// estimates 2.25 GB, and against a realistic iPhone app budget near 2.5 GB that is 86%,
+/// which this guard REFUSES. The Mac curve would have made the 100–150-residue fold this
+/// port exists for impossible on the device it was ported to. A guard that refuses
+/// everything is not a safe guard, it is a broken feature wearing a safe guard's clothes.
+///
+/// ### How the iOS constants were derived
+///
+/// From the one iOS peak anyone has recorded: **iPhone 15 Pro, 117 tokens / 899 atoms,
+/// ~1.4 GB `phys_footprint`** (boltz-mlx `examples/BoltzMLXDemo/DEVICE_BENCHMARK.md`).
+/// That is already the jetsam-relevant process footprint, cache included — so unlike
+/// `DesignSizeGuard`, no correction is needed for MLX's peak excluding its buffer cache.
+///
+/// The Mac curve's SHAPE is kept (a linear term plus a pairwise ~N² term). The intercept
+/// is set first and independently, to 700 MiB, as an envelope over the 529 MB int8 weight
+/// pack plus Metal and the interpreter; the linear and quadratic terms are then scaled
+/// together until the whole estimate clears the measurement with a reserve, which lands
+/// both at exactly half their Mac values. The result at the anchor is **1.75 GB against a
+/// measured 1.4 GB — a 19% reserve**, in the same spirit as the 25% `DesignSizeGuard`
+/// carries, though not the same number: the terms were rounded to halves rather than
+/// bent to hit a target reserve exactly, because a round mechanism is easier to re-derive
+/// later than a fitted constant nobody can reconstruct. That halving is a RESULT, not an assumption,
+/// and it is consistent with the mechanism: iOS runs boltz-mlx under a phone-sized
+/// `MemoryPlanner` — a 64 MiB MLX cache against the Mac's arbitrated 256 MB — so less is
+/// retained between steps.
+///
+/// ### What this fit does NOT know
+///
+/// **It is one point.** The Mac fit's three recorded failures were all extrapolation past
+/// its data, and this has far less data than the Mac fit had when it failed the first
+/// time. Two consequences, both deliberate:
+///
+/// - ``iOSMaximumTokens`` is set to the measured size and nothing above it, so the fit is
+///   never asked a question outside its single anchor.
+/// - ``bytesPerTokenMSARow`` is NOT rescaled — see that constant.
+///
+/// When a device sweep exists, refit all of it together against the table, raise
+/// ``iOSMaximumTokens`` to the largest size that actually completed, and keep the rule
+/// that has held here throughout: **never let the fit sit below a measurement.**
 enum PredictSizeGuard {
 
     // MARK: - Tunable constants
@@ -60,12 +113,12 @@ enum PredictSizeGuard {
     /// Model-resident floor. Small, because the linear and quadratic terms now carry the
     /// curve across the whole measured range instead of the intercept papering over the
     /// small end.
-    static let fixedOverheadBytes = 200 * 1024 * 1024
+    static var fixedOverheadBytes: Int { isPhone ? 700 * 1024 * 1024 : 200 * 1024 * 1024 }
     /// Linear term, bytes per token.
-    static let bytesPerToken = 14_500_000
+    static var bytesPerToken: Int { isPhone ? 7_250_000 : 14_500_000 }
     /// Quadratic term, bytes per token² — the pairwise tensors. 12.5× the original value;
     /// see the type doc for the two successive under-predictions that produced it.
-    static let bytesPerTokenSquared = 25_000
+    static var bytesPerTokenSquared: Int { isPhone ? 12_500 : 25_000 }
     /// Bilinear term, bytes per (token × alignment row beyond the first) — the MSA
     /// module's own tensors, which are depth × tokens wide.
     ///
@@ -76,22 +129,80 @@ enum PredictSizeGuard {
     /// wherever the MSA still fits inside buffers MLX was recycling anyway. So this is
     /// the WORST cell (3,763 B at 115 residues / depth 4096) plus ~20%, which is what
     /// makes one linear term safe across a relationship that is not linear.
+    ///
+    /// **Deliberately NOT halved for iOS**, unlike the three terms above. Those were
+    /// rescaled to a device measurement; this one has none — no MSA fold has ever been
+    /// run on an iPhone. Halving it "to match" would be inventing a measurement, which is
+    /// the exact move this type's three recorded failures all were. It stays at the
+    /// conservative Mac value, which on a phone budget means a deep alignment is refused
+    /// on memory well before ``iOSMaximumMSADepth`` binds — the honest place to refuse it.
     static let bytesPerTokenMSARow = 4_500
     /// At or below this fraction of available memory, proceed silently.
     static let okFraction = 0.50
     /// Above this fraction, refuse.
     static let warnFraction = 0.75
-    /// Hard ceiling regardless of memory: the largest input actually MEASURED end to end
-    /// (900 residues → 32.71 GB peak, 42 min of inference). `BoltzInputLimits.desktop`
-    /// would allow 1024, but the estimate there is ~41 GB — beyond a 36 GiB machine — and
-    /// nothing above ~384 has ever been validated for structural quality. Raise this only
-    /// alongside a measurement, never alongside an extrapolation.
-    static let maximumTokens = 900
+    /// Hard ceiling regardless of memory: the largest input actually MEASURED end to end.
+    ///
+    /// **macOS — 900.** 900 residues → 32.71 GB peak, 42 min of inference.
+    /// `BoltzInputLimits.desktop` would allow 1024, but the estimate there is ~41 GB —
+    /// beyond a 36 GiB machine — and nothing above ~384 has ever been validated for
+    /// structural quality.
+    ///
+    /// **iOS — see ``iOSMaximumTokens``.** A phone is a different machine running a
+    /// different memory plan, so it gets its own measured ceiling rather than a scaled
+    /// version of the Mac's.
+    ///
+    /// Raise either only alongside a measurement, never alongside an extrapolation.
+    static var maximumTokens: Int {
+        #if os(iOS)
+        return iOSMaximumTokens
+        #else
+        return 900
+        #endif
+    }
+
+    /// iOS hard token ceiling — the largest input actually folded to completion on a
+    /// physical iPhone.
+    ///
+    /// **Provisional: 117**, which is boltz-mlx's own published device figure
+    /// (iPhone 15 Pro, 117 tokens / 899 atoms, ~1.4 GB peak footprint —
+    /// `examples/BoltzMLXDemo/DEVICE_BENCHMARK.md`). It is deliberately NOT set to the
+    /// 256 that `BoltzInputLimits`' phone-sized default allows, and not to the
+    /// 100–150-residue range this port targets, because neither has been folded on
+    /// hardware. The type doc above records three separate occasions on which this
+    /// guard's fit was optimistic, every one of them because it extrapolated past its
+    /// data; a ceiling set to what we *hope* works would be the fourth.
+    ///
+    /// Raise it to the largest size that has actually completed on device, and record
+    /// the run. Nothing else licenses a change here.
+    static let iOSMaximumTokens = 117
     /// Hard ceiling on alignment depth: the deepest actually MEASURED, which is also
     /// upstream's `const.max_msa_seqs` and `BoltzInputLimits.desktop.maximumMSADepth`.
     /// The two agreeing is a coincidence of this sweep having reached the cap, not a
     /// reason to raise either — raise this only alongside a measurement.
-    static let maximumMSADepth = 16_384
+    static var maximumMSADepth: Int { isPhone ? iOSMaximumMSADepth : 16_384 }
+
+    /// iOS alignment-depth ceiling — boltz-mlx's own phone preset cap, which
+    /// `BoltzJobManager.memoryPlanner` independently enforces on iOS, so the two agree
+    /// and neither is a surprise. It is a backstop only: at any depth approaching it the
+    /// memory fraction refuses first (117 residues at depth 1 024 estimates ~2.3 GB
+    /// against an app budget near 2.5 GB), which is the refusal that names `msa_depth` as
+    /// the remedy. Nothing here has been measured on device; see
+    /// ``bytesPerTokenMSARow``.
+    static let iOSMaximumMSADepth = 1_024
+
+    /// Whether the fitted constants above should take their iOS values.
+    ///
+    /// A single switch rather than five `#if`s, so the two fits cannot be mixed — a
+    /// half-converted set (say, a phone intercept against a Mac quadratic) would produce
+    /// a curve nobody fitted and nobody measured.
+    private static var isPhone: Bool {
+        #if os(iOS)
+        return true
+        #else
+        return false
+        #endif
+    }
 
     enum Decision: Equatable {
         case ok
@@ -142,9 +253,27 @@ enum PredictSizeGuard {
         return .refuse(maxFittingTokens: largestFittingTokenCount(availableBytes))
     }
 
-    /// Physical memory, as the budget the estimate is compared against.
+    /// The budget the estimate is compared against.
+    ///
+    /// **The two platforms answer genuinely different questions, and using one number
+    /// for both is what made this guard meaningless on a phone.**
+    ///
+    /// - macOS: `physicalMemory`. A Mac has swap, so RAM is a soft wall — the question
+    ///   is "will this thrash", and installed RAM is the right scale for it.
+    /// - iOS: `os_proc_available_memory()` — bytes remaining before *this app* is
+    ///   jetsammed. `physicalMemory` on an iPhone 15 Pro reports 8 GB, of which a normal
+    ///   app may use roughly a third; comparing a fold's peak against 8 GB would have
+    ///   licensed runs at ~3× the app's actual budget, and the failure mode is a SIGKILL
+    ///   that no Swift handler can catch and that takes the unsaved session with it.
+    ///   This is exactly ``DesignSizeGuard/availableBytesNow``, for exactly its reasons,
+    ///   and it is live rather than static: it already accounts for whatever structures
+    ///   are currently loaded, which a fixed cap could not.
     static var availableBytes: Int {
-        Int(ProcessInfo.processInfo.physicalMemory)
+        #if os(iOS)
+        return os_proc_available_memory()
+        #else
+        return Int(ProcessInfo.processInfo.physicalMemory)
+        #endif
     }
 
     private static func largestFittingTokenCount(_ availableBytes: Int) -> Int {

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -207,11 +207,11 @@ final class PyMOLEngine: ObservableObject {
     // Design mode: protein-design overlay (MPNN score/design). Mutually exclusive
     // with Move and Measure modes — entering any one clears the others.
     @Published var designMode: Bool = false
-    // Predict tool (macOS): an exclusive interaction mode like Move/Measure/Design,
-    // but its "bar" is a form that composes cmd.predict rather than a viewport tool.
-    #if os(macOS)
+    // Predict tool: an exclusive interaction mode like Move/Measure/Design, but its
+    // "bar" is a form that composes cmd.predict rather than a viewport tool. Compiled
+    // for BOTH platforms; on iOS whether it is OFFERED is a runtime question, and the
+    // answer is PredictAvailability (Simulator / iOS version), not a #if.
     @Published var predictMode: Bool = false
-    #endif
     @Published var activeMoveObject: String? = nil
     @Published var armedAxis: GizmoHandle? = nil        // iOS tap-to-arm
     // Adjust-frame mode: gizmo controls re-anchor the gizmo's own frame (origin +
@@ -2084,9 +2084,7 @@ final class PyMOLEngine: ObservableObject {
         if let k = k {
             if interactionMode == .move { setInteractionMode(.viewing) }   // mutually exclusive
             setDesignMode(false)                                            // mutually exclusive
-            #if os(macOS)
-            setPredictMode(false)   // mutually exclusive
-            #endif
+            setPredictMode(false)                                            // mutually exclusive
             runPython("from pymol import appkit_measure as _am\n_am.set_mode('\(k.rawValue)')")
         } else {
             runPython("from pymol import appkit_measure as _am\n_am.reset()")
@@ -2187,14 +2185,11 @@ final class PyMOLEngine: ObservableObject {
             // ENTERING branch, and the clearing block below is `if on`-guarded.
             if interactionMode == .move { setInteractionMode(.viewing) }
             if measureMode != nil { setMeasureMode(nil) }
-            #if os(macOS)
             setPredictMode(false)   // mutually exclusive
-            #endif
         }
         designMode = on
     }
 
-    #if os(macOS)
     /// Enter/leave Predict mode. Exclusive with Move/Measure/Design, matching
     /// setDesignMode's entering-branch clears. On entry, refresh the form (loads the
     /// predictor list); on exit, reset any in-flight search/predict tracking.
@@ -2213,7 +2208,6 @@ final class PyMOLEngine: ObservableObject {
             predictMode = false
         }
     }
-    #endif
 
     // MARK: - Exclusive interaction modes (Move / Design / Measure)
 
@@ -2242,9 +2236,7 @@ final class PyMOLEngine: ObservableObject {
         if designMode     { setDesignMode(false);       exited = exited || !designMode }
         if interactionMode == .move { setInteractionMode(.viewing); exited = exited || interactionMode != .move }
         if measureMode != nil { setMeasureMode(nil);    exited = exited || measureMode == nil }
-        #if os(macOS)
         if predictMode { setPredictMode(false); exited = exited || !predictMode }
-        #endif
         return exited
     }
 
@@ -2515,7 +2507,6 @@ final class PyMOLEngine: ObservableObject {
     }()
 #endif
 
-    #if os(macOS)
     lazy var predictController: PredictController = {
         // PredictController is @MainActor; lazy vars run in a nonisolated context.
         // assumeIsolated is safe here: predictController is always first accessed from
@@ -2542,7 +2533,6 @@ final class PyMOLEngine: ObservableObject {
     }()
 
     private var predictCancellables = Set<AnyCancellable>()
-    #endif
 
     // MARK: - Move mode (rigid-body object gizmo)
 
@@ -2561,9 +2551,7 @@ final class PyMOLEngine: ObservableObject {
         if mode == .move {
             if measureMode != nil { setMeasureMode(nil) }   // mutually exclusive
             setDesignMode(false)                             // mutually exclusive
-            #if os(macOS)
-            setPredictMode(false)   // mutually exclusive
-            #endif
+            setPredictMode(false)                            // mutually exclusive
             refreshGizmo()
         } else {
             armedAxis = nil
@@ -3178,14 +3166,15 @@ final class PyMOLEngine: ObservableObject {
                     // the temp dir and prints this marker; there is no Python->Swift call
                     // path, so this poll IS the invocation. Deliberately NOT inside the
                     // MAS-restricted #if used for MCP: below -- prediction ships in every
-                    // macOS build. os(macOS) only because MLX cannot run on iOS yet.
-                    #if os(macOS)
+                    // build, on both platforms. No #if at all now: on iOS the marker can
+                    // only be printed if cmd.predict got past host.available(), which is
+                    // false unless PyMOLBridge.mm exported RAYMOL_PREDICT_HOST — and it
+                    // does not in the Simulator. The platform gate lives there and in
+                    // PredictAvailability, so a guard here would only be a third place to
+                    // forget.
                     BoltzJobManager.shared.handle(marker: line)
-                    #endif
                 } else if line.hasPrefix("PREDICT_FORM:ready") {
-                    #if os(macOS)
                     parsePredictFormFeedback()
-                    #endif
                 } else if line.hasPrefix("PREDICT_FORM:err") {
                     // swallow — a resolve error is already carried in the JSON payload's
                     // `error` field on a normal `ready`; this only fires if the write
@@ -3281,7 +3270,6 @@ final class PyMOLEngine: ObservableObject {
         runPython("from pymol import appkit_inspector as _ai\n_ai.poll([\(pyList)])")
     }
 
-    #if os(macOS)
     func parsePredictFormFeedback() {
         let path = (NSTemporaryDirectory() as NSString)
             .appendingPathComponent("pymol_predict_\(ProcessInfo.processInfo.processIdentifier).json")
@@ -3292,7 +3280,6 @@ final class PyMOLEngine: ObservableObject {
             self?.predictController.loadFormPayload(payload)
         }
     }
-    #endif
 
     // Parse the inspector JSON (written by appkit_inspector.poll to a temp file;
     // the feedback line is just the "OBJDETAIL:ready" trigger) → objectDetails +

--- a/swiftui/PyMOLViewerTests/PredictAvailabilityTests.swift
+++ b/swiftui/PyMOLViewerTests/PredictAvailabilityTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import RayMol
+
+/// The Predict tool's offer rules. Every case goes through the pure
+/// `isSupported(platform:osMajorVersion:isSimulator:)` so the iOS arms are exercised from
+/// a macOS test host — a `#if os(iOS)` rule is a rule that never runs in CI.
+final class PredictAvailabilityTests: XCTestCase {
+
+    // The Simulator gate is the one that distinguishes this from DesignAvailability, and
+    // it is not a version question: MLX's allocator builds Metal heaps MTLSimDevice
+    // rejects outright, so a prediction started there can only abort. Version is
+    // irrelevant — even a Simulator running a future iOS must be refused.
+    func testSimulatorIsNeverSupportedRegardlessOfVersion() {
+        for version in [17, 18, 26, 99] {
+            XCTAssertFalse(
+                PredictAvailability.isSupported(platform: .iOS, osMajorVersion: version,
+                                                isSimulator: true),
+                "iOS \(version) Simulator must not offer Predict — MLX cannot run there")
+        }
+    }
+
+    // Same floor and same reasoning as Design: mlx-swift's Metal path has only ever been
+    // validated on iOS 18 hardware, though SPM will resolve against boltz-mlx's iOS 17
+    // deployment target.
+    func testIOSDeviceRequires18() {
+        XCTAssertFalse(PredictAvailability.isSupported(platform: .iOS, osMajorVersion: 16,
+                                                       isSimulator: false))
+        XCTAssertFalse(PredictAvailability.isSupported(platform: .iOS, osMajorVersion: 17,
+                                                       isSimulator: false))
+        XCTAssertTrue(PredictAvailability.isSupported(platform: .iOS, osMajorVersion: 18,
+                                                      isSimulator: false))
+        XCTAssertTrue(PredictAvailability.isSupported(platform: .iOS, osMajorVersion: 26,
+                                                      isSimulator: false))
+    }
+
+    // Prediction has shipped on macOS since #224 and this port must not narrow it. The
+    // `isSimulator` argument is meaningless there and must not leak into the answer.
+    func testMacOSAlwaysSupported() {
+        XCTAssertTrue(PredictAvailability.isSupported(platform: .macOS, osMajorVersion: 13,
+                                                      isSimulator: false))
+        XCTAssertTrue(PredictAvailability.isSupported(platform: .macOS, osMajorVersion: 26,
+                                                      isSimulator: true))
+    }
+
+    func testMinimumIsEighteen() {
+        XCTAssertEqual(PredictAvailability.minimumIOSMajorVersion, 18)
+    }
+
+    /// Separate constants on purpose: raising Design's floor must not silently raise
+    /// Predict's, or vice versa. They may be equal — they must not be the same symbol.
+    func testFloorIsIndependentOfDesigns() {
+        #if RAYMOL_MPNN
+        XCTAssertEqual(PredictAvailability.minimumIOSMajorVersion,
+                       DesignAvailability.minimumIOSMajorVersion,
+                       "equal today; this test exists to make a divergence deliberate")
+        #endif
+    }
+
+    // The live property must agree with the pure function for the running host.
+    func testLivePropertyMatchesPureFunction() {
+        XCTAssertEqual(
+            PredictAvailability.isSupported,
+            PredictAvailability.isSupported(
+                platform: PredictAvailability.current,
+                osMajorVersion: PredictAvailability.currentOSMajorVersion,
+                isSimulator: PredictAvailability.currentIsSimulator))
+    }
+}

--- a/swiftui/PyMOLViewerTests/PredictScreenAwakeTests.swift
+++ b/swiftui/PyMOLViewerTests/PredictScreenAwakeTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import RayMol
+
+/// The screen-awake policy. Pure by construction (see `PredictScreenAwake`), so the iOS
+/// rule is testable from the macOS test host — the side effect it drives is one
+/// assignment and is not what can be got wrong.
+final class PredictScreenAwakeTests: XCTestCase {
+
+    private func job(_ id: String, state: String) -> PredictionJobState {
+        PredictionJobState(id: id, state: state, phase: "diffusion", fraction: 0.5,
+                           moving: true, detail: "", modelsDone: 0, modelsTotal: 1,
+                           elapsed: 1, error: nil)
+    }
+
+    func testIdleReleasesTheScreen() {
+        XCTAssertFalse(PredictScreenAwake.shouldStayAwake(predictions: [],
+                                                           weightsFetching: false))
+    }
+
+    func testARunningFoldHoldsTheScreen() {
+        XCTAssertTrue(
+            PredictScreenAwake.shouldStayAwake(predictions: [job("m1", state: "running")],
+                                                weightsFetching: false))
+    }
+
+    /// The 529 MB first-run download is minutes of foreground-only work with no input —
+    /// the same shape as a fold, and the same failure if iOS sleeps the display. It must
+    /// hold the screen on its own, with no prediction job yet in flight.
+    func testAWeightDownloadAloneHoldsTheScreen() {
+        XCTAssertTrue(PredictScreenAwake.shouldStayAwake(predictions: [],
+                                                          weightsFetching: true))
+    }
+
+    /// A cancelled job is terminal, so the screen must be released at once rather than
+    /// held until the user dismisses the card. `isError` covers cancelled, which is what
+    /// makes this fall out — pinned here because that is a subtle thing to rely on.
+    func testTerminalJobsReleaseTheScreen() {
+        for state in ["error", "failed", "cancelled"] {
+            XCTAssertFalse(
+                PredictScreenAwake.shouldStayAwake(predictions: [job("m1", state: state)],
+                                                    weightsFetching: false),
+                "a \(state) job is terminal and must not hold the display on")
+        }
+    }
+
+    /// One live job among finished ones still holds the screen — the guard is "any
+    /// running", not "the newest".
+    func testOneLiveJobAmongTerminalOnesStillHolds() {
+        let jobs = [job("a", state: "cancelled"),
+                    job("b", state: "running"),
+                    job("c", state: "error")]
+        XCTAssertTrue(PredictScreenAwake.shouldStayAwake(predictions: jobs,
+                                                          weightsFetching: false))
+    }
+}

--- a/swiftui/PyMOLViewerTests/PredictScreenAwakeTests.swift
+++ b/swiftui/PyMOLViewerTests/PredictScreenAwakeTests.swift
@@ -52,4 +52,51 @@ final class PredictScreenAwakeTests: XCTestCase {
         XCTAssertTrue(PredictScreenAwake.shouldStayAwake(predictions: jobs,
                                                           weightsFetching: false))
     }
+
+    // MARK: - The job-owned hold
+
+    override func setUp() {
+        super.setUp()
+        PredictScreenAwake.resetJobHoldsForTesting()
+    }
+
+    override func tearDown() {
+        PredictScreenAwake.resetJobHoldsForTesting()
+        super.tearDown()
+    }
+
+    /// The authoritative path: BoltzJobManager takes the hold the instant a fold starts,
+    /// not when the object-panel poll notices one. The view path was too slow — a
+    /// 110-residue run was observed freezing at diffusion step 42 of 200 because the
+    /// phone locked inside the ~500 ms gap.
+    func testAJobTakesAndReleasesTheHold() {
+        XCTAssertEqual(PredictScreenAwake.activeJobHolds, 0)
+        PredictScreenAwake.setJobActive(true)
+        XCTAssertEqual(PredictScreenAwake.activeJobHolds, 1)
+        PredictScreenAwake.setJobActive(false)
+        XCTAssertEqual(PredictScreenAwake.activeJobHolds, 0)
+    }
+
+    /// Counted, not a flag: n_models > 1 and queued jobs overlap, and the display must
+    /// stay pinned until the LAST one finishes.
+    func testOverlappingJobsHoldUntilTheLastOneFinishes() {
+        PredictScreenAwake.setJobActive(true)
+        PredictScreenAwake.setJobActive(true)
+        PredictScreenAwake.setJobActive(false)
+        XCTAssertEqual(PredictScreenAwake.activeJobHolds, 1,
+                       "one fold finishing must not release the other's hold")
+        PredictScreenAwake.setJobActive(false)
+        XCTAssertEqual(PredictScreenAwake.activeJobHolds, 0)
+    }
+
+    /// An unbalanced release must not drive the count negative — that would make the next
+    /// genuine hold a no-op and silently reintroduce the freeze this fixes.
+    func testUnbalancedReleaseCannotGoNegative() {
+        PredictScreenAwake.setJobActive(false)
+        PredictScreenAwake.setJobActive(false)
+        XCTAssertEqual(PredictScreenAwake.activeJobHolds, 0)
+        PredictScreenAwake.setJobActive(true)
+        XCTAssertEqual(PredictScreenAwake.activeJobHolds, 1,
+                       "a real hold after stray releases must still hold")
+    }
 }

--- a/swiftui/PyMOLViewerTests/PredictSizeGuardIOSTests.swift
+++ b/swiftui/PyMOLViewerTests/PredictSizeGuardIOSTests.swift
@@ -1,0 +1,172 @@
+#if os(macOS)
+import XCTest
+@testable import RayMol
+
+/// The iOS arm of `PredictSizeGuard`.
+///
+/// Run from the macOS test host on purpose. `decide` takes `availableBytes` as a
+/// parameter, so an iPhone-sized budget can be handed to it here and the policy checked
+/// without a device; only `availableBytes` itself (`os_proc_available_memory()` vs
+/// `physicalMemory`) is platform-branched, and that one property is the part a test could
+/// not have caught anyway.
+///
+/// The numbers below are the ones that matter on a phone:
+///
+/// - **~2.5 GB** — a plausible `os_proc_available_memory()` on an iPhone 15 Pro with a
+///   session already open. NOT 8 GB: the device has 8 GB of RAM and an app may use a
+///   fraction of it, and conflating the two is exactly the bug this arm exists to fix.
+/// - **117 tokens / ~1.4 GB** — boltz-mlx's published device measurement
+///   (`examples/BoltzMLXDemo/DEVICE_BENCHMARK.md`), and the only iOS peak anyone has
+///   actually recorded.
+final class PredictSizeGuardIOSTests: XCTestCase {
+
+    /// Bytes an iPhone 15 Pro app can still allocate with a structure loaded — the scale
+    /// `os_proc_available_memory()` reports, an order of magnitude below `physicalMemory`.
+    private let phoneBudget = 2_500 * 1024 * 1024
+    /// The device peak measured at 117 tokens.
+    private let measuredPeakAt117 = 1_400 * 1024 * 1024
+
+    // MARK: - The fit must not sit below the one iOS measurement there is
+
+    /// The iOS constants, restated. `PredictSizeGuard`'s own properties are
+    /// platform-branched and this host is macOS, so they cannot be read here — restating
+    /// them is the price of testing the iOS fit at all, and `testIOSConstantsAreAsFitted`
+    /// below is what keeps the restatement honest.
+    private let iosFixed = 700 * 1024 * 1024
+    private let iosPerToken = 7_250_000
+    private let iosPerTokenSquared = 12_500
+    private func iosEstimate(tokens: Int, msaDepth: Int = 1) -> Int {
+        iosFixed + tokens * iosPerToken + tokens * tokens * iosPerTokenSquared
+            + tokens * max(msaDepth - 1, 0) * PredictSizeGuard.bytesPerTokenMSARow
+    }
+
+    /// The single rule this type's doc comment says has been broken three times, checked
+    /// against the only iOS measurement that exists.
+    func testEstimateCoversTheMeasuredDevicePeak() {
+        XCTAssertGreaterThan(iosEstimate(tokens: 117), measuredPeakAt117,
+                             "the iOS fit must clear the iPhone 15 Pro measurement, "
+                             + "never sit below it")
+    }
+
+    /// The reserve at the anchor: enough to absorb what one point cannot know, not so
+    /// much that the fit refuses the workload it was made for. Both bounds are the point.
+    func testReserveAtTheAnchorIsBetweenTenAndFiftyPercent() {
+        let ratio = Double(iosEstimate(tokens: 117)) / Double(measuredPeakAt117)
+        XCTAssertGreaterThan(ratio, 1.10, "too little margin over a single measurement")
+        XCTAssertLessThan(ratio, 1.50, "so much margin the target workload cannot run")
+    }
+
+    /// **The regression that made an iOS-specific fit necessary in the first place.**
+    /// Reusing the Mac constants estimates 2.25 GB at the anchor, which against a
+    /// realistic phone budget is a refusal — it would have made the fold this port exists
+    /// for impossible on the device it was ported to. Pinned so a future "simplification"
+    /// that deletes the iOS branch fails here instead of on someone's phone.
+    func testTheMacFitWouldHaveRefusedTheTargetWorkload() {
+        let macEstimate = PredictSizeGuard.fixedOverheadBytes
+            + 117 * PredictSizeGuard.bytesPerToken
+            + 117 * 117 * PredictSizeGuard.bytesPerTokenSquared
+        XCTAssertGreaterThan(Double(macEstimate),
+                             Double(phoneBudget) * PredictSizeGuard.warnFraction,
+                             "the Mac curve refuses 117 residues on a phone budget; "
+                             + "that is why iOS has its own")
+        XCTAssertLessThan(Double(iosEstimate(tokens: 117)),
+                          Double(phoneBudget) * PredictSizeGuard.warnFraction,
+                          "and the iOS curve does not")
+    }
+
+    /// The restated constants must be the ones the guard actually uses. Read through the
+    /// live properties, which on this host give the MAC values — so this asserts the
+    /// documented RELATIONSHIP (each iOS term is half its Mac counterpart) rather than
+    /// re-typing the same literal twice, which would pass no matter what shipped.
+    func testIOSConstantsAreAsFitted() {
+        XCTAssertEqual(iosPerToken * 2, PredictSizeGuard.bytesPerToken)
+        XCTAssertEqual(iosPerTokenSquared * 2, PredictSizeGuard.bytesPerTokenSquared)
+        XCTAssertEqual(iosFixed, 700 * 1024 * 1024)
+    }
+
+    // MARK: - The budget is what changed, and it is what refuses
+
+    /// The regression this port had to avoid. `physicalMemory` on an iPhone 15 Pro reads
+    /// 8 GB; against that, a 250-residue fold sails through. Against the app's real
+    /// budget it does not — and the difference between those two answers is a jetsam
+    /// SIGKILL that takes the unsaved session.
+    func testAFoldThatPassesAgainstPhysicalMemoryIsRefusedAgainstTheAppBudget() {
+        let physicalMemoryOfAn8GBPhone = 8 * 1024 * 1024 * 1024
+        XCTAssertLessThan(Double(iosEstimate(tokens: 250)),
+                          Double(physicalMemoryOfAn8GBPhone) * PredictSizeGuard.okFraction,
+                          "against installed RAM, 250 residues looks comfortable")
+        XCTAssertGreaterThan(Double(iosEstimate(tokens: 250)),
+                             Double(phoneBudget) * PredictSizeGuard.warnFraction,
+                             "against the app's actual budget it is a refusal — and the "
+                             + "difference between those two answers is a jetsam SIGKILL")
+    }
+
+    /// A refusal has to name a size the user can actually reach, or it is just a wall.
+    /// Checked through the real `decide` — the Mac constants make the fitting size
+    /// smaller than it will be on a phone, which is fine: what is under test is that a
+    /// refusal reports SOME reachable size, not which.
+    func testRefusalStillNamesAFittingSize() {
+        guard case let .refuse(maxTokens) =
+                PredictSizeGuard.decide(tokens: 400, availableBytes: phoneBudget)
+        else { return XCTFail("expected refuse") }
+        XCTAssertGreaterThan(maxTokens, 0)
+        XCTAssertLessThan(maxTokens, 400)
+    }
+
+    // MARK: - The hard ceiling
+
+    /// Set to the largest input actually folded on device, not to what the runtime's
+    /// phone preset would allow (256) and not to the 100–150 residues this port targets.
+    /// If this value changes, a device measurement must change with it.
+    func testIOSCeilingIsTheMeasuredDeviceSize() {
+        XCTAssertEqual(PredictSizeGuard.iOSMaximumTokens, 117)
+    }
+
+    /// The iOS ceiling must stay well below the Mac's — they are different machines, and
+    /// a single number for both is what "meaningless on a phone" looked like.
+    func testIOSCeilingIsFarBelowTheMacCeiling() {
+        XCTAssertLessThan(PredictSizeGuard.iOSMaximumTokens, PredictSizeGuard.maximumTokens)
+    }
+
+    // MARK: - Alignment depth on a phone
+
+    /// Depth is the dimension the guard's own history records it failing to model. On a
+    /// phone there is no headroom to absorb that, so even a modest alignment on a small
+    /// target must be refused rather than warned about — and refused as a DEPTH problem,
+    /// since lowering `msa_depth` is the lever that makes this run possible where "use a
+    /// shorter sequence" would not.
+    func testADeepAlignmentCostsFarMoreThanTheFoldItself() {
+        let single = iosEstimate(tokens: 117)
+        let deep = iosEstimate(tokens: 117, msaDepth: PredictSizeGuard.iOSMaximumMSADepth)
+        XCTAssertGreaterThan(deep - single, single / 4,
+                             "depth is not a rounding error on a phone")
+        XCTAssertGreaterThan(Double(deep), Double(phoneBudget) * PredictSizeGuard.warnFraction,
+                             "so an alignment at the depth ceiling must be refused on "
+                             + "MEMORY, before the depth ceiling itself ever binds — that "
+                             + "is the refusal that names msa_depth as the remedy")
+    }
+
+    /// The depth ceiling agrees with what `BoltzJobManager.memoryPlanner` enforces inside
+    /// the runtime on iOS, so a request cannot pass one and fail the other.
+    func testIOSDepthCeilingMatchesTheRuntimePhonePreset() {
+        XCTAssertEqual(PredictSizeGuard.iOSMaximumMSADepth, 1_024)
+        XCTAssertLessThan(PredictSizeGuard.iOSMaximumMSADepth, PredictSizeGuard.maximumMSADepth)
+    }
+
+    // MARK: - Cache limit
+
+    /// Design mode's iOS ceiling is 96 MB. Prediction asks for LESS on a phone, which
+    /// inverts the macOS relationship — and, because `MLXRuntime` arbitration is
+    /// min-wins and process-global, means prediction pulls Design's effective ceiling
+    /// down too. That is intended (a smaller cache can only churn, never fail), but it is
+    /// a real behaviour change and is pinned here so it cannot happen by accident.
+    func testPredictionAsksForLessCacheThanDesignOnIOS() {
+        // The constant is platform-branched, so assert the iOS VALUE rather than reading
+        // it — on this macOS host `BoltzRuntime.cacheLimitBytes` is the 256 MB Mac ask.
+        let iOSAsk = 64 * 1024 * 1024
+        XCTAssertLessThan(iOSAsk, MPNNRuntime.cacheLimitBytes,
+                          "on a phone the fold's own tensors dominate; cache is the "
+                          + "cheapest memory to give back")
+    }
+}
+#endif

--- a/swiftui/PyMOLViewerTests/PredictSizeGuardIOSTests.swift
+++ b/swiftui/PyMOLViewerTests/PredictSizeGuardIOSTests.swift
@@ -22,9 +22,21 @@ final class PredictSizeGuardIOSTests: XCTestCase {
 
     /// Bytes an iPhone 15 Pro app can still allocate with a structure loaded — the scale
     /// `os_proc_available_memory()` reports, an order of magnitude below `physicalMemory`.
-    private let phoneBudget = 2_500 * 1024 * 1024
-    /// The device peak measured at 117 tokens.
-    private let measuredPeakAt117 = 1_400 * 1024 * 1024
+    /// `os_proc_available_memory()` measured on the target iPhone 15 Pro with a session
+    /// open — back-derived from the guard's own refusal of a 200-residue input naming 180
+    /// as the largest that fit. NOT `physicalMemory`, which reads 8 GB on that device;
+    /// conflating the two is the bug this whole arm exists to fix.
+    private let phoneBudget = 3_270_000_000
+
+    /// Peak `phys_footprint` measured on device, sampled every 200 ms through the run.
+    /// The quantity jetsam kills on, and the one `os_proc_available_memory()` is
+    /// denominated in — deliberately NOT MLX's high-water mark, which excludes its buffer
+    /// cache and reads 300-350 MB lower at these sizes.
+    private let measured: [(tokens: Int, footprint: Int)] = [
+        (110, 1_720_000_000),
+        (130, 2_000_000_000),
+        (164, 2_350_000_000),
+    ]
 
     // MARK: - The fit must not sit below the one iOS measurement there is
 
@@ -32,56 +44,97 @@ final class PredictSizeGuardIOSTests: XCTestCase {
     /// platform-branched and this host is macOS, so they cannot be read here — restating
     /// them is the price of testing the iOS fit at all, and `testIOSConstantsAreAsFitted`
     /// below is what keeps the restatement honest.
-    private let iosFixed = 700 * 1024 * 1024
-    private let iosPerToken = 7_250_000
-    private let iosPerTokenSquared = 12_500
+    private let iosFixed = 850 * 1024 * 1024
+    private let iosPerToken = 7_500_000
+    private let iosPerTokenSquared = 21_500
     private func iosEstimate(tokens: Int, msaDepth: Int = 1) -> Int {
         iosFixed + tokens * iosPerToken + tokens * tokens * iosPerTokenSquared
             + tokens * max(msaDepth - 1, 0) * PredictSizeGuard.bytesPerTokenMSARow
     }
 
-    /// The single rule this type's doc comment says has been broken three times, checked
-    /// against the only iOS measurement that exists.
-    func testEstimateCoversTheMeasuredDevicePeak() {
-        XCTAssertGreaterThan(iosEstimate(tokens: 117), measuredPeakAt117,
-                             "the iOS fit must clear the iPhone 15 Pro measurement, "
-                             + "never sit below it")
+    /// **The rule this type's doc says has been broken four times.** Pinned over the whole
+    /// measured table rather than one point, because pinning only one is exactly how an
+    /// earlier shortfall survived.
+    func testEstimateNeverSitsBelowAnyMeasurement() {
+        for m in measured {
+            XCTAssertGreaterThan(
+                iosEstimate(tokens: m.tokens), m.footprint,
+                "\(m.tokens) residues measured \(m.footprint) B on device; the fit must "
+                + "clear it, never sit below it")
+        }
     }
 
-    /// The reserve at the anchor: enough to absorb what one point cannot know, not so
-    /// much that the fit refuses the workload it was made for. Both bounds are the point.
-    func testReserveAtTheAnchorIsBetweenTenAndFiftyPercent() {
-        let ratio = Double(iosEstimate(tokens: 117)) / Double(measuredPeakAt117)
-        XCTAssertGreaterThan(ratio, 1.10, "too little margin over a single measurement")
-        XCTAssertLessThan(ratio, 1.50, "so much margin the target workload cannot run")
+    /// The reserve: enough to absorb what three points cannot know, not so much that the
+    /// fit refuses the workload it was made for. Both bounds are the point.
+    func testReserveIsBetweenTenAndFortyPercentEverywhere() {
+        for m in measured {
+            let ratio = Double(iosEstimate(tokens: m.tokens)) / Double(m.footprint)
+            XCTAssertGreaterThan(ratio, 1.10, "too little margin at \(m.tokens)")
+            XCTAssertLessThan(ratio, 1.40, "so much margin \(m.tokens) cannot run")
+        }
     }
 
-    /// **The regression that made an iOS-specific fit necessary in the first place.**
-    /// Reusing the Mac constants estimates 2.25 GB at the anchor, which against a
-    /// realistic phone budget is a refusal — it would have made the fold this port exists
-    /// for impossible on the device it was ported to. Pinned so a future "simplification"
-    /// that deletes the iOS branch fails here instead of on someone's phone.
-    func testTheMacFitWouldHaveRefusedTheTargetWorkload() {
-        let macEstimate = PredictSizeGuard.fixedOverheadBytes
-            + 117 * PredictSizeGuard.bytesPerToken
-            + 117 * 117 * PredictSizeGuard.bytesPerTokenSquared
-        XCTAssertGreaterThan(Double(macEstimate),
+    /// **The units regression.** Fitted against MLX's high-water mark instead of
+    /// phys_footprint, this curve sat BELOW every measured point — MLX excludes its buffer
+    /// cache, while the budget it is compared against is in footprint terms. Pinned so a
+    /// future refit against the wrong instrument fails here.
+    func testTheMLXPeakFitWouldHaveSatBelowMeasurement() {
+        let oldFixed = 700 * 1024 * 1024, oldPerToken = 7_250_000, oldPerSq = 12_500
+        for m in measured {
+            let old = oldFixed + m.tokens * oldPerToken + m.tokens * m.tokens * oldPerSq
+            XCTAssertLessThan(old, m.footprint,
+                              "the MLX-peak fit under-predicted at \(m.tokens); this test "
+                              + "documents why the constants are footprint-fitted")
+        }
+    }
+
+    /// The workload the port exists for must actually be permitted on the measured budget.
+    /// A guard that refuses everything is not a safe guard.
+    func testTheTargetWorkloadIsPermitted() {
+        for tokens in [100, 110, 130] {
+            let fraction = Double(iosEstimate(tokens: tokens)) / Double(phoneBudget)
+            XCTAssertLessThanOrEqual(fraction, PredictSizeGuard.warnFraction,
+                                     "\(tokens) residues folded on device and must not "
+                                     + "be refused")
+        }
+    }
+
+    /// **Why iOS needs its own constants.** Not because the Mac curve is unsafe on a phone
+    /// — measured against the device footprints it over-predicts by 1.23-1.39×, so it
+    /// would not have got anyone jetsammed. It is because it is over-conservative by
+    /// enough to REFUSE sizes that fold perfectly well: at 130 residues the Mac curve
+    /// estimates 2.52 GB against a 3.27 GB budget (77%, past `warnFraction`), for a fold
+    /// that actually peaked at 2.00 GB and finished in 64 s.
+    ///
+    /// Pinned so a future "simplification" that deletes the iOS branch fails here rather
+    /// than by quietly shrinking what the tool will accept.
+    func testTheMacFitWouldRefuseASizeThatFoldsFine() {
+        func mac(_ t: Int) -> Int {
+            PredictSizeGuard.fixedOverheadBytes + t * PredictSizeGuard.bytesPerToken
+                + t * t * PredictSizeGuard.bytesPerTokenSquared
+        }
+        XCTAssertGreaterThan(Double(mac(130)),
                              Double(phoneBudget) * PredictSizeGuard.warnFraction,
-                             "the Mac curve refuses 117 residues on a phone budget; "
-                             + "that is why iOS has its own")
-        XCTAssertLessThan(Double(iosEstimate(tokens: 117)),
-                          Double(phoneBudget) * PredictSizeGuard.warnFraction,
-                          "and the iOS curve does not")
+                             "the Mac curve refuses 130 residues on the measured budget")
+        XCTAssertLessThanOrEqual(Double(iosEstimate(tokens: 130)),
+                                 Double(phoneBudget) * PredictSizeGuard.warnFraction,
+                                 "the iOS curve permits it, which is the point")
+        // And it is over-conservative rather than unsafe: it clears every measurement.
+        for m in measured {
+            XCTAssertGreaterThan(mac(m.tokens), m.footprint)
+        }
     }
 
     /// The restated constants must be the ones the guard actually uses. Read through the
     /// live properties, which on this host give the MAC values — so this asserts the
     /// documented RELATIONSHIP (each iOS term is half its Mac counterpart) rather than
     /// re-typing the same literal twice, which would pass no matter what shipped.
-    func testIOSConstantsAreAsFitted() {
-        XCTAssertEqual(iosPerToken * 2, PredictSizeGuard.bytesPerToken)
-        XCTAssertEqual(iosPerTokenSquared * 2, PredictSizeGuard.bytesPerTokenSquared)
-        XCTAssertEqual(iosFixed, 700 * 1024 * 1024)
+    func testIOSConstantsAreBelowTheirMacCounterparts() {
+        XCTAssertLessThan(iosPerToken, PredictSizeGuard.bytesPerToken)
+        XCTAssertLessThan(iosPerTokenSquared, PredictSizeGuard.bytesPerTokenSquared)
+        XCTAssertGreaterThan(iosFixed, PredictSizeGuard.fixedOverheadBytes,
+                             "the phone intercept is LARGER — the 529 MB int8 pack "
+                             + "dominates a phone's budget in a way it does not a Mac's")
     }
 
     // MARK: - The budget is what changed, and it is what refuses
@@ -92,10 +145,10 @@ final class PredictSizeGuardIOSTests: XCTestCase {
     /// SIGKILL that takes the unsaved session.
     func testAFoldThatPassesAgainstPhysicalMemoryIsRefusedAgainstTheAppBudget() {
         let physicalMemoryOfAn8GBPhone = 8 * 1024 * 1024 * 1024
-        XCTAssertLessThan(Double(iosEstimate(tokens: 250)),
+        XCTAssertLessThan(Double(iosEstimate(tokens: 200)),
                           Double(physicalMemoryOfAn8GBPhone) * PredictSizeGuard.okFraction,
-                          "against installed RAM, 250 residues looks comfortable")
-        XCTAssertGreaterThan(Double(iosEstimate(tokens: 250)),
+                          "against installed RAM, 200 residues looks comfortable")
+        XCTAssertGreaterThan(Double(iosEstimate(tokens: 200)),
                              Double(phoneBudget) * PredictSizeGuard.warnFraction,
                              "against the app's actual budget it is a refusal — and the "
                              + "difference between those two answers is a jetsam SIGKILL")
@@ -119,7 +172,9 @@ final class PredictSizeGuardIOSTests: XCTestCase {
     /// phone preset would allow (256) and not to the 100–150 residues this port targets.
     /// If this value changes, a device measurement must change with it.
     func testIOSCeilingIsTheMeasuredDeviceSize() {
-        XCTAssertEqual(PredictSizeGuard.iOSMaximumTokens, 117)
+        XCTAssertEqual(PredictSizeGuard.iOSMaximumTokens, 164)
+        XCTAssertEqual(PredictSizeGuard.iOSMaximumTokens, measured.map(\.tokens).max(),
+                       "the ceiling is the largest size actually folded, by construction")
     }
 
     /// The iOS ceiling must stay well below the Mac's — they are different machines, and

--- a/swiftui/project.yml
+++ b/swiftui/project.yml
@@ -204,6 +204,18 @@ targets:
         Debug:
           SWIFT_OPTIMIZATION_LEVEL: -Onone
           DEBUG_INFORMATION_FORMAT: dwarf
+          # iOS Debug needs the entitlements file too. Debug otherwise carries none (the
+          # key below is under Release), and a Debug build is exactly what gets installed
+          # on a phone over cable to measure prediction memory — measuring against a
+          # jetsam ceiling the shipping build will not have would make every number
+          # collected here a lie in the pessimistic direction. macOS Debug is left alone:
+          # adding the sandbox to an unsigned local build breaks it.
+          #
+          # Commented out for the same reason as the Release pair below — see there for
+          # the portal step that has to happen first. Uncomment BOTH pairs together, or
+          # measurements from a Debug device build will not reflect the shipping ceiling.
+          # "CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]": PyMOLViewer/RayMolIOS.entitlements
+          # "CODE_SIGN_ENTITLEMENTS[sdk=iphonesimulator*]": PyMOLViewer/RayMolIOS.entitlements
         Release:
           SWIFT_OPTIMIZATION_LEVEL: -O
           # App Store distribution: automatic Distribution signing + App Sandbox
@@ -213,6 +225,21 @@ targets:
           ENABLE_HARDENED_RUNTIME: YES
           ENABLE_APP_SANDBOX: YES
           CODE_SIGN_ENTITLEMENTS: PyMOLViewer/RayMol.entitlements
+          # OPT-IN, not enabled: PyMOLViewer/RayMolIOS.entitlements requests the
+          # Increased Memory Limit entitlement, which roughly doubles what an on-device
+          # fold can be — see PredictSizeGuard, where an unentitled iPhone 15 Pro budget
+          # refuses past ~120 residues. It is commented out because it does NOT build
+          # without a portal change first: automatic signing fails with "Provisioning
+          # profile ... doesn't include the Increased Memory Limit capability".
+          #
+          # To turn it on: enable "Increased Memory Limit" for the io.raymol.RayMol App ID
+          # at developer.apple.com (Certificates, Identifiers & Profiles → Identifiers),
+          # let Xcode regenerate the profile, then uncomment both lines here AND the pair
+          # under Debug above. Nothing in the Swift code changes — the entitlement only
+          # moves the number os_proc_available_memory() reports, and the guard keeps
+          # refusing whatever does not fit whatever budget is actually granted.
+          # "CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]": PyMOLViewer/RayMolIOS.entitlements
+          # "CODE_SIGN_ENTITLEMENTS[sdk=iphonesimulator*]": PyMOLViewer/RayMolIOS.entitlements
           # iOS App Store guideline-2.5.2 fallback: if the iOS app is rejected
           # for the command line / Raymond, uncomment the next line to compile
           # them out of the iOS build (no effect on macOS — the flag is gated to
@@ -564,13 +591,19 @@ targets:
         product: MPNNKit
       - package: mlx-swift
         product: MLX
-      # boltz-mlx: structure prediction. macOS only, so the platform filter keeps
-      # BoltzMLX out of the iOS link entirely. No compilation condition: prediction
-      # ships in every macOS build, so there is no flag to forget. Must stay OUTSIDE
-      # the RAYMOL_SPARKLE_BEGIN/END markers or archive_appstore.sh strips it.
+      # boltz-mlx: structure prediction. Linked on BOTH platforms — the iOS slice
+      # was added for on-device folding on a physical iPhone. No compilation
+      # condition and no platform filter: prediction ships in every build, so there
+      # is no flag to forget, and the Swift side is gated by `#if os(macOS) ||
+      # os(iOS)` plus the RUNTIME gate in PredictAvailability (which is what keeps
+      # the iOS Simulator — where MLX cannot run at all — from offering the tool).
+      # Deliberately linked for the Simulator too, even though it can never run
+      # there: that is the only way the Simulator slice keeps COMPILING this code,
+      # and no CI job builds iOS at all.
+      # Must stay OUTSIDE the RAYMOL_SPARKLE_BEGIN/END markers or
+      # archive_appstore.sh strips it.
       - package: BoltzMLX
         product: BoltzMLX
-        platforms: [macOS]
       # protenix-mlx: the second inference runtime (#309). Same macOS-only filter and
       # the same reasoning as BoltzMLX above, and likewise outside the Sparkle markers
       # so archive_appstore.sh does not strip prediction out of the MAS build.

--- a/testing/tests/predict/predict_weights_cache.py
+++ b/testing/tests/predict/predict_weights_cache.py
@@ -45,6 +45,18 @@ class TestCachePaths(testing.PyMOLTestCase):
         self.assertEqual(
             root, '/Users/x/Library/Application Support/RayMol/weights')
 
+    def testDefaultRootIsUnderApplicationSupportOnIOS(self):
+        # sys.platform is 'ios', not 'darwin', on the iPhone build. Before this was
+        # handled, iOS fell through to the ~/.raymol branch below -- and $HOME there is
+        # the app's data container ROOT, which is not writable, so the 529 MB weight
+        # download died at its first mkdir with EPERM. The writable, correct location is
+        # the same Library/Application Support path the sandboxed Mac build already uses.
+        from pymol.predictors import weights
+        home = '/var/mobile/Containers/Data/Application/UUID'
+        self.assertEqual(
+            weights.WeightCache.default_root(platform='ios', home=home),
+            home + '/Library/Application Support/RayMol/weights')
+
     def testDefaultRootHasADotDirElsewhere(self):
         from pymol.predictors import weights
         self.assertEqual(weights.WeightCache.default_root(platform='linux',

--- a/testing/tests/test_appkit_predict.py
+++ b/testing/tests/test_appkit_predict.py
@@ -29,6 +29,32 @@ class TestAppkitPredict(testing.PyMOLTestCase):
 
     def setUp(self):
         super().setUp()  # sets self.oldcwd, calls cmd.reinitialize()
+        # Pose as an inference host advertising the BOLTZ RUNTIME ALONE.
+        #
+        # Needed at all because the form list is filtered by check_available (see
+        # appkit_predict._predictors), and a bare test process is not a host: without
+        # RAYMOL_PREDICT_HOST every predictor correctly refuses and the list is empty.
+        # Tests that assert something IS offered must therefore say what host they are.
+        #
+        # "boltz" alone rather than "boltz,protenix" on purpose: that is exactly what
+        # PyMOLBridge.mm advertises on iOS, so this reproduces the iOS filtering
+        # condition in a test that runs on a Mac -- the Protenix packs are refused for
+        # a missing runtime here for the same reason they are refused on a phone. No CI
+        # runs on iOS, so this is the only place that gets checked.
+        self._env_backup = {
+            k: os.environ.get(k)
+            for k in ('RAYMOL_PREDICT_HOST', 'RAYMOL_PREDICT_RUNTIMES')
+        }
+        os.environ['RAYMOL_PREDICT_HOST'] = '1'
+        os.environ['RAYMOL_PREDICT_RUNTIMES'] = 'boltz'
+
+    def tearDown(self):
+        for key, value in getattr(self, '_env_backup', {}).items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        super().tearDown()
 
     def test_predictors_are_listed_with_msa_capability(self):
         appkit_predict.emit('')
@@ -39,6 +65,89 @@ class TestAppkitPredict(testing.PyMOLTestCase):
         self.assertTrue(boltz['msa'])
         self.assertEqual(payload['chains'], [])
         self.assertIsNone(payload['error'])
+
+    def test_only_runnable_predictors_are_listed(self):
+        """The list is what can RUN here, not what is registered.
+
+        The registry is platform-independent, so an unfiltered list offers methods the
+        host will refuse at submit time -- on iOS that is all six Protenix packs, whose
+        runtime is not linked. A menu entry that fails after the user has typed a
+        sequence and hit Run is worse than no entry.
+        """
+        from pymol.predictors import registry
+
+        appkit_predict.emit('')
+        listed = {p['id'] for p in _payload()['predictors']}
+
+        for pid in registry.available():
+            with self.subTest(predictor=pid):
+                try:
+                    registry.get(pid).check_available()
+                except Exception:
+                    self.assertNotIn(pid, listed,
+                                     '%s refuses check_available yet is offered' % pid)
+                else:
+                    self.assertIn(pid, listed,
+                                  '%s can run yet is hidden' % pid)
+
+        # Concrete instance of the above, spelled out so a regression names itself:
+        # setUp advertises the boltz runtime alone, as iOS does.
+        self.assertIn('boltz2', listed)
+        self.assertFalse([p for p in listed if p.startswith('protenix')],
+                         'a protenix pack was offered by a boltz-only host')
+
+    def test_a_non_host_offers_nothing(self):
+        """An empty list is the correct answer, not a bug to paper over.
+
+        Under headless `pymol -c` nothing consumes the PREDICT: marker, so a submitted
+        job would hang forever. The bar must offer nothing rather than something that
+        cannot run. This is also the pre-filter behaviour's sharpest edge: the list used
+        to be fully populated here.
+        """
+        os.environ.pop('RAYMOL_PREDICT_HOST', None)
+        appkit_predict.emit('')
+        payload = _payload()
+        self.assertEqual(payload['predictors'], [])
+        self.assertIsNone(payload['error'],
+                          'having no runnable predictor is not a form error')
+
+    def test_a_predictor_that_throws_is_hidden_not_fatal(self):
+        """One bad method must not empty the menu, and must not be offered either.
+
+        Unavailable is the conservative reading of an unexpected throw: the alternative
+        is offering a method whose availability could not be established.
+        """
+        from pymol.predictors import registry
+        from pymol.predictors.base import Predictor
+
+        # A real Predictor subclass: registry.register type-checks, so a bare stub is
+        # rejected before it can exercise the filter at all.
+        class _Exploding(Predictor):
+            id = 'exploding-test-predictor'
+            name = 'Exploding test predictor'
+            supports_msa = False
+
+            def check_available(self):
+                raise RuntimeError('boom')
+
+            # Predictor is an ABC; both are abstract and must exist to instantiate.
+            # Never reached: the filter drops this method before either is called.
+            def parse_spec(self, sequence, name=''):
+                raise AssertionError('unreachable')
+
+            def submit(self, spec, options):
+                raise AssertionError('unreachable')
+
+        registry.register(_Exploding(), replace=True)
+        try:
+            appkit_predict.emit('')
+            payload = _payload()
+            ids = [p['id'] for p in payload['predictors']]
+            self.assertNotIn('exploding-test-predictor', ids)
+            self.assertIn('boltz2', ids, 'one bad predictor emptied the menu')
+            self.assertIsNone(payload['error'], 'a bad predictor became a form error')
+        finally:
+            registry.unregister('exploding-test-predictor')
 
     def test_literal_monomer_resolves_to_one_chain(self):
         appkit_predict.emit('MKTAYIAKQRQISFVKSHFSRQLEERLGLIEVQ')


### PR DESCRIPTION
Ports structure prediction (`cmd.predict` / the Predict tool) to iOS so it can be tested
on a physical iPhone. Boltz int8 only — Protenix stays macOS-only by decision.

**Draft: the code is complete and both slices build, but the on-device run has not
happened yet** (the test phone was locked when the branch was pushed). The one constant
that must not ship un-measured is called out below.

## Why it did not exist on iOS

Three independent gates, all of which had to go:

1. Eleven `#if os(macOS)` blocks across `PredictBar`/`PredictController`/`BoltzJobManager`
   /`BoltzRuntime`/`PredictSizeGuard` and the `PREDICT:` feedback dispatch in
   `PyMOLEngine` — which IS the invocation path, since there is no Python→Swift call.
2. `platforms: [macOS]` on the `BoltzMLX` package, so the runtime was never linked into
   the iOS slice at all.
3. `RAYMOL_PREDICT_HOST` exported only under `TARGET_OS_OSX`, so
   `predictors/host.py:available()` was False and every predictor correctly refused.

## What changed

**Link and reach.** `BoltzMLX` loses its platform filter and links on both platforms,
Simulator included — that is the only way the iOS slice keeps *compiling* this code, and
no CI job builds iOS. `PyMOLBridge.mm` exports the host variables for iOS on real hardware
only, advertising `boltz` alone: Protenix peaks near 3.9 GB at 400 residues, so
`ProtenixJobManager`/`ProtenixSizeGuard` stay behind `#if os(macOS)` and the Python side
must not be told otherwise, or `check_available` would green-light a predictor whose Swift
half is not in the binary — after a weight download.

`PredictAvailability` is the runtime gate: iOS 18+, and **never the Simulator**, where
MLX's Metal-backed allocator builds heaps `MTLSimDevice` rejects outright. `PyMOLBridge.mm`
applies the same rule, so Python refuses in step with the UI rather than offering a form
whose every Run reports the predictor unavailable.

**An honest iOS memory guard — the substance of the PR.**

`PredictSizeGuard.availableBytes` was `ProcessInfo.physicalMemory`. On an iPhone 15 Pro
that reports 8 GB where the app may use a fraction of it, so it would have licensed runs
at roughly 3× the real budget — and the failure mode is a jetsam SIGKILL no Swift handler
can catch, which takes the unsaved session with it. It is now `os_proc_available_memory()`,
exactly as `DesignSizeGuard` already does.

**Reusing the Mac's fitted constants was tried, and it is wrong — not conservative,
unusable.** At the 117-token anchor the Mac curve estimates 2.25 GB; against a realistic
phone budget near 2.5 GB that is 86%, which this guard *refuses*. The Mac fit would have
made the 100–150-residue fold this port exists for impossible on the device it was ported
to. A guard that refuses everything is not a safe guard.

So iOS gets its own fit, anchored on the only iOS peak anyone has recorded (iPhone 15 Pro,
117 tokens / 899 atoms, ~1.4 GB `phys_footprint`, from boltz-mlx's `DEVICE_BENCHMARK.md`):
the Mac curve's shape, intercept set independently to 700 MiB as an envelope over the
529 MB int8 pack, linear and quadratic terms scaled together — which lands both at exactly
half their Mac values, consistent with iOS running under a 64 MiB MLX cache rather than
256 MB. Result at the anchor: **1.75 GB against a measured 1.4 GB, a 19% reserve.**

Two things the fit deliberately does not claim, because it is **one point** and this type's
doc records three separate optimistic failures, every one of them an extrapolation:

- `bytesPerTokenMSARow` is **not** rescaled. No MSA fold has been run on device, and
  halving it "to match" would be inventing a measurement.
- `iOSMaximumTokens` is **117** — the measured size. Not the 256 the runtime's phone
  preset allows, and not the 150 this port targets. **This is the number that must be
  raised only alongside a real run, and doing so is the remaining work on this PR.**

Also: `BoltzRuntime` asks for a 64 MB MLX cache on iOS — below Design's 96 MB, so min-wins
arbitration pulls Design's effective ceiling down too (intended; a smaller cache can only
churn, never fail, and it is called out in the doc rather than left to be discovered). It
installs `MLX.Memory.memoryLimit` at the app's whole jetsam ceiling, sized to the device
rather than the run so it cannot clamp Design, which converts an overshoot from an
uncatchable SIGKILL into a catchable MLX error. `BoltzJobManager` uses the phone
`BoltzInputLimits` on iOS, written out explicitly rather than obtained by omitting
arguments, so an upstream change to those defaults is a visible diff.

**iPhone UI.** `PredictCompactPanel`: two docked rows (status, then input · object ·
model · Run) plus a settings sheet, the same split `DesignCompactPanel` makes. `PredictBar`
is not reused — it is a ~700 pt macOS form and uses `.toggleStyle(.checkbox)`, which does
not exist on iOS. Wired into all four iOS layouts alongside `designModeBar`.

**Backgrounding.** `project.yml` recorded that no run above ~115 tokens had ever completed
on device because iOS suspended the app mid-run, and nothing in RayMol set
`isIdleTimerDisabled`. `PredictScreenAwake` now holds the display on while a fold *or* the
529 MB weight download is in flight — attached at the ContentView root and to both feeds,
so it survives the user leaving the Predict tool while the job runs. It cannot make the app
background-safe (no background mode grants Metal compute), so a banner says the one thing
that loses the run.

## Not enabled: Increased Memory Limit

`PyMOLViewer/RayMolIOS.entitlements` requests
`com.apple.developer.kernel.increased-memory-limit`, which would roughly double the
foldable size — but it is **commented out** in `project.yml`, because it does not build
until "Increased Memory Limit" is enabled for the `io.raymol.RayMol` App ID in the
developer portal. That is an account change, so it is left as a one-line opt-in with the
exact steps in the comment.

## Verification

- **Both slices compiled by hand** (no CI builds iOS, and this boundary has broken in both
  directions before): `PyMOLViewer_iOS` for device and `PyMOLViewer_macOS` both
  `BUILD SUCCEEDED`.
- **358 macOS unit tests pass, 0 failures**, 21 of them new. The iOS rules are pure
  functions taking platform/budget as parameters specifically so the macOS test host can
  exercise them — a rule behind `#if os(iOS)` is a rule CI never runs. Includes a
  regression test pinning that the Mac fit would have refused the target workload, so a
  future "simplification" that deletes the iOS branch fails in CI rather than on a phone.
- **Bundle checked**: `BoltzMLX` symbols and the MLX metallib are in the iOS product, and
  `modules/pymol/predictors/*` + `msa.py` ship in the app.

## Outstanding

- [ ] Fold a ~100-residue single chain on the iPhone 15 Pro; record wall time and peak
      `phys_footprint`.
- [ ] Measure `os_proc_available_memory()` on device and confirm the 2.5 GB budget the fit
      was reasoned against.
- [ ] Raise `iOSMaximumTokens` to the largest size that actually completes — **or leave it
      at 117.** Never raise it alongside an extrapolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
