### PR TITLE
Add Ctrl+P shortcut to open the Predict tool

### DIFF
--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -3185,6 +3185,7 @@ struct ContentView: View {
                 }
             }
             .disabled(isDesignLocked)
+            .keyboardShortcut("p", modifiers: .control)
         }
     }
 

--- a/swiftui/PyMOLViewer/Shared/PyMOLApp.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLApp.swift
@@ -256,16 +256,31 @@ struct PyMOLApp: App {
                 .disabled(isDesignLocked)
                 .keyboardShortcut("m", modifiers: .control)
             }
-            #if RAYMOL_MPNN
-            // Design menu: toggle Design mode (MPNN score/color overlay). ⌃D.
-            CommandMenu("Design") {
-                Button(engine.designMode ? "Exit Design Mode" : "Enter Design Mode") {
-                    engine.setDesignMode(!engine.designMode)
+            // Grouped so the two menus together count as ONE entry against the
+            // @CommandsBuilder's 10-child ceiling (Group<Commands> exists for
+            // exactly this reason).
+            Group {
+                #if RAYMOL_MPNN
+                // Design menu: toggle Design mode (MPNN score/color overlay). ⌃D.
+                CommandMenu("Design") {
+                    Button(engine.designMode ? "Exit Design Mode" : "Enter Design Mode") {
+                        engine.setDesignMode(!engine.designMode)
+                    }
+                    .disabled(isDesignLocked)
+                    .keyboardShortcut("d", modifiers: .control)
                 }
-                .disabled(isDesignLocked)
-                .keyboardShortcut("d", modifiers: .control)
+                #endif
+                // Predict menu: toggle Predict mode (structure prediction panel). ⌃P.
+                // A real menu command, not the toolbar-Menu button's shortcut, so it
+                // fires reliably (see the ⌘C comment above).
+                CommandMenu("Predict") {
+                    Button(engine.predictMode ? "Exit Predict Mode" : "Enter Predict Mode") {
+                        engine.setPredictMode(!engine.predictMode)
+                    }
+                    .disabled(isDesignLocked)
+                    .keyboardShortcut("p", modifiers: .control)
+                }
             }
-            #endif
             // Movie: enter/exit the Timeline (movie studio) mode. Carries the
             // keyboard shortcut; the toolbar clapperboard is the primary control.
             CommandMenu("Movie") {


### PR DESCRIPTION
## Summary
- Adds a real Commands-based **Predict** menu (macOS menu bar, alongside Mouse/Design/Movie/Notes) so **Ctrl+P** toggles Predict mode reliably.
- The toolbar Tools ▸ Predict menu item now also displays the `⌃P` shortcut hint.

## Why not just add `.keyboardShortcut` to the toolbar button?
I initially added `.keyboardShortcut("p", modifiers: .control)` directly to the Predict `Button` inside the toolbar's `Menu` (`ContentView.swift`). It displayed the `⌃P` hint correctly but the shortcut never actually fired — the codebase already has a comment on the "Copy Image to Clipboard" command explaining this exact limitation: a toolbar-`Menu`-embedded button's `.keyboardShortcut` shows a hint but doesn't register as a working global shortcut; only a real `Commands`/`CommandMenu` entry does.

So the fix follows the same pattern already used for Move (⌃M) and Design (⌃D): a dedicated `CommandMenu("Predict")` in `PyMOLApp.swift`'s `macCommands`, calling `engine.setPredictMode(!engine.predictMode)`.

Since `@CommandsBuilder` has a 10-child ceiling and this pushed the count to 11, the new `CommandMenu("Predict")` is grouped together with the existing `CommandMenu("Design")` inside a `Group { … }` (there's precedent for `Group<Commands>` existing specifically to work around this builder limit).

## Test plan
- [x] `xcodebuild` succeeds (Debug, macOS)
- [x] Launched a local dev build; confirmed Ctrl+P toggles Predict mode on/off
- [x] Confirmed the new "Predict" menu bar item and the toolbar Tools ▸ Predict item both show the `⌃P` shortcut