### PR TITLE
fix(predict): scope the progress-tray ETA to the phase it measures

### DIFF
--- a/modules/pymol/predicting.py
+++ b/modules/pymol/predicting.py
@@ -353,13 +353,41 @@ def format_remaining(seconds):
     return 'over an hour left'
 
 
+def format_phase_remaining(seconds):
+    """'this phase: 4 min left'. The SCOPED spelling, for a prediction card.
+
+    Deliberately identical to ProgressCard.formatPhaseRemaining
+    (ProgressTray.swift), for the same reason format_remaining is.
+
+    The scope is stated because the number is scoped: `remaining` comes from
+    _phase_remaining, which measures the CURRENT PHASE only, while everything
+    beside it on the card -- the percentage, the bar, 'model 4 of 20' -- is the
+    whole job. Unqualified, the two read as one claim: a 1.10.0 capture shows
+    'Diffusion 19% . step 141 of 200 . model 4 of 20 . almost done', where
+    'almost done' means diffusion is seconds from step 200 but reads as if the
+    run were finishing with sixteen models still to go.
+
+    'phase' rather than 'model', which would be the friendlier word: diffusion is
+    band 0.40-0.97 of a model and 'write' follows it, so a phase estimate is not
+    a model estimate and must not be sold as one. A whole-JOB countdown is not
+    offered at all -- compose_progress's bands are layout, not time, so there is
+    nothing honest to extrapolate one from.
+
+    format_remaining stays unscoped, because its other caller is right: a weight
+    download IS the whole task, and 'almost done' there means what it says.
+    """
+    return 'this phase: %s' % (format_remaining(seconds),)
+
+
 def _format_detail(info):
-    """'pending: diffusion 64% step 84 of 200 (model 1 of 3), 4 min left'.
+    """'pending: diffusion 64% step 84 of 200 (model 1 of 3), this phase: 4 min left'.
 
     Short -- it is a tooltip. The percentage is the COMPOSED whole-job value, the
     same number the progress bar draws, so the two can never disagree; the
     stage-local position is said precisely by 'step 84 of 200' instead. The
-    estimate is the current phase's, which is what was actually measured.
+    estimate is the current phase's, which is what was actually measured, and it
+    SAYS so: unqualified, it read as a claim about the whole job it sits beside
+    (see format_phase_remaining).
     """
     parts = ['pending: %s' % (info['phase'],)]
     if info['fraction'] is not None and info['moving']:
@@ -373,7 +401,7 @@ def _format_detail(info):
             min(info['models_done'] + 1, info['models_total']), info['models_total'])
     remaining = info.get('remaining')
     if remaining is not None:
-        detail += ', %s' % (format_remaining(remaining),)
+        detail += ', %s' % (format_phase_remaining(remaining),)
     return detail
 
 

--- a/swiftui/PyMOLViewer/Shared/ProgressTray.swift
+++ b/swiftui/PyMOLViewer/Shared/ProgressTray.swift
@@ -88,7 +88,10 @@ struct ProgressItem: Identifiable, Equatable {
         // An estimate when there is a measured rate to derive one from, and the
         // measured clock otherwise. Never both: the card's detail line is two
         // lines at most, and a countdown is what the reader came for.
-        parts.append(job.remaining.map(ProgressCard.formatRemaining) ?? elapsed)
+        //
+        // The SCOPED spelling: this estimate covers the current phase, and it sits
+        // beside a whole-job percentage and "model k of N". See formatPhaseRemaining.
+        parts.append(job.remaining.map(ProgressCard.formatPhaseRemaining) ?? elapsed)
 
         // Three states, not two. A cancellation is terminal like a failure — same
         // Dismiss button, same sort position, no progress bar — but it is the user's
@@ -232,6 +235,28 @@ struct ProgressCard: View {
             return "\(mins) min left"
         default:      return "over an hour left"
         }
+    }
+
+    /// The SCOPED spelling, for a prediction card. Wraps the buckets rather than
+    /// replacing them, so the weight-download card above keeps its wording.
+    ///
+    /// The scope is stated because the number is scoped: `PredictionJobState.remaining`
+    /// measures the CURRENT PHASE only, while everything beside it on the card -- the
+    /// percentage, the bar, "model 4 of 20" -- is the whole job. Unqualified, the two
+    /// read as one claim: a 1.10.0 capture shows "Diffusion 19% · step 141 of 200 ·
+    /// model 4 of 20 · almost done", where "almost done" means diffusion is seconds
+    /// from step 200 but reads as if the run were finishing with sixteen models to go.
+    ///
+    /// "phase" and not the friendlier "model": diffusion is band 0.40–0.97 of a model
+    /// and `write` follows it, so a phase estimate is not a model estimate and must not
+    /// be sold as one. No whole-JOB countdown is offered at all — compose_progress's
+    /// bands are layout, not time, so there is nothing honest to extrapolate one from.
+    ///
+    /// Identical to `predicting.format_phase_remaining`, for the same reason
+    /// `formatRemaining` is identical to `format_remaining`: the hover tooltip and the
+    /// card must never word one estimate two different ways.
+    static func formatPhaseRemaining(_ seconds: Double) -> String {
+        "this phase: " + formatRemaining(seconds)
     }
 
     /// Coarse for the same reason, and never counts down -- this one is measured.

--- a/swiftui/PyMOLViewerTests/PendingJobTests.swift
+++ b/swiftui/PyMOLViewerTests/PendingJobTests.swift
@@ -89,7 +89,8 @@ final class PendingJobTests: XCTestCase {
     /// The line the user actually reads. The percentage is the COMPOSED value --
     /// the same number the bar draws, so text and bar cannot disagree -- while
     /// "step 84 of 200" says where in the phase we are, and the countdown is the
-    /// phase's own measured estimate rather than the elapsed clock.
+    /// phase's own measured estimate rather than the elapsed clock, and SAYS which
+    /// of the two it is (see formatPhaseRemaining).
     func testAMeasuredPredictionReadsAsPhasePercentStepModelAndEta() {
         let job = PredictionJobState(
             id: "p", state: "running", phase: "diffusion", fraction: 0.6394,
@@ -97,7 +98,39 @@ final class PendingJobTests: XCTestCase {
             elapsed: 412.5, error: nil, bundle: nil,
             step: 84, totalSteps: 200, remaining: 240)
         XCTAssertEqual(ProgressItem.prediction(job).detail,
-                       "Diffusion 64% · step 84 of 200 · model 1 of 3 · 4 min left")
+                       "Diffusion 64% · step 84 of 200 · model 1 of 3 · "
+                       + "this phase: 4 min left")
+    }
+
+    /// The defect the 1.10.0 hero capture shipped with: 20 models, 3 delivered,
+    /// diffusion at step 141 of 200 and seconds from ending. "almost done" sat
+    /// beside an overall 19% and "model 4 of 20", reading as if the whole run
+    /// were finishing with sixteen models still to go.
+    func testTheEtaDoesNotClaimTheWholeJobIsAlmostDone() {
+        let job = PredictionJobState(
+            id: "p", state: "running", phase: "diffusion", fraction: 0.1901,
+            moving: true, detail: "d", modelsDone: 3, modelsTotal: 20,
+            elapsed: 900, error: nil, bundle: nil,
+            step: 141, totalSteps: 200, remaining: 4)
+        XCTAssertEqual(ProgressItem.prediction(job).detail,
+                       "Diffusion 19% · step 141 of 200 · model 4 of 20 · "
+                       + "this phase: almost done")
+    }
+
+    /// The scoped spelling wraps the buckets rather than replacing them, so the
+    /// weight-download card -- which measures a WHOLE task and reads correctly
+    /// unqualified -- keeps the wording it has.
+    func testOnlyThePredictionCardScopesItsEtaToThePhase() {
+        XCTAssertEqual(ProgressCard.formatPhaseRemaining(4), "this phase: almost done")
+        XCTAssertEqual(ProgressCard.formatPhaseRemaining(240), "this phase: 4 min left")
+        XCTAssertEqual(ProgressCard.formatRemaining(4), "almost done")
+        // 950 of 1000 bytes in 95 s -> 10 B/s -> 5 s left.
+        let fetch = WeightsFetchState(
+            id: "boltz2-mlx-int8", state: "running", phase: "download",
+            fraction: 0.95, received: 950, total: 1000, elapsed: 95, error: nil)
+        let detail = WeightDownloadDetail.text(fetch)
+        XCTAssertTrue(detail.hasSuffix("almost done"), detail)
+        XCTAssertFalse(detail.contains("this phase"), detail)
     }
 
     /// With no measured rate yet, the card falls back to the elapsed clock it

--- a/testing/tests/predict/predict_progress.py
+++ b/testing/tests/predict/predict_progress.py
@@ -759,6 +759,35 @@ class TestPendingInfo(testing.PyMOLTestCase):
         self.assertEqual(remaining(3594), 'over an hour left')
         self.assertEqual(remaining(7200), 'over an hour left')
 
+    def testThePhaseScopedFormatterNamesTheScopeItMeasures(self):
+        """`remaining` is seconds left in the CURRENT PHASE, so the prose that
+        renders it must say so. The unscoped bucket wording stays exactly as it
+        is -- the weight-download card measures a WHOLE task and reads correctly."""
+        scoped = self.predicting.format_phase_remaining
+        self.assertEqual(scoped(4), 'this phase: almost done')
+        self.assertEqual(scoped(45), 'this phase: 45 sec left')
+        self.assertEqual(scoped(240), 'this phase: 4 min left')
+        self.assertEqual(scoped(7200), 'this phase: over an hour left')
+
+    def testTheEtaDoesNotClaimTheWholeJobIsAlmostDone(self):
+        """The captured 1.10.0 frame: 20 models, 3 delivered, diffusion at step
+        141 of 200 and nearly over. 'almost done' sat beside an overall 19% and
+        'model 4 of 20', reading as if the whole job were finishing with 16
+        models still to run."""
+        self.register('hero', [[{'phase': 'diffusion', 'fraction': 0.705,
+                                 'step': 141, 'total_steps': 200}]] * 20)
+        self.predicting._TRACK['hero']['done'] = 3
+        self.predicting.pending_info('hero', _self=self.cmd)
+        self.age_phase('hero', 12.0)                # 12 s in, 70.5% of the phase
+        info = self.predicting.pending_info('hero', _self=self.cmd)
+        # Pre-conditions: the frame is reproduced.
+        self.assertLess(info['remaining'], 10.0, 'pre-condition: the PHASE is ending')
+        self.assertAlmostEqual(info['fraction'], 0.190, delta=0.005)
+        self.assertIn('model 4 of 20', info['detail'])
+        # The defect: an unqualified whole-task phrase beside a whole-job 19%.
+        self.assertNotIn(', almost done', info['detail'])
+        self.assertIn('this phase: almost done', info['detail'])
+
     def testStepCountsAndEtaSurviveThePayloadAsScalars(self):
         """A non-scalar would fail the whole PanelPayload decode in Swift."""
         self.register('wire', [[{'phase': 'diffusion', 'fraction': 0.5,


### PR DESCRIPTION
## The bug

The prediction card's countdown is produced by `_phase_remaining`, which by explicit design measures **only the current phase**. But it was rendered in unqualified, whole-task prose and placed beside three *whole-job* facts — the composed percentage, the bar, and `model k of N`. The reader fuses the two scopes into a single claim.

A captured frame from the 1.10.0 hero media reads:

```
Diffusion 19% · step 141 of 200 · model 4 of 20 · almost done
```

`almost done` means *diffusion is seconds from step 200*. Next to an overall 19% and `model 4 of 20`, it reads as though the whole run were finishing — with sixteen models still to go.

Both numbers are correct and simply differently scoped. Diffusion is band `0.40–0.97`, so:

```
within-model = 0.40 + 0.705 × 0.57 = 0.802
whole-job    = (3 + 0.802) / 20     = 0.190   → 19%
```

A test reproduces this arithmetically and asserted the shipped string verbatim before the fix.

**The defect is wider than the `almost done` bucket.** `4 min left · model 4 of 20` mis-reads identically — it means four minutes left in *this model's* diffusion. Fixing only the sub-10-second band would have been a symptom fix.

## The fix

`format_remaining` / `formatRemaining` are left **untouched**. Their other caller is the weight-download card, where the download *is* the whole task and `almost done` means exactly what it says. Instead a scoped spelling wraps the existing buckets and is used only on the prediction path — in both languages, worded identically so the hover tooltip and the card can never diverge:

```
Diffusion 19% · step 141 of 200 · model 4 of 20 · this phase: almost done
```

- `modules/pymol/predicting.py` — new `format_phase_remaining()`, used by `_format_detail`
- `swiftui/PyMOLViewer/Shared/ProgressTray.swift` — new `ProgressCard.formatPhaseRemaining`, used by `ProgressItem.prediction`

## Notes for the reviewer

**Why "phase" and not the friendlier "model".** Diffusion is band `0.40–0.97` of a model and `write` follows it, so a phase estimate is not a model estimate and must not be sold as one. `model almost done` would overclaim on the same axis, just less.

**Why no whole-job countdown.** `compose_progress` documents its bands as *layout, not time* (`load` is ~10 s cold and ~0 s warm; inference is 6.5 s at 60 residues and 675 s at 600), so there is nothing honest to extrapolate a whole-job estimate from. A real one **is** derivable from completed-model durations (`elapsed / models_done × models_left`) once at least one model has landed — that's a reasonable follow-up, but it adds a new estimate rather than correcting wording, so it is deliberately out of scope here.

**On the hero media.** `swiftui/PyMOLViewer/Resources/whatsnew-1100-predict-progress.mp4` does not exist in any ref or working tree in this repo, and `WhatsNew.json` has no 1.10.0 entry, so nothing needed re-wiring here. Any capture of this card taken from now on will carry the corrected wording; an existing local capture would need re-recording.

## Verification

- **Python:** `Ran 384 tests … OK` — full `testing/tests/predict` suite, including 2 new tests (one reproducing the captured frame numerically)
- **Swift:** `Executed 421 tests, with 4 tests skipped and 0 failures` — `** TEST SUCCEEDED **`, including 2 new tests plus the updated existing detail assertion
- **iOS:** `** BUILD SUCCEEDED **` — checked by hand because `ProgressTray.swift` lives in `Shared/` and no CI compiles the iOS target

🤖 Generated with [Claude Code](https://claude.com/claude-code)
