### PR TITLE
Notes: insert keeps the editor open; optional clickable thumbnail on view links (#281, #282)

### DIFF
--- a/docs/superpowers/plans/2026-08-19-design-mode-multi-residue-selection.md
+++ b/docs/superpowers/plans/2026-08-19-design-mode-multi-residue-selection.md
@@ -14,6 +14,7 @@
 
 - **Platforms:** macOS *and* iOS. Design mode is gated on the `RAYMOL_MPNN` compilation condition, which `swiftui/project.yml` sets for `macosx*`, `iphoneos*`, and `iphonesimulator*`. Every Swift change must compile for both.
 - **CI does not cover this code.** No workflow runs `PyMOLViewerTests`, and CI never compiles the iOS target. Swift tests and both-platform compiles are **manual** (Task 8). Do not treat a green CI as verification.
+- **Xcode scheme names** (there is no scheme called `RayMol`): tests run under `UnitTests_macOS`; the app targets are `PyMOLViewer_macOS` and `PyMOLViewer_iOS`; the project is `swiftui/PyMOLViewer.xcodeproj`. `-skipPackagePluginValidation` is required — the project pulls SwiftPM dependencies (MPNNKit, mlx-swift, Sparkle, BoltzMLX, ProtenixMLX) whose plugins otherwise block the build.
 - **New Python test files are invisible to CI unless registered.** `.github/workflows/raymol-embedded-tests.yml` hand-lists test files. This plan therefore adds tests to `testing/tests/raymol/design_region.py`, which is already listed (line ~73). Do not create a new Python test file.
 - **Python tests run through PyMOL, not pytest.** A working environment is ALREADY BUILT at `.venv-sdd/` in this worktree, and its pure-Python layer is symlinked back to `modules/`, so your edits are live. Verified command:
   ```bash
@@ -572,7 +573,8 @@ Append to `swiftui/PyMOLViewerTests/DesignRegionTests.swift`, inside the existin
 - [ ] **Step 2: Run the tests to verify they fail**
 
 ```bash
-cd swiftui && xcodebuild test -scheme RayMol -destination 'platform=macOS' \
+cd swiftui && xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS \
+  -destination 'platform=macOS' -skipPackagePluginValidation \
   -only-testing:PyMOLViewerTests/DesignRegionTests 2>&1 | tail -30
 ```
 
@@ -749,7 +751,8 @@ In the `#if DEBUG` block of `DesignController.swift`, next to `injectRegion` (~l
 - [ ] **Step 7: Run the tests to verify they pass**
 
 ```bash
-cd swiftui && xcodebuild test -scheme RayMol -destination 'platform=macOS' \
+cd swiftui && xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS \
+  -destination 'platform=macOS' -skipPackagePluginValidation \
   -only-testing:PyMOLViewerTests/DesignRegionTests 2>&1 | tail -30
 ```
 
@@ -959,7 +962,8 @@ Append to `swiftui/PyMOLViewerTests/DesignRegionTests.swift` (reuses `seleContro
 - [ ] **Step 2: Run the tests to verify they fail**
 
 ```bash
-cd swiftui && xcodebuild test -scheme RayMol -destination 'platform=macOS' \
+cd swiftui && xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS \
+  -destination 'platform=macOS' -skipPackagePluginValidation \
   -only-testing:PyMOLViewerTests/DesignRegionTests 2>&1 | tail -30
 ```
 
@@ -1110,7 +1114,8 @@ The pink marker *is* `sele` now, so nothing should push a selection outward. Del
 - [ ] **Step 8: Run the tests to verify they pass**
 
 ```bash
-cd swiftui && xcodebuild test -scheme RayMol -destination 'platform=macOS' \
+cd swiftui && xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS \
+  -destination 'platform=macOS' -skipPackagePluginValidation \
   -only-testing:PyMOLViewerTests/DesignRegionTests 2>&1 | tail -30
 ```
 
@@ -1230,7 +1235,8 @@ Then find the `handleViewportHit` region-edit test near line 564 (`testHandleVie
 - [ ] **Step 2: Run the tests to verify they fail**
 
 ```bash
-cd swiftui && xcodebuild test -scheme RayMol -destination 'platform=macOS' \
+cd swiftui && xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS \
+  -destination 'platform=macOS' -skipPackagePluginValidation \
   -only-testing:PyMOLViewerTests/DesignIOSPortTests 2>&1 | tail -30
 ```
 
@@ -1315,7 +1321,8 @@ Expected: no output. (Matches under `swiftui/build_ios_restricted/` or in `docs/
 - [ ] **Step 7: Run the full design test suite**
 
 ```bash
-cd swiftui && xcodebuild test -scheme RayMol -destination 'platform=macOS' \
+cd swiftui && xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS \
+  -destination 'platform=macOS' -skipPackagePluginValidation \
   -only-testing:PyMOLViewerTests 2>&1 | tail -40
 ```
 
@@ -1382,7 +1389,8 @@ Append to `swiftui/PyMOLViewerTests/DesignIOSPortTests.swift`:
 - [ ] **Step 2: Run it to verify it fails**
 
 ```bash
-cd swiftui && xcodebuild test -scheme RayMol -destination 'platform=macOS' \
+cd swiftui && xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS \
+  -destination 'platform=macOS' -skipPackagePluginValidation \
   -only-testing:PyMOLViewerTests/DesignIOSPortTests/testEmptyHitClearsThroughTheSameRouting 2>&1 | tail -20
 ```
 
@@ -1499,7 +1507,8 @@ In `setDesignMode(_:)` in `PyMOLEngine.swift`, replace the final `designMode = o
 - [ ] **Step 6: Run the tests to verify they pass**
 
 ```bash
-cd swiftui && xcodebuild test -scheme RayMol -destination 'platform=macOS' \
+cd swiftui && xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS \
+  -destination 'platform=macOS' -skipPackagePluginValidation \
   -only-testing:PyMOLViewerTests 2>&1 | tail -40
 ```
 
@@ -1595,7 +1604,8 @@ Append to `swiftui/PyMOLViewerTests/DesignRegionTests.swift`:
 
 ```bash
 .venv-sdd/bin/pymol -ckqy testing/testing.py --run testing/tests/raymol/design_region.py
-cd swiftui && xcodebuild test -scheme RayMol -destination 'platform=macOS' \
+cd swiftui && xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS \
+  -destination 'platform=macOS' -skipPackagePluginValidation \
   -only-testing:PyMOLViewerTests/DesignRegionTests 2>&1 | tail -25
 ```
 
@@ -1654,7 +1664,8 @@ In `parseObjectPanelFeedback` in the same file, immediately after the `guard let
 
 ```bash
 .venv-sdd/bin/pymol -ckqy testing/testing.py --run testing/tests/raymol/design_region.py
-cd swiftui && xcodebuild test -scheme RayMol -destination 'platform=macOS' \
+cd swiftui && xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS \
+  -destination 'platform=macOS' -skipPackagePluginValidation \
   -only-testing:PyMOLViewerTests 2>&1 | tail -40
 ```
 
@@ -1725,11 +1736,14 @@ In `DesignCompactPanel.swift`, inside `actionRow`, immediately after `regionButt
 The core must be built BEFORE `xcodebuild`, or `xcodebuild` silently links a stale `libpymol_core.a` and you test old code:
 
 ```bash
-pip install --verbose --no-build-isolation --config-settings testing=True .
 cd swiftui && xcodegen generate && \
-  xcodebuild -scheme RayMol -destination 'platform=macOS' \
-  -skipPackagePluginValidation build 2>&1 | tail -20
+  xcodebuild -project PyMOLViewer.xcodeproj -scheme PyMOLViewer_macOS \
+  -destination 'platform=macOS' -skipPackagePluginValidation build 2>&1 | tail -20
 ```
+
+The core is ALREADY built for this branch (see Global Constraints) and
+`libpymol_core.a` is present, so do not re-run `pip install` here — a rebuild
+would destroy the symlinks the Python suite depends on.
 
 Expected: `BUILD SUCCEEDED`.
 
@@ -1738,7 +1752,7 @@ Expected: `BUILD SUCCEEDED`.
 CI never compiles iOS, and `ContentView.swift` has leaked platform-only symbols in both directions before (#174, #226, #238). This step is the only thing that catches it:
 
 ```bash
-cd swiftui && xcodebuild -scheme PyMOLViewer_iOS \
+cd swiftui && xcodebuild -project PyMOLViewer.xcodeproj -scheme PyMOLViewer_iOS \
   -destination 'generic/platform=iOS Simulator' \
   -skipPackagePluginValidation build 2>&1 | tail -20
 ```
@@ -1748,7 +1762,8 @@ Expected: `BUILD SUCCEEDED`. If it fails on a symbol the macOS build accepted, t
 - [ ] **Step 5: Run the whole Swift and Python design suites**
 
 ```bash
-cd swiftui && xcodebuild test -scheme RayMol -destination 'platform=macOS' \
+cd swiftui && xcodebuild test -project PyMOLViewer.xcodeproj -scheme UnitTests_macOS \
+  -destination 'platform=macOS' -skipPackagePluginValidation \
   -only-testing:PyMOLViewerTests 2>&1 | tail -40
 ```
 

--- a/docs/superpowers/plans/2026-08-19-design-mode-multi-residue-selection.md
+++ b/docs/superpowers/plans/2026-08-19-design-mode-multi-residue-selection.md
@@ -15,7 +15,11 @@
 - **Platforms:** macOS *and* iOS. Design mode is gated on the `RAYMOL_MPNN` compilation condition, which `swiftui/project.yml` sets for `macosx*`, `iphoneos*`, and `iphonesimulator*`. Every Swift change must compile for both.
 - **CI does not cover this code.** No workflow runs `PyMOLViewerTests`, and CI never compiles the iOS target. Swift tests and both-platform compiles are **manual** (Task 8). Do not treat a green CI as verification.
 - **New Python test files are invisible to CI unless registered.** `.github/workflows/raymol-embedded-tests.yml` hand-lists test files. This plan therefore adds tests to `testing/tests/raymol/design_region.py`, which is already listed (line ~73). Do not create a new Python test file.
-- **Python tests run through PyMOL, not pytest:** `pymol -ckqy testing/testing.py --run tests/raymol/design_region.py`. The repo's `.venv` PyMOL is broken (namespace-package conflict); use a Homebrew `pymol` with a shadow `PYTHONPATH` pointing at this worktree's `modules/`.
+- **Python tests run through PyMOL, not pytest.** A working environment is ALREADY BUILT at `.venv-sdd/` in this worktree, and its pure-Python layer is symlinked back to `modules/`, so your edits are live. Verified command:
+  ```bash
+  .venv-sdd/bin/pymol -ckqy testing/testing.py --run testing/tests/raymol/design_region.py
+  ```
+  Note the path form `testing/tests/...`, matching `.github/workflows/raymol-embedded-tests.yml`. The form in the test file's own docstring (`tests/raymol/...`) is WRONG: `cli()` resolves no files, silently does nothing, and exits 1 without printing one word. The exit code is the failure count, so 0 means pass. Do NOT rebuild or reinstall — neither the Homebrew `pymol` nor the shared repo `.venv` can run this suite, and a rebuild would cost you the working symlinks.
 - **`poll_panel` runs on the main thread every 500 ms and is a measured hot spot** (PR #270 fixed a 713 ms tick). Anything added to it must be O(1) when Design mode is off.
 - **`cmd.enable` is exclusive for selections.** Enabling `sele` disables other selections; `_preselect` must stay `enable=0`. Unchanged behaviour, but do not "fix" it.
 - **Decisions carried from the spec, all binding:**
@@ -121,7 +125,7 @@ Append to `testing/tests/raymol/design_region.py` inside `class TestDesignRegion
 - [ ] **Step 2: Run the tests to verify they fail**
 
 ```bash
-pymol -ckqy testing/testing.py --run tests/raymol/design_region.py
+.venv-sdd/bin/pymol -ckqy testing/testing.py --run testing/tests/raymol/design_region.py
 ```
 
 Expected: FAIL — `AttributeError: module 'pymol.raymol_design' has no attribute 'sele_design_indices'` (and the same for `sele_digest` / `set_design_active`).
@@ -241,7 +245,7 @@ def sele_design_indices(obj, state, src=''):
 - [ ] **Step 5: Run the tests to verify they pass**
 
 ```bash
-pymol -ckqy testing/testing.py --run tests/raymol/design_region.py
+.venv-sdd/bin/pymol -ckqy testing/testing.py --run testing/tests/raymol/design_region.py
 ```
 
 Expected: PASS, all tests in `TestDesignRegion` (the five new ones plus the four pre-existing).
@@ -354,7 +358,7 @@ Append to `testing/tests/raymol/design_region.py` inside `class TestDesignRegion
 - [ ] **Step 2: Run the tests to verify they fail**
 
 ```bash
-pymol -ckqy testing/testing.py --run tests/raymol/design_region.py
+.venv-sdd/bin/pymol -ckqy testing/testing.py --run testing/tests/raymol/design_region.py
 ```
 
 Expected: FAIL — `AttributeError: module 'pymol.raymol_design' has no attribute 'toggle_sele_residue'`.
@@ -423,7 +427,7 @@ def clear_sele():
 - [ ] **Step 4: Run the tests to verify they pass**
 
 ```bash
-pymol -ckqy testing/testing.py --run tests/raymol/design_region.py
+.venv-sdd/bin/pymol -ckqy testing/testing.py --run testing/tests/raymol/design_region.py
 ```
 
 Expected: PASS.
@@ -1590,7 +1594,7 @@ Append to `swiftui/PyMOLViewerTests/DesignRegionTests.swift`:
 - [ ] **Step 2: Run both suites to verify they fail**
 
 ```bash
-pymol -ckqy testing/testing.py --run tests/raymol/design_region.py
+.venv-sdd/bin/pymol -ckqy testing/testing.py --run testing/tests/raymol/design_region.py
 cd swiftui && xcodebuild test -scheme RayMol -destination 'platform=macOS' \
   -only-testing:PyMOLViewerTests/DesignRegionTests 2>&1 | tail -25
 ```
@@ -1649,7 +1653,7 @@ In `parseObjectPanelFeedback` in the same file, immediately after the `guard let
 - [ ] **Step 6: Run both suites to verify they pass**
 
 ```bash
-pymol -ckqy testing/testing.py --run tests/raymol/design_region.py
+.venv-sdd/bin/pymol -ckqy testing/testing.py --run testing/tests/raymol/design_region.py
 cd swiftui && xcodebuild test -scheme RayMol -destination 'platform=macOS' \
   -only-testing:PyMOLViewerTests 2>&1 | tail -40
 ```
@@ -1749,11 +1753,11 @@ cd swiftui && xcodebuild test -scheme RayMol -destination 'platform=macOS' \
 ```
 
 ```bash
-pymol -ckqy testing/testing.py --run tests/raymol/design_region.py
-pymol -ckqy testing/testing.py --run tests/raymol/design_editing.py
-pymol -ckqy testing/testing.py --run tests/raymol/design_enumerate.py
-pymol -ckqy testing/testing.py --run tests/raymol/design_color.py
-pymol -ckqy testing/testing.py --run tests/raymol/design_saverestore.py
+.venv-sdd/bin/pymol -ckqy testing/testing.py --run testing/tests/raymol/design_region.py
+.venv-sdd/bin/pymol -ckqy testing/testing.py --run testing/tests/raymol/design_editing.py
+.venv-sdd/bin/pymol -ckqy testing/testing.py --run testing/tests/raymol/design_enumerate.py
+.venv-sdd/bin/pymol -ckqy testing/testing.py --run testing/tests/raymol/design_color.py
+.venv-sdd/bin/pymol -ckqy testing/testing.py --run testing/tests/raymol/design_saverestore.py
 ```
 
 Expected: all PASS. Report actual output; do not claim success without it.

--- a/docs/superpowers/plans/2026-08-19-design-mode-multi-residue-selection.md
+++ b/docs/superpowers/plans/2026-08-19-design-mode-multi-residue-selection.md
@@ -1,0 +1,1794 @@
+# Design-Mode Multi-Residue Selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a click in Design mode build a multi-residue selection exactly as a click in normal mode does, with the *count* of selected residues deciding the mode — one residue keeps today's single-residue behaviour, two or more auto-designate the redesign region.
+
+**Architecture:** Invert the current data flow. Today `DesignController.setPinned` owns `pinnedResidueIndex` and pushes a one-residue `sele` outward purely as a pink marker. After this change PyMOL's `sele` is the single source of truth: clicks *toggle* `sele`, and a new `syncFromSele()` is the only writer of `pinnedResidueIndex` and `selectedResidueIndices`, deriving both from `sele ∩ scope(focusObject, editSourceObject)`. The modal "Tap to edit region" toggle and the macOS shift-click shortcut are deleted, since the count now carries that information.
+
+**Tech Stack:** Swift 5 / SwiftUI (`@MainActor` `ObservableObject`), Python 3 (bundled `pymol` modules), PyMOL selection algebra, XCTest, `pymol.testing` (unittest), xcodegen + xcodebuild.
+
+**Spec:** `docs/superpowers/specs/2026-08-19-design-mode-multi-residue-selection-design.md`
+
+## Global Constraints
+
+- **Platforms:** macOS *and* iOS. Design mode is gated on the `RAYMOL_MPNN` compilation condition, which `swiftui/project.yml` sets for `macosx*`, `iphoneos*`, and `iphonesimulator*`. Every Swift change must compile for both.
+- **CI does not cover this code.** No workflow runs `PyMOLViewerTests`, and CI never compiles the iOS target. Swift tests and both-platform compiles are **manual** (Task 8). Do not treat a green CI as verification.
+- **New Python test files are invisible to CI unless registered.** `.github/workflows/raymol-embedded-tests.yml` hand-lists test files. This plan therefore adds tests to `testing/tests/raymol/design_region.py`, which is already listed (line ~73). Do not create a new Python test file.
+- **Python tests run through PyMOL, not pytest:** `pymol -ckqy testing/testing.py --run tests/raymol/design_region.py`. The repo's `.venv` PyMOL is broken (namespace-package conflict); use a Homebrew `pymol` with a shadow `PYTHONPATH` pointing at this worktree's `modules/`.
+- **`poll_panel` runs on the main thread every 500 ms and is a measured hot spot** (PR #270 fixed a 713 ms tick). Anything added to it must be O(1) when Design mode is off.
+- **`cmd.enable` is exclusive for selections.** Enabling `sele` disables other selections; `_preselect` must stay `enable=0`. Unchanged behaviour, but do not "fix" it.
+- **Decisions carried from the spec, all binding:**
+  - D1 — Design clicks always expand to **residue** scope, ignoring `mouse_selection_mode` (atom mode maps to zero guide residues → a click that selects nothing).
+  - D2 — Exiting Design mode **no longer clears `sele`**.
+  - D3 — 2+ residues auto-*designate*; MPNN runs only on the Redesign button.
+  - D4 — A click on a non-focus object refocuses **and** selects that residue.
+  - D5 — The lasso dropdown stays, but writes `sele` instead of snapshotting.
+  - D6 — `regionEditMode` is **deleted** (property, UI on both platforms, tests).
+  - D7 — Sidechain sticks stay tied to `{pinned} ∪ {hovered}`; not extended to the region.
+  - D8 — The macOS shift-click region shortcut is **deleted**.
+
+---
+
+### Task 1: Python — read the active `sele`
+
+Adds the read half of the new contract: map `sele` to guide-order residue indices for a focus object, plus a cheap digest for change detection that is gated on Design mode being active.
+
+**Files:**
+- Modify: `modules/pymol/raymol_design.py` (add after `selected_design_indices`, which ends ~line 148)
+- Test: `testing/tests/raymol/design_region.py` (append to `TestDesignRegion`)
+
+**Interfaces:**
+- Consumes: existing `_tmp(name)`, `_scope(obj, src)`, `_obj_residue_order(obj)` in the same module.
+- Produces:
+  - `set_design_active(on) -> str` — arms/disarms the digest.
+  - `sele_digest() -> str` — `''` when disarmed, else `"<count>:<md5-16>"`.
+  - `sele_design_indices(obj, state, src='') -> str` — writes `$TMPDIR/raymol_design_sele.json` = `{'indices': [int], 'digest': str, 'n_total': int}`; returns `'DESIGN_SELE:<n>'`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `testing/tests/raymol/design_region.py` inside `class TestDesignRegion`:
+
+```python
+    def _sele_payload(self):
+        with open(os.path.join(tempfile.gettempdir(),
+                               'raymol_design_sele.json')) as f:
+            return json.load(f)
+
+    def testSeleIndicesMapInGuideOrder(self):
+        obj = self._peptide()
+        cmd.select('sele', '%s and resi 2+4' % obj)
+        from pymol import raymol_design as rd
+        marker = rd.sele_design_indices(obj, 1)
+        self.assertTrue(marker.startswith('DESIGN_SELE:'))
+        data = self._sele_payload()
+        # resi 2 and 4 -> 0-based guide-order indices 1 and 3.
+        self.assertEqual(data['indices'], [1, 3])
+        self.assertEqual(data['n_total'], 2)
+
+    def testSeleIndicesEmptyWithoutSele(self):
+        obj = self._peptide()          # reinitialize() in _peptide drops any 'sele'
+        from pymol import raymol_design as rd
+        rd.sele_design_indices(obj, 1)
+        data = self._sele_payload()
+        self.assertEqual(data['indices'], [])
+        self.assertEqual(data['n_total'], 0)
+
+    def testSeleIndicesScopeToFocusObject(self):
+        obj = self._peptide()
+        cmd.fab('AAAAA', 'm2')
+        cmd.select('sele', '(m1 and resi 2) or (m2 and resi 3)')
+        from pymol import raymol_design as rd
+        rd.sele_design_indices('m1', 1)
+        data = self._sele_payload()
+        # Only m1's residue is designable here; m2's still counts toward n_total.
+        self.assertEqual(data['indices'], [1])
+        self.assertEqual(data['n_total'], 2)
+
+    def testSeleIndicesResolveOriginalOntoWorkingCopy(self):
+        obj = self._peptide()
+        cmd.create('%s_design' % obj, obj, zoom=0)
+        cmd.select('sele', '%s and resi 2+4' % obj)   # selection on the ORIGINAL
+        from pymol import raymol_design as rd
+        # Focus = working copy, no src: the original's selection does not intersect.
+        rd.sele_design_indices('%s_design' % obj, 1)
+        self.assertEqual(self._sele_payload()['indices'], [])
+        # With src = original it maps by (chain, resi) onto the copy's guide order.
+        rd.sele_design_indices('%s_design' % obj, 1, src=obj)
+        self.assertEqual(self._sele_payload()['indices'], [1, 3])
+
+    def testSeleDigestIsGatedOnDesignActive(self):
+        obj = self._peptide()
+        cmd.select('sele', '%s and resi 2' % obj)
+        from pymol import raymol_design as rd
+        rd.set_design_active(0)
+        self.assertEqual(rd.sele_digest(), '',
+                         'digest must cost nothing while Design mode is off')
+        rd.set_design_active(1)
+        try:
+            d1 = rd.sele_digest()
+            self.assertTrue(d1)
+            # Re-selecting the SAME residues must not change the digest.
+            cmd.select('sele', '%s and resi 2' % obj)
+            self.assertEqual(rd.sele_digest(), d1)
+            # A different residue set must change it.
+            cmd.select('sele', '%s and resi 2+3' % obj)
+            self.assertNotEqual(rd.sele_digest(), d1)
+        finally:
+            rd.set_design_active(0)   # never leak the flag into another test
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+pymol -ckqy testing/testing.py --run tests/raymol/design_region.py
+```
+
+Expected: FAIL — `AttributeError: module 'pymol.raymol_design' has no attribute 'sele_design_indices'` (and the same for `sele_digest` / `set_design_active`).
+
+- [ ] **Step 3: Add `hashlib` to the imports**
+
+In `modules/pymol/raymol_design.py`, change the import block at the top from:
+
+```python
+import json
+import os
+import tempfile
+```
+
+to:
+
+```python
+import hashlib
+import json
+import os
+import tempfile
+```
+
+- [ ] **Step 4: Implement the read half**
+
+Insert into `modules/pymol/raymol_design.py` immediately after `selected_design_indices` (i.e. before `def apply_design_coloring`):
+
+```python
+# Design mode active? The selection digest below is O(selected residues) and is
+# called from appkit_inspector.poll_panel, which runs on the MAIN thread every
+# 500 ms and is a measured hot spot (PR #270). Gating on this flag keeps the cost
+# at a single boolean check whenever Design mode is not on. A list rather than a
+# bare module global so the setter never needs `global`.
+_DESIGN_ACTIVE = [False]
+
+
+def set_design_active(on):
+    """Arm or disarm the Design-mode 'sele' digest computed by poll_panel."""
+    _DESIGN_ACTIVE[0] = bool(on) if isinstance(on, bool) else bool(int(on))
+    return 'DESIGN_ACTIVE:%d' % (1 if _DESIGN_ACTIVE[0] else 0)
+
+
+def _sele_residue_keys():
+    """Sorted (model, chain, resi) of every guide residue in the active 'sele'.
+
+    '?sele' rather than 'sele' so a session that has never had a selection yields
+    [] instead of raising. Guide atoms only, so the key set is one entry per
+    residue regardless of how many of its atoms the user picked.
+    """
+    keys = []
+    try:
+        cmd.iterate('(?sele) and polymer and guide',
+                    'keys.append((model, chain, resi))', space={'keys': keys})
+    except Exception:
+        return []
+    return sorted(keys)
+
+
+def _digest_of(keys):
+    """Stable short fingerprint of a residue-key list."""
+    return '%d:%s' % (len(keys),
+                      hashlib.md5(repr(keys).encode('utf-8')).hexdigest()[:16])
+
+
+def sele_digest():
+    """Fingerprint of the active 'sele' residue set, or '' when Design is off.
+
+    Used purely for change detection: the Swift side re-derives its selection
+    state only when this value differs from the last one it saw.
+    """
+    if not _DESIGN_ACTIVE[0]:
+        return ''
+    return _digest_of(_sele_residue_keys())
+
+
+def sele_design_indices(obj, state, src=''):
+    """Map the active 'sele' -> full-length residue indices in obj's guide order.
+
+    The Design-mode counterpart of selected_design_indices, hard-wired to 'sele'
+    so the viewer's ordinary selection is the single source of truth for what
+    Design mode is working on. Scoped through _scope(obj, src) so a selection made
+    on the ORIGINAL object still maps onto a focused working copy by (chain, resi)
+    identity once an edit session has begun.
+
+    Output: $TMPDIR/raymol_design_sele.json =
+        {'indices': [int], 'digest': str, 'n_total': int}
+      indices  - 'sele' within the scope, as 0-based indices into obj's guide order
+      digest   - fingerprint of the WHOLE 'sele' residue set (all objects)
+      n_total  - residue count of 'sele' across ALL objects, so a caller can tell
+                 "nothing selected" from "selected, but on another structure"
+
+    `state` is accepted for signature symmetry with selected_design_indices and is
+    likewise unused: guide order is read from the current state.
+    Returns 'DESIGN_SELE:<n>'.
+    """
+    order = _obj_residue_order(obj)
+    scope = _scope(obj, src)
+    sel_res = set()
+    try:
+        cmd.iterate('%s and (?sele) and polymer and guide' % scope,
+                    'sel_res.add((chain, resi))', space={'sel_res': sel_res})
+    except Exception:
+        pass
+    indices = [i for i, cr in enumerate(order) if cr in sel_res]
+    keys = _sele_residue_keys()
+    payload = {'indices': indices,
+               'digest': _digest_of(keys),
+               'n_total': len(keys)}
+    try:
+        with open(_tmp('raymol_design_sele.json'), 'w') as f:
+            json.dump(payload, f)
+    except Exception:
+        pass
+    return 'DESIGN_SELE:%d' % len(indices)
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+pymol -ckqy testing/testing.py --run tests/raymol/design_region.py
+```
+
+Expected: PASS, all tests in `TestDesignRegion` (the five new ones plus the four pre-existing).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add modules/pymol/raymol_design.py testing/tests/raymol/design_region.py
+git commit -m "feat(design): read the active 'sele' as guide-order residue indices
+
+Adds sele_design_indices (sele -> full-length indices, scoped to the focus
+object and its edit source) plus a design-mode-gated digest for cheap change
+detection, so 'sele' can become the single source of truth for what Design
+mode is working on.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Python — mutate the active `sele`
+
+The write half: the four `sele` mutations a Design-mode gesture can perform, using the same selection algebra as `metal_pick.pick_at` so the two modes cannot drift.
+
+**Files:**
+- Modify: `modules/pymol/raymol_design.py` (add after `sele_design_indices` from Task 1)
+- Test: `testing/tests/raymol/design_region.py`
+
+**Interfaces:**
+- Consumes: `_residue_sel(obj, chain, resi)` from the same module.
+- Produces:
+  - `toggle_sele_residue(obj, chain, resi) -> str` (`'DESIGN_SELE_TOGGLE:on'|':off'`)
+  - `set_sele_residue(obj, chain, resi) -> str` (`'DESIGN_SELE_SET:ok'`)
+  - `set_sele_from_selection(name) -> str` (`'DESIGN_SELE_NAMED:ok'`)
+  - `clear_sele() -> str` (`'DESIGN_SELE_CLEAR:ok'`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `testing/tests/raymol/design_region.py` inside `class TestDesignRegion`:
+
+```python
+    def _sele_resis(self):
+        """Sorted resi strings of the guide residues currently in 'sele'."""
+        out = set()
+        cmd.iterate('(?sele) and polymer and guide',
+                    'out.add(resi)', space={'out': out})
+        return sorted(out, key=int)
+
+    def testToggleSeleResidueAddsThenRemoves(self):
+        obj = self._peptide()
+        from pymol import raymol_design as rd
+        self.assertEqual(rd.toggle_sele_residue(obj, '', '2'),
+                         'DESIGN_SELE_TOGGLE:on')
+        self.assertEqual(self._sele_resis(), ['2'])
+        rd.toggle_sele_residue(obj, '', '4')
+        self.assertEqual(self._sele_resis(), ['2', '4'])
+        # Same residue again -> removed, matching a normal-mode click.
+        self.assertEqual(rd.toggle_sele_residue(obj, '', '2'),
+                         'DESIGN_SELE_TOGGLE:off')
+        self.assertEqual(self._sele_resis(), ['4'])
+
+    def testSetSeleResidueReplaces(self):
+        obj = self._peptide()
+        from pymol import raymol_design as rd
+        rd.toggle_sele_residue(obj, '', '2')
+        rd.toggle_sele_residue(obj, '', '3')
+        rd.set_sele_residue(obj, '', '5')
+        self.assertEqual(self._sele_resis(), ['5'],
+                         'set must replace the selection, not extend it')
+
+    def testSetSeleFromSelectionCopiesNamedRegion(self):
+        obj = self._peptide()
+        cmd.select('loop', '%s and resi 2+3' % obj)
+        from pymol import raymol_design as rd
+        rd.set_sele_from_selection('loop')
+        self.assertEqual(self._sele_resis(), ['2', '3'])
+
+    def testSetSeleFromMissingSelectionEmpties(self):
+        obj = self._peptide()
+        from pymol import raymol_design as rd
+        rd.toggle_sele_residue(obj, '', '2')
+        # A name that does not exist must empty 'sele', never raise.
+        rd.set_sele_from_selection('nope')
+        self.assertEqual(self._sele_resis(), [])
+
+    def testToggleIsResidueScopedRegardlessOfMouseSelectionMode(self):
+        # D1: Design clicks always expand to RESIDUE scope. With
+        # mouse_selection_mode = 0 (atom) a normal-mode click would commit a single
+        # ATOM, which maps to zero guide residues -- a click that silently selects
+        # nothing. Design must ignore the setting entirely.
+        obj = self._peptide()
+        from pymol import raymol_design as rd
+        for mode in (0, 1, 2, 4):
+            cmd.set('mouse_selection_mode', mode)
+            rd.clear_sele()
+            rd.toggle_sele_residue(obj, '', '2')
+            self.assertEqual(self._sele_resis(), ['2'],
+                             'mouse_selection_mode %d must not change the scope '
+                             'of a Design-mode click' % mode)
+        cmd.set('mouse_selection_mode', 1)   # restore the default
+
+    def testClearSeleEmpties(self):
+        obj = self._peptide()
+        from pymol import raymol_design as rd
+        rd.toggle_sele_residue(obj, '', '2')
+        self.assertEqual(rd.clear_sele(), 'DESIGN_SELE_CLEAR:ok')
+        self.assertEqual(self._sele_resis(), [])
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+pymol -ckqy testing/testing.py --run tests/raymol/design_region.py
+```
+
+Expected: FAIL — `AttributeError: module 'pymol.raymol_design' has no attribute 'toggle_sele_residue'`.
+
+- [ ] **Step 3: Implement the write half**
+
+Insert into `modules/pymol/raymol_design.py` immediately after `sele_design_indices`:
+
+```python
+def toggle_sele_residue(obj, chain, resi):
+    """Add or remove one residue in the active 'sele' (a Design-mode click).
+
+    Deliberately mirrors metal_pick.pick_at's toggle idiom so that a click means
+    the same thing in Design mode as in normal mode: already selected -> remove,
+    otherwise add. Always leaves 'sele' enabled so the renderer's pink committed
+    pass draws it. Returns 'DESIGN_SELE_TOGGLE:on' or ':off'.
+    """
+    expr = '(%s)' % _residue_sel(obj, chain, resi)
+    try:
+        already = cmd.count_atoms('(?sele) and %s' % expr) > 0
+    except Exception:
+        already = False
+    if already:
+        cmd.select('sele', '(?sele) and not %s' % expr, enable=1)
+    else:
+        cmd.select('sele', '(?sele) or %s' % expr, enable=1)
+    return 'DESIGN_SELE_TOGGLE:%s' % ('off' if already else 'on')
+
+
+def set_sele_residue(obj, chain, resi):
+    """Replace the active 'sele' with exactly one residue.
+
+    Used when a Design-mode click lands on a DIFFERENT object than the current
+    focus: design retargets to that object and the selection starts fresh there,
+    so residues of the previous focus never linger in the region.
+    Returns 'DESIGN_SELE_SET:ok'.
+    """
+    cmd.select('sele', _residue_sel(obj, chain, resi), enable=1)
+    return 'DESIGN_SELE_SET:ok'
+
+
+def set_sele_from_selection(name):
+    """Replace the active 'sele' with the contents of the named selection.
+
+    Backs the lasso dropdown: designating a named region writes it into 'sele' so
+    'sele' stays the single source of truth instead of the controller holding a
+    second, divergent copy. '?name' so a stale name empties the selection rather
+    than raising. Returns 'DESIGN_SELE_NAMED:ok'.
+    """
+    cmd.select('sele', '(?%s)' % name, enable=1)
+    return 'DESIGN_SELE_NAMED:ok'
+
+
+def clear_sele():
+    """Empty the active 'sele' (a Design-mode click on empty space).
+
+    Matches metal_pick.pick_at's empty-space behaviour. enable=0 because there is
+    nothing to draw, and an enabled empty selection would still suppress other
+    selections (cmd.enable is exclusive for selections).
+    Returns 'DESIGN_SELE_CLEAR:ok'.
+    """
+    cmd.select('sele', 'none', enable=0)
+    return 'DESIGN_SELE_CLEAR:ok'
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+pymol -ckqy testing/testing.py --run tests/raymol/design_region.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add modules/pymol/raymol_design.py testing/tests/raymol/design_region.py
+git commit -m "feat(design): add the 'sele' mutations a Design-mode gesture performs
+
+toggle/set/named/clear, using the same selection algebra as metal_pick.pick_at
+so a click cannot come to mean different things in the two modes.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Swift — derive the mode from `sele` (`syncFromSele`)
+
+The heart of the change. Adds the read closure, an engine-free in-memory fallback so the state machine is unit-testable, and the single function that derives `pinnedResidueIndex` and `selectedResidueIndices`.
+
+**Files:**
+- Modify: `swiftui/PyMOLViewer/Shared/DesignController.swift`
+- Test: `swiftui/PyMOLViewerTests/DesignRegionTests.swift`
+
+**Interfaces:**
+- Consumes: existing private `stickKey(_:_:)`, `lastSet`, `focusObject`, `editSourceObject`, `reconcileSticks()`, `DesignResidue.valid`.
+- Produces, for Tasks 4/6/7:
+  - `typealias SeleStateFn = (_ obj: String, _ src: String?, _ state: Int) -> (indices: [Int], digest: String, total: Int)`
+  - `@discardableResult func syncFromSele() -> Int` — returns the designable-residue count it derived.
+  - `@Published private(set) var seleResiduesOffFocus: Int`
+  - `private var pickedSelectionName: String?`, `private var stubSele: Set<String>`
+  - private helpers `seleToggleLocal(_:_:)`, `seleSetLocal(_:_:)`, `seleClearLocal()`, `seleStateLocal()`
+  - `#if DEBUG func injectSele(seleState:toggleSele:setSeleResidue:setSeleNamed:clearSele:)`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `swiftui/PyMOLViewerTests/DesignRegionTests.swift`, inside the existing test class (it already has a controller-construction pattern; mirror the one used by the neighbouring tests in the file):
+
+```swift
+    // MARK: – 'sele' as the single source of truth
+
+    private func seleController() -> DesignController {
+        let emptySet = DesignResidueSet(object: "stub", state: 1, residues: [])
+        return DesignController(
+            enumerate: { _, _ in emptySet },
+            score: { _, _ in MPNNModel.ScoreResult(logProbs: [], currentAALogProb: []) },
+            applyColoring: { _, _, _, _, _, _, _ in },
+            dim: { _ in }, snapshot: { _ in }, restore: { })
+    }
+
+    // No selection -> nothing active. This is the idle state the greyed propensity
+    // row renders.
+    func testSyncFromSeleWithNothingSelected() {
+        let c = seleController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: [true, true, true])
+        XCTAssertEqual(c.syncFromSele(), 0)
+        XCTAssertNil(c.pinnedResidueIndex)
+        XCTAssertTrue(c.selectedResidueIndices.isEmpty)
+        XCTAssertFalse(c.regionModeActive)
+    }
+
+    // Exactly one selected residue must reproduce today's single-residue
+    // behaviour: pinned, and NOT region mode, so the propensity pills still show.
+    func testOneSelectedResiduePinsAndStaysOutOfRegionMode() {
+        let c = seleController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: [true, true, true])
+        c.injectSele(seleState: { _, _, _ in (indices: [1], digest: "d1", total: 1) })
+        XCTAssertEqual(c.syncFromSele(), 1)
+        XCTAssertEqual(c.pinnedResidueIndex, 1)
+        XCTAssertTrue(c.selectedResidueIndices.isEmpty,
+                      "a single residue must not enter region mode")
+        XCTAssertFalse(c.regionModeActive)
+        XCTAssertNil(c.selectedSelectionName,
+                     "the region label belongs to region mode only")
+    }
+
+    // Two or more selected residues auto-designate the region and drop the pin,
+    // so the palette row replaces the propensity pills.
+    func testTwoSelectedResiduesEnterRegionMode() {
+        let c = seleController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: [true, true, true])
+        c.injectSele(seleState: { _, _, _ in (indices: [0, 2], digest: "d2", total: 2) })
+        XCTAssertEqual(c.syncFromSele(), 2)
+        XCTAssertNil(c.pinnedResidueIndex,
+                     "region mode must clear the single-residue pin")
+        XCTAssertEqual(c.selectedResidueIndices, [0, 2])
+        XCTAssertTrue(c.regionModeActive)
+        XCTAssertEqual(c.selectedSelectionName, "sele",
+                       "a click-built region is labelled 'sele'")
+    }
+
+    // Non-designable positions (missing backbone) never count, so selecting one
+    // designable and one invalid residue is still single-residue mode.
+    func testInvalidResiduesAreDroppedFromTheCount() {
+        let c = seleController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: [true, false, true])
+        c.injectSele(seleState: { _, _, _ in (indices: [0, 1], digest: "d3", total: 2) })
+        XCTAssertEqual(c.syncFromSele(), 1,
+                       "index 1 is not designable and must not count")
+        XCTAssertEqual(c.pinnedResidueIndex, 0)
+        XCTAssertTrue(c.selectedResidueIndices.isEmpty)
+    }
+
+    // Out-of-range indices from a stale payload must not crash or leak in.
+    func testOutOfRangeIndicesAreIgnored() {
+        let c = seleController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: [true, true, true])
+        c.injectSele(seleState: { _, _, _ in (indices: [1, 99, -1], digest: "d4", total: 3) })
+        XCTAssertEqual(c.syncFromSele(), 1)
+        XCTAssertEqual(c.pinnedResidueIndex, 1)
+    }
+
+    // Residues selected on OTHER structures are reported so the UI can say so
+    // instead of silently ignoring them.
+    func testOffFocusResiduesAreCounted() {
+        let c = seleController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: [true, true, true])
+        c.injectSele(seleState: { _, _, _ in (indices: [0], digest: "d5", total: 3) })
+        c.syncFromSele()
+        XCTAssertEqual(c.seleResiduesOffFocus, 2)
+    }
+
+    // With no focus object there is nothing to resolve against; sync must reset
+    // rather than keep stale indices.
+    func testSyncWithoutFocusResets() {
+        let c = seleController()
+        c.injectSele(seleState: { _, _, _ in (indices: [0, 1], digest: "d6", total: 2) })
+        XCTAssertEqual(c.syncFromSele(), 0)
+        XCTAssertTrue(c.selectedResidueIndices.isEmpty)
+        XCTAssertNil(c.pinnedResidueIndex)
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd swiftui && xcodebuild test -scheme RayMol -destination 'platform=macOS' \
+  -only-testing:PyMOLViewerTests/DesignRegionTests 2>&1 | tail -30
+```
+
+Expected: FAIL to compile — `value of type 'DesignController' has no member 'injectSele'` / `'syncFromSele'` / `'seleResiduesOffFocus'`.
+
+- [ ] **Step 3: Add the typealiases**
+
+In `swiftui/PyMOLViewer/Shared/DesignController.swift`, immediately after the `SelectedIndicesFn` typealias (~line 113):
+
+```swift
+    /// Read the active 'sele' for `obj`, scoped to `obj` + its edit `src` exactly as
+    /// `SelectedIndicesFn` is. Returns the full-length guide indices inside that
+    /// scope, a digest of the WHOLE selection (used only for change detection), and
+    /// the total selected residue count across all objects.
+    typealias SeleStateFn = (_ obj: String, _ src: String?, _ state: Int)
+        -> (indices: [Int], digest: String, total: Int)
+    /// Add or remove one residue in the active 'sele'.
+    typealias ToggleSeleFn = (_ obj: String, _ chain: String, _ resi: String) -> Void
+    /// Replace the active 'sele' with exactly one residue.
+    typealias SetSeleResidueFn = (_ obj: String, _ chain: String, _ resi: String) -> Void
+    /// Replace the active 'sele' with the contents of a named selection.
+    typealias SetSeleNamedFn = (_ name: String) -> Void
+    /// Empty the active 'sele'.
+    typealias ClearSeleFn = () -> Void
+```
+
+- [ ] **Step 4: Add the stored properties**
+
+In the same file, immediately after `private var selectedIndicesFn` (~line 144):
+
+```swift
+    // MARK: – 'sele' access (single source of truth)
+    //
+    // OPTIONAL rather than defaulted closures: a stored property's default value
+    // cannot reference `self`, and the engine-free fallbacks below must read
+    // `lastSet` / `focusObject`. nil therefore means "use the local fallback",
+    // which is what unit tests get — and that matters, because
+    // `pinnedResidueIndex` is now DERIVED: against no-op stubs every existing pin
+    // assertion would read nil.
+    private var seleStateFn: SeleStateFn?
+    private var toggleSeleFn: ToggleSeleFn?
+    private var setSeleResidueFn: SetSeleResidueFn?
+    private var setSeleNamedFn: SetSeleNamedFn?
+    private var clearSeleFn: ClearSeleFn?
+
+    /// In-memory stand-in for PyMOL's 'sele' used by the fallbacks. Keys are
+    /// "chain\u{1}resi" — the same encoding `stickKey` produces.
+    private var stubSele: Set<String> = []
+
+    /// Digest of the selection the last `syncFromSele()` resolved. The panel-poll
+    /// hook compares against this so it only re-derives when 'sele' really changed.
+    private(set) var lastSeleDigest: String = ""
+
+    /// Name of the last selection explicitly designated through the lasso dropdown.
+    /// Any click clears it, so a click-built region falls back to the "sele" label.
+    private var pickedSelectionName: String?
+```
+
+And with the other `@Published` region properties (next to `selectedSelectionName`):
+
+```swift
+    /// Residues in 'sele' that are NOT on the focus object. Design ignores them,
+    /// so the UI surfaces the count rather than silently dropping them.
+    @Published private(set) var seleResiduesOffFocus: Int = 0
+```
+
+- [ ] **Step 5: Add the local fallbacks and `syncFromSele`**
+
+Insert into `DesignController.swift` immediately before `func pickSelection(_ name: String)` (~line 728):
+
+```swift
+    // MARK: – Engine-free 'sele' fallbacks
+    //
+    // Used when no closure is injected, so unit tests drive the REAL derivation
+    // instead of no-op stubs. Behaviourally identical to the Python helpers:
+    // toggle adds/removes, set replaces, clear empties.
+
+    private func seleToggleLocal(_ chain: String, _ resi: String) {
+        let k = stickKey(chain, resi)
+        if stubSele.contains(k) { stubSele.remove(k) } else { stubSele.insert(k) }
+    }
+
+    private func seleSetLocal(_ chain: String, _ resi: String) {
+        stubSele = [stickKey(chain, resi)]
+    }
+
+    private func seleClearLocal() { stubSele.removeAll() }
+
+    /// Local counterpart of `SeleStateFn`: resolve `stubSele` against the focus
+    /// object's residue set, in guide order.
+    private func seleStateLocal() -> (indices: [Int], digest: String, total: Int) {
+        guard let obj = focusObject, let set = lastSet[obj] else {
+            return (indices: [], digest: "\(stubSele.count)", total: stubSele.count)
+        }
+        let idx = set.residues.enumerated().compactMap { i, r in
+            stubSele.contains(stickKey(r.chain, r.resi)) ? i : nil
+        }
+        return (indices: idx, digest: "\(stubSele.count):\(idx)", total: stubSele.count)
+    }
+
+    /// Read the current 'sele' state through the injected closure, or the local
+    /// fallback when none is injected. Only reached with a focus object present
+    /// (`syncFromSele` guards first), so the no-focus branch just defers to the
+    /// fallback rather than inventing an empty result.
+    private func readSeleState() -> (indices: [Int], digest: String, total: Int) {
+        guard let obj = focusObject, let set = lastSet[obj] else { return seleStateLocal() }
+        if let fn = seleStateFn { return fn(obj, editSourceObject, set.state) }
+        return seleStateLocal()
+    }
+
+    // MARK: – Deriving the mode from 'sele'
+
+    /// Re-derive the Design-mode selection state from the active 'sele'.
+    ///
+    /// This is the ONLY writer of `pinnedResidueIndex` and
+    /// `selectedResidueIndices`. The count of DESIGNABLE residues in
+    /// `sele ∩ scope(focusObject, editSourceObject)` picks the mode:
+    ///   0  → nothing active (propensity row renders in its greyed idle form)
+    ///   1  → that residue is pinned; the region stays empty so `regionModeActive`
+    ///        is false and the propensity pills behave exactly as before
+    ///   ≥2 → the region is designated on 'sele'; the pin is cleared so the
+    ///        palette row and the Redesign button take over
+    ///
+    /// Returns the designable count, so callers and tests can assert the mode
+    /// without re-reading three properties.
+    @discardableResult
+    func syncFromSele() -> Int {
+        guard let obj = focusObject, let set = lastSet[obj] else {
+            pinnedResidueIndex = nil
+            selectedResidueIndices = []
+            selectedSelectionName = nil
+            seleResiduesOffFocus = 0
+            return 0
+        }
+        let state = readSeleState()
+        lastSeleDigest = state.digest
+        let inScope = state.indices.filter { $0 >= 0 && $0 < set.residues.count }
+        let valid = inScope.filter { set.residues[$0].valid }.sorted()
+        seleResiduesOffFocus = max(0, state.total - inScope.count)
+        if valid.count >= 2 {
+            selectedResidueIndices = valid
+            selectedSelectionName = pickedSelectionName ?? "sele"
+            pinnedResidueIndex = nil
+        } else {
+            selectedResidueIndices = []
+            selectedSelectionName = nil
+            pinnedResidueIndex = valid.first
+        }
+        reconcileSticks()
+        return valid.count
+    }
+```
+
+- [ ] **Step 6: Add the DEBUG injection hook**
+
+In the `#if DEBUG` block of `DesignController.swift`, next to `injectRegion` (~line 1272):
+
+```swift
+    /// Override the 'sele' closures for testing. Any argument left nil keeps the
+    /// engine-free local fallback for that operation.
+    func injectSele(seleState: SeleStateFn? = nil,
+                    toggleSele: ToggleSeleFn? = nil,
+                    setSeleResidue: SetSeleResidueFn? = nil,
+                    setSeleNamed: SetSeleNamedFn? = nil,
+                    clearSele: ClearSeleFn? = nil) {
+        if let seleState { self.seleStateFn = seleState }
+        if let toggleSele { self.toggleSeleFn = toggleSele }
+        if let setSeleResidue { self.setSeleResidueFn = setSeleResidue }
+        if let setSeleNamed { self.setSeleNamedFn = setSeleNamed }
+        if let clearSele { self.clearSeleFn = clearSele }
+    }
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+```bash
+cd swiftui && xcodebuild test -scheme RayMol -destination 'platform=macOS' \
+  -only-testing:PyMOLViewerTests/DesignRegionTests 2>&1 | tail -30
+```
+
+Expected: PASS — all seven new tests plus the pre-existing `DesignRegionTests`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add swiftui/PyMOLViewer/Shared/DesignController.swift \
+        swiftui/PyMOLViewerTests/DesignRegionTests.swift
+git commit -m "feat(design): derive pin and region from 'sele' via syncFromSele
+
+syncFromSele becomes the only writer of pinnedResidueIndex and
+selectedResidueIndices: 0 selected = idle, 1 = pinned (unchanged
+single-residue behaviour), 2+ = region auto-designated.
+
+The 'sele' closures are optional with engine-free in-memory fallbacks, so unit
+tests exercise the real derivation -- necessary now that pinnedResidueIndex is
+derived rather than assigned.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Swift — route every selection gesture through `sele`
+
+Rewires taps, the viewport three-way rule, the lasso dropdown, and clear so they all mutate `sele` and then re-derive. Also removes the outward `sele` write (`pinnedIndicatorFn`) and stops Design-mode exit from wiping the user's selection (D2).
+
+**Files:**
+- Modify: `swiftui/PyMOLViewer/Shared/DesignController.swift`
+- Test: `swiftui/PyMOLViewerTests/DesignRegionTests.swift`
+
+**Interfaces:**
+- Consumes: `syncFromSele()`, `readSeleState()`, `seleToggleLocal/seleSetLocal/seleClearLocal`, `pickedSelectionName`, `stubSele` (Task 3); existing `focusAwait(_:)`, `residueIndex(chain:resi:)`, `selectedIndicesFn`.
+- Produces: `tapResidue(residueIndex:)`, `toggleRegionResidue(residueIndex:)`, `setPinned(chain:resi:)`, `handleViewportHit(object:chain:resi:hasResidue:)`, `pickSelection(_:)`, `clearSelection()` — all now `sele`-backed. Removes `PinnedIndicatorFn`, `pinnedIndicatorFn`, and the `pinnedIndicator:` init parameter.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `swiftui/PyMOLViewerTests/DesignRegionTests.swift` (reuses `seleController()` from Task 3):
+
+```swift
+    // MARK: – Gestures route through 'sele'
+
+    // Successive taps accumulate, exactly like normal-mode clicks: 1 -> pin,
+    // 2 -> region. This is the behaviour the whole change exists to deliver.
+    func testSuccessiveTapsAccumulateIntoARegion() {
+        let c = seleController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: [true, true, true])
+
+        c.tapResidue(residueIndex: 1)
+        XCTAssertEqual(c.pinnedResidueIndex, 1)
+        XCTAssertFalse(c.regionModeActive)
+
+        c.tapResidue(residueIndex: 0)
+        XCTAssertEqual(c.selectedResidueIndices, [0, 1], "region stays sorted")
+        XCTAssertNil(c.pinnedResidueIndex)
+        XCTAssertTrue(c.regionModeActive)
+
+        c.tapResidue(residueIndex: 2)
+        XCTAssertEqual(c.selectedResidueIndices, [0, 1, 2])
+    }
+
+    // Tapping a selected residue removes it, matching pick_at's toggle.
+    func testTapOnSelectedResidueDeselects() {
+        let c = seleController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: [true, true, true])
+        c.tapResidue(residueIndex: 1)
+        c.tapResidue(residueIndex: 2)
+        XCTAssertEqual(c.selectedResidueIndices, [1, 2])
+
+        c.tapResidue(residueIndex: 2)
+        XCTAssertEqual(c.pinnedResidueIndex, 1, "back to single-residue mode")
+        XCTAssertTrue(c.selectedResidueIndices.isEmpty)
+
+        c.tapResidue(residueIndex: 1)
+        XCTAssertNil(c.pinnedResidueIndex, "last residue removed -> nothing active")
+    }
+
+    // A click on empty space clears, as it does in normal mode. Focus is kept.
+    func testEmptySpaceHitClearsSelectionButKeepsFocus() {
+        let c = seleController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: [true, true, true])
+        c.tapResidue(residueIndex: 0)
+        c.tapResidue(residueIndex: 1)
+        XCTAssertTrue(c.regionModeActive)
+
+        c.handleViewportHit(object: "", chain: "", resi: "", hasResidue: false)
+        XCTAssertTrue(c.selectedResidueIndices.isEmpty)
+        XCTAssertNil(c.pinnedResidueIndex)
+        XCTAssertEqual(c.focusObject, "m1", "clearing must not change focus")
+    }
+
+    // A hit on the focus object with no resolvable residue is a no-op, not a clear.
+    func testHitOnFocusObjectWithoutResidueIsNoOp() {
+        let c = seleController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: [true, true, true])
+        c.tapResidue(residueIndex: 0)
+        c.handleViewportHit(object: "m1", chain: "A", resi: "99", hasResidue: true)
+        XCTAssertEqual(c.pinnedResidueIndex, 0,
+                       "an unresolvable residue must not disturb the selection")
+    }
+
+    // The lasso dropdown writes 'sele' and keeps its own label.
+    func testPickSelectionWritesSeleAndKeepsItsLabel() {
+        let c = seleController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: [true, true, true])
+        c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 0, count: r.count) },
+                       selectedIndices: { _, _, _, _ in [0, 2] })
+        c.pickSelection("loop")
+        XCTAssertEqual(c.selectedResidueIndices, [0, 2])
+        XCTAssertEqual(c.selectedSelectionName, "loop")
+
+        // A subsequent click detaches from the named region.
+        c.tapResidue(residueIndex: 1)
+        XCTAssertEqual(c.selectedResidueIndices, [0, 1, 2])
+        XCTAssertEqual(c.selectedSelectionName, "sele")
+    }
+
+    // clearSelection empties 'sele' rather than only the mirrored array, so a
+    // following sync cannot resurrect the region.
+    func testClearSelectionEmptiesSele() {
+        let c = seleController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: [true, true, true])
+        c.tapResidue(residueIndex: 0)
+        c.tapResidue(residueIndex: 1)
+        c.clearSelection()
+        XCTAssertTrue(c.selectedResidueIndices.isEmpty)
+        XCTAssertEqual(c.syncFromSele(), 0, "'sele' itself must be empty, not just the mirror")
+    }
+
+    // D3: reaching 2+ residues ARMS the Redesign button; it must never run MPNN
+    // on its own. Auto-running would burn an inference per click and throw away
+    // every intermediate result.
+    func testBuildingARegionNeverRunsInference() {
+        let c = seleController()
+        var designCalls = 0
+        c.injectRegion(designRegion: { r, _, _, _, _ in
+            designCalls += 1
+            return Array(repeating: 0, count: r.count)
+        })
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: [true, true, true])
+
+        c.tapResidue(residueIndex: 0)
+        c.tapResidue(residueIndex: 1)
+        c.tapResidue(residueIndex: 2)
+
+        XCTAssertTrue(c.regionModeActive, "3 residues must designate a region")
+        XCTAssertEqual(designCalls, 0,
+                       "designating a region must not run inference (D3)")
+    }
+
+    // D4: a hit on a NON-focus object retargets design AND selects that residue in
+    // one gesture, so the first click on another structure is never dead. The
+    // selection must be applied after the async focus completes, or it would be
+    // resolved against the previous object's residue set.
+    func testHitOnOtherObjectRefocusesAndSelects() async {
+        let residues = (1...3).map { i in
+            DesignResidue(chain: "A", resi: "\(i)", resn: "ALA", aa: 5,
+                          backbone: MPNNModel.Residue(n: .zero, ca: .zero, c: .zero,
+                                                      o: .zero, chain: 0, resSeq: i),
+                          valid: true)
+        }
+        let c = DesignController(
+            enumerate: { obj, _ in
+                DesignResidueSet(object: obj, state: 1, residues: residues)
+            },
+            score: { _, _ in MPNNModel.ScoreResult(logProbs: [], currentAALogProb: []) },
+            applyColoring: { _, _, _, _, _, _, _ in },
+            dim: { _ in }, snapshot: { _ in }, restore: { })
+        c.allObjects = ["m1", "m2"]
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: [true, true, true])
+        c.tapResidue(residueIndex: 0)       // a residue selected on the OLD focus
+
+        // Drive the async refocus path directly so the test can await it.
+        c.handleViewportHit(object: "m2", chain: "A", resi: "2", hasResidue: true)
+        // handleViewportHit spawns a Task for the refocus; yield until it settles.
+        for _ in 0..<10 where c.focusObject != "m2" { await Task.yield() }
+
+        XCTAssertEqual(c.focusObject, "m2", "the click must retarget design")
+        XCTAssertEqual(c.pinnedResidueIndex, 1,
+                       "the clicked residue must be selected by the same click (D4)")
+        XCTAssertTrue(c.selectedResidueIndices.isEmpty,
+                      "old-focus residues must not linger in the region")
+    }
+
+    // D2: leaving Design mode must NOT wipe the user's ordinary selection.
+    func testExitDoesNotClearSele() {
+        let c = seleController()
+        var cleared = false
+        c.injectSele(clearSele: { cleared = true })
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: [true, true, true])
+        c.tapResidue(residueIndex: 0)
+        c.exit()
+        XCTAssertFalse(cleared,
+                       "exiting Design mode must leave 'sele' alone (D2)")
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd swiftui && xcodebuild test -scheme RayMol -destination 'platform=macOS' \
+  -only-testing:PyMOLViewerTests/DesignRegionTests 2>&1 | tail -30
+```
+
+Expected: FAIL — `testSuccessiveTapsAccumulateIntoARegion` fails because `tapResidue` still calls `setPinned`, which replaces rather than accumulates; `testExitDoesNotClearSele` fails because `exit()` still calls `pinnedIndicatorFn("", "", "")`.
+
+- [ ] **Step 3: Rewrite `tapResidue`, `toggleRegionResidue`, and `setPinned`**
+
+In `DesignController.swift`, replace the whole existing `toggleRegionResidue`, `tapResidue`, and `setPinned` implementations with:
+
+```swift
+    /// Toggle one residue (full-length index) in the active 'sele'.
+    ///
+    /// The single gesture entry point: the viewport, the sequence strip, and the
+    /// compact panel all land here, so a click means the same thing everywhere and
+    /// the same thing it means in normal mode. The resulting mode (pin vs region)
+    /// is DERIVED by `syncFromSele`, never decided here.
+    func tapResidue(residueIndex i: Int) {
+        guard let obj = focusObject, let set = lastSet[obj],
+              i >= 0, i < set.residues.count else { return }
+        let r = set.residues[i]
+        pickedSelectionName = nil        // a click detaches from any named region
+        if let fn = toggleSeleFn { fn(obj, r.chain, r.resi) }
+        else { seleToggleLocal(r.chain, r.resi) }
+        syncFromSele()
+    }
+
+    /// Historical name for `tapResidue`, kept because call sites and tests read
+    /// naturally with it. Both go through 'sele', so they are now the same action.
+    func toggleRegionResidue(residueIndex i: Int) {
+        tapResidue(residueIndex: i)
+    }
+
+    /// Toggle one residue addressed by (chain, resi). Retained because the sequence
+    /// strip and several tests address residues that way. The pin itself is derived
+    /// by `syncFromSele` — this method never writes `pinnedResidueIndex`.
+    func setPinned(chain: String, resi: String) {
+        guard let idx = residueIndex(chain: chain, resi: resi) else { return }
+        tapResidue(residueIndex: idx)
+    }
+```
+
+- [ ] **Step 4: Rewrite `handleViewportHit` and add `focusThenSelect`**
+
+Replace the existing `handleViewportHit` body with:
+
+```swift
+    /// Unified viewport-hit routing shared between iOS (`designPickResidue`) and
+    /// macOS (`onChange(of: engine.longPressHit)`).
+    ///
+    /// Four-way rule, matching normal-mode click semantics:
+    ///   - `object` empty (a miss) → clear 'sele'; focus is untouched
+    ///   - `object != focusObject` → refocus there AND select that residue (D4),
+    ///     so the first click on another structure is never dead
+    ///   - `object == focusObject && hasResidue` → toggle that residue in 'sele'
+    ///   - `object == focusObject && !hasResidue` → no-op (a non-residue patch)
+    func handleViewportHit(object: String, chain: String, resi: String, hasResidue: Bool) {
+        guard !object.isEmpty else {
+            // Empty-space click clears, exactly as metal_pick.pick_at does.
+            pickedSelectionName = nil
+            if let fn = clearSeleFn { fn() } else { seleClearLocal() }
+            syncFromSele()
+            return
+        }
+        if object != focusObject {
+            focusThenSelect(object: object, chain: chain, resi: resi, hasResidue: hasResidue)
+        } else if hasResidue, let idx = residueIndex(chain: chain, resi: resi) {
+            tapResidue(residueIndex: idx)
+        }
+        // object == focusObject && !hasResidue → no-op
+    }
+
+    /// Retarget design to `object`, then seed 'sele' with the clicked residue.
+    ///
+    /// The two steps cannot be reordered or collapsed: `focusAwait` is async (it
+    /// enumerates residues and may score), and until it completes `lastSet[object]`
+    /// does not exist — so a `syncFromSele()` run before it would resolve the new
+    /// selection against the OLD object's residue set and silently produce garbage
+    /// indices.
+    private func focusThenSelect(object: String, chain: String, resi: String,
+                                 hasResidue: Bool) {
+        Task {
+            await focusAwait(object)
+            pickedSelectionName = nil
+            if hasResidue {
+                if let fn = setSeleResidueFn { fn(object, chain, resi) }
+                else { seleSetLocal(chain, resi) }
+            } else {
+                if let fn = clearSeleFn { fn() } else { seleClearLocal() }
+            }
+            syncFromSele()
+        }
+    }
+```
+
+- [ ] **Step 5: Rewrite `pickSelection` and `clearSelection`**
+
+Replace both existing implementations with:
+
+```swift
+    /// Designate `name` as the region by writing it into 'sele' (D5), so 'sele'
+    /// stays the single source of truth rather than the controller holding a
+    /// second, divergent copy. The resulting indices come back through
+    /// `syncFromSele` like every other selection change.
+    func pickSelection(_ name: String) {
+        guard let obj = focusObject, let set = lastSet[obj] else { return }
+        pickedSelectionName = name
+        if let fn = setSeleNamedFn {
+            fn(name)
+        } else {
+            // Engine-free fallback: resolve the name through the injected index
+            // mapper so unit tests can designate a named region with no live PyMOL.
+            let full = selectedIndicesFn(obj, name, editSourceObject, set.state)
+            stubSele = Set(full.compactMap { i in
+                (i >= 0 && i < set.residues.count)
+                    ? stickKey(set.residues[i].chain, set.residues[i].resi) : nil
+            })
+        }
+        syncFromSele()
+    }
+
+    /// Clear the region by emptying 'sele' → back to nothing selected.
+    func clearSelection() {
+        pickedSelectionName = nil
+        if let fn = clearSeleFn { fn() } else { seleClearLocal() }
+        syncFromSele()
+    }
+```
+
+Note: `pickSelection` sets `pickedSelectionName` *before* `syncFromSele()` so the label survives; at `valid.count >= 2` the sync uses it, and a later `tapResidue` clears it.
+
+- [ ] **Step 6: Sync after a focus change**
+
+In `focusAwait(_:)`, immediately after the existing `syncFocusResidues()` call that follows `lastSet[object] = set`, add:
+
+```swift
+            syncFromSele()        // derive pin/region for the NEW focus's scope
+```
+
+- [ ] **Step 7: Remove the outward `sele` write (`pinnedIndicatorFn`)**
+
+The pink marker *is* `sele` now, so nothing should push a selection outward. Delete all of:
+
+- the `PinnedIndicatorFn` typealias (~line 83) and its doc comment,
+- `private var pinnedIndicatorFn: PinnedIndicatorFn = { _, _, _ in }` (~line 141),
+- the `pinnedIndicator: @escaping PinnedIndicatorFn = { _, _, _ in },` init parameter (~line 306) and its `self.pinnedIndicatorFn = pinnedIndicator` assignment,
+- every call site: `pinnedIndicatorFn("", "", "")` in `exit()` (this is D2 — exiting no longer clears `sele`), in `focusAwait`'s focus-change block, and in `teardownEditSession`.
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+```bash
+cd swiftui && xcodebuild test -scheme RayMol -destination 'platform=macOS' \
+  -only-testing:PyMOLViewerTests/DesignRegionTests 2>&1 | tail -30
+```
+
+Expected: PASS. The build will still fail elsewhere if `PyMOLEngine.swift` passes `pinnedIndicator:` — remove that argument now (its full replacement wiring lands in Task 6):
+
+```swift
+// In PyMOLEngine.swift, delete the whole `pinnedIndicator: { ... },` closure
+// argument from the DesignController(...) construction.
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add swiftui/PyMOLViewer/Shared/DesignController.swift \
+        swiftui/PyMOLViewer/Shared/PyMOLEngine.swift \
+        swiftui/PyMOLViewerTests/DesignRegionTests.swift
+git commit -m "feat(design): route every selection gesture through 'sele'
+
+Taps, the viewport three-way rule, the lasso dropdown and clear all mutate
+'sele' and then re-derive, so successive clicks accumulate a region the way
+normal-mode clicks do. A click on another structure now refocuses AND selects
+that residue (D4), and an empty-space click clears.
+
+Drops the outward one-residue 'sele' write: the pink marker IS 'sele'. Leaving
+Design mode therefore no longer wipes the user's selection (D2).
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Delete `regionEditMode` and the macOS shift-click
+
+The count now carries what the modal toggle used to (D6), and a plain tap has made shift-click an exact duplicate with a documented double-fire hazard (D8).
+
+**Files:**
+- Modify: `swiftui/PyMOLViewer/Shared/DesignController.swift` (~lines 230, 388–392, 750–762, 788)
+- Modify: `swiftui/PyMOLViewer/Shared/ContentView.swift` (~lines 843, 3730–3746, 3789, 3844–3867)
+- Modify: `swiftui/PyMOLViewer/Shared/DesignCompactPanel.swift` (~lines 174–183, 220–237)
+- Test: `swiftui/PyMOLViewerTests/DesignIOSPortTests.swift` (~lines 445–500, 549–590)
+
+**Interfaces:**
+- Consumes: `tapResidue(residueIndex:)`, `syncFromSele()` (Tasks 3–4).
+- Produces: no new API. Removes `DesignController.regionEditMode`, `ContentView.regionEditToggle`, and `DesignCompactPanel.regionEditButton`.
+
+- [ ] **Step 1: Rewrite the tests that encode the old rule**
+
+In `swiftui/PyMOLViewerTests/DesignIOSPortTests.swift`, replace `testTapPinsWhenRegionEditModeIsOff`, `testTapTogglesRegionWhenRegionEditModeIsOn`, and `testTapIgnoresInvalidResiduesInRegionEditMode` with the count-driven equivalents (keep every other test in the file untouched):
+
+```swift
+    // One tap pins for inspection; the region stays empty so the propensity pills
+    // still show. This is the single-residue behaviour the change preserves.
+    func testSingleTapPinsAndDoesNotBuildARegion() {
+        let c = makeController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
+
+        c.tapResidue(residueIndex: 1)
+
+        XCTAssertEqual(c.pinnedResidueIndex, 1)
+        XCTAssertTrue(c.selectedResidueIndices.isEmpty,
+                      "one residue must not enter region mode")
+    }
+
+    // A second tap on a different residue turns the selection into a region and
+    // drops the pin — no mode toggle involved.
+    func testSecondTapBuildsRegionAndDropsThePin() {
+        let c = makeController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
+
+        c.tapResidue(residueIndex: 1)
+        c.tapResidue(residueIndex: 0)
+        XCTAssertEqual(c.selectedResidueIndices, [0, 1], "region stays sorted")
+        XCTAssertNil(c.pinnedResidueIndex)
+
+        // Tapping a member removes it, dropping back to single-residue mode.
+        c.tapResidue(residueIndex: 1)
+        XCTAssertTrue(c.selectedResidueIndices.isEmpty)
+        XCTAssertEqual(c.pinnedResidueIndex, 0)
+    }
+
+    // Non-designable positions can never be pinned or enter a region, however
+    // many times they are tapped.
+    func testTapIgnoresNonDesignableResidues() {
+        let c = makeController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: [true, false, true])
+
+        c.tapResidue(residueIndex: 1)
+        XCTAssertNil(c.pinnedResidueIndex,
+                     "a residue with no backbone is not designable")
+        XCTAssertTrue(c.selectedResidueIndices.isEmpty)
+
+        // A designable residue alongside it still works normally.
+        c.tapResidue(residueIndex: 2)
+        XCTAssertEqual(c.pinnedResidueIndex, 2)
+    }
+```
+
+Then find the `handleViewportHit` region-edit test near line 564 (`testHandleViewportHit…RegionEditMode…`) and replace it with:
+
+```swift
+    // Two viewport hits on the focus object accumulate into a region, so the
+    // viewport and the sequence strip agree without any mode switch.
+    func testHandleViewportHitAccumulatesRegionOnFocusObject() {
+        let c = makeController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
+
+        c.handleViewportHit(object: "m1", chain: "A", resi: "2", hasResidue: true)
+        XCTAssertEqual(c.pinnedResidueIndex, 1)
+
+        c.handleViewportHit(object: "m1", chain: "A", resi: "3", hasResidue: true)
+        XCTAssertEqual(c.selectedResidueIndices, [1, 2])
+        XCTAssertNil(c.pinnedResidueIndex)
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd swiftui && xcodebuild test -scheme RayMol -destination 'platform=macOS' \
+  -only-testing:PyMOLViewerTests/DesignIOSPortTests 2>&1 | tail -30
+```
+
+Expected: PASS. Unusually for a TDD step these tests pass immediately — Task 4 already made the count-driven rule true — so the point of running them now is to prove the rewrite captures real behaviour rather than accommodating the deletion that follows. The file still references `c.regionEditMode` at the other lines listed above; those references are what stops compiling in Step 3, and they get deleted there.
+
+- [ ] **Step 3: Delete `regionEditMode` from the controller**
+
+In `swiftui/PyMOLViewer/Shared/DesignController.swift`:
+
+- Delete the property and its doc comment (~line 226–230):
+
+```swift
+    /// True while the user is building an ad-hoc region by tapping positions.
+    /// Replaces shift-click, which does not exist on touch (and whose SwiftUI
+    /// modifier is unavailable on iOS). Ships on macOS too — the explicit toggle
+    /// is the discoverable path; shift-click remains as a power-user shortcut.
+    @Published var regionEditMode = false
+```
+
+- Delete the `regionEditMode = false` line from `clearRegionState()` (~line 788).
+- Update the `handleViewportHit` doc comment written in Task 4 if it still mentions region-edit mode (it should not).
+
+- [ ] **Step 4: Delete the macOS toggle and the shift-click gesture**
+
+In `swiftui/PyMOLViewer/Shared/ContentView.swift`:
+
+- In `controls` (~line 3786), delete the `stripDivider` + `regionEditToggle` pair so it reads:
+
+```swift
+    private var controls: some View {
+        HStack(spacing: 8) {
+            selectionButton
+            if controller.regionModeActive {
+                stripDivider
+```
+
+- Delete the entire `private var regionEditToggle: some View { … }` property (~lines 3842–3867) including its leading comment block.
+- In the sequence-strip column (~lines 3730–3746), delete the comment block and the whole `#if os(macOS) .highPriorityGesture(…) #endif` shift gesture, leaving:
+
+```swift
+        .contentShape(Rectangle())
+        .onHover { hovering in
+            if hovering {
+                controller.setHovered(chain: residue.chain, resi: residue.resi)
+            } else {
+                controller.clearHover()
+            }
+        }
+        // A plain tap toggles this position in 'sele' — the same gesture, and the
+        // same meaning, as a click in the viewport or in normal mode.
+        .onTapGesture {
+            controller.tapResidue(residueIndex: i)
+        }
+```
+
+- In the Design-mode click-routing comment (~line 843), drop the sentence about region-edit mode being honoured on macOS; it no longer exists.
+
+- [ ] **Step 5: Delete the iOS toggle**
+
+In `swiftui/PyMOLViewer/Shared/DesignCompactPanel.swift`:
+
+- In `actionRow` (~line 180), delete the `regionEditButton` line so it reads:
+
+```swift
+        HStack(spacing: 8) {
+            regionButton
+            if controller.regionModeActive { redesignButton }
+```
+
+- Update the row's leading comment (~line 174) from `region picker · edit-mode toggle · redesign …` to `region picker · redesign …`.
+- Delete the entire `private var regionEditButton: some View { … }` property (~lines 220–237).
+
+- [ ] **Step 6: Verify no reference survives**
+
+```bash
+grep -rn "regionEditMode\|regionEditButton\|regionEditToggle\|Tap to edit" \
+  swiftui/PyMOLViewer swiftui/PyMOLViewerTests
+```
+
+Expected: no output. (Matches under `swiftui/build_ios_restricted/` or in `docs/superpowers/plans/` are historical and must be left alone — this grep deliberately does not search them.)
+
+- [ ] **Step 7: Run the full design test suite**
+
+```bash
+cd swiftui && xcodebuild test -scheme RayMol -destination 'platform=macOS' \
+  -only-testing:PyMOLViewerTests 2>&1 | tail -40
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add swiftui/PyMOLViewer/Shared/DesignController.swift \
+        swiftui/PyMOLViewer/Shared/ContentView.swift \
+        swiftui/PyMOLViewer/Shared/DesignCompactPanel.swift \
+        swiftui/PyMOLViewerTests/DesignIOSPortTests.swift
+git commit -m "refactor(design): delete the region-edit toggle and shift-click
+
+The count of 'sele' now decides single-vs-region, so the modal toggle has no
+job left on either platform. Shift-click goes with it: once a plain tap toggles
+region membership the gesture is an exact duplicate carrying the double-fire
+no-op hazard its own comment documented, and removing it deletes the sequence
+strip's last #if os(macOS) branch.
+
+Rewrites the four tests that asserted the toggle's behaviour to assert the
+count-driven rule instead.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Wire the engine to real PyMOL closures
+
+Connects the controller's `sele` closures to the Python helpers, makes an iOS empty-space tap reach the controller, and arms the poll digest while Design mode is on.
+
+**Files:**
+- Modify: `swiftui/PyMOLViewer/Shared/PyMOLEngine.swift` (`DesignController(...)` construction ~line 2100+, `designPickResidue` ~line 2854, `setDesignMode` ~line 2173)
+- Test: `swiftui/PyMOLViewerTests/DesignIOSPortTests.swift`
+
+**Interfaces:**
+- Consumes: `sele_design_indices`, `toggle_sele_residue`, `set_sele_residue`, `set_sele_from_selection`, `clear_sele`, `set_design_active` (Tasks 1–2); `injectSele` and `handleViewportHit` (Tasks 3–4).
+- Produces: a fully wired `DesignController`; `designPickResidue` now forwards misses.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `swiftui/PyMOLViewerTests/DesignIOSPortTests.swift`:
+
+```swift
+    // An iOS tap that MISSES must reach the controller as an empty hit so it
+    // clears the selection. The old designPickResidue returned early on a miss,
+    // making empty-space taps silently inert.
+    func testEmptyHitClearsThroughTheSameRouting() {
+        let c = makeController()
+        var clearCalls = 0
+        c.injectSele(clearSele: { clearCalls += 1 })
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
+        c.tapResidue(residueIndex: 0)
+
+        c.handleViewportHit(object: "", chain: "", resi: "", hasResidue: false)
+
+        XCTAssertEqual(clearCalls, 1,
+                       "a miss must clear 'sele' through the injected closure")
+        XCTAssertEqual(c.focusObject, "m1", "a miss must not change focus")
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+```bash
+cd swiftui && xcodebuild test -scheme RayMol -destination 'platform=macOS' \
+  -only-testing:PyMOLViewerTests/DesignIOSPortTests/testEmptyHitClearsThroughTheSameRouting 2>&1 | tail -20
+```
+
+Expected: PASS if Task 4 landed correctly (`clearSeleFn` is called). If it FAILS with `clearCalls == 0`, Task 4's empty-space branch is wrong — fix that before continuing.
+
+- [ ] **Step 3: Wire the five closures**
+
+In `swiftui/PyMOLViewer/Shared/PyMOLEngine.swift`, add these arguments to the `DesignController(...)` construction, next to the existing `selectedIndices:` closure:
+
+```swift
+        seleState: { [weak self] obj, src, state in
+            guard let self else { return (indices: [], digest: "", total: 0) }
+            let srcArg = (src?.isEmpty == false) ? src! : ""
+            self.runPython("""
+                from pymol import raymol_design as _rd
+                _rd.sele_design_indices('\(obj)', \(state), src='\(srcArg)')
+                """)
+            let path = FileManager.default.temporaryDirectory
+                .appendingPathComponent("raymol_design_sele.json")
+            guard let data = FileManager.default.contents(atPath: path.path),
+                  let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { return (indices: [], digest: "", total: 0) }
+            return (indices: (root["indices"] as? [Int]) ?? [],
+                    digest: (root["digest"] as? String) ?? "",
+                    total: (root["n_total"] as? Int) ?? 0)
+        },
+        toggleSele: { [weak self] obj, chain, resi in
+            self?.runPython("""
+                from pymol import raymol_design as _rd
+                _rd.toggle_sele_residue('\(obj)', '\(chain)', '\(resi)')
+                """)
+        },
+        setSeleResidue: { [weak self] obj, chain, resi in
+            self?.runPython("""
+                from pymol import raymol_design as _rd
+                _rd.set_sele_residue('\(obj)', '\(chain)', '\(resi)')
+                """)
+        },
+        setSeleNamed: { [weak self] name in
+            self?.runPython("""
+                from pymol import raymol_design as _rd
+                _rd.set_sele_from_selection('\(name)')
+                """)
+        },
+        clearSele: { [weak self] in
+            self?.runPython("from pymol import raymol_design as _rd; _rd.clear_sele()")
+        },
+```
+
+Then add the matching non-optional init parameters to `DesignController.init` (in `DesignController.swift`), each defaulting to `nil` so existing constructions — including every test helper — keep compiling:
+
+```swift
+                     seleState: SeleStateFn? = nil,
+                     toggleSele: ToggleSeleFn? = nil,
+                     setSeleResidue: SetSeleResidueFn? = nil,
+                     setSeleNamed: SetSeleNamedFn? = nil,
+                     clearSele: ClearSeleFn? = nil,
+```
+
+and in the init body:
+
+```swift
+        self.seleStateFn = seleState
+        self.toggleSeleFn = toggleSele
+        self.setSeleResidueFn = setSeleResidue
+        self.setSeleNamedFn = setSeleNamed
+        self.clearSeleFn = clearSele
+```
+
+- [ ] **Step 4: Forward iOS misses**
+
+Replace the body of `designPickResidue` in `PyMOLEngine.swift` with:
+
+```swift
+    func designPickResidue(ndcX: Float, ndcY: Float, aspect: Float) {
+        guard designMode, isReady else { return }
+        runPython("from pymol import metal_pick as _mp; _mp.hover_design_at(\(ndcX), \(ndcY), \(aspect))")
+        let path = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("pymol_hover_design.json")
+        var obj = "", chain = "", resi = ""
+        var hit = false
+        if let data = FileManager.default.contents(atPath: path),
+           let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            hit   = (root["hit"] as? Bool) ?? false
+            obj   = root["obj"]   as? String ?? ""
+            chain = root["chain"] as? String ?? ""
+            resi  = root["resi"]  as? String ?? ""
+        }
+        // A MISS must still reach the controller: an empty-space tap clears the
+        // selection (normal-mode parity). The previous early return on `hit ==
+        // false` made empty taps silently inert. An empty `object` is exactly what
+        // the macOS path already delivers on a miss (longPressPick builds
+        // LongPressHit with obj: "" and isEmpty: true), so both platforms converge.
+        MainActor.assumeIsolated {
+            designController.handleViewportHit(object: hit ? obj : "",
+                                               chain: chain, resi: resi,
+                                               hasResidue: hit)
+        }
+    }
+```
+
+- [ ] **Step 5: Arm the digest while Design mode is on**
+
+In `setDesignMode(_:)` in `PyMOLEngine.swift`, replace the final `designMode = on` with:
+
+```swift
+        designMode = on
+        // Arm/disarm the Design-mode 'sele' digest that poll_panel computes. Off ⇒
+        // that 500 ms main-thread poll pays one boolean check (see raymol_design
+        // .sele_digest), which is why this must be toggled rather than always on.
+        runPython("from pymol import raymol_design as _rd; _rd.set_design_active(\(on ? 1 : 0))")
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+```bash
+cd swiftui && xcodebuild test -scheme RayMol -destination 'platform=macOS' \
+  -only-testing:PyMOLViewerTests 2>&1 | tail -40
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add swiftui/PyMOLViewer/Shared/PyMOLEngine.swift \
+        swiftui/PyMOLViewer/Shared/DesignController.swift \
+        swiftui/PyMOLViewerTests/DesignIOSPortTests.swift
+git commit -m "feat(design): wire the 'sele' closures to the engine
+
+Connects read/toggle/set/named/clear to raymol_design, arms the poll digest
+only while Design mode is on, and forwards iOS viewport MISSES to
+handleViewportHit so an empty-space tap clears the selection the way it does in
+normal mode (it was silently inert).
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Notice `sele` changes made outside Design mode
+
+A `select` typed at the prompt, a Seeker drag, or an object-panel action must also drive Design mode. Piggybacks the existing 500 ms panel poll rather than adding a timer.
+
+**Files:**
+- Modify: `modules/pymol/appkit_inspector.py` (`poll_panel`, after the `payload = {…}` literal ~line 631)
+- Modify: `swiftui/PyMOLViewer/Panels/ObjectPanel.swift` (`PanelPayload` ~line 4072, `parseObjectPanelFeedback` ~line 4140)
+- Test: `testing/tests/raymol/design_region.py`, `swiftui/PyMOLViewerTests/DesignRegionTests.swift`
+
+**Interfaces:**
+- Consumes: `raymol_design.sele_digest()` (Task 1), `DesignController.syncFromSele()` / `lastSeleDigest` (Task 3).
+- Produces: `PanelPayload.design_sele: String?`; a digest-gated `syncFromSele()` call on each poll tick.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `testing/tests/raymol/design_region.py`:
+
+```python
+    def testPollPanelCarriesDesignSeleDigest(self):
+        obj = self._peptide()
+        cmd.select('sele', '%s and resi 2' % obj)
+        from pymol import appkit_inspector as ai
+        from pymol import raymol_design as rd
+        rd.set_design_active(1)
+        try:
+            ai.poll_panel()
+            path = os.path.join(tempfile.gettempdir(),
+                                'pymol_objpanel_%d.json' % os.getpid())
+            with open(path) as f:
+                payload = json.load(f)
+            self.assertTrue(payload.get('design_sele'),
+                            "poll_panel must carry the digest while Design is active")
+            # And it must cost nothing once Design mode is off.
+            rd.set_design_active(0)
+            ai.poll_panel()
+            with open(path) as f:
+                payload = json.load(f)
+            self.assertEqual(payload.get('design_sele'), '')
+        finally:
+            rd.set_design_active(0)
+```
+
+Append to `swiftui/PyMOLViewerTests/DesignRegionTests.swift`:
+
+```swift
+    // The poll must re-derive only when the digest actually changed, so a quiet
+    // 500 ms tick costs nothing.
+    func testSyncFromSeleRecordsTheDigestItResolved() {
+        let c = seleController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: [true, true, true])
+        c.injectSele(seleState: { _, _, _ in (indices: [0], digest: "abc123", total: 1) })
+        c.syncFromSele()
+        XCTAssertEqual(c.lastSeleDigest, "abc123",
+                       "the resolved digest must be recorded for poll gating")
+    }
+
+    // The panel payload's new field must be optional so an older bundled
+    // appkit_inspector.py still decodes (the whole panel would freeze otherwise).
+    func testPanelPayloadDecodesWithoutDesignSele() throws {
+        let json = """
+        {"objects":[],"selections":[],"enabled":[],"sel_counts":{}}
+        """.data(using: .utf8)!
+        let payload = try JSONDecoder().decode(PanelPayload.self, from: json)
+        XCTAssertNil(payload.design_sele)
+    }
+```
+
+- [ ] **Step 2: Run both suites to verify they fail**
+
+```bash
+pymol -ckqy testing/testing.py --run tests/raymol/design_region.py
+cd swiftui && xcodebuild test -scheme RayMol -destination 'platform=macOS' \
+  -only-testing:PyMOLViewerTests/DesignRegionTests 2>&1 | tail -25
+```
+
+Expected: Python FAILs (`design_sele` missing → `assertTrue(None)`); Swift FAILs to compile (`PanelPayload` has no member `design_sele`).
+
+- [ ] **Step 3: Add the digest to the poll payload**
+
+In `modules/pymol/appkit_inspector.py`, immediately after the `payload = { … }` literal closes and **before** `blob = json.dumps(payload)`:
+
+```python
+        # Design-mode selection fingerprint. Computed inside raymol_design and
+        # GATED there on Design mode being active, so this main-thread 500 ms poll
+        # pays a single boolean check whenever Design mode is off (PR #270 made
+        # this tick's cost a standing constraint). Its own try: a failure here must
+        # not cost the panel its update.
+        try:
+            from pymol import raymol_design as _rd
+            payload['design_sele'] = _rd.sele_digest()
+        except Exception:
+            payload['design_sele'] = ''
+```
+
+- [ ] **Step 4: Add the optional payload field**
+
+In `swiftui/PyMOLViewer/Panels/ObjectPanel.swift`, inside `struct PanelPayload: Decodable`, after `msa_searches`:
+
+```swift
+    /// Design-mode 'sele' fingerprint, '' while Design mode is off. Optional for
+    /// the same reason as every field above: a non-optional would fail the whole
+    /// decode against an older bundled appkit_inspector.py and freeze the panel on
+    /// its last list.
+    let design_sele: String?
+```
+
+- [ ] **Step 5: Re-derive when the digest changes**
+
+In `parseObjectPanelFeedback` in the same file, immediately after the `guard let payload = try? JSONDecoder().decode(...)` block:
+
+```swift
+        #if RAYMOL_MPNN
+        // 'sele' is the single source of truth for Design mode, so a selection made
+        // OUTSIDE it — `select` at the prompt, a Seeker drag, the object panel —
+        // must drive it too. Gated on the digest so a quiet tick does no work, and
+        // on designMode so nothing runs when the feature is not in use.
+        if let digest = payload.design_sele, !digest.isEmpty, designMode {
+            MainActor.assumeIsolated {
+                if digest != designController.lastSeleDigest {
+                    designController.syncFromSele()
+                }
+            }
+        }
+        #endif
+```
+
+- [ ] **Step 6: Run both suites to verify they pass**
+
+```bash
+pymol -ckqy testing/testing.py --run tests/raymol/design_region.py
+cd swiftui && xcodebuild test -scheme RayMol -destination 'platform=macOS' \
+  -only-testing:PyMOLViewerTests 2>&1 | tail -40
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add modules/pymol/appkit_inspector.py \
+        swiftui/PyMOLViewer/Panels/ObjectPanel.swift \
+        testing/tests/raymol/design_region.py \
+        swiftui/PyMOLViewerTests/DesignRegionTests.swift
+git commit -m "feat(design): pick up 'sele' changes made outside Design mode
+
+Piggybacks the existing 500 ms panel poll with a design-mode-gated digest, so a
+'select' typed at the prompt or a Seeker drag becomes the design region without
+adding a second timer. The re-derive is skipped whenever the digest is
+unchanged, and the payload field is optional so an older bundled Python still
+decodes.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Surface off-focus residues, then verify on both platforms
+
+A small honesty fix — residues selected on other structures are silently ignored by design, so say so — followed by the manual verification this repo's CI cannot do.
+
+**Files:**
+- Modify: `swiftui/PyMOLViewer/Shared/ContentView.swift` (`controls`, ~line 3786)
+- Modify: `swiftui/PyMOLViewer/Shared/DesignCompactPanel.swift` (`actionRow`, ~line 178)
+
+**Interfaces:**
+- Consumes: `DesignController.seleResiduesOffFocus` (Task 3).
+- Produces: no new API.
+
+- [ ] **Step 1: Add the hint to the macOS region strip**
+
+In `ContentView.swift`, inside `DesignRegionStripView.controls`, immediately after `selectionButton`:
+
+```swift
+            if controller.seleResiduesOffFocus > 0 {
+                Text("+\(controller.seleResiduesOffFocus) off-structure")
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundColor(theme.active.panelText.color.opacity(0.5))
+                    .help("Selected residues on other structures. Design only ever "
+                          + "works on the focused structure, so these are ignored.")
+            }
+```
+
+- [ ] **Step 2: Add the same hint to the iOS panel**
+
+In `DesignCompactPanel.swift`, inside `actionRow`, immediately after `regionButton`:
+
+```swift
+            if controller.seleResiduesOffFocus > 0 {
+                Text("+\(controller.seleResiduesOffFocus)")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(theme.active.panelText.color.opacity(0.5))
+                    .accessibilityLabel(
+                        "\(controller.seleResiduesOffFocus) selected residues on other structures, ignored")
+            }
+```
+
+- [ ] **Step 3: Compile the macOS target the two-stage way**
+
+The core must be built BEFORE `xcodebuild`, or `xcodebuild` silently links a stale `libpymol_core.a` and you test old code:
+
+```bash
+pip install --verbose --no-build-isolation --config-settings testing=True .
+cd swiftui && xcodegen generate && \
+  xcodebuild -scheme RayMol -destination 'platform=macOS' \
+  -skipPackagePluginValidation build 2>&1 | tail -20
+```
+
+Expected: `BUILD SUCCEEDED`.
+
+- [ ] **Step 4: Compile the iOS target by hand**
+
+CI never compiles iOS, and `ContentView.swift` has leaked platform-only symbols in both directions before (#174, #226, #238). This step is the only thing that catches it:
+
+```bash
+cd swiftui && xcodebuild -scheme PyMOLViewer_iOS \
+  -destination 'generic/platform=iOS Simulator' \
+  -skipPackagePluginValidation build 2>&1 | tail -20
+```
+
+Expected: `BUILD SUCCEEDED`. If it fails on a symbol the macOS build accepted, that symbol is macOS-only and needs a `#if os(macOS)` guard or a cross-platform replacement.
+
+- [ ] **Step 5: Run the whole Swift and Python design suites**
+
+```bash
+cd swiftui && xcodebuild test -scheme RayMol -destination 'platform=macOS' \
+  -only-testing:PyMOLViewerTests 2>&1 | tail -40
+```
+
+```bash
+pymol -ckqy testing/testing.py --run tests/raymol/design_region.py
+pymol -ckqy testing/testing.py --run tests/raymol/design_editing.py
+pymol -ckqy testing/testing.py --run tests/raymol/design_enumerate.py
+pymol -ckqy testing/testing.py --run tests/raymol/design_color.py
+pymol -ckqy testing/testing.py --run tests/raymol/design_saverestore.py
+```
+
+Expected: all PASS. Report actual output; do not claim success without it.
+
+- [ ] **Step 6: Functional check in a disposable macOS VM**
+
+Use the `mac-vm-test` (or `raymol-mac-vm`) skill — never the host UI. Load a structure, enter Design mode, and confirm each row of the behaviour table:
+
+1. Click one residue → propensity pills become live, residue badge shows the label, the pink marker appears.
+2. Click a second residue → palette row replaces the pills, "Redesign selection · 2 res" appears, both residues pink.
+3. Click one of the two again → back to single-residue mode with pills.
+4. Click empty space → selection clears, pills grey out, focus unchanged.
+5. With two structures loaded, click a residue on the non-focus one → design retargets to it AND that residue is selected in one click.
+6. Type `select sele, resi 10-14` at the prompt → within ~500 ms the region shows 5 residues without any click.
+7. Press Redesign → it runs once; it must NOT have fired on any of the clicks above.
+8. Exit Design mode → `sele` survives (D2); the pink markers remain.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add swiftui/PyMOLViewer/Shared/ContentView.swift \
+        swiftui/PyMOLViewer/Shared/DesignCompactPanel.swift
+git commit -m "feat(design): show how many selected residues design is ignoring
+
+Residues selected on non-focus structures are scoped out of the region, which
+was silent. Both panels now report the count.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Notes for the executor
+
+- **`focusAwait` is async.** Any code that sets a selection right after changing focus must await the focus first, or `syncFromSele()` resolves indices against the previous object's residue set. `focusThenSelect` in Task 4 exists solely for this.
+- **`stickKey` is the shared residue-key encoding** (`"chain\u{1}resi"`). The in-memory `sele` fallback reuses it deliberately; do not introduce a second encoding.
+- **Do not add `cmd.enable('sele')` anywhere new.** The Python helpers already pass `enable=1`, and `cmd.enable` is exclusive for selections — an extra call risks disabling `_preselect`-adjacent state.
+- **`pinnedResidueIndex` is derived.** If a new feature needs to pin something, it must go through `sele`, not assign the property.

--- a/docs/superpowers/specs/2026-08-19-design-mode-multi-residue-selection-design.md
+++ b/docs/superpowers/specs/2026-08-19-design-mode-multi-residue-selection-design.md
@@ -138,10 +138,13 @@ identity). Passing `selection='sele'` is sufficient; no new mapping logic.
   `(chain, resi)` set for change detection; `n_total` is the residue count of
   `sele` across all objects, so the UI can tell "nothing selected" from
   "selected, but on another structure".
-- `toggle_sele_residue(obj, chain, resi)` — add/remove one residue in `sele`
-  using the same idiom as `pick_at` (`cmd.select('sele', ..., enable=1)`), and
-  `set_sele_residue(obj, chain, resi)` / `clear_sele()` for the refocus and
-  empty-space cases.
+- `toggle_sele_residue(obj, chain, resi, src='')` — add/remove one residue in
+  `sele` using the same idiom as `pick_at` (`cmd.select('sele', ..., enable=1)`),
+  and `set_sele_residue(obj, chain, resi, src='')` / `clear_sele()` for the
+  refocus and empty-space cases. The writers take `src` and resolve the residue
+  through the same `_scope(obj, src)` the readers use — a WRITE scoped to the
+  focus object alone disagrees with the residue-identity READ from the first
+  mutation of an edit session onward (see D9).
 - `set_design_active(on)` — module flag read by the poll (see Refresh).
 - `set_pinned_indicator` keeps its definition but loses every call site: nothing in
   the pin path or in `exit()` writes `sele` outward any more (see D2).
@@ -196,9 +199,23 @@ gains the `sele` digest, computed **only while design mode is active** (the
 digest differs from the last one seen.
 
 This gate matters: `poll_panel` runs on the main thread every 500 ms and is a
-previously measured hot spot (PR #270 fixed a 713 ms tick on a large `.pse`). With
-design mode off the added cost is one boolean check. With it on, the work is
-O(selected residues), which is normally a handful.
+previously measured hot spot (PR #270 fixed a 713 ms tick on a large `.pse`). Three
+tiers of cost:
+
+- **Design mode off** — one boolean check (`set_design_active`'s flag), nothing else.
+- **Design mode on, `sele` unchanged** — the digest only: one `cmd.iterate` over
+  the guide atoms of `sele`, i.e. O(selected residues), plus an md5 of the key
+  list. The digest matches, so Swift skips the re-derive.
+- **Design mode on, `sele` changed** — the re-derive runs `sele_design_indices`,
+  and that is **not** O(selected residues): it calls `_obj_residue_order(obj)`, a
+  `cmd.iterate` with a Python callback over EVERY guide residue of the focus
+  object, plus a second `iterate` over `sele ∩ scope`. So the changed-tick cost is
+  O(residues in the focus object) on the main thread — the same shape as the PR
+  #270 hot path, though bounded by one focus object rather than a whole session,
+  and it cannot recur faster than 2 Hz or without the selection actually changing.
+
+The digest gate is therefore load-bearing, not an optimisation: it is what keeps
+the O(object) work off the quiet ticks.
 
 ## Decisions
 
@@ -235,6 +252,16 @@ O(selected residues), which is normally a handful.
   "toggled twice — added then removed — a silent no-op". Deleting it also removes
   the last `#if os(macOS)` divergence in the sequence strip, which is valuable given
   this file's history of platform-only symbols leaking across targets.
+- **D9 — `sele` writes are scoped identically to `sele` reads.** Both sides go
+  through `_scope(obj, src)`, so a residue is addressed by `(chain, resi)` identity
+  across an edit session's working copy and its original, not by object membership.
+  Two consequences are deliberate: a scoped "add" marks the residue on *both*
+  objects (which is what makes it survive a repack's topology replace of the
+  working copy), and `_sele_residue_keys()` therefore folds `<src>_designNN` onto
+  `<src>` so one residue marked twice is still counted once — otherwise `n_total`
+  exceeds the in-scope count and the UI invents a "+N on another structure" badge.
+  Asymmetric scoping made a region member impossible to remove mid-session and let
+  every repack silently shrink the region.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-08-19-design-mode-multi-residue-selection-design.md
+++ b/docs/superpowers/specs/2026-08-19-design-mode-multi-residue-selection-design.md
@@ -20,7 +20,8 @@ residue can be active at a time. Multi-residue selection *does* exist
 
 - the "Select region…" lasso dropdown (named selections), or
 - flipping the modal **"Tap to edit region"** toggle (`regionEditMode`, the
-  `hand.tap` button) so that taps call `toggleRegionResidue` instead of pinning.
+  `hand.tap` button) so that taps call `toggleRegionResidue` instead of pinning, or
+- on macOS only, shift-clicking a column of the sequence strip.
 
 So the same physical gesture means "replace the single selection" in one mode and
 "add to the selection" in the other, and the multi-select path is behind a mode
@@ -50,7 +51,8 @@ output of design mode rather than its input.
   click and discard every intermediate result.)
 - Single-residue redesign through the region path. One residue keeps the
   propensity-pill route, which already expresses "mutate this position".
-- Removing the `regionEditMode` toggle (see Decision D6).
+- Reworking the design overlay's layout, coloring modes, repack, or compare paths.
+  This change is confined to how a selection is made and how the mode is derived.
 
 ## Behavior specification
 
@@ -175,9 +177,11 @@ identity). Passing `selection='sele'` is sufficient; no new mapping logic.
 
 **`ContentView.swift`** (macOS design bar) and **`DesignCompactPanel.swift`** (iOS)
 
-- Sequence-strip clicks route through the same toggle path; shift-click remains as
-  a harmless alias for the same action.
-- The `regionEditMode` button stays but no longer changes behavior (D6).
+- Sequence-strip clicks route through the same toggle path as viewport clicks; the
+  macOS-only shift-click gesture is deleted (D8), removing the strip's last
+  `#if os(macOS)` branch.
+- The region-edit toggle is deleted from both the macOS design bar
+  (`regionEditToggle`) and the iOS compact panel (`regionEditButton`) (D6).
 
 ## Refresh: noticing external `sele` changes
 
@@ -217,11 +221,20 @@ O(selected residues), which is normally a handful.
   residue shows transient sticks. Showing sticks for every region member would
   explode on a large region, and the global "show sidechains" toggle already
   covers that intent.
-- **D6 — `regionEditMode` is kept but inert.** Its branch in `tapResidue` is
-  removed; the button and the published flag remain so existing call sites and
-  accessibility labels keep working. *Known cost:* a control that changes nothing
-  usually reads as a bug. Removing it (button + flag + tests) or repurposing it as
-  a "lock region" affordance are both small follow-ups.
+- **D6 — `regionEditMode` is removed entirely.** The count of `sele` now decides
+  single-vs-region, so the modal toggle has no job left, and a control that changes
+  nothing reads as a bug. Deleted: the `@Published var regionEditMode`, its branch
+  in `tapResidue`, its reset in `clearRegionState`, `regionEditToggle` in
+  `ContentView.swift`, and `regionEditButton` in `DesignCompactPanel.swift`. No
+  XCUITest depends on its `"Tap to edit region"` accessibility label (only
+  historical plan docs mention it, which stay untouched).
+- **D8 — The macOS shift-click shortcut is removed too.** Once a plain tap toggles
+  region membership, `TapGesture().modifiers(.shift)` calling
+  `toggleRegionResidue` is an exact duplicate of the plain tap. Its own comment
+  documents the hazard: if SwiftUI ever delivered both, the position would be
+  "toggled twice — added then removed — a silent no-op". Deleting it also removes
+  the last `#if os(macOS)` divergence in the sequence strip, which is valuable given
+  this file's history of platform-only symbols leaking across targets.
 
 ## Testing
 
@@ -263,10 +276,14 @@ behavior this change removes, and will fail until updated:
 - `testTapIgnoresInvalidResiduesInRegionEditMode` — same premise; keep the
   invalid-residue assertion but drop the `regionEditMode` framing.
 
-This is the concrete cost of D6: the only tests that prove the toggle does anything
-are the ones the change invalidates. `testTapPinsWhenRegionEditModeIsOff` and the
-stick-ownership tests at `DesignIOSPortTests:1032` / `DesignEditingTests:363`
-survive unchanged (verified against the new semantics).
+Because D6 deletes `regionEditMode`, both of these stop compiling rather than
+merely failing, so they are rewritten (not deleted) to assert the count-driven rule
+— the multi-residue coverage they provide is exactly what this change needs.
+`testTapPinsWhenRegionEditModeIsOff` loses its `regionEditMode` assertion but keeps
+its body. `testHandleViewportHitRegionEditMode` (`DesignIOSPortTests:564`) likewise
+becomes a plain multi-tap test. The stick-ownership tests at
+`DesignIOSPortTests:1032` and `DesignEditingTests:363` survive unchanged (verified
+against the new semantics).
 
 **Manual / functional**
 

--- a/docs/superpowers/specs/2026-08-19-design-mode-multi-residue-selection-design.md
+++ b/docs/superpowers/specs/2026-08-19-design-mode-multi-residue-selection-design.md
@@ -132,12 +132,17 @@ identity). Passing `selection='sele'` is sufficient; no new mapping logic.
 **`modules/pymol/raymol_design.py`**
 
 - `design_selection_state(obj, state, src='')` — writes
-  `$TMPDIR/raymol_design_sele.json` = `{'indices': [int], 'digest': str, 'n_total': int}`.
+  `$TMPDIR/raymol_design_sele.json` =
+  `{'indices': [int], 'digest': str, 'n_off': int, 'n_total': int}`.
   `indices` is `sele ∩ scope` in guide order (same contract as
   `selected_design_indices`); `digest` is a cheap fingerprint of the selected
-  `(chain, resi)` set for change detection; `n_total` is the residue count of
-  `sele` across all objects, so the UI can tell "nothing selected" from
-  "selected, but on another structure".
+  `(model, chain, resi)` set for change detection; **`n_off`** is the number of
+  selected residues lying OUTSIDE the scope (on neither `obj` nor `src`), which is
+  what lets the UI say "selected, but on another structure". `n_total` is the count
+  of distinct `(model, chain, resi)` keys and is **not** a residue count — during an
+  edit session one residue marked on both the working copy and the original counts
+  twice in it — so `n_off` must be read directly and never reconstructed as
+  `n_total - len(indices)`.
 - `toggle_sele_residue(obj, chain, resi, src='')` — add/remove one residue in
   `sele` using the same idiom as `pick_at` (`cmd.select('sele', ..., enable=1)`),
   and `set_sele_residue(obj, chain, resi, src='')` / `clear_sele()` for the
@@ -255,13 +260,32 @@ the O(object) work off the quiet ticks.
 - **D9 — `sele` writes are scoped identically to `sele` reads.** Both sides go
   through `_scope(obj, src)`, so a residue is addressed by `(chain, resi)` identity
   across an edit session's working copy and its original, not by object membership.
-  Two consequences are deliberate: a scoped "add" marks the residue on *both*
-  objects (which is what makes it survive a repack's topology replace of the
-  working copy), and `_sele_residue_keys()` therefore folds `<src>_designNN` onto
-  `<src>` so one residue marked twice is still counted once — otherwise `n_total`
-  exceeds the in-scope count and the UI invents a "+N on another structure" badge.
   Asymmetric scoping made a region member impossible to remove mid-session and let
   every repack silently shrink the region.
+
+  A scoped "add" therefore marks the residue on **both** objects, deliberately:
+  that is what survives `load_repacked`'s topology replace of the working copy.
+  Three consequences follow, and each is handled where the information to handle it
+  exists:
+
+  - **The off-structure count is reported, never derived.** `sele_design_indices`
+    knows `obj` and `src`, so it counts the selected residues whose model is
+    neither and publishes `n_off`; Swift uses it verbatim. The digest stays keyed
+    on the RAW `(model, chain, resi)` — no canonicalisation of working-copy names —
+    because the digest guards the re-derive and must be at least as sensitive as
+    the state it guards. Folding `<src>_designNN` onto `<src>` was tried and
+    rejected: its precondition is name shape plus source existence, so two
+    independent structures named `foo` and `foo_design` collapse, and moving the
+    same residue selection from one to the other leaves the digest unchanged — the
+    poll skips, and the region never arms.
+  - **Ending a session by KEEPING the copy narrows `sele` off it**
+    (`drop_object_from_sele`). Keep clears `editSourceObject` while the copy lives
+    on, so nothing could address it again; the membership would be stuck selected
+    and pink with no way to clear it.
+  - **A repack re-asserts `sele` onto the replaced object.** `load_repacked(obj,
+    pdb, src)` captures `sele ∩ scope` before the delete and re-selects it on the
+    replacement, because the surviving membership lives on the original — which
+    `make_working_copy` disabled, so nothing visible would carry the pink pass.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-08-19-design-mode-multi-residue-selection-design.md
+++ b/docs/superpowers/specs/2026-08-19-design-mode-multi-residue-selection-design.md
@@ -1,0 +1,287 @@
+# Design-mode multi-residue selection
+
+**Date:** 2026-08-19
+**Branch:** `claude/residue-design-selection-7ca455`
+**Platforms:** macOS + iOS (Design mode is gated on `RAYMOL_MPNN`, now enabled for both)
+
+## Problem
+
+Design mode and normal (viewing) mode disagree about what a click means.
+
+In **normal mode**, a viewport click runs `metal_pick.pick_at`, which *toggles* the
+picked residue in and out of PyMOL's `sele`. Clicking three residues selects three;
+clicking a selected one removes it; clicking empty space clears. Multi-residue
+selection is the default and needs no ceremony.
+
+In **design mode**, a click runs `DesignController.handleViewportHit` →
+`tapResidue` → `setPinned`, which sets a single `pinnedResidueIndex`. Only one
+residue can be active at a time. Multi-residue selection *does* exist
+(`selectedResidueIndices`) but is reachable only via:
+
+- the "Select region…" lasso dropdown (named selections), or
+- flipping the modal **"Tap to edit region"** toggle (`regionEditMode`, the
+  `hand.tap` button) so that taps call `toggleRegionResidue` instead of pinning.
+
+So the same physical gesture means "replace the single selection" in one mode and
+"add to the selection" in the other, and the multi-select path is behind a mode
+switch users must discover. That inconsistency is the bug.
+
+Additionally the data flow is inverted: `setPinned` owns `pinnedResidueIndex` and
+then *pushes* a one-residue `sele` outward via `raymol_design.set_pinned_indicator`
+purely so the renderer draws a pink committed-selection marker. `sele` is an
+output of design mode rather than its input.
+
+## Goals
+
+1. A plain click in design mode builds a multi-residue selection exactly as it
+   does in normal mode.
+2. One residue selected → today's single-residue behavior is preserved verbatim
+   (propensity pill row, tap-a-pill to mutate).
+3. Two or more selected → the region is automatically designated on `sele`, so the
+   "Redesign selection · N res" action targets it with no dropdown step.
+4. `sele` becomes the single source of truth, so a selection made anywhere —
+   Seeker/sequence panel, `select` at the command line, the object panel — drives
+   design mode too.
+
+## Non-goals
+
+- Auto-*running* a redesign. Reaching 2+ residues arms the Redesign button; MPNN
+  inference fires only on an explicit press. (Auto-run would burn an inference per
+  click and discard every intermediate result.)
+- Single-residue redesign through the region path. One residue keeps the
+  propensity-pill route, which already expresses "mutate this position".
+- Removing the `regionEditMode` toggle (see Decision D6).
+
+## Behavior specification
+
+### Click → `sele`
+
+| Click target | Effect |
+|---|---|
+| Residue on the focus object, not in `sele` | add that residue to `sele` |
+| Residue on the focus object, already in `sele` | remove that residue from `sele` |
+| Residue on a **different** object | refocus design to that object, then `sele` ← just that residue |
+| Empty space | `sele` ← `none` |
+
+Clicking an already-selected residue both deselects and unpins. The old
+single-residue behavior (`setPinned` toggles the pin off when the same residue is
+clicked twice) already agreed with normal-mode toggle semantics, so the two
+unify without a special case.
+
+### `sele` → mode
+
+Let `N` = number of designable residues in `sele ∩ scope(focusObject, editSourceObject)`.
+
+| `N` | Resulting state |
+|---|---|
+| 0 | `pinnedResidueIndex = nil`, `selectedResidueIndices = []`. Propensity row renders in its existing greyed/idle form. |
+| 1 | `pinnedResidueIndex = i`, `selectedResidueIndices = []`. `regionModeActive` stays `false`, so the propensity pill row and pill-tap mutation behave exactly as today. |
+| ≥2 | `pinnedResidueIndex = nil`, `selectedResidueIndices = [...]`. `regionModeActive` becomes `true`, so the palette row replaces the pills and "Redesign selection · N res" is armed. |
+
+Keeping `selectedResidueIndices` empty at `N == 1` is deliberate: `regionModeActive`
+is defined as `!selectedResidueIndices.isEmpty` and gates the pills-vs-palette
+switch, so this preserves goal 2 without editing every consumer.
+
+Residues that are not designable (missing backbone, `valid == false`) are dropped
+from the count and from the region, as `pickSelection` already does.
+
+The region's label (`selectedSelectionName`, shown on the lasso button) follows the
+last explicit designation: `pickSelection(name)` records `name`, and any subsequent
+click clears that record so the label falls back to `"sele"`. This keeps a
+dropdown-chosen region readable as e.g. `interface` while a click-built one reads
+as `sele`.
+
+`sele` residues that live on objects other than the focus object are ignored for
+design purposes — they still render pink, but the region is always
+`sele ∩ focus object`. This falls out of reusing the existing `_scope` helper.
+
+## Architecture
+
+### Inverting the data flow
+
+```
+click ──▶ toggle residue in 'sele'   (Python, residue-scoped)
+              │
+              ▼
+        syncFromSele()               (Swift, @MainActor)
+              │  sele ∩ scope(focus, editSource) → full-length guide indices
+              │  → filter to valid
+              │
+              ├─▶ N == 1  → pinnedResidueIndex = i,   selectedResidueIndices = []
+              └─▶ N >= 2  → pinnedResidueIndex = nil, selectedResidueIndices = [...]
+```
+
+`pinnedResidueIndex` and `selectedResidueIndices` remain `@Published` properties
+(much of the UI reads them) but become **derived state, written only by
+`syncFromSele()`**. The outward `sele` write in `set_pinned_indicator` leaves the
+pin path entirely: the pink marker *is* `sele`, which the renderer already draws.
+
+### Reuse
+
+`raymol_design.selected_design_indices(obj, selection, state, src)` already does
+the hard part — it maps a named selection to full-length residue indices in the
+object's canonical guide order, and its `_scope(obj, src)` already covers the
+edit-session case where the focus object is the working copy `foo_design01` while
+the selection was made on the original `foo` (matched by `(chain, resi)`
+identity). Passing `selection='sele'` is sufficient; no new mapping logic.
+
+### New / changed surfaces
+
+**`modules/pymol/raymol_design.py`**
+
+- `design_selection_state(obj, state, src='')` — writes
+  `$TMPDIR/raymol_design_sele.json` = `{'indices': [int], 'digest': str, 'n_total': int}`.
+  `indices` is `sele ∩ scope` in guide order (same contract as
+  `selected_design_indices`); `digest` is a cheap fingerprint of the selected
+  `(chain, resi)` set for change detection; `n_total` is the residue count of
+  `sele` across all objects, so the UI can tell "nothing selected" from
+  "selected, but on another structure".
+- `toggle_sele_residue(obj, chain, resi)` — add/remove one residue in `sele`
+  using the same idiom as `pick_at` (`cmd.select('sele', ..., enable=1)`), and
+  `set_sele_residue(obj, chain, resi)` / `clear_sele()` for the refocus and
+  empty-space cases.
+- `set_design_active(on)` — module flag read by the poll (see Refresh).
+- `set_pinned_indicator` keeps its definition but loses every call site: nothing in
+  the pin path or in `exit()` writes `sele` outward any more (see D2).
+
+**`swiftui/PyMOLViewer/Shared/DesignController.swift`**
+
+- New injected closures (matching the existing closure-injection pattern so unit
+  tests keep bypassing PyMOL): `SeleStateFn` (read indices + digest),
+  `ToggleSeleFn`, `SetSeleFn`, `ClearSeleFn`.
+  Their **defaults maintain an in-memory residue set** rather than being no-ops, so
+  the state machine is exercisable without PyMOL. This matters for existing tests:
+  `DesignEditingTests` calls `setPinned(chain:resi:)` and then asserts
+  `pinnedResidueIndex == 1`, which would fail against no-op stubs now that the
+  property is derived. With the in-memory default those assertions keep passing
+  unchanged.
+- `syncFromSele()` — the state machine above.
+- `tapResidue(residueIndex:)` — toggles `sele`, then syncs. No longer branches on
+  `regionEditMode`.
+- `handleViewportHit(object:chain:resi:hasResidue:)` — extended to the four-row
+  table above; empty `object` now clears `sele` instead of no-op'ing.
+- `pickSelection(name)` — sets `sele ← name`, then syncs, so one truth remains.
+- `clearSelection()` — clears `sele`, then syncs.
+- `setPinned` — retained for the sequence-strip/test call sites but reduced to a
+  `sele` toggle + sync; it no longer writes `pinnedResidueIndex` directly.
+
+**`swiftui/PyMOLViewer/Shared/PyMOLEngine.swift`**
+
+- Wire the new closures.
+- `designPickResidue` (iOS) currently early-returns when the pick misses, so an
+  empty-space tap cannot clear. Change it to call
+  `handleViewportHit(object: "", …, hasResidue: false)` on a miss.
+- Set the Python design-active flag on design enter/exit.
+
+**`ContentView.swift`** (macOS design bar) and **`DesignCompactPanel.swift`** (iOS)
+
+- Sequence-strip clicks route through the same toggle path; shift-click remains as
+  a harmless alias for the same action.
+- The `regionEditMode` button stays but no longer changes behavior (D6).
+
+## Refresh: noticing external `sele` changes
+
+Design-mode clicks refresh synchronously, so the poll is only a backstop for
+changes made *outside* design mode (a typed `select`, a Seeker drag, the object
+panel).
+
+Rather than adding a timer, piggyback the existing 500 ms
+`appkit_inspector.poll_panel` tick, which already gathers selection *names*. It
+gains the `sele` digest, computed **only while design mode is active** (the
+`set_design_active` flag). Swift re-derives via `syncFromSele()` only when the
+digest differs from the last one seen.
+
+This gate matters: `poll_panel` runs on the main thread every 500 ms and is a
+previously measured hot spot (PR #270 fixed a 713 ms tick on a large `.pse`). With
+design mode off the added cost is one boolean check. With it on, the work is
+O(selected residues), which is normally a handful.
+
+## Decisions
+
+- **D1 — Clicks always expand to residue scope**, ignoring `mouse_selection_mode`.
+  With that setting on *atom* (0), `_mode_expr` returns a single-atom expression;
+  `selected_design_indices` matches through `guide` atoms, so picking a side-chain
+  atom would map to **zero** residues — a click that silently selects nothing.
+  Design operates on residues, so residue scope is forced. Whole-chain regions
+  remain reachable via the lasso dropdown or a Seeker chain-select.
+- **D2 — Exiting design mode no longer clears `sele`.** Today `exit()` sends
+  `pinnedIndicatorFn("", "", "")`, wiping the selection. Once `sele` is the user's
+  ordinary selection, destroying it on a mode change is the surprising behavior.
+- **D3 — 2+ residues auto-*designate*, never auto-run.** See Non-goals.
+- **D4 — A click on a non-focus object refocuses *and* selects that residue**, so
+  there is no dead first click. Previously it refocused and discarded the selection.
+- **D5 — The lasso dropdown stays**, rewritten to set `sele` rather than snapshot
+  its own copy.
+- **D7 — Sidechain sticks stay tied to `{pinned} ∪ {hovered}`.** `reconcileSticks`
+  is not extended to the region: at `N >= 2` the pin is `nil`, so only the hovered
+  residue shows transient sticks. Showing sticks for every region member would
+  explode on a large region, and the global "show sidechains" toggle already
+  covers that intent.
+- **D6 — `regionEditMode` is kept but inert.** Its branch in `tapResidue` is
+  removed; the button and the published flag remain so existing call sites and
+  accessibility labels keep working. *Known cost:* a control that changes nothing
+  usually reads as a bug. Removing it (button + flag + tests) or repurposing it as
+  a "lock region" affordance are both small follow-ups.
+
+## Testing
+
+TDD. This repo hand-lists test files in CI, so tests go into files already
+registered rather than new unregistered ones (a new file must also be added to
+`.github/workflows/raymol-embedded-tests.yml`).
+
+**Python — `testing/tests/raymol/design_region.py`** (already in CI)
+
+- `design_selection_state` returns guide-order indices for a 1-residue, 3-residue,
+  and empty `sele`.
+- Non-designable (missing-backbone) residues are dropped.
+- A `sele` spanning two objects yields only the focus object's residues.
+- A `sele` made on the original maps onto the working copy `foo_design01` by
+  `(chain, resi)` identity.
+- `digest` changes iff the selected residue set changes (stable across a no-op
+  re-select; different for a different set).
+- `toggle_sele_residue` adds then removes; `clear_sele` empties.
+
+**Swift — `swiftui/PyMOLViewerTests/DesignRegionTests.swift`**
+
+- `syncFromSele` state machine at N = 0, 1, 2, 3, including the
+  `pinnedResidueIndex` / `selectedResidueIndices` / `regionModeActive` triple.
+- `handleViewportHit`: toggle on focus object; refocus-plus-select on another
+  object; clear on empty space.
+- Sequence-strip tap parity with a viewport tap.
+- Region survives the transition into an edit session (working-copy focus).
+
+**Existing tests that encode the old rule and must be rewritten**
+
+Two blocks in `swiftui/PyMOLViewerTests/DesignIOSPortTests.swift` assert the
+behavior this change removes, and will fail until updated:
+
+- `testTapTogglesRegionWhenRegionEditModeIsOn` — asserts that with
+  `regionEditMode = true` a *single* tap yields `selectedResidueIndices == [1]` and
+  `pinnedResidueIndex == nil`. Under the new rule one tap is always `N == 1`, so it
+  pins. Rewrite to the count-driven rule: one tap pins, a second tap on a different
+  residue produces a 2-residue region with `pinnedResidueIndex == nil`.
+- `testTapIgnoresInvalidResiduesInRegionEditMode` — same premise; keep the
+  invalid-residue assertion but drop the `regionEditMode` framing.
+
+This is the concrete cost of D6: the only tests that prove the toggle does anything
+are the ones the change invalidates. `testTapPinsWhenRegionEditModeIsOff` and the
+stick-ownership tests at `DesignIOSPortTests:1032` / `DesignEditingTests:363`
+survive unchanged (verified against the new semantics).
+
+**Manual / functional**
+
+Both targets must be compiled by hand: no CI workflow runs `PyMOLViewerTests`, and
+CI never compiles the iOS target, so a symbol that leaks across the
+platform boundary is caught only locally. Functional verification of the click
+behavior runs in a disposable macOS VM per the project's testing convention.
+
+## Risks
+
+- **Fighting over `sele`.** Two writers (design mode and `pick_at`) touch the same
+  selection. Mitigated because design mode never runs `pick_at` — `MetalViewport`
+  already routes design-mode clicks down a separate branch.
+- **`cmd.enable('sele')` is exclusive for selections**, so enabling it disables
+  others. This is pre-existing `pick_at` behavior and unchanged here; `_preselect`
+  must stay `enable=0`, as it already is.
+- **Poll cost** if the design-active gate is ever bypassed. Covered by the design-active
+  gate plus the digest, so the re-derive is skipped on unchanged ticks.

--- a/modules/pymol/appkit_inspector.py
+++ b/modules/pymol/appkit_inspector.py
@@ -629,6 +629,16 @@ def poll_panel():
             # the same tick.
             'msa_searches': _search_map(),
         }
+        # Design-mode selection fingerprint. Computed inside raymol_design and
+        # GATED there on Design mode being active, so this main-thread 500 ms poll
+        # pays a single boolean check whenever Design mode is off (PR #270 made
+        # this tick's cost a standing constraint). Its own try: a failure here must
+        # not cost the panel its update.
+        try:
+            from pymol import raymol_design as _rd
+            payload['design_sele'] = _rd.sele_digest()
+        except Exception:
+            payload['design_sele'] = ''
         # Serialise BEFORE opening the file. open(..., 'w') truncates immediately, so
         # doing the dumps inside the `with` leaves a ZERO-BYTE file behind when a value
         # turns out not to be JSON-serialisable -- worse than a stale one, and it takes

--- a/modules/pymol/raymol_design.py
+++ b/modules/pymol/raymol_design.py
@@ -85,26 +85,14 @@ def enumerate_design_residues(obj, state):
     return 'DESIGN_RESIDUES:ready'
 
 
-def _selection_names():
-    """User-facing named selections in the session (includes the active 'sele').
-
-    Excludes PyMOL's internal selections (leading underscore, e.g. '_preselect',
-    '_pkbase2') which are transient machinery, not things a user would redesign.
-    """
-    try:
-        return [n for n in cmd.get_names('selections') if not n.startswith('_')]
-    except Exception:
-        return []
-
-
 def _scope(obj, src):
     """Selection scope covering the target object and (if editing) its source.
 
     A region selection is normally made on the ORIGINAL object; once editing
     begins the focus is the working copy '<obj>_designNN', which has identical
     (chain, resi) residues. Scoping to both means selections made on either
-    resolve to the target structure by residue identity, so they don't vanish
-    from the dropdown the moment a working copy is created.
+    resolve to the target structure by residue identity, so the region does not
+    vanish the moment a working copy is created.
     """
     if src and src != obj:
         return '((%s) or (%s))' % (obj, src)
@@ -150,60 +138,6 @@ def _obj_residue_order(obj):
     except Exception:
         return []
     return order
-
-
-def list_design_selections(obj, state, src=''):
-    """Write user selections that touch the target structure's residues, w/ counts.
-
-    Only selections intersecting the target (obj, plus its source `src` when a
-    working copy is focused) are listed — internal '_' selections are already
-    excluded by _selection_names. Output:
-    $TMPDIR/raymol_design_selections.json = {'selections': [{'name','n'}]}.
-    The count is polymer (guide) residues in the intersection. Returns a marker.
-    """
-    scope = _scope(obj, src)
-    out = []
-    for name in _selection_names():
-        try:
-            n = cmd.count_atoms('%s and (%s) and polymer and guide' % (scope, name))
-        except Exception:
-            n = 0
-        if n > 0:
-            out.append({'name': name, 'n': int(n)})
-    try:
-        with open(_tmp('raymol_design_selections.json'), 'w') as f:
-            json.dump({'selections': out}, f)
-    except Exception:
-        pass
-    return 'DESIGN_SELECTIONS:%d' % len(out)
-
-
-def selected_design_indices(obj, selection, state, src=''):
-    """Map a selection → full-length residue indices in obj's guide order.
-
-    The selection's residues are read within the target scope (obj + `src`), so
-    a selection made on the ORIGINAL object still maps onto the focused working
-    copy by (chain, resi) identity. Output:
-    $TMPDIR/raymol_design_selected.json = {'indices': [int]}. Returns a marker.
-    """
-    # state is accepted for signature symmetry with enumerate_design_residues but
-    # not used here: guide order is read from the current state. Multi-state objects
-    # at a non-default state may misalign; Design-mode editing is single-state (spec).
-    order = _obj_residue_order(obj)
-    scope = _scope(obj, src)
-    sel_res = set()
-    try:
-        cmd.iterate('%s and (%s) and polymer and guide' % (scope, selection),
-                    'sel_res.add((chain, resi))', space={'sel_res': sel_res})
-    except Exception:
-        pass
-    indices = [i for i, cr in enumerate(order) if cr in sel_res]
-    try:
-        with open(_tmp('raymol_design_selected.json'), 'w') as f:
-            json.dump({'indices': indices}, f)
-    except Exception:
-        pass
-    return 'DESIGN_SELECTED:%d' % len(indices)
 
 
 # Design mode active? The selection digest below is O(selected residues) and is
@@ -267,9 +201,9 @@ def sele_digest():
 def sele_design_indices(obj, state, src=''):
     """Map the active 'sele' -> full-length residue indices in obj's guide order.
 
-    The Design-mode counterpart of selected_design_indices, hard-wired to 'sele'
-    so the viewer's ordinary selection is the single source of truth for what
-    Design mode is working on. Scoped through _scope(obj, src) so a selection made
+    Hard-wired to 'sele': the viewer's ordinary selection is the single source of
+    truth for what Design mode is working on, and the only one — there is no
+    named-selection path. Scoped through _scope(obj, src) so a selection made
     on the ORIGINAL object still maps onto a focused working copy by (chain, resi)
     identity once an edit session has begun.
 
@@ -286,8 +220,8 @@ def sele_design_indices(obj, state, src=''):
                  marked on both the working copy and the original counts twice
                  here, which is exactly why n_off exists as its own field
 
-    `state` is accepted for signature symmetry with selected_design_indices and is
-    likewise unused: guide order is read from the current state.
+    `state` is accepted for signature symmetry with enumerate_design_residues but
+    is unused: guide order is read from the current state.
     Returns 'DESIGN_SELE:<n>'.
     """
     order = _obj_residue_order(obj)
@@ -381,18 +315,6 @@ def drop_object_from_sele(obj):
     if not n:
         cmd.select('sele', 'none', enable=0)
     return 'DESIGN_SELE_DROP:%d' % n
-
-
-def set_sele_from_selection(name):
-    """Replace the active 'sele' with the contents of the named selection.
-
-    Backs the lasso dropdown: designating a named region writes it into 'sele' so
-    'sele' stays the single source of truth instead of the controller holding a
-    second, divergent copy. '?name' so a stale name empties the selection rather
-    than raising. Returns 'DESIGN_SELE_NAMED:ok'.
-    """
-    cmd.select('sele', '(?%s)' % name, enable=1)
-    return 'DESIGN_SELE_NAMED:ok'
 
 
 def clear_sele():

--- a/modules/pymol/raymol_design.py
+++ b/modules/pymol/raymol_design.py
@@ -266,6 +266,62 @@ def sele_design_indices(obj, state, src=''):
     return 'DESIGN_SELE:%d' % len(indices)
 
 
+def toggle_sele_residue(obj, chain, resi):
+    """Add or remove one residue in the active 'sele' (a Design-mode click).
+
+    Deliberately mirrors metal_pick.pick_at's toggle idiom so that a click means
+    the same thing in Design mode as in normal mode: already selected -> remove,
+    otherwise add. Always leaves 'sele' enabled so the renderer's pink committed
+    pass draws it. Returns 'DESIGN_SELE_TOGGLE:on' or ':off'.
+    """
+    expr = '(%s)' % _residue_sel(obj, chain, resi)
+    try:
+        already = cmd.count_atoms('(?sele) and %s' % expr) > 0
+    except Exception:
+        already = False
+    if already:
+        cmd.select('sele', '(?sele) and not %s' % expr, enable=1)
+    else:
+        cmd.select('sele', '(?sele) or %s' % expr, enable=1)
+    return 'DESIGN_SELE_TOGGLE:%s' % ('off' if already else 'on')
+
+
+def set_sele_residue(obj, chain, resi):
+    """Replace the active 'sele' with exactly one residue.
+
+    Used when a Design-mode click lands on a DIFFERENT object than the current
+    focus: design retargets to that object and the selection starts fresh there,
+    so residues of the previous focus never linger in the region.
+    Returns 'DESIGN_SELE_SET:ok'.
+    """
+    cmd.select('sele', _residue_sel(obj, chain, resi), enable=1)
+    return 'DESIGN_SELE_SET:ok'
+
+
+def set_sele_from_selection(name):
+    """Replace the active 'sele' with the contents of the named selection.
+
+    Backs the lasso dropdown: designating a named region writes it into 'sele' so
+    'sele' stays the single source of truth instead of the controller holding a
+    second, divergent copy. '?name' so a stale name empties the selection rather
+    than raising. Returns 'DESIGN_SELE_NAMED:ok'.
+    """
+    cmd.select('sele', '(?%s)' % name, enable=1)
+    return 'DESIGN_SELE_NAMED:ok'
+
+
+def clear_sele():
+    """Empty the active 'sele' (a Design-mode click on empty space).
+
+    Matches metal_pick.pick_at's empty-space behaviour. enable=0 because there is
+    nothing to draw, and an enabled empty selection would still suppress other
+    selections (cmd.enable is exclusive for selections).
+    Returns 'DESIGN_SELE_CLEAR:ok'.
+    """
+    cmd.select('sele', 'none', enable=0)
+    return 'DESIGN_SELE_CLEAR:ok'
+
+
 def _record_design_metrics(obj, metric, rows, state=0):
     """Keep a scored design pass in the metric store. Never raises.
 

--- a/modules/pymol/raymol_design.py
+++ b/modules/pymol/raymol_design.py
@@ -4,6 +4,7 @@ pattern (writes JSON to TMPDIR, returns a short marker)."""
 import hashlib
 import json
 import os
+import re
 import tempfile
 
 from pymol import cmd
@@ -111,6 +112,38 @@ def _scope(obj, src):
     return '(%s)' % obj
 
 
+def _residue_pred(chain, resi):
+    """One residue as an object-free predicate, tolerating an empty chain id.
+
+    Split out of _residue_sel so the same residue term can be intersected with
+    either a single object or the whole _scope(obj, src) — see _scoped_residue_sel.
+    """
+    if chain:
+        return 'chain %s and resi %s' % (chain, resi)
+    return 'resi %s' % resi
+
+
+def _scoped_residue_sel(obj, chain, resi, src):
+    """One residue within the READ scope: the target object plus its edit source.
+
+    Design-mode 'sele' READS resolve residues through _scope(obj, src) — by
+    (chain, resi) IDENTITY across the working copy and the original — so the
+    WRITES must use the same scope or the two disagree the moment an edit session
+    repoints the focus at the working copy while the selection still sits on the
+    original's atoms.  Writing object-scoped there made a region member impossible
+    to remove (the toggle saw no focus-object atoms in 'sele', so it ADDED them,
+    and the read deduped the result back to the same region) and let a repack's
+    topology replace silently drop residues clicked during the session, because
+    their only 'sele' membership lived on the atoms the replace annihilated.
+    """
+    return '%s and (%s)' % (_scope(obj, src), _residue_pred(chain, resi))
+
+
+#: Design working copies are named '<src>_design' / '<src>_designNN' by
+#: make_working_copy and carry IDENTICAL (chain, resi) residues.
+_WORKING_COPY_RE = re.compile(r'^(.+)_design\d*$')
+
+
 def _obj_residue_order(obj):
     """(chain, resi) for obj's polymer residues in canonical guide order —
     the same order enumerate_design_residues emits, so indices align with the
@@ -192,12 +225,31 @@ def set_design_active(on):
     return 'DESIGN_ACTIVE:%d' % (1 if _DESIGN_ACTIVE[0] else 0)
 
 
+def _canonical_model(model, objects):
+    """Collapse a Design working copy onto the source object it mirrors.
+
+    A working copy '<src>_designNN' holds the SAME residues as <src>, and every
+    Design read resolves 'sele' through _scope(obj, src), which matches a residue
+    on either object — so a scoped write legitimately marks both. Keyed on the raw
+    model name that one residue would count TWICE, making n_total exceed the
+    in-scope count and the UI report a bogus "+N on another structure".
+    Only collapse when the source object actually exists, so a user object that
+    merely happens to end in '_design' keeps its own identity.
+    """
+    m = _WORKING_COPY_RE.match(model)
+    if m and m.group(1) in objects:
+        return m.group(1)
+    return model
+
+
 def _sele_residue_keys():
-    """Sorted (model, chain, resi) of every guide residue in the active 'sele'.
+    """Sorted, de-duplicated (model, chain, resi) of the active 'sele's residues.
 
     '?sele' rather than 'sele' so a session that has never had a selection yields
     [] instead of raising. Guide atoms only, so the key set is one entry per
-    residue regardless of how many of its atoms the user picked.
+    residue regardless of how many of its atoms the user picked. Design working
+    copies are folded onto their source object (see _canonical_model) so one
+    residue marked on both never counts twice.
     """
     keys = []
     try:
@@ -205,7 +257,15 @@ def _sele_residue_keys():
                     'keys.append((model, chain, resi))', space={'keys': keys})
     except Exception:
         return []
-    return sorted(keys)
+    # get_object_list() only when a working-copy-shaped name is actually present:
+    # this runs on the 500 ms main-thread poll tick.
+    if any(_WORKING_COPY_RE.match(k[0]) for k in keys):
+        try:
+            objects = set(cmd.get_object_list())
+        except Exception:
+            objects = set()
+        keys = [(_canonical_model(m, objects), c, r) for m, c, r in keys]
+    return sorted(set(keys))
 
 
 def _digest_of(keys):
@@ -266,15 +326,21 @@ def sele_design_indices(obj, state, src=''):
     return 'DESIGN_SELE:%d' % len(indices)
 
 
-def toggle_sele_residue(obj, chain, resi):
+def toggle_sele_residue(obj, chain, resi, src=''):
     """Add or remove one residue in the active 'sele' (a Design-mode click).
 
     Deliberately mirrors metal_pick.pick_at's toggle idiom so that a click means
     the same thing in Design mode as in normal mode: already selected -> remove,
     otherwise add. Always leaves 'sele' enabled so the renderer's pink committed
-    pass draws it. Returns 'DESIGN_SELE_TOGGLE:on' or ':off'.
+    pass draws it.
+
+    `src` is the edit-session source object, and it is what makes the toggle
+    ACTUALLY a toggle: the residue is resolved through _scoped_residue_sel, the
+    same scope sele_design_indices reads, so membership is tested and cleared on
+    the working copy AND the original together. See _scoped_residue_sel for what
+    an object-scoped write broke. Returns 'DESIGN_SELE_TOGGLE:on' or ':off'.
     """
-    expr = '(%s)' % _residue_sel(obj, chain, resi)
+    expr = '(%s)' % _scoped_residue_sel(obj, chain, resi, src)
     try:
         already = cmd.count_atoms('(?sele) and %s' % expr) > 0
     except Exception:
@@ -286,15 +352,17 @@ def toggle_sele_residue(obj, chain, resi):
     return 'DESIGN_SELE_TOGGLE:%s' % ('off' if already else 'on')
 
 
-def set_sele_residue(obj, chain, resi):
+def set_sele_residue(obj, chain, resi, src=''):
     """Replace the active 'sele' with exactly one residue.
 
     Used when a Design-mode click lands on a DIFFERENT object than the current
     focus: design retargets to that object and the selection starts fresh there,
     so residues of the previous focus never linger in the region.
-    Returns 'DESIGN_SELE_SET:ok'.
+    Scoped through `src` for the same reason toggle_sele_residue is — the write
+    must be visible to a read that resolves by residue identity across an edit
+    session's working copy and its original. Returns 'DESIGN_SELE_SET:ok'.
     """
-    cmd.select('sele', _residue_sel(obj, chain, resi), enable=1)
+    cmd.select('sele', _scoped_residue_sel(obj, chain, resi, src), enable=1)
     return 'DESIGN_SELE_SET:ok'
 
 
@@ -313,9 +381,10 @@ def set_sele_from_selection(name):
 def clear_sele():
     """Empty the active 'sele' (a Design-mode click on empty space).
 
-    Matches metal_pick.pick_at's empty-space behaviour. enable=0 because there is
-    nothing to draw, and an enabled empty selection would still suppress other
-    selections (cmd.enable is exclusive for selections).
+    enable=0 — deliberately NOT what metal_pick.pick_at does (it leaves 'sele'
+    enabled and empty): there is nothing left to draw, and an enabled empty
+    selection would still suppress every other selection, because cmd.enable is
+    exclusive for selections.
     Returns 'DESIGN_SELE_CLEAR:ok'.
     """
     cmd.select('sele', 'none', enable=0)
@@ -580,10 +649,8 @@ _COMPARE_STATE = {}
 
 
 def _residue_sel(obj, chain, resi):
-    """Build a residue selection, tolerating an empty chain id."""
-    if chain:
-        return '(%s) and chain %s and resi %s' % (obj, chain, resi)
-    return '(%s) and resi %s' % (obj, resi)
+    """Build a residue selection on ONE object, tolerating an empty chain id."""
+    return '(%s) and %s' % (obj, _residue_pred(chain, resi))
 
 
 def set_residue_sticks(obj, chain, resi, on):

--- a/modules/pymol/raymol_design.py
+++ b/modules/pymol/raymol_design.py
@@ -1,6 +1,7 @@
 """RayMol Design-mode core helpers: residue enumeration, coloring, and
 exact visual-state save/restore. Mirrors the appkit_sequence bundled-module
 pattern (writes JSON to TMPDIR, returns a short marker)."""
+import hashlib
 import json
 import os
 import tempfile
@@ -175,6 +176,94 @@ def selected_design_indices(obj, selection, state, src=''):
     except Exception:
         pass
     return 'DESIGN_SELECTED:%d' % len(indices)
+
+
+# Design mode active? The selection digest below is O(selected residues) and is
+# called from appkit_inspector.poll_panel, which runs on the MAIN thread every
+# 500 ms and is a measured hot spot (PR #270). Gating on this flag keeps the cost
+# at a single boolean check whenever Design mode is not on. A list rather than a
+# bare module global so the setter never needs `global`.
+_DESIGN_ACTIVE = [False]
+
+
+def set_design_active(on):
+    """Arm or disarm the Design-mode 'sele' digest computed by poll_panel."""
+    _DESIGN_ACTIVE[0] = bool(on) if isinstance(on, bool) else bool(int(on))
+    return 'DESIGN_ACTIVE:%d' % (1 if _DESIGN_ACTIVE[0] else 0)
+
+
+def _sele_residue_keys():
+    """Sorted (model, chain, resi) of every guide residue in the active 'sele'.
+
+    '?sele' rather than 'sele' so a session that has never had a selection yields
+    [] instead of raising. Guide atoms only, so the key set is one entry per
+    residue regardless of how many of its atoms the user picked.
+    """
+    keys = []
+    try:
+        cmd.iterate('(?sele) and polymer and guide',
+                    'keys.append((model, chain, resi))', space={'keys': keys})
+    except Exception:
+        return []
+    return sorted(keys)
+
+
+def _digest_of(keys):
+    """Stable short fingerprint of a residue-key list."""
+    return '%d:%s' % (len(keys),
+                      hashlib.md5(repr(keys).encode('utf-8')).hexdigest()[:16])
+
+
+def sele_digest():
+    """Fingerprint of the active 'sele' residue set, or '' when Design is off.
+
+    Used purely for change detection: the Swift side re-derives its selection
+    state only when this value differs from the last one it saw.
+    """
+    if not _DESIGN_ACTIVE[0]:
+        return ''
+    return _digest_of(_sele_residue_keys())
+
+
+def sele_design_indices(obj, state, src=''):
+    """Map the active 'sele' -> full-length residue indices in obj's guide order.
+
+    The Design-mode counterpart of selected_design_indices, hard-wired to 'sele'
+    so the viewer's ordinary selection is the single source of truth for what
+    Design mode is working on. Scoped through _scope(obj, src) so a selection made
+    on the ORIGINAL object still maps onto a focused working copy by (chain, resi)
+    identity once an edit session has begun.
+
+    Output: $TMPDIR/raymol_design_sele.json =
+        {'indices': [int], 'digest': str, 'n_total': int}
+      indices  - 'sele' within the scope, as 0-based indices into obj's guide order
+      digest   - fingerprint of the WHOLE 'sele' residue set (all objects)
+      n_total  - residue count of 'sele' across ALL objects, so a caller can tell
+                 "nothing selected" from "selected, but on another structure"
+
+    `state` is accepted for signature symmetry with selected_design_indices and is
+    likewise unused: guide order is read from the current state.
+    Returns 'DESIGN_SELE:<n>'.
+    """
+    order = _obj_residue_order(obj)
+    scope = _scope(obj, src)
+    sel_res = set()
+    try:
+        cmd.iterate('%s and (?sele) and polymer and guide' % scope,
+                    'sel_res.add((chain, resi))', space={'sel_res': sel_res})
+    except Exception:
+        pass
+    indices = [i for i, cr in enumerate(order) if cr in sel_res]
+    keys = _sele_residue_keys()
+    payload = {'indices': indices,
+               'digest': _digest_of(keys),
+               'n_total': len(keys)}
+    try:
+        with open(_tmp('raymol_design_sele.json'), 'w') as f:
+            json.dump(payload, f)
+    except Exception:
+        pass
+    return 'DESIGN_SELE:%d' % len(indices)
 
 
 def _record_design_metrics(obj, metric, rows, state=0):

--- a/modules/pymol/raymol_design.py
+++ b/modules/pymol/raymol_design.py
@@ -4,7 +4,6 @@ pattern (writes JSON to TMPDIR, returns a short marker)."""
 import hashlib
 import json
 import os
-import re
 import tempfile
 
 from pymol import cmd
@@ -139,10 +138,6 @@ def _scoped_residue_sel(obj, chain, resi, src):
     return '%s and (%s)' % (_scope(obj, src), _residue_pred(chain, resi))
 
 
-#: Design working copies are named '<src>_design' / '<src>_designNN' by
-#: make_working_copy and carry IDENTICAL (chain, resi) residues.
-_WORKING_COPY_RE = re.compile(r'^(.+)_design\d*$')
-
 
 def _obj_residue_order(obj):
     """(chain, resi) for obj's polymer residues in canonical guide order —
@@ -225,31 +220,23 @@ def set_design_active(on):
     return 'DESIGN_ACTIVE:%d' % (1 if _DESIGN_ACTIVE[0] else 0)
 
 
-def _canonical_model(model, objects):
-    """Collapse a Design working copy onto the source object it mirrors.
-
-    A working copy '<src>_designNN' holds the SAME residues as <src>, and every
-    Design read resolves 'sele' through _scope(obj, src), which matches a residue
-    on either object — so a scoped write legitimately marks both. Keyed on the raw
-    model name that one residue would count TWICE, making n_total exceed the
-    in-scope count and the UI report a bogus "+N on another structure".
-    Only collapse when the source object actually exists, so a user object that
-    merely happens to end in '_design' keeps its own identity.
-    """
-    m = _WORKING_COPY_RE.match(model)
-    if m and m.group(1) in objects:
-        return m.group(1)
-    return model
-
-
 def _sele_residue_keys():
     """Sorted, de-duplicated (model, chain, resi) of the active 'sele's residues.
 
     '?sele' rather than 'sele' so a session that has never had a selection yields
-    [] instead of raising. Guide atoms only, so the key set is one entry per
-    residue regardless of how many of its atoms the user picked. Design working
-    copies are folded onto their source object (see _canonical_model) so one
-    residue marked on both never counts twice.
+    [] instead of raising. Guide atoms only, plus set(), so the key set is one
+    entry per residue regardless of how many of its atoms (or altloc guides) the
+    user picked.
+
+    Keyed on the RAW model name, deliberately: this is what the change digest is
+    built from, so it must be at least as sensitive as the state it guards. Two
+    independent objects that merely look like a working-copy pair ('foo' and
+    'foo_design') must not collapse, or moving the same residue selection from one
+    to the other would leave the digest unchanged, the poll would skip the
+    re-derive, and the region would never arm. The consequence — one residue marked
+    on BOTH a working copy and its original counts twice here — is handled where
+    the information to handle it exists: sele_design_indices knows `obj` and `src`
+    and reports the off-scope count directly as `n_off`.
     """
     keys = []
     try:
@@ -257,14 +244,6 @@ def _sele_residue_keys():
                     'keys.append((model, chain, resi))', space={'keys': keys})
     except Exception:
         return []
-    # get_object_list() only when a working-copy-shaped name is actually present:
-    # this runs on the 500 ms main-thread poll tick.
-    if any(_WORKING_COPY_RE.match(k[0]) for k in keys):
-        try:
-            objects = set(cmd.get_object_list())
-        except Exception:
-            objects = set()
-        keys = [(_canonical_model(m, objects), c, r) for m, c, r in keys]
     return sorted(set(keys))
 
 
@@ -298,8 +277,14 @@ def sele_design_indices(obj, state, src=''):
         {'indices': [int], 'digest': str, 'n_total': int}
       indices  - 'sele' within the scope, as 0-based indices into obj's guide order
       digest   - fingerprint of the WHOLE 'sele' residue set (all objects)
-      n_total  - residue count of 'sele' across ALL objects, so a caller can tell
-                 "nothing selected" from "selected, but on another structure"
+      n_off    - residues in 'sele' that lie OUTSIDE the scope (on neither obj nor
+                 src), so the caller can say "selected, but on another structure"
+                 instead of silently ignoring them. Computed from the model names
+                 directly; do NOT reconstruct it as n_total - len(indices).
+      n_total  - count of distinct (model, chain, resi) keys in 'sele' across all
+                 objects. NOT a residue count: during an edit session one residue
+                 marked on both the working copy and the original counts twice
+                 here, which is exactly why n_off exists as its own field
 
     `state` is accepted for signature symmetry with selected_design_indices and is
     likewise unused: guide order is read from the current state.
@@ -315,8 +300,15 @@ def sele_design_indices(obj, state, src=''):
         pass
     indices = [i for i, cr in enumerate(order) if cr in sel_res]
     keys = _sele_residue_keys()
+    # Off-scope count straight from the model names. A residue marked on BOTH the
+    # working copy and the original is in scope on both, so it is excluded here by
+    # construction — no de-duplication of the key set required, and none performed
+    # (the digest must stay maximally sensitive).
+    in_scope = set([obj]) | (set([src]) if src else set())
+    n_off = sum(1 for m, _c, _r in keys if m not in in_scope)
     payload = {'indices': indices,
                'digest': _digest_of(keys),
+               'n_off': n_off,
                'n_total': len(keys)}
     try:
         with open(_tmp('raymol_design_sele.json'), 'w') as f:
@@ -364,6 +356,31 @@ def set_sele_residue(obj, chain, resi, src=''):
     """
     cmd.select('sele', _scoped_residue_sel(obj, chain, resi, src), enable=1)
     return 'DESIGN_SELE_SET:ok'
+
+
+def drop_object_from_sele(obj):
+    """Narrow the active 'sele' so none of `obj`'s atoms are in it.
+
+    Called when an edit session ENDS by keeping the working copy. A residue added
+    during a session is deliberately marked on both the copy and the original (that
+    is what survives a repack), but the Keep path clears `editSourceObject` while
+    the copy lives on — so from then on no Design write can address the copy, and a
+    click that removes a region member would leave it selected and pink there, with
+    a spurious off-structure badge and no way to clear it from the UI. Narrowing at
+    teardown keeps the invariant that 'sele' membership only ever lives on objects
+    the current scope can address.
+
+    enable follows emptiness: an enabled EMPTY 'sele' would suppress every other
+    selection, because cmd.enable is exclusive for selections.
+    Returns 'DESIGN_SELE_DROP:<remaining atoms>'.
+    """
+    try:
+        n = cmd.select('sele', '(?sele) and not (%s)' % obj, enable=1) or 0
+    except Exception:
+        return 'DESIGN_SELE_DROP:err'
+    if not n:
+        cmd.select('sele', 'none', enable=0)
+    return 'DESIGN_SELE_DROP:%d' % n
 
 
 def set_sele_from_selection(name):
@@ -901,7 +918,7 @@ def mutate_residue_display(obj, chain, resi, aa_index):
     return 'DESIGN_MUTDISP:ok'
 
 
-def load_repacked(obj, pdb_str):
+def load_repacked(obj, pdb_str, src=''):
     """Replace obj's structure from an all-atom PDB string (repack output).
 
     Full topology replace: reads pdb_str into a temp object, copies the
@@ -914,11 +931,26 @@ def load_repacked(obj, pdb_str):
 
     After renaming, cartoon rep is enabled so the replaced object is visible.
     On any failure after read but before rename, the temp object is cleaned up.
-    Returns 'DESIGN_REPACKED:ok'.
+
+    The replace annihilates obj's atoms, and with them their 'sele' membership. The
+    same residues usually stay marked on the edit source, but make_working_copy
+    DISABLED that object — so the region would remain armed while the pink pass drew
+    nothing at all. Every residue Design's scope considers selected is therefore
+    re-asserted onto the replaced (visible) object afterwards; `src` is what makes
+    the pre-session residues, which were only ever marked on the original, part of
+    that set. Returns 'DESIGN_REPACKED:ok'.
     """
     # Capture the camera view BEFORE any structural replacement so the viewport
     # does not jump when load+delete+rename triggers PyMOL's auto-zoom.
     v = cmd.get_view()
+    # Which residues does Design's scope consider selected? Read BEFORE the replace:
+    # afterwards obj's own atoms are gone.
+    sele_keys = []
+    try:
+        cmd.iterate('%s and (?sele) and polymer and guide' % _scope(obj, src),
+                    'k.append((chain, resi))', space={'k': sele_keys})
+    except Exception:
+        sele_keys = []
     tmp = cmd.get_unused_name('_rp')
     renamed = False
     try:
@@ -940,6 +972,21 @@ def load_repacked(obj, pdb_str):
     finally:
         if not renamed and tmp in cmd.get_object_list():
             cmd.delete(tmp)
+    # Re-assert the region's 'sele' membership on the object the user can SEE.
+    # Grouped per chain ('resi 3+4+5') rather than one term per residue, so a large
+    # region stays a short expression.
+    if renamed and sele_keys:
+        by_chain = {}
+        for chain, resi in set(sele_keys):
+            by_chain.setdefault(chain, set()).add(resi)
+        terms = []
+        for chain, resis in by_chain.items():
+            terms.append('(%s)' % _residue_pred(chain, '+'.join(sorted(resis))))
+        try:
+            cmd.select('sele', '(?sele) or ((%s) and (%s))'
+                       % (obj, ' or '.join(terms)), enable=1)
+        except Exception:
+            pass
     # Restore the camera view exactly as it was before the replace (zoom=0 on
     # create already prevented the initial zoom; this covers the repack path).
     cmd.set_view(v)

--- a/swiftui/PyMOLViewer/Panels/NotesInspectorView.swift
+++ b/swiftui/PyMOLViewer/Panels/NotesInspectorView.swift
@@ -236,10 +236,15 @@ final class AnalysisNotesStore: ObservableObject {
         scheduleSave()
     }
 
+    /// Register a view bookmark. `insertsMarkdown: false` records the bookmark
+    /// without writing the bare text link, so the caller can compose a richer
+    /// marker instead — a thumbnail bound to the link, via addScreenshot's
+    /// `linkedBookmarkID`.
     @discardableResult
     func addViewBookmark(id: UUID = UUID(), title: String, view: [Float],
                          kind: BookmarkKind = .camera,
-                         sceneName: String? = nil) -> ViewBookmark? {
+                         sceneName: String? = nil,
+                         insertsMarkdown: Bool = true) -> ViewBookmark? {
         guard view.count == 25 else { return nil }
         let cleanTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
         let bookmark = ViewBookmark(id: id,
@@ -248,15 +253,30 @@ final class AnalysisNotesStore: ObservableObject {
                                     createdAt: portableTimestamp(), kind: kind,
                                     sceneName: sceneName)
         viewBookmarks.append(bookmark)
+        if insertsMarkdown {
+            appendViewLink(bookmark)
+        } else {
+            saveState = .pending
+            scheduleSave()
+        }
+        return bookmark
+    }
+
+    /// Append the bare text marker for an already registered bookmark.
+    func appendViewLink(_ bookmark: ViewBookmark) {
         let separator = text.isEmpty || text.hasSuffix("\n") ? "" : "\n"
         text += "\(separator)[\(bookmark.title)](raymol-view://\(bookmark.id.uuidString))"
         saveState = .pending
         scheduleSave()
-        return bookmark
     }
 
+    /// Copy a rendered PNG into the note's asset store and insert its marker.
+    /// With `linkedBookmarkID` the marker is a linked image —
+    /// `[![title](raymol-asset://asset)](raymol-view://bookmark)` — so the
+    /// preview's thumbnail restores that camera or scene when clicked.
     @discardableResult
-    func addScreenshot(title: String, from sourceURL: URL) -> ScreenshotAsset? {
+    func addScreenshot(title: String, from sourceURL: URL,
+                       linkedBookmarkID: UUID? = nil) -> ScreenshotAsset? {
         let id = UUID()
         let cleanTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
         let asset = ScreenshotAsset(id: id,
@@ -270,7 +290,12 @@ final class AnalysisNotesStore: ObservableObject {
             try fileManager.copyItem(at: sourceURL, to: destination)
             screenshots.append(asset)
             let separator = text.isEmpty || text.hasSuffix("\n") ? "" : "\n"
-            text += "\(separator)![\(asset.title)](raymol-asset://\(asset.id.uuidString))"
+            let image = "![\(asset.title)](raymol-asset://\(asset.id.uuidString))"
+            if let linkedBookmarkID {
+                text += "\(separator)[\(image)](raymol-view://\(linkedBookmarkID.uuidString))"
+            } else {
+                text += separator + image
+            }
             saveState = .pending
             scheduleSave()
             return asset
@@ -324,6 +349,12 @@ final class AnalysisNotesStore: ObservableObject {
     var cleanMarkdown: String {
         var result = text
         for bookmark in viewBookmarks {
+            // Thumbnails bound to this link collapse first: their marker wraps
+            // the image markdown, so the bare-link replacement below misses it.
+            result = result.replacingOccurrences(
+                of: AnalysisNoteMarkers.linkedImagePattern(bookmarkID: bookmark.id),
+                with: "**\(bookmark.resolvedKind.label) view:** \(bookmark.title)",
+                options: .regularExpression)
             let source = "[\(bookmark.title)](raymol-view://\(bookmark.id.uuidString))"
             result = result.replacingOccurrences(of: source,
                 with: "**\(bookmark.resolvedKind.label) view:** \(bookmark.title)")
@@ -647,6 +678,10 @@ private enum AnalysisNotesExporter {
                                  screenshots: [AnalysisNotesStore.ScreenshotAsset]) -> String {
         var result = line
         for bookmark in bookmarks {
+            result = result.replacingOccurrences(
+                of: AnalysisNoteMarkers.linkedImagePattern(bookmarkID: bookmark.id),
+                with: "\(bookmark.resolvedKind.label) view: \(bookmark.title)",
+                options: .regularExpression)
             result = result.replacingOccurrences(of: "[\(bookmark.title)](raymol-view://\(bookmark.id.uuidString))",
                                                   with: "\(bookmark.resolvedKind.label) view: \(bookmark.title)")
         }
@@ -679,13 +714,29 @@ private enum AnalysisNotesExporter {
     }
 }
 
+/// Shared regular-expression fragments for RayMol's private note markers.
+enum AnalysisNoteMarkers {
+    static let uuid = "[0-9A-Fa-f-]{36}"
+
+    /// A thumbnail bound to a specific view link.
+    static func linkedImagePattern(bookmarkID: UUID) -> String {
+        #"\[!\[[^\]]*\]\(raymol-asset://\#(uuid)\)\]\(raymol-view://\#(bookmarkID.uuidString)\)"#
+    }
+}
+
 enum AnalysisNotePreviewBlock: Equatable {
     case markdown(String)
     case image(UUID)
+    /// A thumbnail (first id) that restores a view bookmark (second id) on tap.
+    case linkedImage(UUID, UUID)
 }
 
 enum AnalysisNotePreviewParser {
-    private static let imagePattern = #"!\[[^\]]*\]\(raymol-asset://([0-9A-Fa-f-]{36})\)"#
+    // The linked alternative comes first so a wrapped thumbnail is never split
+    // into a stray "[" plus a bare image.
+    private static let imagePattern =
+        #"\[!\[[^\]]*\]\(raymol-asset://(\#(AnalysisNoteMarkers.uuid))\)\]\(raymol-view://(\#(AnalysisNoteMarkers.uuid))\)"#
+        + #"|!\[[^\]]*\]\(raymol-asset://(\#(AnalysisNoteMarkers.uuid))\)"#
 
     /// Split the note into display blocks while preserving the position of each
     /// linked RayMol image. A single structural newline around a standalone image
@@ -707,8 +758,7 @@ enum AnalysisNotePreviewParser {
 
         for match in matches {
             guard let markerRange = Range(match.range, in: markdown),
-                  let idRange = Range(match.range(at: 1), in: markdown),
-                  let id = UUID(uuidString: String(markdown[idRange])) else { continue }
+                  let block = imageBlock(match, in: markdown) else { continue }
 
             let startsLine = markerRange.lowerBound == markdown.startIndex
                 || markdown[markdown.index(before: markerRange.lowerBound)] == "\n"
@@ -725,7 +775,7 @@ enum AnalysisNotePreviewParser {
                 blocks.append(.markdown(String(markdown[cursor..<textEnd])))
             }
 
-            blocks.append(.image(id))
+            blocks.append(block)
             cursor = markerRange.upperBound
             if standalone, cursor < markdown.endIndex, markdown[cursor] == "\n" {
                 cursor = markdown.index(after: cursor)
@@ -736,6 +786,17 @@ enum AnalysisNotePreviewParser {
             blocks.append(.markdown(String(markdown[cursor...])))
         }
         return blocks
+    }
+
+    private static func imageBlock(_ match: NSTextCheckingResult,
+                                   in markdown: String) -> AnalysisNotePreviewBlock? {
+        func id(_ group: Int) -> UUID? {
+            guard let range = Range(match.range(at: group), in: markdown) else { return nil }
+            return UUID(uuidString: String(markdown[range]))
+        }
+        if let asset = id(1), let bookmark = id(2) { return .linkedImage(asset, bookmark) }
+        if let asset = id(3) { return .image(asset) }
+        return nil
     }
 }
 
@@ -748,6 +809,7 @@ struct NotesInspectorView: View {
     @State private var viewName = ""
     @State private var pendingView: [Float]?
     @State private var pendingKind: AnalysisNotesStore.BookmarkKind = .camera
+    @AppStorage("analysisNotesViewLinkThumbnail") private var includeViewThumbnail = true
     @State private var searchText = ""
     @State private var showingExporter = false
     @State private var exportData = Data()
@@ -938,15 +1000,7 @@ struct NotesInspectorView: View {
         .padding(.vertical, compactLayout ? 8 : 12)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onDisappear { notes.flush() }
-        .alert("Insert View Link", isPresented: $showingViewNamePrompt) {
-            TextField("Link name", text: $viewName)
-            Button("Insert") { insertPendingView() }
-            Button("Cancel", role: .cancel) { pendingView = nil }
-        } message: {
-            Text(pendingKind == .camera
-                 ? "Camera links restore orientation, zoom, and clipping."
-                 : "Scene links restore the full PyMOL scene. Save the .pse after adding one so the scene travels with the session.")
-        }
+        .sheet(isPresented: $showingViewNamePrompt) { viewLinkPrompt }
         .alert("Nothing to Insert", isPresented: Binding(
             get: { insertionNotice != nil },
             set: { if !$0 { insertionNotice = nil } }
@@ -1070,11 +1124,30 @@ struct NotesInspectorView: View {
                 screenshotView(asset)
                     .frame(maxWidth: .infinity, alignment: .leading)
             } else {
-                Label("Linked image unavailable", systemImage: "photo.badge.exclamationmark")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                missingImageLabel
+            }
+        case .linkedImage(let assetID, let bookmarkID):
+            if let asset = notes.screenshots.first(where: { $0.id == assetID }) {
+                let bookmark = notes.viewBookmarks.first { $0.id == bookmarkID }
+                Button { if let bookmark { restore(bookmark) } } label: {
+                    VStack(alignment: .leading, spacing: 4) { screenshotView(asset) }
+                }
+                .buttonStyle(.plain)
+                .disabled(bookmark == nil)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .help(bookmark.map { "Restore \($0.resolvedKind.label.lowercased()) view: \($0.title)" }
+                      ?? "Linked view unavailable")
+                .accessibilityLabel(bookmark.map { "Restore view \($0.title)" } ?? asset.title)
+            } else {
+                missingImageLabel
             }
         }
+    }
+
+    private var missingImageLabel: some View {
+        Label("Linked image unavailable", systemImage: "photo.badge.exclamationmark")
+            .font(.caption)
+            .foregroundStyle(.secondary)
     }
 
     private func renderMarkdown(_ source: String) -> AttributedString {
@@ -1110,6 +1183,45 @@ struct NotesInspectorView: View {
         }
     }
 
+    /// A sheet rather than an alert: alerts accept only text fields and buttons,
+    /// and the thumbnail option needs a real Toggle.
+    private var viewLinkPrompt: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Insert View Link").font(.headline)
+            Text(pendingKind == .camera
+                 ? "Camera links restore orientation, zoom, and clipping."
+                 : "Scene links restore the full PyMOL scene. Save the .pse after adding one so the scene travels with the session.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            TextField("Link name", text: $viewName)
+                .textFieldStyle(.roundedBorder)
+                .onSubmit { commitViewLinkPrompt() }
+
+            Toggle("Include image of the view", isOn: $includeViewThumbnail)
+                .help("Insert a thumbnail of the current view; clicking it in the preview restores this view")
+
+            HStack {
+                Spacer()
+                Button("Cancel", role: .cancel) {
+                    pendingView = nil
+                    showingViewNamePrompt = false
+                }
+                .keyboardShortcut(.cancelAction)
+                Button("Insert") { commitViewLinkPrompt() }
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(18)
+        .frame(minWidth: 320)
+    }
+
+    private func commitViewLinkPrompt() {
+        showingViewNamePrompt = false
+        insertPendingView()
+    }
+
     private func beginViewLink(_ kind: AnalysisNotesStore.BookmarkKind) {
         guard let view = engine.captureView() else { return }
         pendingView = view
@@ -1120,13 +1232,35 @@ struct NotesInspectorView: View {
 
     private func insertPendingView() {
         guard let view = pendingView else { return }
+        pendingView = nil
         let id = UUID()
+        let title = markdownSafe(viewName)
         let sceneName = pendingKind == .scene ? "__raymol_note_\(id.uuidString.replacingOccurrences(of: "-", with: ""))" : nil
         if let sceneName { engine.runCommand("scene \(sceneName), store") }
-        _ = notes.addViewBookmark(id: id, title: markdownSafe(viewName), view: view,
-                                  kind: pendingKind, sceneName: sceneName)
-        pendingView = nil
-        isPreviewing = true
+        let thumbnail = includeViewThumbnail ? renderNoteScreenshot() : nil
+        guard let bookmark = notes.addViewBookmark(id: id, title: title, view: view,
+                                                  kind: pendingKind, sceneName: sceneName,
+                                                  insertsMarkdown: thumbnail == nil) else {
+            if let thumbnail { try? FileManager.default.removeItem(at: thumbnail) }
+            return
+        }
+        if let thumbnail {
+            // Fall back to the bare link if the render could not be filed, so the
+            // bookmark never ends up with no marker in the note.
+            if notes.addScreenshot(title: title, from: thumbnail, linkedBookmarkID: id) == nil {
+                notes.appendViewLink(bookmark)
+            }
+            try? FileManager.default.removeItem(at: thumbnail)
+        }
+    }
+
+    /// Render the live view to a temporary PNG. The caller owns the file.
+    private func renderNoteScreenshot() -> URL? {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("raymol-note-\(UUID().uuidString).png")
+        engine.renderHiResPNG(url.path, width: 1600, height: 1200)
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        return url
     }
 
     private func restore(_ bookmark: AnalysisNotesStore.ViewBookmark) {
@@ -1138,13 +1272,9 @@ struct NotesInspectorView: View {
     }
 
     private func insertMetalScreenshot() {
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("raymol-note-\(UUID().uuidString).png")
-        engine.renderHiResPNG(url.path, width: 1600, height: 1200)
-        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        guard let url = renderNoteScreenshot() else { return }
         _ = notes.addScreenshot(title: "Molecular view \(notes.screenshots.count + 1)", from: url)
         try? FileManager.default.removeItem(at: url)
-        isPreviewing = true
     }
 
     private func insertResidueSummary(contacts: Bool) {
@@ -1164,7 +1294,6 @@ struct NotesInspectorView: View {
             return "- [\(label)](\(residueURL(object: object, chain: chain, resi: resi)))"
         }
         appendMarkdown(lines.joined(separator: "\n") + "\n")
-        isPreviewing = true
     }
 
     private func insertMeasurementSummary() {
@@ -1183,7 +1312,6 @@ struct NotesInspectorView: View {
             return "- **\(name)** (\(kind)): \(String(format: kind == "distance" ? "%.2f" : "%.1f", value)) \(unit) — \(picks)"
         }
         appendMarkdown(lines.joined(separator: "\n") + "\n")
-        isPreviewing = true
     }
 
     private func appendMarkdown(_ value: String) {

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -4102,6 +4102,11 @@ struct PanelPayload: Decodable {
     // key does not cost the ALIGNMENTS section, it freezes the ENTIRE object
     // panel on its last list.
     let msa_searches: [MSASearchSummary]?
+    /// Design-mode 'sele' fingerprint, '' while Design mode is off. Optional for
+    /// the same reason as every field above: a non-optional would fail the whole
+    /// decode against an older bundled appkit_inspector.py and freeze the panel on
+    /// its last list.
+    let design_sele: String?
 
     struct AlignmentSummary: Decodable {
         let depth: Int
@@ -4138,6 +4143,20 @@ extension PyMOLEngine {
         guard let payload = try? JSONDecoder().decode(PanelPayload.self, from: data) else {
             return
         }
+
+        #if RAYMOL_MPNN
+        // 'sele' is the single source of truth for Design mode, so a selection made
+        // OUTSIDE it — `select` at the prompt, a Seeker drag, the object panel —
+        // must drive it too. Gated on the digest so a quiet tick does no work, and
+        // on designMode so nothing runs when the feature is not in use.
+        if let digest = payload.design_sele, !digest.isEmpty, designMode {
+            MainActor.assumeIsolated {
+                if digest != designController.lastSeleDigest {
+                    designController.syncFromSele()
+                }
+            }
+        }
+        #endif
 
         let enabledSet = Set(payload.enabled)
         let groupSet = Set(payload.groups ?? [])

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -4151,9 +4151,7 @@ extension PyMOLEngine {
         // on designMode so nothing runs when the feature is not in use.
         if let digest = payload.design_sele, !digest.isEmpty, designMode {
             MainActor.assumeIsolated {
-                if digest != designController.lastSeleDigest {
-                    designController.syncFromSele()
-                }
+                designController.syncFromSeleIfChanged(digest: digest)
             }
         }
         #endif

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -839,10 +839,10 @@ struct ContentView: View {
             }
             #if RAYMOL_MPNN
             // Design mode click routing: a click (left or right) sets longPressHit.
-            // Routes through the shared handleViewportHit three-way rule so iOS and
-            // macOS behave identically — and so region-edit mode is honoured on macOS
-            // (the previous direct setPinned call bypassed tapResidue and therefore
-            // always pinned even when the user was building a region by clicking).
+            // Routes through handleViewportHit (four-way rule: empty space clears,
+            // same-object residue tap toggles region membership via tapResidue, same-
+            // object non-residue tap is a no-op, different object refocuses) so iOS and
+            // macOS behave identically.
             // Clears longPressHit so the context-menu dialog never fires in design mode.
             .onChange(of: engine.longPressHit) { hit in
                 guard engine.designMode, let hit = hit else { return }
@@ -3634,8 +3634,8 @@ private let designPinnedColor = Color(red: 0.98, green: 0.60, blue: 0.10)
 /// propensity pills, the residue badge, and the hover sidechain sticks all
 /// react identically to hovering here vs. mousing over the structure.
 ///
-/// Tapping a column calls setPinned(chain:resi:), the same path as a viewport
-/// click-to-pin, so clicking here pins the same way as clicking in the scene.
+/// Tapping a column calls tapResidue(residueIndex:), the same action as a
+/// viewport click, so the strip and the structure always agree.
 ///
 /// Feature 11: the PINNED column gets a persistent gold/orange border + fill;
 /// the HOVERED column gets a transient subtle-grey fill.
@@ -3727,23 +3727,8 @@ struct DesignSequenceStripView: View {
                 controller.clearHover()
             }
         }
-        // macOS keeps shift-click as a shortcut for building an ad-hoc region.
-        // `TapGesture().modifiers(_:)` is unavailable on iOS — this was the single
-        // iOS compile error in the whole Design feature. The cross-platform path is
-        // controller.regionEditMode, which a plain tap honours (see tapResidue).
-        //
-        // The shift gesture is DISABLED while regionEditMode is on: in that mode a
-        // plain tap already toggles the region, so leaving both active would make
-        // correctness depend on SwiftUI suppressing one of them. If it ever failed to,
-        // the position would be toggled twice — added then removed — a silent no-op.
-        #if os(macOS)
-        .highPriorityGesture(
-            TapGesture().modifiers(.shift).onEnded {
-                controller.toggleRegionResidue(residueIndex: i)
-            },
-            including: controller.regionEditMode ? .subviews : .all
-        )
-        #endif
+        // A plain tap toggles this position in 'sele' — the same gesture, and the
+        // same meaning, as a click in the viewport or in normal mode.
         .onTapGesture {
             controller.tapResidue(residueIndex: i)
         }
@@ -3785,8 +3770,6 @@ private struct DesignRegionStripView: View {
     private var controls: some View {
         HStack(spacing: 8) {
             selectionButton
-            stripDivider
-            regionEditToggle
             if controller.regionModeActive {
                 stripDivider
                 Text("palette \(controller.paletteAllowed.filter { $0 < 20 }.count)/20")
@@ -3836,34 +3819,6 @@ private struct DesignRegionStripView: View {
                                   dismiss: { showPicker = false })
                 .presentationCompactAdaptation(.popover)
         }
-    }
-
-    // Explicit region-building mode: while on, a plain tap on a sequence column or
-    // in the viewport adds/removes that position. This is the touch replacement for
-    // shift-click, and the discoverable path on macOS too.
-    private var regionEditToggle: some View {
-        Button {
-            controller.regionEditMode.toggle()
-        } label: {
-            HStack(spacing: 4) {
-                Image(systemName: controller.regionEditMode
-                        ? "hand.tap.fill" : "hand.tap")
-                    .font(.system(size: 10))
-                Text("Tap to edit")
-                    .font(.system(size: 11,
-                                  weight: controller.regionEditMode ? .semibold : .regular))
-            }
-            .foregroundColor(controller.regionEditMode
-                             ? .white : theme.active.panelText.color.opacity(0.85))
-            .padding(.horizontal, 7).padding(.vertical, 3)
-            .background(controller.regionEditMode
-                        ? theme.active.accent.color
-                        : theme.active.panelText.color.opacity(0.06),
-                        in: RoundedRectangle(cornerRadius: 5))
-        }
-        .buttonStyle(.plain)
-        .help("Build a region by tapping positions in the sequence or the structure")
-        .accessibilityLabel("Tap to edit region, \(controller.regionEditMode ? "on" : "off")")
     }
 
     // Prominent call-to-action: solid accent fill + icon so it clearly invites a click.

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -1643,8 +1643,13 @@ struct ContentView: View {
                             return
                         }
                         if let sel = selectionName {
-                            c.refreshSelections()
-                            c.pickSelection(sel)
+                            // Unified path: a named selection reaches Design mode by
+                            // becoming 'sele', exactly as it does from the prompt.
+                            // '?' so a name that does not exist empties 'sele' rather
+                            // than raising, and the guard below reports it.
+                            engine.runPython(
+                                "from pymol import cmd as _c; _c.select('sele', '(?\(sel))', enable=1)")
+                            c.syncFromSele()
                             guard c.regionModeActive else {
                                 NSLog("AUTODESIGN_FAIL: selection '\(sel)' matched no designable residues")
                                 return
@@ -3827,12 +3832,11 @@ struct DesignSequenceStripView: View {
 
 // MARK: – Region-redesign strip (Phase 2c)
 
-// Selection dropdown + Redesign/Revert + "Redesigning region…" spinner. Its own
-// View struct so @ObservedObject re-renders on region-state @Published changes.
+// Redesign/Revert + "Redesigning region…" spinner. Its own View struct so
+// @ObservedObject re-renders on region-state @Published changes.
 private struct DesignRegionStripView: View {
     @ObservedObject var controller: DesignController
     @ObservedObject var theme: ThemeManager
-    @State private var showPicker = false
 
     var body: some View {
         Group {
@@ -3853,7 +3857,14 @@ private struct DesignRegionStripView: View {
 
     private var controls: some View {
         HStack(spacing: 8) {
-            selectionButton
+            // No region picker: 'sele' IS the region, so the only way to choose one
+            // is to click residues. The hint keeps the strip from rendering as an
+            // empty band before a region exists.
+            if !controller.regionModeActive {
+                Text("Select 2 or more residues to redesign a region")
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.active.panelText.color.opacity(0.5))
+            }
             if controller.seleResiduesOffFocus > 0 {
                 Text("+\(controller.seleResiduesOffFocus) off-structure")
                     .font(.system(size: 10, design: .monospaced))
@@ -3884,32 +3895,6 @@ private struct DesignRegionStripView: View {
             Spacer(minLength: 0)
         }
         .padding(.horizontal, 12).padding(.vertical, 6)
-    }
-
-    private var selectionButton: some View {
-        Button {
-            controller.refreshSelections()
-            showPicker = true
-        } label: {
-            HStack(spacing: 4) {
-                Image(systemName: "lasso").font(.system(size: 10))
-                Text(controller.selectedSelectionName ?? "Select region…")
-                    .font(.system(size: 11)).lineLimit(1)
-                Image(systemName: "chevron.down").font(.system(size: 8))
-            }
-            .foregroundColor(theme.active.panelText.color.opacity(0.85))
-            .padding(.horizontal, 7).padding(.vertical, 3)
-            .background(theme.active.panelText.color.opacity(0.06),
-                        in: RoundedRectangle(cornerRadius: 5))
-        }
-        .buttonStyle(.plain)
-        .popover(isPresented: $showPicker) {
-            DesignSelectionPicker(controller: controller,
-                                  fontSize: 12,
-                                  minWidth: 190,
-                                  dismiss: { showPicker = false })
-                .presentationCompactAdaptation(.popover)
-        }
     }
 
     // Prominent call-to-action: solid accent fill + icon so it clearly invites a click.

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -3770,6 +3770,13 @@ private struct DesignRegionStripView: View {
     private var controls: some View {
         HStack(spacing: 8) {
             selectionButton
+            if controller.seleResiduesOffFocus > 0 {
+                Text("+\(controller.seleResiduesOffFocus) off-structure")
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundColor(theme.active.panelText.color.opacity(0.5))
+                    .help("Selected residues on other structures. Design only ever "
+                          + "works on the focused structure, so these are ignored.")
+            }
             if controller.regionModeActive {
                 stripDivider
                 Text("palette \(controller.paletteAllowed.filter { $0 < 20 }.count)/20")

--- a/swiftui/PyMOLViewer/Shared/DesignCompactPanel.swift
+++ b/swiftui/PyMOLViewer/Shared/DesignCompactPanel.swift
@@ -179,6 +179,13 @@ struct DesignCompactPanel: View {
     private var actionRow: some View {
         HStack(spacing: 8) {
             regionButton
+            if controller.seleResiduesOffFocus > 0 {
+                Text("+\(controller.seleResiduesOffFocus)")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(theme.active.panelText.color.opacity(0.5))
+                    .accessibilityLabel(
+                        "\(controller.seleResiduesOffFocus) selected residues on other structures, ignored")
+            }
             if controller.regionModeActive { redesignButton }
             if controller.redesignSnapshot != nil { revertButton }
             Spacer(minLength: 0)

--- a/swiftui/PyMOLViewer/Shared/DesignCompactPanel.swift
+++ b/swiftui/PyMOLViewer/Shared/DesignCompactPanel.swift
@@ -180,7 +180,7 @@ struct DesignCompactPanel: View {
         HStack(spacing: 8) {
             regionButton
             if controller.seleResiduesOffFocus > 0 {
-                Text("+\(controller.seleResiduesOffFocus)")
+                Label("\(controller.seleResiduesOffFocus)", systemImage: "eye.slash")
                     .font(.system(size: 11, design: .monospaced))
                     .foregroundColor(theme.active.panelText.color.opacity(0.5))
                     .accessibilityLabel(

--- a/swiftui/PyMOLViewer/Shared/DesignCompactPanel.swift
+++ b/swiftui/PyMOLViewer/Shared/DesignCompactPanel.swift
@@ -171,7 +171,7 @@ struct DesignCompactPanel: View {
         .padding(.horizontal, 12).padding(.vertical, 8)
     }
 
-    // Row 4: region picker · edit-mode toggle · redesign (region only) · revert (if snapshot) ·
+    // Row 4: region picker · redesign (region only) · revert (if snapshot) ·
     // spacer · repack (editing) · compare (editing) · Keep / Discard (editing).
     //
     // Decomposed into leaf properties to keep each expression short for the Swift
@@ -179,7 +179,6 @@ struct DesignCompactPanel: View {
     private var actionRow: some View {
         HStack(spacing: 8) {
             regionButton
-            regionEditButton
             if controller.regionModeActive { redesignButton }
             if controller.redesignSnapshot != nil { revertButton }
             Spacer(minLength: 0)
@@ -215,24 +214,6 @@ struct DesignCompactPanel: View {
                                   dismiss: { showPicker = false })
                 .presentationCompactAdaptation(.popover)
         }
-    }
-
-    private var regionEditButton: some View {
-        Button { controller.regionEditMode.toggle() } label: {
-            Image(systemName: controller.regionEditMode ? "hand.tap.fill" : "hand.tap")
-                .font(.system(size: 13))
-                .foregroundColor(controller.regionEditMode
-                                 ? .white
-                                 : theme.active.panelText.color.opacity(0.85))
-                .padding(.horizontal, 9).padding(.vertical, 6)
-                .background(controller.regionEditMode
-                            ? theme.active.accent.color
-                            : theme.active.panelText.color.opacity(0.08),
-                            in: RoundedRectangle(cornerRadius: 6))
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(
-            "Tap to edit region, \(controller.regionEditMode ? "on" : "off")")
     }
 
     private var redesignButton: some View {

--- a/swiftui/PyMOLViewer/Shared/DesignCompactPanel.swift
+++ b/swiftui/PyMOLViewer/Shared/DesignCompactPanel.swift
@@ -1,77 +1,6 @@
 #if RAYMOL_MPNN
 import SwiftUI
 
-// MARK: – Shared selection picker
-
-/// Selection popover shared by DesignRegionStripView (macOS/iPad strip) and
-/// DesignCompactPanel (iPhone dock). `fontSize`, `minWidth`, `itemHPadding`, and
-/// `itemVPadding` are caller-supplied so each context meets its own touch-target
-/// requirements without forking the view.
-///
-/// `clearButtonText` defaults to "Clear selection" — the original macOS label.
-/// Pass a different string only if the call site genuinely needs different wording.
-struct DesignSelectionPicker: View {
-    @ObservedObject var controller: DesignController
-    /// Point size for item-row text.
-    let fontSize: CGFloat
-    /// Minimum row width (not including the internal horizontal padding).
-    let minWidth: CGFloat
-    /// Horizontal padding on each row item. Default = 10 (macOS/iPad).
-    var itemHPadding: CGFloat = 10
-    /// Vertical padding on each row item. Default = 5 (macOS/iPad).
-    var itemVPadding: CGFloat = 5
-    /// Label for the "clear" button shown when a region is active.
-    var clearButtonText: String = "Clear selection"
-    /// Called when the user picks an item or taps the clear button.
-    let dismiss: () -> Void
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            if controller.availableSelections.isEmpty {
-                Text("No selections — create one first")
-                    .font(.system(size: 11))   // 11 pt for empty state (original macOS size)
-                    .foregroundColor(.secondary)
-                    .padding(8)
-            } else {
-                ForEach(controller.availableSelections) { opt in
-                    Button {
-                        controller.pickSelection(opt.name)
-                        dismiss()
-                    } label: {
-                        HStack {
-                            Text(opt.name).font(.system(size: fontSize))
-                            Spacer(minLength: 12)
-                            Text("\(opt.count) res")
-                                .font(.system(size: max(fontSize - 1, 10)))
-                                .foregroundColor(.secondary)
-                        }
-                        .padding(.horizontal, itemHPadding).padding(.vertical, itemVPadding)
-                        .frame(minWidth: minWidth)
-                        .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                }
-            }
-            if controller.regionModeActive {
-                Divider()
-                Button {
-                    controller.clearSelection()
-                    dismiss()
-                } label: {
-                    Text(clearButtonText)
-                        .font(.system(size: fontSize))
-                        .foregroundColor(.red)
-                        .padding(.horizontal, itemHPadding).padding(.vertical, itemVPadding)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-            }
-        }
-        .padding(6)
-        .frame(maxWidth: max(minWidth + 60, 260))
-    }
-}
-
 // MARK: – Compact panel (iPhone)
 
 /// Compact Design panel for iPhone (compact width, either orientation).
@@ -89,7 +18,6 @@ struct DesignCompactPanel: View {
     @ObservedObject var theme: ThemeManager
 
     @State private var showSettings = false
-    @State private var showPicker = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -104,16 +32,13 @@ struct DesignCompactPanel: View {
                 // Row 3: propensity / palette pills (identical logic to macOS overlay)
                 Divider().opacity(0.3)
                 DesignPillRow(controller: controller, theme: theme)
-                // Row 4: region picker · edit-mode toggle · redesign · actions
+                // Row 4: region hint · redesign · revert · edit-session actions
                 Divider().opacity(0.3)
                 actionRow
             }
         }
         .background(theme.active.panelBackground.color)
         .tint(theme.active.accent.color)
-        // Close the region picker if the user switches to a different object —
-        // the existing selection may no longer be valid.
-        .onChange(of: controller.focusObject) { _ in showPicker = false }
         .sheet(isPresented: $showSettings) {
             DesignSettingsSheet(controller: controller)
         }
@@ -171,14 +96,22 @@ struct DesignCompactPanel: View {
         .padding(.horizontal, 12).padding(.vertical, 8)
     }
 
-    // Row 4: region picker · redesign (region only) · revert (if snapshot) ·
-    // spacer · repack (editing) · compare (editing) · Keep / Discard (editing).
+    // Row 4: region hint (until a region exists) · redesign (region only) ·
+    // revert (if snapshot) · spacer · repack (editing) · compare (editing) ·
+    // Keep / Discard (editing).
     //
     // Decomposed into leaf properties to keep each expression short for the Swift
     // type-checker, following the pattern in DesignSequenceStripView.seqCols.
     private var actionRow: some View {
         HStack(spacing: 8) {
-            regionButton
+            // No region picker: 'sele' IS the region, so tapping residues is the
+            // only way to build one. The hint keeps the row from reading as empty.
+            if !controller.regionModeActive {
+                Text("Tap 2+ residues to redesign")
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.active.panelText.color.opacity(0.5))
+                    .lineLimit(1)
+            }
             if controller.seleResiduesOffFocus > 0 {
                 Label("\(controller.seleResiduesOffFocus)", systemImage: "eye.slash")
                     .font(.system(size: 11, design: .monospaced))
@@ -192,35 +125,6 @@ struct DesignCompactPanel: View {
             if controller.editing { editControls }
         }
         .padding(.horizontal, 12).padding(.vertical, 6)
-    }
-
-    private var regionButton: some View {
-        Button {
-            controller.refreshSelections()
-            showPicker = true
-        } label: {
-            HStack(spacing: 4) {
-                Image(systemName: "lasso").font(.system(size: 11))
-                // Cap the label so a long selection name cannot crowd Keep/Discard.
-                Text(controller.selectedSelectionName ?? "Region")
-                    .font(.system(size: 12)).lineLimit(1)
-                    .frame(maxWidth: 100)
-            }
-            .foregroundColor(theme.active.panelText.color.opacity(0.85))
-            .padding(.horizontal, 9).padding(.vertical, 6)
-            .background(theme.active.panelText.color.opacity(0.08),
-                        in: RoundedRectangle(cornerRadius: 6))
-        }
-        .buttonStyle(.plain)
-        .popover(isPresented: $showPicker) {
-            DesignSelectionPicker(controller: controller,
-                                  fontSize: 14,
-                                  minWidth: 220,
-                                  itemHPadding: 12,
-                                  itemVPadding: 9,
-                                  dismiss: { showPicker = false })
-                .presentationCompactAdaptation(.popover)
-        }
     }
 
     private var redesignButton: some View {
@@ -287,8 +191,8 @@ struct DesignCompactPanel: View {
         .fixedSize()
         .accessibilityLabel("Compare with original")
 
-        // Keep/Discard: .fixedSize() so a long selection name in regionButton
-        // cannot push these off-screen.
+        // Keep/Discard: .fixedSize() so nothing to their left can push them
+        // off-screen.
         Button { Task { await controller.keepEditsAwait() } } label: {
             Text("Keep").font(.system(size: 12, weight: .semibold))
         }

--- a/swiftui/PyMOLViewer/Shared/DesignController.swift
+++ b/swiftui/PyMOLViewer/Shared/DesignController.swift
@@ -759,6 +759,15 @@ final class DesignController: ObservableObject {
         editSourceObject = nil
         clearRegionState()
         compareEnabled = false   // bare assignment — do NOT call setCompare(false)
+        // Re-derive: `clearRegionState()` above wipes the region, but 'sele' was
+        // never touched by the teardown, so without this the derived state and
+        // 'sele' silently disagree — pink markers on 2+ residues while the Redesign
+        // button and palette row are gone. The panel poll cannot repair it: it is
+        // digest-gated, and an unchanged 'sele' yields an identical digest, so the
+        // re-derive is skipped and the wrong state persists until the user happens
+        // to click a residue. Runs last, after `focusObject` has been re-pointed at
+        // the source object, so the sync resolves against the right residue set.
+        syncFromSele()
     }
 
     // MARK: – Engine-free 'sele' fallbacks

--- a/swiftui/PyMOLViewer/Shared/DesignController.swift
+++ b/swiftui/PyMOLViewer/Shared/DesignController.swift
@@ -111,6 +111,20 @@ final class DesignController: ObservableObject {
     typealias ListSelectionsFn = (_ obj: String, _ src: String?, _ state: Int) -> [DesignSelectionOption]
     /// Map a selection → full-length residue indices in `obj`'s guide order (scoped to `obj`+`src`).
     typealias SelectedIndicesFn = (_ obj: String, _ selection: String, _ src: String?, _ state: Int) -> [Int]
+    /// Read the active 'sele' for `obj`, scoped to `obj` + its edit `src` exactly as
+    /// `SelectedIndicesFn` is. Returns the full-length guide indices inside that
+    /// scope, a digest of the WHOLE selection (used only for change detection), and
+    /// the total selected residue count across all objects.
+    typealias SeleStateFn = (_ obj: String, _ src: String?, _ state: Int)
+        -> (indices: [Int], digest: String, total: Int)
+    /// Add or remove one residue in the active 'sele'.
+    typealias ToggleSeleFn = (_ obj: String, _ chain: String, _ resi: String) -> Void
+    /// Replace the active 'sele' with exactly one residue.
+    typealias SetSeleResidueFn = (_ obj: String, _ chain: String, _ resi: String) -> Void
+    /// Replace the active 'sele' with the contents of a named selection.
+    typealias SetSeleNamedFn = (_ name: String) -> Void
+    /// Empty the active 'sele'.
+    typealias ClearSeleFn = () -> Void
     /// Release the cached MPNN model. Invoked on the inference queue from `exit()`,
     /// never on the main thread — the model is owned by that queue.
     typealias ReleaseModelFn = () -> Void
@@ -143,6 +157,32 @@ final class DesignController: ObservableObject {
     private var listSelectionsFn: ListSelectionsFn = { _, _, _ in [] }
     private var selectedIndicesFn: SelectedIndicesFn = { _, _, _, _ in [] }
     private var releaseModelFn: ReleaseModelFn = { }
+
+    // MARK: – 'sele' access (single source of truth)
+    //
+    // OPTIONAL rather than defaulted closures: a stored property's default value
+    // cannot reference `self`, and the engine-free fallbacks below must read
+    // `lastSet` / `focusObject`. nil therefore means "use the local fallback",
+    // which is what unit tests get — and that matters, because
+    // `pinnedResidueIndex` is now DERIVED: against no-op stubs every existing pin
+    // assertion would read nil.
+    private var seleStateFn: SeleStateFn?
+    private var toggleSeleFn: ToggleSeleFn?
+    private var setSeleResidueFn: SetSeleResidueFn?
+    private var setSeleNamedFn: SetSeleNamedFn?
+    private var clearSeleFn: ClearSeleFn?
+
+    /// In-memory stand-in for PyMOL's 'sele' used by the fallbacks. Keys are
+    /// "chain\u{1}resi" — the same encoding `stickKey` produces.
+    private var stubSele: Set<String> = []
+
+    /// Digest of the selection the last `syncFromSele()` resolved. The panel-poll
+    /// hook compares against this so it only re-derives when 'sele' really changed.
+    private(set) var lastSeleDigest: String = ""
+
+    /// Name of the last selection explicitly designated through the lasso dropdown.
+    /// Any click clears it, so a click-built region falls back to the "sele" label.
+    private var pickedSelectionName: String?
 
     // MARK: – Edit-session published state (Task 2)
 
@@ -178,6 +218,9 @@ final class DesignController: ObservableObject {
     @Published var paletteAllowed: Set<Int> = Set(0..<20)
     /// Name of the selection currently designated as the region (nil = single-residue mode).
     @Published private(set) var selectedSelectionName: String?
+    /// Residues in 'sele' that are NOT on the focus object. Design ignores them,
+    /// so the UI surfaces the count rather than silently dropping them.
+    @Published private(set) var seleResiduesOffFocus: Int = 0
     /// Selections available in the dropdown, refreshed on open.
     @Published private(set) var availableSelections: [DesignSelectionOption] = []
     /// Pre-batch sequence + editCount captured before the last region redesign (nil = nothing to revert).
@@ -711,6 +754,87 @@ final class DesignController: ObservableObject {
         editSourceObject = nil
         clearRegionState()
         compareEnabled = false   // bare assignment — do NOT call setCompare(false)
+    }
+
+    // MARK: – Engine-free 'sele' fallbacks
+    //
+    // Used when no closure is injected, so unit tests drive the REAL derivation
+    // instead of no-op stubs. Behaviourally identical to the Python helpers:
+    // toggle adds/removes, set replaces, clear empties.
+
+    private func seleToggleLocal(_ chain: String, _ resi: String) {
+        let k = stickKey(chain, resi)
+        if stubSele.contains(k) { stubSele.remove(k) } else { stubSele.insert(k) }
+    }
+
+    private func seleSetLocal(_ chain: String, _ resi: String) {
+        stubSele = [stickKey(chain, resi)]
+    }
+
+    private func seleClearLocal() { stubSele.removeAll() }
+
+    /// Local counterpart of `SeleStateFn`: resolve `stubSele` against the focus
+    /// object's residue set, in guide order.
+    private func seleStateLocal() -> (indices: [Int], digest: String, total: Int) {
+        guard let obj = focusObject, let set = lastSet[obj] else {
+            return (indices: [], digest: "\(stubSele.count)", total: stubSele.count)
+        }
+        let idx = set.residues.enumerated().compactMap { i, r in
+            stubSele.contains(stickKey(r.chain, r.resi)) ? i : nil
+        }
+        return (indices: idx, digest: "\(stubSele.count):\(idx)", total: stubSele.count)
+    }
+
+    /// Read the current 'sele' state through the injected closure, or the local
+    /// fallback when none is injected. Only reached with a focus object present
+    /// (`syncFromSele` guards first), so the no-focus branch just defers to the
+    /// fallback rather than inventing an empty result.
+    private func readSeleState() -> (indices: [Int], digest: String, total: Int) {
+        guard let obj = focusObject, let set = lastSet[obj] else { return seleStateLocal() }
+        if let fn = seleStateFn { return fn(obj, editSourceObject, set.state) }
+        return seleStateLocal()
+    }
+
+    // MARK: – Deriving the mode from 'sele'
+
+    /// Re-derive the Design-mode selection state from the active 'sele'.
+    ///
+    /// This is the ONLY writer of `pinnedResidueIndex` and
+    /// `selectedResidueIndices`. The count of DESIGNABLE residues in
+    /// `sele ∩ scope(focusObject, editSourceObject)` picks the mode:
+    ///   0  → nothing active (propensity row renders in its greyed idle form)
+    ///   1  → that residue is pinned; the region stays empty so `regionModeActive`
+    ///        is false and the propensity pills behave exactly as before
+    ///   ≥2 → the region is designated on 'sele'; the pin is cleared so the
+    ///        palette row and the Redesign button take over
+    ///
+    /// Returns the designable count, so callers and tests can assert the mode
+    /// without re-reading three properties.
+    @discardableResult
+    func syncFromSele() -> Int {
+        guard let obj = focusObject, let set = lastSet[obj] else {
+            pinnedResidueIndex = nil
+            selectedResidueIndices = []
+            selectedSelectionName = nil
+            seleResiduesOffFocus = 0
+            return 0
+        }
+        let state = readSeleState()
+        lastSeleDigest = state.digest
+        let inScope = state.indices.filter { $0 >= 0 && $0 < set.residues.count }
+        let valid = inScope.filter { set.residues[$0].valid }.sorted()
+        seleResiduesOffFocus = max(0, state.total - inScope.count)
+        if valid.count >= 2 {
+            selectedResidueIndices = valid
+            selectedSelectionName = pickedSelectionName ?? "sele"
+            pinnedResidueIndex = nil
+        } else {
+            selectedResidueIndices = []
+            selectedSelectionName = nil
+            pinnedResidueIndex = valid.first
+        }
+        reconcileSticks()
+        return valid.count
     }
 
     // MARK: – Region redesign: designation + palette (Task 2)
@@ -1275,6 +1399,20 @@ final class DesignController: ObservableObject {
         self.designRegionFn = designRegion
         self.listSelectionsFn = listSelections
         self.selectedIndicesFn = selectedIndices
+    }
+
+    /// Override the 'sele' closures for testing. Any argument left nil keeps the
+    /// engine-free local fallback for that operation.
+    func injectSele(seleState: SeleStateFn? = nil,
+                    toggleSele: ToggleSeleFn? = nil,
+                    setSeleResidue: SetSeleResidueFn? = nil,
+                    setSeleNamed: SetSeleNamedFn? = nil,
+                    clearSele: ClearSeleFn? = nil) {
+        if let seleState { self.seleStateFn = seleState }
+        if let toggleSele { self.toggleSeleFn = toggleSele }
+        if let setSeleResidue { self.setSeleResidueFn = setSeleResidue }
+        if let setSeleNamed { self.setSeleNamedFn = setSeleNamed }
+        if let clearSele { self.clearSeleFn = clearSele }
     }
 
     /// Override the model-release closure for testing (Phase 2d).

--- a/swiftui/PyMOLViewer/Shared/DesignController.swift
+++ b/swiftui/PyMOLViewer/Shared/DesignController.swift
@@ -337,7 +337,12 @@ final class DesignController: ObservableObject {
                      designRegion: @escaping DesignRegionFn = { r, _, _, _, _ in Array(repeating: 0, count: r.count) },
                      listSelections: @escaping ListSelectionsFn = { _, _, _ in [] },
                      selectedIndices: @escaping SelectedIndicesFn = { _, _, _, _ in [] },
-                     releaseModel: @escaping ReleaseModelFn = { }) {
+                     releaseModel: @escaping ReleaseModelFn = { },
+                     seleState: SeleStateFn? = nil,
+                     toggleSele: ToggleSeleFn? = nil,
+                     setSeleResidue: SetSeleResidueFn? = nil,
+                     setSeleNamed: SetSeleNamedFn? = nil,
+                     clearSele: ClearSeleFn? = nil) {
         self.enumerate = enumerate
         self.score = score
         self.applyColoring = applyColoring
@@ -359,6 +364,11 @@ final class DesignController: ObservableObject {
         self.listSelectionsFn = listSelections
         self.selectedIndicesFn = selectedIndices
         self.releaseModelFn = releaseModel
+        self.seleStateFn = seleState
+        self.toggleSeleFn = toggleSele
+        self.setSeleResidueFn = setSeleResidue
+        self.setSeleNamedFn = setSeleNamed
+        self.clearSeleFn = clearSele
     }
 
     // MARK: – Public interface

--- a/swiftui/PyMOLViewer/Shared/DesignController.swift
+++ b/swiftui/PyMOLViewer/Shared/DesignController.swift
@@ -260,12 +260,6 @@ final class DesignController: ObservableObject {
     /// Region mode = a selection is designated. Drives the pill-row hat-switch + Redesign button.
     var regionModeActive: Bool { !selectedResidueIndices.isEmpty }
 
-    /// True while the user is building an ad-hoc region by tapping positions.
-    /// Replaces shift-click, which does not exist on touch (and whose SwiftUI
-    /// modifier is unavailable on iOS). Ships on macOS too — the explicit toggle
-    /// is the discoverable path; shift-click remains as a power-user shortcut.
-    @Published var regionEditMode = false
-
     /// Label for the blocking "Calculating…" overlay while a long design inference
     /// runs (nil = not busy). Covers exactly two edit-triggered heavy ops — a region
     /// redesign and a manual repack. The redesign clears `isRedesigning` BEFORE the
@@ -906,12 +900,6 @@ final class DesignController: ObservableObject {
         syncFromSele()
     }
 
-    /// Historical name for `tapResidue`, kept because call sites and tests read
-    /// naturally with it. Both go through 'sele', so they are now the same action.
-    func toggleRegionResidue(residueIndex i: Int) {
-        tapResidue(residueIndex: i)
-    }
-
     /// Clear the region by emptying 'sele' → back to nothing selected.
     func clearSelection() {
         pickedSelectionName = nil
@@ -943,7 +931,6 @@ final class DesignController: ObservableObject {
         availableSelections = []
         pendingSizeWarning = nil
         suppressSizeGuardOnce = false   // defence in depth: clear on focus change / mode exit
-        regionEditMode = false
         designToken += 1   // cancel any in-flight region design
         designMirror.set(designToken)
     }

--- a/swiftui/PyMOLViewer/Shared/DesignController.swift
+++ b/swiftui/PyMOLViewer/Shared/DesignController.swift
@@ -72,7 +72,11 @@ final class DesignController: ObservableObject {
     /// Run MPNN sidechain repack off-main for the given residues + sequence; returns an all-atom PDB string.
     typealias RepackFn = ([MPNNModel.Residue], [Int]) throws -> String
     /// Load a repacked PDB string into the named working-copy object.
-    typealias LoadRepackedFn = (String, String) -> Void
+    /// Replace an object's structure from a PDB string. The third parameter is the
+    /// edit-session source: `load_repacked` re-asserts 'sele' onto the replaced
+    /// (visible) object afterwards, and needs the scope to know which residues the
+    /// region contains — the pre-session ones were only ever marked on the original.
+    typealias LoadRepackedFn = (_ obj: String, _ pdb: String, _ src: String?) -> Void
 
     /// Show or hide all sidechain sticks on `obj` (with cnc element coloring on show).
     typealias ShowAllSidechainsFn = (String, Bool) -> Void
@@ -109,9 +113,15 @@ final class DesignController: ObservableObject {
     /// Read the active 'sele' for `obj`, scoped to `obj` + its edit `src` exactly as
     /// `SelectedIndicesFn` is. Returns the full-length guide indices inside that
     /// scope, a digest of the WHOLE selection (used only for change detection), and
-    /// the total selected residue count across all objects.
+    /// the number of selected residues OUTSIDE that scope.
+    ///
+    /// `off` is reported, never derived. Python computes it from the model names it
+    /// already has; reconstructing it here as "total selected − in scope" was the
+    /// source of every wrong-badge variant, because during an edit session one
+    /// residue legitimately carries 'sele' membership on both the working copy and
+    /// the original and so appears twice in any whole-session total.
     typealias SeleStateFn = (_ obj: String, _ src: String?, _ state: Int)
-        -> (indices: [Int], digest: String, total: Int)
+        -> (indices: [Int], digest: String, off: Int)
     /// Add or remove one residue in the active 'sele'.
     ///
     /// `src` is the edit-session source object and is NOT optional decoration: the
@@ -132,6 +142,8 @@ final class DesignController: ObservableObject {
     typealias SetSeleNamedFn = (_ name: String) -> Void
     /// Empty the active 'sele'.
     typealias ClearSeleFn = () -> Void
+    /// Narrow the active 'sele' so none of `obj`'s atoms are in it.
+    typealias DropObjectFromSeleFn = (_ obj: String) -> Void
     /// Release the cached MPNN model. Invoked on the inference queue from `exit()`,
     /// never on the main thread — the model is owned by that queue.
     typealias ReleaseModelFn = () -> Void
@@ -157,7 +169,7 @@ final class DesignController: ObservableObject {
     private var compare: CompareFn = { _, _ in }
     private var resetCompareFn: ResetCompareFn = { _ in }
     private var repack: RepackFn = { _, _ in "" }
-    private var loadRepacked: LoadRepackedFn = { _, _ in }
+    private var loadRepacked: LoadRepackedFn = { _, _, _ in }
     private var showAllSidechainsFn: ShowAllSidechainsFn = { _, _ in }
     private var designRegionFn: DesignRegionFn = { r, _, _, _, _ in Array(repeating: 0, count: r.count) }
     private var listSelectionsFn: ListSelectionsFn = { _, _, _ in [] }
@@ -177,6 +189,7 @@ final class DesignController: ObservableObject {
     private var setSeleResidueFn: SetSeleResidueFn?
     private var setSeleNamedFn: SetSeleNamedFn?
     private var clearSeleFn: ClearSeleFn?
+    private var dropObjectFromSeleFn: DropObjectFromSeleFn?
 
     /// In-memory stand-in for PyMOL's 'sele' used by the fallbacks. Keys are
     /// "chain\u{1}resi" — the same encoding `stickKey` produces.
@@ -344,7 +357,7 @@ final class DesignController: ObservableObject {
                      compare: @escaping CompareFn = { _, _ in },
                      resetCompare: @escaping ResetCompareFn = { _ in },
                      repack: @escaping RepackFn = { _, _ in "" },
-                     loadRepacked: @escaping LoadRepackedFn = { _, _ in },
+                     loadRepacked: @escaping LoadRepackedFn = { _, _, _ in },
                      showAllSidechains: @escaping ShowAllSidechainsFn = { _, _ in },
                      designRegion: @escaping DesignRegionFn = { r, _, _, _, _ in Array(repeating: 0, count: r.count) },
                      listSelections: @escaping ListSelectionsFn = { _, _, _ in [] },
@@ -354,7 +367,8 @@ final class DesignController: ObservableObject {
                      toggleSele: ToggleSeleFn? = nil,
                      setSeleResidue: SetSeleResidueFn? = nil,
                      setSeleNamed: SetSeleNamedFn? = nil,
-                     clearSele: ClearSeleFn? = nil) {
+                     clearSele: ClearSeleFn? = nil,
+                     dropObjectFromSele: DropObjectFromSeleFn? = nil) {
         self.enumerate = enumerate
         self.score = score
         self.applyColoring = applyColoring
@@ -381,6 +395,7 @@ final class DesignController: ObservableObject {
         self.setSeleResidueFn = setSeleResidue
         self.setSeleNamedFn = setSeleNamed
         self.clearSeleFn = clearSele
+        self.dropObjectFromSeleFn = dropObjectFromSele
     }
 
     // MARK: – Public interface
@@ -774,6 +789,14 @@ final class DesignController: ObservableObject {
         } else {
             // Keep path: working copy stays; re-enable the original so both are visible.
             if let src { enableOriginalFn(src) }
+            // ...and narrow 'sele' off the retained copy. A residue clicked during
+            // the session is marked on BOTH objects (that is what survives a
+            // repack), but `editSourceObject` is cleared below, so from here on no
+            // Design write can address the copy: a click removing that region member
+            // would leave it selected and pink there, with a spurious off-structure
+            // badge and no way to clear it from the UI. Runs BEFORE the closing
+            // `syncFromSele()` so the re-derive sees the narrowed selection.
+            if let w, let fn = dropObjectFromSeleFn { fn(w) }
         }
         rescoreToken += 1; repackToken += 1
         rescoreMirror.set(rescoreToken); repackMirror.set(repackToken)
@@ -816,21 +839,22 @@ final class DesignController: ObservableObject {
 
     /// Local counterpart of `SeleStateFn`: resolve `stubSele` against the focus
     /// object's residue set, in guide order.
-    private func seleStateLocal() -> (indices: [Int], digest: String, total: Int) {
+    private func seleStateLocal() -> (indices: [Int], digest: String, off: Int) {
         guard let obj = focusObject, let set = lastSet[obj] else {
-            return (indices: [], digest: "\(stubSele.count)", total: stubSele.count)
+            return (indices: [], digest: "\(stubSele.count)", off: stubSele.count)
         }
         let idx = set.residues.enumerated().compactMap { i, r in
             stubSele.contains(stickKey(r.chain, r.resi)) ? i : nil
         }
-        return (indices: idx, digest: "\(stubSele.count):\(idx)", total: stubSele.count)
+        return (indices: idx, digest: "\(stubSele.count):\(idx)",
+                off: max(0, stubSele.count - idx.count))
     }
 
     /// Read the current 'sele' state through the injected closure, or the local
     /// fallback when none is injected. Only reached with a focus object present
     /// (`syncFromSele` guards first), so the no-focus branch just defers to the
     /// fallback rather than inventing an empty result.
-    private func readSeleState() -> (indices: [Int], digest: String, total: Int) {
+    private func readSeleState() -> (indices: [Int], digest: String, off: Int) {
         guard let obj = focusObject, let set = lastSet[obj] else { return seleStateLocal() }
         if let fn = seleStateFn { return fn(obj, editSourceObject, set.state) }
         return seleStateLocal()
@@ -864,7 +888,7 @@ final class DesignController: ObservableObject {
         lastSeleDigest = state.digest
         let inScope = state.indices.filter { $0 >= 0 && $0 < set.residues.count }
         let valid = inScope.filter { set.residues[$0].valid }.sorted()
-        seleResiduesOffFocus = max(0, state.total - inScope.count)
+        seleResiduesOffFocus = max(0, state.off)
         if valid.count >= 2 {
             selectedResidueIndices = valid
             selectedSelectionName = pickedSelectionName ?? "sele"
@@ -898,11 +922,19 @@ final class DesignController: ObservableObject {
     /// Entering Design mode with 2+ objects loaded (so `enter()` does not
     /// auto-focus) and any non-empty 'sele' is exactly that state. Adopting the
     /// digest the poll itself saw closes it.
+    ///
+    /// The condition is "did the sync actually RESOLVE a digest", not
+    /// `focusObject == nil`: there is a second no-digest path where `focusObject`
+    /// is non-nil but `lastSet[obj]` is missing. `focusAwait` sets `focusObject`
+    /// BEFORE calling `enumerate` and its catch only sets `errorText`, so after a
+    /// failed focus the controller sits in exactly that state — and the poll would
+    /// re-derive on every tick forever, which is the symptom this guard exists for.
     @discardableResult
     func syncFromSeleIfChanged(digest: String) -> Bool {
         guard digest != lastSeleDigest else { return false }
+        let before = lastSeleDigest
         syncFromSele()
-        if focusObject == nil { lastSeleDigest = digest }
+        if lastSeleDigest == before { lastSeleDigest = digest }
         return true
     }
 
@@ -1295,7 +1327,7 @@ final class DesignController: ObservableObject {
             #if DEBUG
             NSLog("[Design] loadRepacked: starting, pdb=%d chars into '%@'", pdb.count, w)
             #endif
-            loadRepacked(w, pdb)
+            loadRepacked(w, pdb, editSourceObject)
             #if DEBUG
             NSLog("[Design] loadRepacked: done")
             #endif
@@ -1484,12 +1516,14 @@ final class DesignController: ObservableObject {
                     toggleSele: ToggleSeleFn? = nil,
                     setSeleResidue: SetSeleResidueFn? = nil,
                     setSeleNamed: SetSeleNamedFn? = nil,
-                    clearSele: ClearSeleFn? = nil) {
+                    clearSele: ClearSeleFn? = nil,
+                    dropObjectFromSele: DropObjectFromSeleFn? = nil) {
         if let seleState { self.seleStateFn = seleState }
         if let toggleSele { self.toggleSeleFn = toggleSele }
         if let setSeleResidue { self.setSeleResidueFn = setSeleResidue }
         if let setSeleNamed { self.setSeleNamedFn = setSeleNamed }
         if let clearSele { self.clearSeleFn = clearSele }
+        if let dropObjectFromSele { self.dropObjectFromSeleFn = dropObjectFromSele }
     }
 
     /// Override the model-release closure for testing (Phase 2d).

--- a/swiftui/PyMOLViewer/Shared/DesignController.swift
+++ b/swiftui/PyMOLViewer/Shared/DesignController.swift
@@ -106,14 +106,10 @@ final class DesignController: ObservableObject {
                                 _ nativeSequence: [Int],
                                 _ omit: [Set<Int>],
                                 _ temperature: Float) throws -> [Int]
-    /// List selections touching the target (`obj`, plus its source `src` when a working copy is focused).
-    typealias ListSelectionsFn = (_ obj: String, _ src: String?, _ state: Int) -> [DesignSelectionOption]
-    /// Map a selection → full-length residue indices in `obj`'s guide order (scoped to `obj`+`src`).
-    typealias SelectedIndicesFn = (_ obj: String, _ selection: String, _ src: String?, _ state: Int) -> [Int]
-    /// Read the active 'sele' for `obj`, scoped to `obj` + its edit `src` exactly as
-    /// `SelectedIndicesFn` is. Returns the full-length guide indices inside that
-    /// scope, a digest of the WHOLE selection (used only for change detection), and
-    /// the number of selected residues OUTSIDE that scope.
+    /// Read the active 'sele' for `obj`, scoped to `obj` + its edit `src`. Returns
+    /// the full-length guide indices inside that scope, a digest of the WHOLE
+    /// selection (used only for change detection), and the number of selected
+    /// residues OUTSIDE that scope.
     ///
     /// `off` is reported, never derived. Python computes it from the model names it
     /// already has; reconstructing it here as "total selected − in scope" was the
@@ -138,8 +134,6 @@ final class DesignController: ObservableObject {
     /// exactly as it does for `ToggleSeleFn`.
     typealias SetSeleResidueFn = (_ obj: String, _ chain: String, _ resi: String,
                                   _ src: String?) -> Void
-    /// Replace the active 'sele' with the contents of a named selection.
-    typealias SetSeleNamedFn = (_ name: String) -> Void
     /// Empty the active 'sele'.
     typealias ClearSeleFn = () -> Void
     /// Narrow the active 'sele' so none of `obj`'s atoms are in it.
@@ -172,8 +166,6 @@ final class DesignController: ObservableObject {
     private var loadRepacked: LoadRepackedFn = { _, _, _ in }
     private var showAllSidechainsFn: ShowAllSidechainsFn = { _, _ in }
     private var designRegionFn: DesignRegionFn = { r, _, _, _, _ in Array(repeating: 0, count: r.count) }
-    private var listSelectionsFn: ListSelectionsFn = { _, _, _ in [] }
-    private var selectedIndicesFn: SelectedIndicesFn = { _, _, _, _ in [] }
     private var releaseModelFn: ReleaseModelFn = { }
 
     // MARK: – 'sele' access (single source of truth)
@@ -187,7 +179,6 @@ final class DesignController: ObservableObject {
     private var seleStateFn: SeleStateFn?
     private var toggleSeleFn: ToggleSeleFn?
     private var setSeleResidueFn: SetSeleResidueFn?
-    private var setSeleNamedFn: SetSeleNamedFn?
     private var clearSeleFn: ClearSeleFn?
     private var dropObjectFromSeleFn: DropObjectFromSeleFn?
 
@@ -198,10 +189,6 @@ final class DesignController: ObservableObject {
     /// Digest of the selection the last `syncFromSele()` resolved. The panel-poll
     /// hook compares against this so it only re-derives when 'sele' really changed.
     private(set) var lastSeleDigest: String = ""
-
-    /// Name of the last selection explicitly designated through the lasso dropdown.
-    /// Any click clears it, so a click-built region falls back to the "sele" label.
-    private var pickedSelectionName: String?
 
     // MARK: – Edit-session published state (Task 2)
 
@@ -231,17 +218,13 @@ final class DesignController: ObservableObject {
     /// Set when the session begins; cleared in teardownEditSession.
     private(set) var editSourceObject: String?
 
-    /// Full-length residue indices (into set.residues) of the picked region, valid only.
+    /// Full-length residue indices (into set.residues) of the selected region, valid only.
     @Published private(set) var selectedResidueIndices: [Int] = []
     /// Allowed amino-acid alphabet indices (0..<20) for region sampling; toggled off → omit.
     @Published var paletteAllowed: Set<Int> = Set(0..<20)
-    /// Name of the selection currently designated as the region (nil = single-residue mode).
-    @Published private(set) var selectedSelectionName: String?
     /// Residues in 'sele' that are NOT on the focus object. Design ignores them,
     /// so the UI surfaces the count rather than silently dropping them.
     @Published private(set) var seleResiduesOffFocus: Int = 0
-    /// Selections available in the dropdown, refreshed on open.
-    @Published private(set) var availableSelections: [DesignSelectionOption] = []
     /// Pre-batch sequence + editCount captured before the last region redesign (nil = nothing to revert).
     @Published private(set) var redesignSnapshot: RedesignSnapshot?
     /// True while a region design() call is running off-main.
@@ -360,13 +343,10 @@ final class DesignController: ObservableObject {
                      loadRepacked: @escaping LoadRepackedFn = { _, _, _ in },
                      showAllSidechains: @escaping ShowAllSidechainsFn = { _, _ in },
                      designRegion: @escaping DesignRegionFn = { r, _, _, _, _ in Array(repeating: 0, count: r.count) },
-                     listSelections: @escaping ListSelectionsFn = { _, _, _ in [] },
-                     selectedIndices: @escaping SelectedIndicesFn = { _, _, _, _ in [] },
                      releaseModel: @escaping ReleaseModelFn = { },
                      seleState: SeleStateFn? = nil,
                      toggleSele: ToggleSeleFn? = nil,
                      setSeleResidue: SetSeleResidueFn? = nil,
-                     setSeleNamed: SetSeleNamedFn? = nil,
                      clearSele: ClearSeleFn? = nil,
                      dropObjectFromSele: DropObjectFromSeleFn? = nil) {
         self.enumerate = enumerate
@@ -387,13 +367,10 @@ final class DesignController: ObservableObject {
         self.loadRepacked = loadRepacked
         self.showAllSidechainsFn = showAllSidechains
         self.designRegionFn = designRegion
-        self.listSelectionsFn = listSelections
-        self.selectedIndicesFn = selectedIndices
         self.releaseModelFn = releaseModel
         self.seleStateFn = seleState
         self.toggleSeleFn = toggleSele
         self.setSeleResidueFn = setSeleResidue
-        self.setSeleNamedFn = setSeleNamed
         self.clearSeleFn = clearSele
         self.dropObjectFromSeleFn = dropObjectFromSele
     }
@@ -455,7 +432,6 @@ final class DesignController: ObservableObject {
     func handleViewportHit(object: String, chain: String, resi: String, hasResidue: Bool) {
         guard !object.isEmpty else {
             // Empty-space click clears, exactly as metal_pick.pick_at does.
-            pickedSelectionName = nil
             if let fn = clearSeleFn { fn() } else { seleClearLocal() }
             syncFromSele()
             return
@@ -499,7 +475,6 @@ final class DesignController: ObservableObject {
         //    'sele' on a NON-focused object — pink markers plus "nothing selected",
         //    because every read is scoped to the focus object.
         guard focusObject == object, lastSet[object] != nil else { return }
-        pickedSelectionName = nil
         if hasResidue {
             if let fn = setSeleResidueFn { fn(object, chain, resi, editSourceObject) }
             else { seleSetLocal(chain, resi) }
@@ -880,7 +855,6 @@ final class DesignController: ObservableObject {
         guard let obj = focusObject, let set = lastSet[obj] else {
             pinnedResidueIndex = nil
             selectedResidueIndices = []
-            selectedSelectionName = nil
             seleResiduesOffFocus = 0
             return 0
         }
@@ -891,18 +865,9 @@ final class DesignController: ObservableObject {
         seleResiduesOffFocus = max(0, state.off)
         if valid.count >= 2 {
             selectedResidueIndices = valid
-            selectedSelectionName = pickedSelectionName ?? "sele"
             pinnedResidueIndex = nil
         } else {
             selectedResidueIndices = []
-            selectedSelectionName = nil
-            // Below 2 residues there is no region for a lasso name to label, so the
-            // name must not survive to label the NEXT one. Without this, designating
-            // a selection that resolves to exactly ONE designable residue leaves
-            // `pickedSelectionName` set (the branch above never runs), and a later
-            // click-built or externally-selected region silently inherits the old
-            // name on the lasso button.
-            pickedSelectionName = nil
             pinnedResidueIndex = valid.first
         }
         reconcileSticks()
@@ -940,38 +905,6 @@ final class DesignController: ObservableObject {
 
     // MARK: – Region redesign: designation + palette (Task 2)
 
-    /// Refresh the dropdown from the current session selections (call on menu open).
-    /// Scoped to the focus object AND its edit source, so selections made on the
-    /// original still appear once a working copy is focused.
-    func refreshSelections() {
-        guard let obj = focusObject, let set = lastSet[obj] else { availableSelections = []; return }
-        availableSelections = listSelectionsFn(obj, editSourceObject, set.state)
-    }
-
-    /// Designate `name` as the region by writing it into 'sele' (D5), so 'sele'
-    /// stays the single source of truth rather than the controller holding a
-    /// second, divergent copy. The resulting indices come back through
-    /// `syncFromSele` like every other selection change.
-    ///
-    /// `pickedSelectionName` is set BEFORE `syncFromSele()` so the label survives:
-    /// at `valid.count >= 2` the sync uses it, and a later `tapResidue` clears it.
-    func pickSelection(_ name: String) {
-        guard let obj = focusObject, let set = lastSet[obj] else { return }
-        pickedSelectionName = name
-        if let fn = setSeleNamedFn {
-            fn(name)
-        } else {
-            // Engine-free fallback: resolve the name through the injected index
-            // mapper so unit tests can designate a named region with no live PyMOL.
-            let full = selectedIndicesFn(obj, name, editSourceObject, set.state)
-            stubSele = Set(full.compactMap { i in
-                (i >= 0 && i < set.residues.count)
-                    ? stickKey(set.residues[i].chain, set.residues[i].resi) : nil
-            })
-        }
-        syncFromSele()
-    }
-
     /// Toggle one residue (full-length index) in the active 'sele'.
     ///
     /// The single gesture entry point: the viewport, the sequence strip, and the
@@ -982,16 +915,8 @@ final class DesignController: ObservableObject {
         guard let obj = focusObject, let set = lastSet[obj],
               i >= 0, i < set.residues.count else { return }
         let r = set.residues[i]
-        pickedSelectionName = nil        // a click detaches from any named region
         if let fn = toggleSeleFn { fn(obj, r.chain, r.resi, editSourceObject) }
         else { seleToggleLocal(r.chain, r.resi) }
-        syncFromSele()
-    }
-
-    /// Clear the region by emptying 'sele' → back to nothing selected.
-    func clearSelection() {
-        pickedSelectionName = nil
-        if let fn = clearSeleFn { fn() } else { seleClearLocal() }
         syncFromSele()
     }
 
@@ -1002,21 +927,13 @@ final class DesignController: ObservableObject {
     }
 
     /// Reset all region state. Region state can exist without an edit session
-    /// (a selection picked before the first redesign), so this is called on
+    /// (residues selected before the first redesign), so this is called on
     /// mode exit and focus change too, not only in teardownEditSession.
     private func clearRegionState() {
         selectedResidueIndices = []
-        selectedSelectionName = nil
-        // The lasso name must not outlive the region it labels: `syncFromSele`
-        // prefers it on every derive, so a stale one would label a click-built
-        // region after re-entering Design mode or switching focus with 2+ residues
-        // still in 'sele'. Reset here because this is the one point both `exit()`
-        // and the focus-change path go through.
-        pickedSelectionName = nil
         paletteAllowed = Set(0..<20)
         redesignSnapshot = nil
         isRedesigning = false
-        availableSelections = []
         pendingSizeWarning = nil
         suppressSizeGuardOnce = false   // defence in depth: clear on focus change / mode exit
         designToken += 1   // cancel any in-flight region design
@@ -1028,7 +945,7 @@ final class DesignController: ObservableObject {
     /// Fire-and-forget region redesign (UI button). Wraps redesignSelectionAwait.
     func redesignSelection() { Task { await redesignSelectionAwait() } }
 
-    /// Run design() over the picked region with the rest of the sequence fixed,
+    /// Run design() over the selected region with the rest of the sequence fixed,
     /// scatter the result into editedSequence, then rescore + (auto)repack.
     /// Snapshots editedSequence first for a one-level revert.
     func redesignSelectionAwait() async {
@@ -1501,13 +1418,9 @@ final class DesignController: ObservableObject {
         self.setSticksFn = fn
     }
 
-    /// Override the region closures for testing (Task 2/3).
-    func injectRegion(designRegion: @escaping DesignRegionFn,
-                      listSelections: @escaping ListSelectionsFn = { _, _, _ in [] },
-                      selectedIndices: @escaping SelectedIndicesFn = { _, _, _, _ in [] }) {
+    /// Override the region design closure for testing (Task 2/3).
+    func injectRegion(designRegion: @escaping DesignRegionFn) {
         self.designRegionFn = designRegion
-        self.listSelectionsFn = listSelections
-        self.selectedIndicesFn = selectedIndices
     }
 
     /// Override the 'sele' closures for testing. Any argument left nil keeps the
@@ -1515,13 +1428,11 @@ final class DesignController: ObservableObject {
     func injectSele(seleState: SeleStateFn? = nil,
                     toggleSele: ToggleSeleFn? = nil,
                     setSeleResidue: SetSeleResidueFn? = nil,
-                    setSeleNamed: SetSeleNamedFn? = nil,
                     clearSele: ClearSeleFn? = nil,
                     dropObjectFromSele: DropObjectFromSeleFn? = nil) {
         if let seleState { self.seleStateFn = seleState }
         if let toggleSele { self.toggleSeleFn = toggleSele }
         if let setSeleResidue { self.setSeleResidueFn = setSeleResidue }
-        if let setSeleNamed { self.setSeleNamedFn = setSeleNamed }
         if let clearSele { self.clearSeleFn = clearSele }
         if let dropObjectFromSele { self.dropObjectFromSeleFn = dropObjectFromSele }
     }

--- a/swiftui/PyMOLViewer/Shared/DesignController.swift
+++ b/swiftui/PyMOLViewer/Shared/DesignController.swift
@@ -207,7 +207,16 @@ final class DesignController: ObservableObject {
     /// false = overlap (grey + transparent ghost behind design); true = grid (own confidence colors).
     @Published private(set) var sideBySide = false
     /// True while all sidechain sticks are shown on the design (and parent when compare is on).
-    @Published private(set) var showSidechains = false
+    /// True while all sidechain sticks are shown on the design (and parent when
+    /// compare is on). Defaults ON: designing is a sidechain-level activity, so the
+    /// target structure arrives with its sidechains visible.
+    ///
+    /// The default alone would be a REGRESSION rather than a feature —
+    /// `reconcileSticks()` early-returns while this is set, on the assumption that a
+    /// global show-all pass has already made every sidechain visible. So the flag is
+    /// only ever true in company with that pass: `focusAwait` issues it for the new
+    /// focus, and `exit()` / a focus change take it back down again.
+    @Published private(set) var showSidechains = true
     /// Mean per-residue native-fit log-probability over the valid residues of the focus object.
     /// nil until the first score result arrives. Updated after every rescore (including edits).
     /// Higher (closer to 0) = better sequence–structure fit.
@@ -385,6 +394,11 @@ final class DesignController: ObservableObject {
 
     /// Called when exiting Design mode: restore visuals and cancel any pending score.
     func exit() {
+        // Same reason the focus-change path does it: restore() below re-applies
+        // colours and transparency but NOT representation visibility, so the
+        // show-all pass has to be taken down explicitly or the user's structure is
+        // left covered in sticks after leaving Design mode.
+        if showSidechains, let obj = focusObject { showAllSidechainsFn(obj, false) }
         // Hide any sticks WE added first — restore() only re-applies colors and
         // transparency, not representation visibility, so it won't undo shown sticks.
         teardownSticks(on: focusObject)
@@ -560,6 +574,10 @@ final class DesignController: ObservableObject {
             // C1/C2: If an edit session is active when focus changes, discard it
             // (delete working copy, re-enable source) before switching focus.
             if editing { teardownEditSession(discardCopy: true) }
+            // Take the global show-all pass back down on the structure we are
+            // leaving, or every object visited in one session accumulates sticks
+            // (restore() re-applies colours and transparency, never representations).
+            if showSidechains, let prev = previous { showAllSidechainsFn(prev, false) }
             teardownSticks(on: previous)
             hoveredResidueIndex = nil
             pinnedResidueIndex = nil   // re-derived below by syncFromSele for the new scope
@@ -580,6 +598,11 @@ final class DesignController: ObservableObject {
             lastSet[object] = set
             syncFocusResidues()   // populate sequence strip as soon as residues are known
             syncFromSele()        // derive pin/region for the NEW focus's scope
+            // Sidechains are shown by default (see `showSidechains`). Issued here,
+            // after the residue set is known, so the flag and the on-screen state
+            // cannot disagree — reconcileSticks() suppresses per-residue sticks
+            // whenever the flag is set, so the flag must never be set alone.
+            if showSidechains { showAllSidechainsFn(object, true) }
 
             let key = DesignCacheKey(object: object, state: set.state, sequenceHash: set.sequenceHash)
             if let scores = cache.get(key) {

--- a/swiftui/PyMOLViewer/Shared/DesignController.swift
+++ b/swiftui/PyMOLViewer/Shared/DesignController.swift
@@ -77,11 +77,6 @@ final class DesignController: ObservableObject {
     /// Show or hide all sidechain sticks on `obj` (with cnc element coloring on show).
     typealias ShowAllSidechainsFn = (String, Bool) -> Void
 
-    /// Set or clear the persistent committed 'sele' marker for the pinned residue in the
-    /// 3D viewer.  Called with (obj, chain, resi) to commit the pink indicator, or
-    /// ("", "", "") to clear it on unpin / focus-change / teardown / exit.
-    typealias PinnedIndicatorFn = (_ obj: String, _ chain: String, _ resi: String) -> Void
-
     /// Apply per-residue coloring to `objectName`.
     /// `values`: (chain, resi, scalar?) for every residue in the set order.
     /// `metric` and `state` are for the metric store (#308), not for the colour: the
@@ -152,7 +147,6 @@ final class DesignController: ObservableObject {
     private var repack: RepackFn = { _, _ in "" }
     private var loadRepacked: LoadRepackedFn = { _, _ in }
     private var showAllSidechainsFn: ShowAllSidechainsFn = { _, _ in }
-    private var pinnedIndicatorFn: PinnedIndicatorFn = { _, _, _ in }
     private var designRegionFn: DesignRegionFn = { r, _, _, _, _ in Array(repeating: 0, count: r.count) }
     private var listSelectionsFn: ListSelectionsFn = { _, _, _ in [] }
     private var selectedIndicesFn: SelectedIndicesFn = { _, _, _, _ in [] }
@@ -346,7 +340,6 @@ final class DesignController: ObservableObject {
                      repack: @escaping RepackFn = { _, _ in "" },
                      loadRepacked: @escaping LoadRepackedFn = { _, _ in },
                      showAllSidechains: @escaping ShowAllSidechainsFn = { _, _ in },
-                     pinnedIndicator: @escaping PinnedIndicatorFn = { _, _, _ in },
                      designRegion: @escaping DesignRegionFn = { r, _, _, _, _ in Array(repeating: 0, count: r.count) },
                      listSelections: @escaping ListSelectionsFn = { _, _, _ in [] },
                      selectedIndices: @escaping SelectedIndicesFn = { _, _, _, _ in [] },
@@ -368,7 +361,6 @@ final class DesignController: ObservableObject {
         self.repack = repack
         self.loadRepacked = loadRepacked
         self.showAllSidechainsFn = showAllSidechains
-        self.pinnedIndicatorFn = pinnedIndicator
         self.designRegionFn = designRegion
         self.listSelectionsFn = listSelections
         self.selectedIndicesFn = selectedIndices
@@ -402,7 +394,8 @@ final class DesignController: ObservableObject {
         errorText = nil
         hoveredResidueIndex = nil
         pinnedResidueIndex = nil
-        pinnedIndicatorFn("", "", "")   // clear any persistent 'sele' marker on exit
+        // D2: 'sele' IS the pink marker now, and it belongs to the user — leaving
+        // Design mode must not wipe their selection, so nothing is pushed outward.
         clearRegionState()
         rescoreToken += 1; repackToken += 1   // cancel any in-flight scoring or repack
         rescoreMirror.set(rescoreToken); repackMirror.set(repackToken)
@@ -422,26 +415,56 @@ final class DesignController: ObservableObject {
     /// Unified viewport-hit routing shared between iOS (`designPickResidue`) and
     /// macOS (`onChange(of: engine.longPressHit)`).
     ///
-    /// Three-way rule:
-    ///   - `object` empty → no-op (tap on empty space or non-object background)
-    ///   - `object != focusObject` → `focus(object)` (retarget design to new structure)
-    ///   - `object == focusObject && hasResidue` → `tapResidue(residueIndex:)` for the residue;
-    ///     no-op if the residue doesn't resolve (e.g. missing backbone)
-    ///   - `object == focusObject && !hasResidue` → no-op (tap on backbone/solvent patch)
-    ///
-    /// Using `tapResidue` (not `setPinned` directly) for the same-object case means
-    /// region-edit mode works on both platforms: a tap in region-edit mode toggles
-    /// region membership rather than pinning.  The previous macOS `onChange` block
-    /// called `setPinned` directly and therefore ignored region-edit mode; routing
-    /// through this shared method fixes that uniformly.
+    /// Four-way rule, matching normal-mode click semantics:
+    ///   - `object` empty (a miss) → clear 'sele'; focus is untouched
+    ///   - `object != focusObject` → refocus there AND select that residue (D4),
+    ///     so the first click on another structure is never dead
+    ///   - `object == focusObject && hasResidue` → toggle that residue in 'sele'
+    ///   - `object == focusObject && !hasResidue` → no-op (a non-residue patch)
     func handleViewportHit(object: String, chain: String, resi: String, hasResidue: Bool) {
-        guard !object.isEmpty else { return }
+        guard !object.isEmpty else {
+            // Empty-space click clears, exactly as metal_pick.pick_at does.
+            pickedSelectionName = nil
+            if let fn = clearSeleFn { fn() } else { seleClearLocal() }
+            syncFromSele()
+            return
+        }
         if object != focusObject {
-            focus(object)
+            focusThenSelect(object: object, chain: chain, resi: resi, hasResidue: hasResidue)
         } else if hasResidue, let idx = residueIndex(chain: chain, resi: resi) {
             tapResidue(residueIndex: idx)
         }
         // object == focusObject && !hasResidue → no-op
+    }
+
+    /// Fire-and-forget refocus-then-select (used by the viewport hit path). Wraps
+    /// `refocusAndSelect` in a Task, mirroring `focus` / `focusAwait`.
+    private func focusThenSelect(object: String, chain: String, resi: String,
+                                 hasResidue: Bool) {
+        Task {
+            await refocusAndSelect(object: object, chain: chain, resi: resi,
+                                   hasResidue: hasResidue)
+        }
+    }
+
+    /// Retarget design to `object`, then seed 'sele' with the clicked residue.
+    ///
+    /// The two steps cannot be reordered or collapsed: `focusAwait` is async (it
+    /// enumerates residues and may score), and until it completes `lastSet[object]`
+    /// does not exist — so a `syncFromSele()` run before it would resolve the new
+    /// selection against the OLD object's residue set and silently produce garbage
+    /// indices.
+    private func refocusAndSelect(object: String, chain: String, resi: String,
+                                  hasResidue: Bool) async {
+        await focusAwait(object)
+        pickedSelectionName = nil
+        if hasResidue {
+            if let fn = setSeleResidueFn { fn(object, chain, resi) }
+            else { seleSetLocal(chain, resi) }
+        } else {
+            if let fn = clearSeleFn { fn() } else { seleClearLocal() }
+        }
+        syncFromSele()
     }
 
     // MARK: – Propensity hover/pin
@@ -489,27 +512,12 @@ final class DesignController: ObservableObject {
         reconcileSticks()
     }
 
-    /// Pin or unpin a residue. Tapping the same residue again toggles the pin
-    /// off. Pinned sticks are persistent; unpinning removes them (unless the
-    /// residue is also currently hovered, in which case reconcile keeps them
-    /// as transient hover sticks).
-    /// Also sets / clears the persistent pink 'sele' committed-selection marker in
-    /// the 3D viewer so the pinned residue is always visually highlighted.
+    /// Toggle one residue addressed by (chain, resi). Retained because the sequence
+    /// strip and several tests address residues that way. The pin itself is derived
+    /// by `syncFromSele` — this method never writes `pinnedResidueIndex`.
     func setPinned(chain: String, resi: String) {
-        let idx = residueIndex(chain: chain, resi: resi)
-        pinnedResidueIndex = (idx == pinnedResidueIndex) ? nil : idx
-        // Apply or clear the persistent committed 'sele' marker in the viewer.
-        let obj = focusObject ?? ""
-        if let i = pinnedResidueIndex,
-           let focus = focusObject,
-           let set = lastSet[focus],
-           i >= 0, i < set.residues.count {
-            let r = set.residues[i]
-            pinnedIndicatorFn(obj, r.chain, r.resi)
-        } else {
-            pinnedIndicatorFn(obj, "", "")
-        }
-        reconcileSticks()
+        guard let idx = residueIndex(chain: chain, resi: resi) else { return }
+        tapResidue(residueIndex: idx)
     }
 
     /// Switch the coloring meaning and immediately recolor the focused object from cache.
@@ -537,8 +545,7 @@ final class DesignController: ObservableObject {
             if editing { teardownEditSession(discardCopy: true) }
             teardownSticks(on: previous)
             hoveredResidueIndex = nil
-            pinnedResidueIndex = nil
-            pinnedIndicatorFn("", "", "")  // clear stale 'sele' marker for the previous focus
+            pinnedResidueIndex = nil   // re-derived below by syncFromSele for the new scope
             clearRegionState()
         }
         focusObject = object
@@ -555,6 +562,7 @@ final class DesignController: ObservableObject {
             let set = try enumerate(object, currentState(object))
             lastSet[object] = set
             syncFocusResidues()   // populate sequence strip as soon as residues are known
+            syncFromSele()        // derive pin/region for the NEW focus's scope
 
             let key = DesignCacheKey(object: object, state: set.state, sequenceHash: set.sequenceHash)
             if let scores = cache.get(key) {
@@ -723,9 +731,6 @@ final class DesignController: ObservableObject {
     private func teardownEditSession(discardCopy: Bool) {
         let src = editSourceObject
         let w = workingObject
-        // Clear the persistent 'sele' indicator — the focus object is changing (working
-        // copy → source or Design mode is ending) so any stale marker must be removed.
-        pinnedIndicatorFn("", "", "")
         // Clear grid_mode and un-grey the parent BEFORE the discard/enable block so
         // grid mode never outlasts a session and the parent's confidence colors are
         // restored regardless of how the session ends (discard or keep).
@@ -847,48 +852,57 @@ final class DesignController: ObservableObject {
         availableSelections = listSelectionsFn(obj, editSourceObject, set.state)
     }
 
-    /// Designate `name` as the region: snapshot its designable residues (valid only)
-    /// as `selectedResidueIndices`, in full-length space. Enters region mode.
+    /// Designate `name` as the region by writing it into 'sele' (D5), so 'sele'
+    /// stays the single source of truth rather than the controller holding a
+    /// second, divergent copy. The resulting indices come back through
+    /// `syncFromSele` like every other selection change.
+    ///
+    /// `pickedSelectionName` is set BEFORE `syncFromSele()` so the label survives:
+    /// at `valid.count >= 2` the sync uses it, and a later `tapResidue` clears it.
     func pickSelection(_ name: String) {
         guard let obj = focusObject, let set = lastSet[obj] else { return }
-        let full = selectedIndicesFn(obj, name, editSourceObject, set.state)
-        let valid = full.filter { $0 >= 0 && $0 < set.residues.count && set.residues[$0].valid }
-        selectedResidueIndices = valid
-        selectedSelectionName = valid.isEmpty ? nil : name
-    }
-
-    /// Add or remove one residue (full-length index) from an ad-hoc region built by
-    /// shift-clicking positions. Only designable (valid) residues can be included.
-    /// Detaches from any named selection (the region is now user-built).
-    func toggleRegionResidue(residueIndex i: Int) {
-        guard let obj = focusObject, let set = lastSet[obj],
-              i >= 0, i < set.residues.count, set.residues[i].valid else { return }
-        if let pos = selectedResidueIndices.firstIndex(of: i) {
-            selectedResidueIndices.remove(at: pos)
+        pickedSelectionName = name
+        if let fn = setSeleNamedFn {
+            fn(name)
         } else {
-            selectedResidueIndices = (selectedResidueIndices + [i]).sorted()
+            // Engine-free fallback: resolve the name through the injected index
+            // mapper so unit tests can designate a named region with no live PyMOL.
+            let full = selectedIndicesFn(obj, name, editSourceObject, set.state)
+            stubSele = Set(full.compactMap { i in
+                (i >= 0 && i < set.residues.count)
+                    ? stickKey(set.residues[i].chain, set.residues[i].resi) : nil
+            })
         }
-        selectedSelectionName = selectedResidueIndices.isEmpty ? nil : "custom"
+        syncFromSele()
     }
 
-    /// Route a plain tap on residue `i` (full-length index). In region-edit mode a
-    /// tap toggles region membership; otherwise it pins the residue for inspection,
-    /// which is the pre-existing behaviour.
+    /// Toggle one residue (full-length index) in the active 'sele'.
+    ///
+    /// The single gesture entry point: the viewport, the sequence strip, and the
+    /// compact panel all land here, so a click means the same thing everywhere and
+    /// the same thing it means in normal mode. The resulting mode (pin vs region)
+    /// is DERIVED by `syncFromSele`, never decided here.
     func tapResidue(residueIndex i: Int) {
-        if regionEditMode {
-            toggleRegionResidue(residueIndex: i)
-            return
-        }
         guard let obj = focusObject, let set = lastSet[obj],
               i >= 0, i < set.residues.count else { return }
         let r = set.residues[i]
-        setPinned(chain: r.chain, resi: r.resi)
+        pickedSelectionName = nil        // a click detaches from any named region
+        if let fn = toggleSeleFn { fn(obj, r.chain, r.resi) }
+        else { seleToggleLocal(r.chain, r.resi) }
+        syncFromSele()
     }
 
-    /// Clear the region → return to single-residue (Phase-2b) mode.
+    /// Historical name for `tapResidue`, kept because call sites and tests read
+    /// naturally with it. Both go through 'sele', so they are now the same action.
+    func toggleRegionResidue(residueIndex i: Int) {
+        tapResidue(residueIndex: i)
+    }
+
+    /// Clear the region by emptying 'sele' → back to nothing selected.
     func clearSelection() {
-        selectedResidueIndices = []
-        selectedSelectionName = nil
+        pickedSelectionName = nil
+        if let fn = clearSeleFn { fn() } else { seleClearLocal() }
+        syncFromSele()
     }
 
     /// Toggle an amino acid (0..<20) in/out of the region sampling palette.
@@ -1418,6 +1432,19 @@ final class DesignController: ObservableObject {
     /// Override the model-release closure for testing (Phase 2d).
     func injectReleaseModel(_ fn: @escaping ReleaseModelFn) {
         self.releaseModelFn = fn
+    }
+
+    /// Awaitable entry to the refocus-then-select path, so a test can await the
+    /// async refocus deterministically instead of polling `focusObject` through a
+    /// guessed number of `Task.yield()`s — `focusAwait` crosses a real
+    /// DispatchQueue hop, so any fixed yield count is a race. Delegates to the SAME
+    /// private method the synchronous `focusThenSelect` wraps in a Task; it does not
+    /// duplicate the body. Mirrors `focus` / `focusAwait` and
+    /// `applyMutation` / `applyMutationAwait`.
+    func refocusAndSelectAwait(object: String, chain: String, resi: String,
+                               hasResidue: Bool) async {
+        await refocusAndSelect(object: object, chain: chain, resi: resi,
+                               hasResidue: hasResidue)
     }
 
     /// Set focus + a synthetic residue set (built from `nativeSequence`) without the async

--- a/swiftui/PyMOLViewer/Shared/DesignController.swift
+++ b/swiftui/PyMOLViewer/Shared/DesignController.swift
@@ -113,9 +113,21 @@ final class DesignController: ObservableObject {
     typealias SeleStateFn = (_ obj: String, _ src: String?, _ state: Int)
         -> (indices: [Int], digest: String, total: Int)
     /// Add or remove one residue in the active 'sele'.
-    typealias ToggleSeleFn = (_ obj: String, _ chain: String, _ resi: String) -> Void
-    /// Replace the active 'sele' with exactly one residue.
-    typealias SetSeleResidueFn = (_ obj: String, _ chain: String, _ resi: String) -> Void
+    ///
+    /// `src` is the edit-session source object and is NOT optional decoration: the
+    /// write has to resolve in the same scope `SeleStateFn` reads (`obj` + `src`,
+    /// matched by residue identity). Object-scoped, a toggle inside an edit session
+    /// could never REMOVE a region member — the focus object is the working copy
+    /// while the selection sits on the original's atoms, so the toggle found
+    /// nothing to remove and added instead — and residues clicked during the
+    /// session lost their membership when a repack replaced the working copy's
+    /// topology.
+    typealias ToggleSeleFn = (_ obj: String, _ chain: String, _ resi: String,
+                              _ src: String?) -> Void
+    /// Replace the active 'sele' with exactly one residue. `src` scopes the write
+    /// exactly as it does for `ToggleSeleFn`.
+    typealias SetSeleResidueFn = (_ obj: String, _ chain: String, _ resi: String,
+                                  _ src: String?) -> Void
     /// Replace the active 'sele' with the contents of a named selection.
     typealias SetSeleNamedFn = (_ name: String) -> Void
     /// Empty the active 'sele'.
@@ -461,14 +473,20 @@ final class DesignController: ObservableObject {
     private func refocusAndSelect(object: String, chain: String, resi: String,
                                   hasResidue: Bool) async {
         await focusAwait(object)
-        // A failed focus (enumerate threw) leaves no residue set for `object`, so a
-        // write here would replace the user's selection with a residue that cannot
-        // resolve — they would be left with neither their old selection nor a usable
-        // new one. Bail instead and leave 'sele' exactly as it was.
-        guard lastSet[object] != nil else { return }
+        // Two guards, for two different failures:
+        //  - `lastSet[object] != nil`: a failed focus (enumerate threw) leaves no
+        //    residue set, so a write would replace the user's selection with a
+        //    residue that cannot resolve — neither their old selection nor a usable
+        //    new one. Bail and leave 'sele' exactly as it was.
+        //  - `focusObject == object`: existence is not CURRENCY. Two rapid clicks on
+        //    two different non-focus objects spawn two Tasks; if the loser resumes
+        //    last its write would land while the winner owns the focus, leaving
+        //    'sele' on a NON-focused object — pink markers plus "nothing selected",
+        //    because every read is scoped to the focus object.
+        guard focusObject == object, lastSet[object] != nil else { return }
         pickedSelectionName = nil
         if hasResidue {
-            if let fn = setSeleResidueFn { fn(object, chain, resi) }
+            if let fn = setSeleResidueFn { fn(object, chain, resi, editSourceObject) }
             else { seleSetLocal(chain, resi) }
         } else {
             if let fn = clearSeleFn { fn() } else { seleClearLocal() }
@@ -854,10 +872,38 @@ final class DesignController: ObservableObject {
         } else {
             selectedResidueIndices = []
             selectedSelectionName = nil
+            // Below 2 residues there is no region for a lasso name to label, so the
+            // name must not survive to label the NEXT one. Without this, designating
+            // a selection that resolves to exactly ONE designable residue leaves
+            // `pickedSelectionName` set (the branch above never runs), and a later
+            // click-built or externally-selected region silently inherits the old
+            // name on the lasso button.
+            pickedSelectionName = nil
             pinnedResidueIndex = valid.first
         }
         reconcileSticks()
         return valid.count
+    }
+
+    /// Panel-poll entry point: re-derive only when the observed digest differs from
+    /// the last one resolved. Returns true iff a re-derive happened.
+    ///
+    /// The gate lives here rather than at the call site so it is testable without
+    /// the engine, and so the no-focus case can be handled where it is understood:
+    /// `syncFromSele()` cannot read a digest without a focus object (the read is
+    /// scoped to one), so it leaves `lastSeleDigest` untouched and the 500 ms poll
+    /// would re-derive on EVERY tick for as long as Design mode is on with no focus
+    /// — republishing four `@Published` properties and invalidating the design bar,
+    /// the compact panel and the sequence strip twice a second, indefinitely.
+    /// Entering Design mode with 2+ objects loaded (so `enter()` does not
+    /// auto-focus) and any non-empty 'sele' is exactly that state. Adopting the
+    /// digest the poll itself saw closes it.
+    @discardableResult
+    func syncFromSeleIfChanged(digest: String) -> Bool {
+        guard digest != lastSeleDigest else { return false }
+        syncFromSele()
+        if focusObject == nil { lastSeleDigest = digest }
+        return true
     }
 
     // MARK: – Region redesign: designation + palette (Task 2)
@@ -905,7 +951,7 @@ final class DesignController: ObservableObject {
               i >= 0, i < set.residues.count else { return }
         let r = set.residues[i]
         pickedSelectionName = nil        // a click detaches from any named region
-        if let fn = toggleSeleFn { fn(obj, r.chain, r.resi) }
+        if let fn = toggleSeleFn { fn(obj, r.chain, r.resi, editSourceObject) }
         else { seleToggleLocal(r.chain, r.resi) }
         syncFromSele()
     }

--- a/swiftui/PyMOLViewer/Shared/DesignController.swift
+++ b/swiftui/PyMOLViewer/Shared/DesignController.swift
@@ -457,6 +457,11 @@ final class DesignController: ObservableObject {
     private func refocusAndSelect(object: String, chain: String, resi: String,
                                   hasResidue: Bool) async {
         await focusAwait(object)
+        // A failed focus (enumerate threw) leaves no residue set for `object`, so a
+        // write here would replace the user's selection with a residue that cannot
+        // resolve — they would be left with neither their old selection nor a usable
+        // new one. Bail instead and leave 'sele' exactly as it was.
+        guard lastSet[object] != nil else { return }
         pickedSelectionName = nil
         if hasResidue {
             if let fn = setSeleResidueFn { fn(object, chain, resi) }
@@ -926,6 +931,12 @@ final class DesignController: ObservableObject {
     private func clearRegionState() {
         selectedResidueIndices = []
         selectedSelectionName = nil
+        // The lasso name must not outlive the region it labels: `syncFromSele`
+        // prefers it on every derive, so a stale one would label a click-built
+        // region after re-entering Design mode or switching focus with 2+ residues
+        // still in 'sele'. Reset here because this is the one point both `exit()`
+        // and the focus-change path go through.
+        pickedSelectionName = nil
         paletteAllowed = Set(0..<20)
         redesignSnapshot = nil
         isRedesigning = false

--- a/swiftui/PyMOLViewer/Shared/DesignResidues.swift
+++ b/swiftui/PyMOLViewer/Shared/DesignResidues.swift
@@ -39,11 +39,4 @@ struct DesignResidueSet {
         return DesignResidueSet(object: raw.object, state: raw.state, residues: residues)
     }
 }
-
-/// One entry in the region-redesign selection dropdown.
-struct DesignSelectionOption: Identifiable, Equatable {
-    let name: String
-    let count: Int
-    var id: String { name }
-}
 #endif

--- a/swiftui/PyMOLViewer/Shared/MetalViewport.swift
+++ b/swiftui/PyMOLViewer/Shared/MetalViewport.swift
@@ -1042,8 +1042,9 @@ extension MetalViewport {
             #if RAYMOL_MPNN
             if engine.designMode {
                 // In Design mode a viewport tap targets a residue, mirroring the
-                // macOS long-press path. Region-edit mode makes it toggle region
-                // membership instead of pinning — see DesignController.tapResidue.
+                // macOS long-press path. The tap always TOGGLES that residue in
+                // 'sele'; the COUNT of selected residues then decides the mode
+                // (1 → pinned, 2+ → region) — see DesignController.syncFromSele.
                 engine.designPickResidue(ndcX: ndcX, ndcY: ndcY, aspect: aspect)
                 return
             }

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -2470,16 +2470,22 @@ final class PyMOLEngine: ObservableObject {
                     digest: (root["digest"] as? String) ?? "",
                     total: (root["n_total"] as? Int) ?? 0)
         },
-        toggleSele: { [weak self] obj, chain, resi in
+        // `src` is passed through to Python so the WRITE resolves in the same scope
+        // the read does — see raymol_design._scoped_residue_sel. Dropping it makes a
+        // region member un-removable inside an edit session and lets a repack
+        // silently shrink the region.
+        toggleSele: { [weak self] obj, chain, resi, src in
+            let srcArg = (src?.isEmpty == false) ? src! : ""
             self?.runPython("""
                 from pymol import raymol_design as _rd
-                _rd.toggle_sele_residue('\(obj)', '\(chain)', '\(resi)')
+                _rd.toggle_sele_residue('\(obj)', '\(chain)', '\(resi)', src='\(srcArg)')
                 """)
         },
-        setSeleResidue: { [weak self] obj, chain, resi in
+        setSeleResidue: { [weak self] obj, chain, resi, src in
+            let srcArg = (src?.isEmpty == false) ? src! : ""
             self?.runPython("""
                 from pymol import raymol_design as _rd
-                _rd.set_sele_residue('\(obj)', '\(chain)', '\(resi)')
+                _rd.set_sele_residue('\(obj)', '\(chain)', '\(resi)', src='\(srcArg)')
                 """)
         },
         setSeleNamed: { [weak self] name in
@@ -2882,29 +2888,48 @@ final class PyMOLEngine: ObservableObject {
     /// Runs on the main thread (UIKit tap callback); uses MainActor.assumeIsolated
     /// to satisfy Swift Concurrency's actor-isolation check (same pattern as
     /// readDesignHoverHit).
+    /// What a `hover_design_at` payload means for the controller.
+    ///
+    /// Two outcomes that a single `hit == false` cannot express, and conflating them
+    /// destroys the user's selection:
+    ///   - nil  → the payload could not be READ (missing file, unparseable JSON, no
+    ///            `hit` key). The pick told us nothing, so the tap must be a no-op.
+    ///   - hit:false → the pick RAN and missed empty space, which must clear 'sele'
+    ///            for normal-mode parity.
+    /// `hover_design_at` always writes `obj` alongside `hit`, so a decodable payload
+    /// carrying `hit` is always a genuine pick result.
+    /// Static and payload-in so the distinction is unit-testable without an engine.
+    static func designPickOutcome(payload: [String: Any]?)
+        -> (object: String, chain: String, resi: String, hit: Bool)? {
+        guard let root = payload, let hit = root["hit"] as? Bool else { return nil }
+        return (object: hit ? (root["obj"] as? String ?? "") : "",
+                chain: root["chain"] as? String ?? "",
+                resi: root["resi"] as? String ?? "",
+                hit: hit)
+    }
+
     func designPickResidue(ndcX: Float, ndcY: Float, aspect: Float) {
         guard designMode, isReady else { return }
         runPython("from pymol import metal_pick as _mp; _mp.hover_design_at(\(ndcX), \(ndcY), \(aspect))")
         let path = (NSTemporaryDirectory() as NSString)
             .appendingPathComponent("pymol_hover_design.json")
-        var obj = "", chain = "", resi = ""
-        var hit = false
-        if let data = FileManager.default.contents(atPath: path),
-           let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-            hit   = (root["hit"] as? Bool) ?? false
-            obj   = root["obj"]   as? String ?? ""
-            chain = root["chain"] as? String ?? ""
-            resi  = root["resi"]  as? String ?? ""
-        }
-        // A MISS must still reach the controller: an empty-space tap clears the
-        // selection (normal-mode parity). The previous early return on `hit ==
-        // false` made empty taps silently inert. An empty `object` is exactly what
-        // the macOS path already delivers on a miss (longPressPick builds
-        // LongPressHit with obj: "" and isEmpty: true), so both platforms converge.
+        let data = FileManager.default.contents(atPath: path)
+        let root = data.flatMap {
+            try? JSONSerialization.jsonObject(with: $0) as? [String: Any]
+        } ?? nil
+        // An unreadable payload must NOT reach the controller: `handleViewportHit`
+        // with an empty object CLEARS 'sele', so treating "I could not read the
+        // pick" as "the pick missed" would silently destroy the user's selection.
+        guard let out = PyMOLEngine.designPickOutcome(payload: root) else { return }
+        // A genuine MISS does still reach the controller: an empty-space tap clears
+        // the selection (normal-mode parity). The old early return on `hit == false`
+        // made empty taps silently inert. An empty `object` is exactly what the
+        // macOS path already delivers on a miss (longPressPick builds LongPressHit
+        // with obj: "" and isEmpty: true), so both platforms converge.
         MainActor.assumeIsolated {
-            designController.handleViewportHit(object: hit ? obj : "",
-                                               chain: chain, resi: resi,
-                                               hasResidue: hit)
+            designController.handleViewportHit(object: out.object,
+                                               chain: out.chain, resi: out.resi,
+                                               hasResidue: out.hit)
         }
     }
 

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -2400,16 +2400,6 @@ final class PyMOLEngine: ObservableObject {
                 _rd.show_all_sidechains('\(obj)', \(on ? 1 : 0))
                 """)
         },
-        pinnedIndicator: { [weak self] obj, chain, resi in
-            // Commit the pinned residue to 'sele' (pink committed-selection pass) or clear it.
-            // Uses the same idiom as pick_at: cmd.select('sele', ..., enable=1) for the committed
-            // pink pass, or 'none'/enable=0 to clear. Runs on the @MainActor (called from
-            // setPinned / exit / focus-change), so runPython is safe on the main thread.
-            self?.runPython("""
-                from pymol import raymol_design as _rd
-                _rd.set_pinned_indicator('\(obj)', '\(chain)', '\(resi)')
-                """)
-        },
         designRegion: { [weak self] residues, fixed, native, omit, temperature in
             guard let self else {
                 throw NSError(domain: "raymol.design", code: 2,

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -2181,6 +2181,10 @@ final class PyMOLEngine: ObservableObject {
             if measureMode != nil { setMeasureMode(nil) }
         }
         designMode = on
+        // Arm/disarm the Design-mode 'sele' digest that poll_panel computes. Off ⇒
+        // that 500 ms main-thread poll pays one boolean check (see raymol_design
+        // .sele_digest), which is why this must be toggled rather than always on.
+        runPython("from pymol import raymol_design as _rd; _rd.set_design_active(\(on ? 1 : 0))")
     }
 
     // MARK: - Exclusive interaction modes (Move / Design / Measure)
@@ -2449,6 +2453,43 @@ final class PyMOLEngine: ObservableObject {
             // Called on DesignController's inference queue, which is the only
             // context that touches _mpnnModel — see loadedMPNNModel().
             self?._mpnnModel = nil
+        },
+        seleState: { [weak self] obj, src, state in
+            guard let self else { return (indices: [], digest: "", total: 0) }
+            let srcArg = (src?.isEmpty == false) ? src! : ""
+            self.runPython("""
+                from pymol import raymol_design as _rd
+                _rd.sele_design_indices('\(obj)', \(state), src='\(srcArg)')
+                """)
+            let path = FileManager.default.temporaryDirectory
+                .appendingPathComponent("raymol_design_sele.json")
+            guard let data = FileManager.default.contents(atPath: path.path),
+                  let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { return (indices: [], digest: "", total: 0) }
+            return (indices: (root["indices"] as? [Int]) ?? [],
+                    digest: (root["digest"] as? String) ?? "",
+                    total: (root["n_total"] as? Int) ?? 0)
+        },
+        toggleSele: { [weak self] obj, chain, resi in
+            self?.runPython("""
+                from pymol import raymol_design as _rd
+                _rd.toggle_sele_residue('\(obj)', '\(chain)', '\(resi)')
+                """)
+        },
+        setSeleResidue: { [weak self] obj, chain, resi in
+            self?.runPython("""
+                from pymol import raymol_design as _rd
+                _rd.set_sele_residue('\(obj)', '\(chain)', '\(resi)')
+                """)
+        },
+        setSeleNamed: { [weak self] name in
+            self?.runPython("""
+                from pymol import raymol_design as _rd
+                _rd.set_sele_from_selection('\(name)')
+                """)
+        },
+        clearSele: { [weak self] in
+            self?.runPython("from pymol import raymol_design as _rd; _rd.clear_sele()")
         }
         )
         // Propagate isCalculating into @Published isDesignCalculating so
@@ -2846,18 +2887,24 @@ final class PyMOLEngine: ObservableObject {
         runPython("from pymol import metal_pick as _mp; _mp.hover_design_at(\(ndcX), \(ndcY), \(aspect))")
         let path = (NSTemporaryDirectory() as NSString)
             .appendingPathComponent("pymol_hover_design.json")
-        guard let data = FileManager.default.contents(atPath: path),
-              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let hit = root["hit"] as? Bool, hit,
-              let chain = root["chain"] as? String,
-              let resi  = root["resi"]  as? String
-        else { return }
-        let focusObj = root["obj"] as? String ?? ""
+        var obj = "", chain = "", resi = ""
+        var hit = false
+        if let data = FileManager.default.contents(atPath: path),
+           let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            hit   = (root["hit"] as? Bool) ?? false
+            obj   = root["obj"]   as? String ?? ""
+            chain = root["chain"] as? String ?? ""
+            resi  = root["resi"]  as? String ?? ""
+        }
+        // A MISS must still reach the controller: an empty-space tap clears the
+        // selection (normal-mode parity). The previous early return on `hit ==
+        // false` made empty taps silently inert. An empty `object` is exactly what
+        // the macOS path already delivers on a miss (longPressPick builds
+        // LongPressHit with obj: "" and isEmpty: true), so both platforms converge.
         MainActor.assumeIsolated {
-            designController.handleViewportHit(object: focusObj,
-                                               chain: chain,
-                                               resi: resi,
-                                               hasResidue: true)   // guard above ensures hit==true
+            designController.handleViewportHit(object: hit ? obj : "",
+                                               chain: chain, resi: resi,
+                                               hasResidue: hit)
         }
     }
 

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -2386,7 +2386,7 @@ final class PyMOLEngine: ObservableObject {
             let model = try self.loadedMPNNModel()
             return try MPNNRuntime.withMLXErrorsAsThrows { try model.repack(residues, sequence: seq).pdb }
         },
-        loadRepacked: { [weak self] obj, pdb in
+        loadRepacked: { [weak self] obj, pdb, src in
             // Write PDB to a temp file; Python reads it back to avoid multi-line
             // escaping in the runPython string (same marshalling as applyColoring).
             let path = (NSTemporaryDirectory() as NSString)
@@ -2395,7 +2395,7 @@ final class PyMOLEngine: ObservableObject {
             self?.runPython("""
                 from pymol import raymol_design as _rd
                 with open('\(path)') as _f:
-                    _rd.load_repacked('\(obj)', _f.read())
+                    _rd.load_repacked('\(obj)', _f.read(), src='\(src ?? "")')
                 """)
         },
         showAllSidechains: { [weak self] obj, on in
@@ -2455,7 +2455,7 @@ final class PyMOLEngine: ObservableObject {
             self?._mpnnModel = nil
         },
         seleState: { [weak self] obj, src, state in
-            guard let self else { return (indices: [], digest: "", total: 0) }
+            guard let self else { return (indices: [], digest: "", off: 0) }
             let srcArg = (src?.isEmpty == false) ? src! : ""
             self.runPython("""
                 from pymol import raymol_design as _rd
@@ -2465,10 +2465,13 @@ final class PyMOLEngine: ObservableObject {
                 .appendingPathComponent("raymol_design_sele.json")
             guard let data = FileManager.default.contents(atPath: path.path),
                   let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-            else { return (indices: [], digest: "", total: 0) }
+            else { return (indices: [], digest: "", off: 0) }
+            // n_off, never n_total - indices.count: during an edit session one
+            // residue is legitimately marked on both the working copy and the
+            // original, so any whole-session total counts it twice.
             return (indices: (root["indices"] as? [Int]) ?? [],
                     digest: (root["digest"] as? String) ?? "",
-                    total: (root["n_total"] as? Int) ?? 0)
+                    off: (root["n_off"] as? Int) ?? 0)
         },
         // `src` is passed through to Python so the WRITE resolves in the same scope
         // the read does — see raymol_design._scoped_residue_sel. Dropping it makes a
@@ -2496,6 +2499,12 @@ final class PyMOLEngine: ObservableObject {
         },
         clearSele: { [weak self] in
             self?.runPython("from pymol import raymol_design as _rd; _rd.clear_sele()")
+        },
+        dropObjectFromSele: { [weak self] obj in
+            self?.runPython("""
+                from pymol import raymol_design as _rd
+                _rd.drop_object_from_sele('\(obj)')
+                """)
         }
         )
         // Propagate isCalculating into @Published isDesignCalculating so
@@ -2908,28 +2917,39 @@ final class PyMOLEngine: ObservableObject {
                 hit: hit)
     }
 
+    /// Read a hover-pick payload file and deliver the outcome — or deliver NOTHING
+    /// when the payload cannot be read (no file, non-JSON bytes, JSON that is not an
+    /// object, no `hit` key). `deliver` reaching the controller is the decision this
+    /// function exists to make: `handleViewportHit(object: "")` CLEARS 'sele', so an
+    /// unreadable payload must not be routed at all. Static, file-in, closure-out, so
+    /// the guard itself is testable without a live core.
+    static func routeDesignPick(payloadPath: String,
+                                deliver: (_ object: String, _ chain: String,
+                                          _ resi: String, _ hit: Bool) -> Void) {
+        guard let data = FileManager.default.contents(atPath: payloadPath) else { return }
+        let root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+        guard let out = designPickOutcome(payload: root) else { return }
+        deliver(out.object, out.chain, out.resi, out.hit)
+    }
+
     func designPickResidue(ndcX: Float, ndcY: Float, aspect: Float) {
         guard designMode, isReady else { return }
         runPython("from pymol import metal_pick as _mp; _mp.hover_design_at(\(ndcX), \(ndcY), \(aspect))")
         let path = (NSTemporaryDirectory() as NSString)
             .appendingPathComponent("pymol_hover_design.json")
-        let data = FileManager.default.contents(atPath: path)
-        let root = data.flatMap {
-            try? JSONSerialization.jsonObject(with: $0) as? [String: Any]
-        } ?? nil
         // An unreadable payload must NOT reach the controller: `handleViewportHit`
         // with an empty object CLEARS 'sele', so treating "I could not read the
         // pick" as "the pick missed" would silently destroy the user's selection.
-        guard let out = PyMOLEngine.designPickOutcome(payload: root) else { return }
-        // A genuine MISS does still reach the controller: an empty-space tap clears
-        // the selection (normal-mode parity). The old early return on `hit == false`
+        // A genuine MISS does still reach it: an empty-space tap clears the
+        // selection (normal-mode parity). The old early return on `hit == false`
         // made empty taps silently inert. An empty `object` is exactly what the
         // macOS path already delivers on a miss (longPressPick builds LongPressHit
         // with obj: "" and isEmpty: true), so both platforms converge.
-        MainActor.assumeIsolated {
-            designController.handleViewportHit(object: out.object,
-                                               chain: out.chain, resi: out.resi,
-                                               hasResidue: out.hit)
+        PyMOLEngine.routeDesignPick(payloadPath: path) { obj, chain, resi, hit in
+            MainActor.assumeIsolated {
+                designController.handleViewportHit(object: obj, chain: chain,
+                                                   resi: resi, hasResidue: hit)
+            }
         }
     }
 

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -2453,37 +2453,6 @@ final class PyMOLEngine: ObservableObject {
             opts.omit = omit
             return try MPNNRuntime.withMLXErrorsAsThrows { try model.design(residues, options: opts).indices }
         },
-        listSelections: { [weak self] obj, src, state in
-            guard let self else { return [] }
-            let srcArg = (src?.isEmpty == false) ? src! : ""
-            self.runPython("""
-                from pymol import raymol_design as _rd
-                _rd.list_design_selections('\(obj)', \(state), src='\(srcArg)')
-                """)
-            let path = FileManager.default.temporaryDirectory
-                .appendingPathComponent("raymol_design_selections.json")
-            guard let data = FileManager.default.contents(atPath: path.path),
-                  let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  let arr = root["selections"] as? [[String: Any]] else { return [] }
-            return arr.compactMap { d in
-                guard let name = d["name"] as? String, let n = d["n"] as? Int else { return nil }
-                return DesignSelectionOption(name: name, count: n)
-            }
-        },
-        selectedIndices: { [weak self] obj, sel, src, state in
-            guard let self else { return [] }
-            let srcArg = (src?.isEmpty == false) ? src! : ""
-            self.runPython("""
-                from pymol import raymol_design as _rd
-                _rd.selected_design_indices('\(obj)', '\(sel)', \(state), src='\(srcArg)')
-                """)
-            let path = FileManager.default.temporaryDirectory
-                .appendingPathComponent("raymol_design_selected.json")
-            guard let data = FileManager.default.contents(atPath: path.path),
-                  let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  let idx = root["indices"] as? [Int] else { return [] }
-            return idx
-        },
         releaseModel: { [weak self] in
             // Called on DesignController's inference queue, which is the only
             // context that touches _mpnnModel — see loadedMPNNModel().
@@ -2524,12 +2493,6 @@ final class PyMOLEngine: ObservableObject {
             self?.runPython("""
                 from pymol import raymol_design as _rd
                 _rd.set_sele_residue('\(obj)', '\(chain)', '\(resi)', src='\(srcArg)')
-                """)
-        },
-        setSeleNamed: { [weak self] name in
-            self?.runPython("""
-                from pymol import raymol_design as _rd
-                _rd.set_sele_from_selection('\(name)')
                 """)
         },
         clearSele: { [weak self] in

--- a/swiftui/PyMOLViewerTests/AnalysisNotesStoreTests.swift
+++ b/swiftui/PyMOLViewerTests/AnalysisNotesStoreTests.swift
@@ -172,6 +172,77 @@ final class AnalysisNotesStoreTests: XCTestCase {
         ])
     }
 
+    @MainActor
+    func testLinkedThumbnailComposesWrappedMarkdownAndCleansToViewLabel() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AnalysisNotesStoreTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let source = root.appendingPathComponent("source.png")
+        try Data([0x89, 0x50, 0x4E, 0x47]).write(to: source)
+        let store = AnalysisNotesStore(fallbackDirectory: root, debounceInterval: 60)
+        let bookmark = try XCTUnwrap(store.addViewBookmark(
+            title: "Ligand pocket", view: (0..<25).map(Float.init),
+            kind: .camera, insertsMarkdown: false
+        ))
+        XCTAssertEqual(store.text, "")
+        let asset = try XCTUnwrap(store.addScreenshot(title: "Ligand pocket", from: source,
+                                                      linkedBookmarkID: bookmark.id))
+
+        XCTAssertEqual(store.text,
+                       "[![Ligand pocket](raymol-asset://\(asset.id.uuidString))]"
+                       + "(raymol-view://\(bookmark.id.uuidString))")
+        XCTAssertEqual(store.cleanMarkdown, "**Camera view:** Ligand pocket")
+    }
+
+    @MainActor
+    func testAppendViewLinkAddsBareTextLink() throws {
+        let store = AnalysisNotesStore(debounceInterval: 60)
+        let bookmark = try XCTUnwrap(store.addViewBookmark(
+            title: "Interface", view: (0..<25).map(Float.init), insertsMarkdown: false
+        ))
+        store.appendViewLink(bookmark)
+        XCTAssertEqual(store.text, "[Interface](raymol-view://\(bookmark.id.uuidString))")
+    }
+
+    func testPreviewParserRecognizesThumbnailsBoundToViewLinks() {
+        let asset = UUID()
+        let bookmark = UUID()
+        let plain = UUID()
+        let markdown = """
+        Before.
+        [![Pocket](raymol-asset://\(asset.uuidString))](raymol-view://\(bookmark.uuidString))
+        Between.
+        ![Plain](raymol-asset://\(plain.uuidString))
+        After.
+        """
+
+        XCTAssertEqual(AnalysisNotePreviewParser.blocks(in: markdown), [
+            .markdown("Before."),
+            .linkedImage(asset, bookmark),
+            .markdown("Between."),
+            .image(plain),
+            .markdown("After.")
+        ])
+    }
+
+    @MainActor
+    func testHTMLExportKeepsLinkedThumbnailReadableWhenAssetIsMissing() {
+        let store = AnalysisNotesStore(debounceInterval: 60)
+        let bookmark = try? XCTUnwrap(store.addViewBookmark(
+            title: "Contact map", view: (0..<25).map(Float.init),
+            kind: .scene, sceneName: "__raymol_note_test", insertsMarkdown: false
+        ))
+        guard let bookmark else { return XCTFail("bookmark") }
+        store.text = "[![Contact map](raymol-asset://\(UUID().uuidString))]"
+            + "(raymol-view://\(bookmark.id.uuidString))"
+
+        let html = store.exportHTML()
+        XCTAssertTrue(html.contains("Scene view: Contact map"), html)
+        XCTAssertFalse(html.contains("raymol-asset://"), html)
+    }
+
     func testPreviewParserLeavesOtherMarkdownLinksUntouched() {
         let markdown = "[View](raymol-view://1234) and [site](https://raymol.io/)"
 

--- a/swiftui/PyMOLViewerTests/DesignEditingTests.swift
+++ b/swiftui/PyMOLViewerTests/DesignEditingTests.swift
@@ -129,7 +129,7 @@ final class DesignEditingTests: XCTestCase {
         }
         c.injectRepack(
             repack: { _, seq in repackedSeqs.append(seq); return "PDBDATA" },
-            loadRepacked: { obj, pdb in loaded.append((obj, pdb)) })
+            loadRepacked: { obj, pdb, _ in loaded.append((obj, pdb)) })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
         c.autoRepack = false   // test manual repack path; disable auto so mutation stays dirty
         await c.applyMutationAwait(residueIndex: 0, aa: 1)
@@ -150,7 +150,7 @@ final class DesignEditingTests: XCTestCase {
                 logProbs: Array(repeating: Array(repeating: -3, count: 21), count: s.count),
                 currentAALogProb: Array(repeating: -3, count: s.count))
         }
-        c.injectRepack(repack: { _, _ in repacks += 1; return "P" }, loadRepacked: { _, _ in })
+        c.injectRepack(repack: { _, _ in repacks += 1; return "P" }, loadRepacked: { _, _, _ in })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3)); c.autoRepack = true
         await c.applyMutationAwait(residueIndex: 0, aa: 1)
         XCTAssertEqual(repacks, 1)      // repack ran exactly once
@@ -167,7 +167,7 @@ final class DesignEditingTests: XCTestCase {
                 logProbs: Array(repeating: Array(repeating: -3, count: 21), count: s.count),
                 currentAALogProb: Array(repeating: -3, count: s.count))
         }
-        c.injectRepack(repack: { _, _ in repackCalls += 1; return "PDBDATA" }, loadRepacked: { _, _ in })
+        c.injectRepack(repack: { _, _ in repackCalls += 1; return "PDBDATA" }, loadRepacked: { _, _, _ in })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
         c.applyMutation(residueIndex: 0, aa: 1)     // begins session, marks dirty
         XCTAssertTrue(c.repackDirty)
@@ -221,7 +221,7 @@ final class DesignEditingTests: XCTestCase {
             snapshot: { _ in },
             restore: { })
         c.injectEdit(makeWorkingCopy: { $0 + "_design" }, mutateDisplay: { _, _, _, _ in }, discard: { _, _ in }, compare: { _, _ in })
-        c.injectRepack(repack: { _, _ in "PDBDATA" }, loadRepacked: { _, _ in })
+        c.injectRepack(repack: { _, _ in "PDBDATA" }, loadRepacked: { _, _, _ in })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: [true, true, true])
 
         // Sync mutation → detached Task starts rescoreWorkingObject → dispatches to inferenceQueue → blocks

--- a/swiftui/PyMOLViewerTests/DesignEditingTests.swift
+++ b/swiftui/PyMOLViewerTests/DesignEditingTests.swift
@@ -441,5 +441,73 @@ final class DesignEditingTests: XCTestCase {
         XCTAssertFalse(disabledObjs.contains("compare_false_fired"),
                        "setCompare(false) was called after discard — original may have been re-disabled")
     }
+
+    // MARK: – Sidechains shown by default on the target structure
+
+    // Entering Design mode and focusing a structure must SHOW its sidechains.
+    // The flag defaulting to true is not enough on its own: reconcileSticks()
+    // early-returns while it is set, so without an explicit show-all pass the
+    // structure would end up with FEWER sidechains than before, not more.
+    func testFocusShowsAllSidechainsByDefault() async {
+        let c = makeController()
+        var calls: [(String, Bool)] = []
+        c.injectShowAllSidechains { obj, on in calls.append((obj, on)) }
+        XCTAssertTrue(c.showSidechains, "sidechains must default to on")
+
+        await c.focusAwait("m1")
+
+        XCTAssertEqual(calls.filter { $0.1 }.map { $0.0 }, ["m1"],
+                       "focusing must issue exactly one show-all for the focused structure")
+    }
+
+    // Switching focus must not leave the previous structure covered in sticks.
+    func testSwitchingFocusHidesSidechainsOnThePreviousStructure() async {
+        let c = makeController()
+        var calls: [(String, Bool)] = []
+        c.injectShowAllSidechains { obj, on in calls.append((obj, on)) }
+
+        await c.focusAwait("m1")
+        calls.removeAll()
+        await c.focusAwait("m2")
+
+        XCTAssertTrue(calls.contains { $0 == ("m1", false) },
+                      "the previous focus must be un-sticked, or every visited structure accumulates sidechains")
+        XCTAssertTrue(calls.contains { $0 == ("m2", true) },
+                      "the new focus must get the show-all pass")
+    }
+
+    // Leaving Design mode must hide them again. restore() re-applies colours and
+    // transparency but NOT representation visibility (see exit()'s own comment),
+    // so without an explicit hide the user's structure stays sticky after exit.
+    func testExitHidesSidechains() async {
+        let c = makeController()
+        var calls: [(String, Bool)] = []
+        c.injectShowAllSidechains { obj, on in calls.append((obj, on)) }
+
+        await c.focusAwait("m1")
+        calls.removeAll()
+        c.exit()
+
+        XCTAssertTrue(calls.contains { $0 == ("m1", false) },
+                      "exit must hide the sidechains it showed")
+    }
+
+    // A user who turns them off keeps that choice when focusing another
+    // structure — the default is a default, not an override.
+    func testFocusRespectsAUserTurningSidechainsOff() async {
+        let c = makeController()
+        var calls: [(String, Bool)] = []
+        c.injectShowAllSidechains { obj, on in calls.append((obj, on)) }
+
+        await c.focusAwait("m1")
+        c.setShowSidechains(false)
+        XCTAssertFalse(c.showSidechains)
+        calls.removeAll()
+
+        await c.focusAwait("m2")
+
+        XCTAssertFalse(calls.contains { $0 == ("m2", true) },
+                       "focus must not re-show sidechains the user turned off")
+    }
 }
 #endif

--- a/swiftui/PyMOLViewerTests/DesignIOSPortTests.swift
+++ b/swiftui/PyMOLViewerTests/DesignIOSPortTests.swift
@@ -890,7 +890,7 @@ final class DesignIOSPortTests: XCTestCase {
                      mutateDisplay: { _, _, _, _ in },
                      discard: { _, _ in }, compare: { _, _ in })
         c.injectRepack(repack: { _, _ in throw RepError(msg: "simulated MLX failure") },
-                       loadRepacked: { _, _ in })
+                       loadRepacked: { _, _, _ in })
         // Rescore (called after repack in the new order) must succeed; inject a
         // well-formed result so it doesn't throw and erroneously set errorText from a
         // different code path. rescoreWorkingObject does not clear errorText, so the
@@ -928,7 +928,7 @@ final class DesignIOSPortTests: XCTestCase {
         // repack closure runs on the inference queue (off-main).
         c.injectRepack(
             repack: { _, _ in callOrder.append("repack"); return "ATOM  ..." },
-            loadRepacked: { _, _ in })
+            loadRepacked: { _, _, _ in })
         // score closure also runs on the inference queue (off-main); both are serial.
         c.injectScore { _, s in
             callOrder.append("score")
@@ -970,7 +970,7 @@ final class DesignIOSPortTests: XCTestCase {
         // within the block is deterministic.
         c.injectRepack(
             repack: { _, _ in "ATOM  ..." },
-            loadRepacked: { _, _ in events.append("topology-replace") })
+            loadRepacked: { _, _, _ in events.append("topology-replace") })
         c.injectScore { _, s in
             MPNNModel.ScoreResult(
                 logProbs: Array(repeating: Array(repeating: -3, count: 21), count: s.count),

--- a/swiftui/PyMOLViewerTests/DesignIOSPortTests.swift
+++ b/swiftui/PyMOLViewerTests/DesignIOSPortTests.swift
@@ -442,59 +442,51 @@ final class DesignIOSPortTests: XCTestCase {
         XCTAssertEqual(designCalls, 1, "macOS default provider must let the design run")
     }
 
-    // Region-edit OFF: a plain tap pins for inspection, exactly as before.
-    func testTapPinsWhenRegionEditModeIsOff() {
+    // One tap pins for inspection; the region stays empty so the propensity pills
+    // still show. This is the single-residue behaviour the change preserves.
+    func testSingleTapPinsAndDoesNotBuildARegion() {
         let c = makeController()
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
-        XCTAssertFalse(c.regionEditMode)
 
         c.tapResidue(residueIndex: 1)
 
         XCTAssertEqual(c.pinnedResidueIndex, 1)
         XCTAssertTrue(c.selectedResidueIndices.isEmpty,
-                      "pinning must not build a region")
+                      "one residue must not enter region mode")
     }
 
-    // Region-edit ON: the same tap toggles region membership and does not pin.
-    func testTapTogglesRegionWhenRegionEditModeIsOn() {
+    // A second tap on a different residue turns the selection into a region and
+    // drops the pin — no mode toggle involved.
+    func testSecondTapBuildsRegionAndDropsThePin() {
         let c = makeController()
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
-        c.regionEditMode = true
 
         c.tapResidue(residueIndex: 1)
-        XCTAssertEqual(c.selectedResidueIndices, [1])
-        XCTAssertNil(c.pinnedResidueIndex, "region editing must not also pin")
-
         c.tapResidue(residueIndex: 0)
         XCTAssertEqual(c.selectedResidueIndices, [0, 1], "region stays sorted")
-        XCTAssertNil(c.pinnedResidueIndex, "region editing must not also pin")
+        XCTAssertNil(c.pinnedResidueIndex)
 
+        // Tapping a member removes it, dropping back to single-residue mode.
         c.tapResidue(residueIndex: 1)
-        XCTAssertEqual(c.selectedResidueIndices, [0], "a second tap removes")
-        XCTAssertNil(c.pinnedResidueIndex, "region editing must not also pin")
+        XCTAssertTrue(c.selectedResidueIndices.isEmpty)
+        XCTAssertEqual(c.pinnedResidueIndex, 0)
     }
 
-    // Non-designable positions cannot enter a region, however they are tapped.
-    func testTapIgnoresInvalidResiduesInRegionEditMode() {
+    // Non-designable positions can never be pinned or enter a region, however
+    // many times they are tapped.
+    func testTapIgnoresNonDesignableResidues() {
         let c = makeController()
-        c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: [true, false, true])
-        c.regionEditMode = true
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: [true, false, true])
 
         c.tapResidue(residueIndex: 1)
+        XCTAssertNil(c.pinnedResidueIndex,
+                     "a residue with no backbone is not designable")
+        XCTAssertTrue(c.selectedResidueIndices.isEmpty)
 
-        XCTAssertTrue(c.selectedResidueIndices.isEmpty,
-                      "an invalid residue must never join the region")
-    }
-
-    // Leaving Design mode must not strand the toggle on for the next session.
-    func testExitClearsRegionEditMode() {
-        let c = makeController()
-        c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
-        c.regionEditMode = true
-
-        c.exit()
-
-        XCTAssertFalse(c.regionEditMode)
+        // A designable residue alongside it still works normally.
+        c.tapResidue(residueIndex: 2)
+        XCTAssertEqual(c.pinnedResidueIndex, 2)
     }
 
     // MARK: – Task 8: MPNNRuntime configuration
@@ -561,20 +553,18 @@ final class DesignIOSPortTests: XCTestCase {
                       "pinning via handleViewportHit must not build a region")
     }
 
-    // Same-object tap in region-edit mode → toggleRegionResidue via tapResidue.
-    // This is the improvement over the previous macOS behaviour: the old onChange
-    // block called setPinned directly, bypassing region-edit mode.
-    func testHandleViewportHitInRegionEditModeTogglesRegion() {
+    // Two viewport hits on the focus object accumulate into a region, so the
+    // viewport and the sequence strip agree without any mode switch.
+    func testHandleViewportHitAccumulatesRegionOnFocusObject() {
         let c = makeController()
-        c.setFocusForTest("obj1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
-        c.regionEditMode = true
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
 
-        c.handleViewportHit(object: "obj1", chain: "A", resi: "2", hasResidue: true)
+        c.handleViewportHit(object: "m1", chain: "A", resi: "2", hasResidue: true)
+        XCTAssertEqual(c.pinnedResidueIndex, 1)
 
-        XCTAssertEqual(c.selectedResidueIndices, [1],
-                       "in region-edit mode, tapping a residue on the focus object must toggle its region membership")
-        XCTAssertNil(c.pinnedResidueIndex,
-                     "region editing via handleViewportHit must not also pin")
+        c.handleViewportHit(object: "m1", chain: "A", resi: "3", hasResidue: true)
+        XCTAssertEqual(c.selectedResidueIndices, [1, 2])
+        XCTAssertNil(c.pinnedResidueIndex)
     }
 
     // An empty object name means the tap landed on empty space — must be a no-op.

--- a/swiftui/PyMOLViewerTests/DesignIOSPortTests.swift
+++ b/swiftui/PyMOLViewerTests/DesignIOSPortTests.swift
@@ -538,8 +538,9 @@ final class DesignIOSPortTests: XCTestCase {
                        "tapping any object when nothing is focused must refocus")
     }
 
-    // Same-object tap with a valid residue → pin via tapResidue (not setPinned directly,
-    // so region-edit mode is honoured consistently on both platforms).
+    // Same-object tap with a valid residue → routed through tapResidue (not
+    // setPinned directly), so the tap toggles 'sele' and the COUNT decides the mode
+    // — one residue pins — identically on both platforms.
     func testHandleViewportHitPinsOnFocusObjectWithResidue() {
         let c = makeController()
         c.setFocusForTest("obj1", nativeSequence: [5, 5, 5], validFlags: allValid(3))

--- a/swiftui/PyMOLViewerTests/DesignIOSPortTests.swift
+++ b/swiftui/PyMOLViewerTests/DesignIOSPortTests.swift
@@ -969,6 +969,12 @@ final class DesignIOSPortTests: XCTestCase {
                 currentAALogProb: Array(repeating: -3, count: s.count))
         }
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
+        // This test is about the PER-RESIDUE reconcile path, which is only live while
+        // the global show-all is off — reconcileSticks() early-returns otherwise.
+        // Sidechains now default ON, so turn them off to reach the path under test.
+        // (The default-on path is covered by
+        // testRepackReShowsAllSidechainsWhenTheyAreOn below.)
+        c.setShowSidechains(false)
 
         // Pin residue 1 (chain "A", resi "2") — this is the residue we will mutate.
         // On iOS, pill mutations always apply to the active (pinned) residue.
@@ -989,6 +995,44 @@ final class DesignIOSPortTests: XCTestCase {
             XCTAssertTrue(showAfterRepack,
                 "the mutated residue's sidechain (resi '2') must be re-requested after " +
                 "the topology replace — reconcileSticks must add pinned sticks post-repack")
+        }
+    }
+
+    // With sidechains ON (the default), a repack replaces the object's topology and
+    // annihilates its sticks, so the GLOBAL show-all must be re-issued for the
+    // working object — the counterpart of the per-residue path above.
+    func testRepackReShowsAllSidechainsWhenTheyAreOn() async {
+        let c = makeController()
+        var showAllCalls: [(String, Bool)] = []
+        var events: [String] = []
+        c.injectShowAllSidechains { obj, on in
+            showAllCalls.append((obj, on))
+            events.append(on ? "show-all-\(obj)" : "hide-all-\(obj)")
+        }
+        c.injectSetSticks { _, _, _, on in on }
+        c.injectEdit(makeWorkingCopy: { $0 + "_design" },
+                     mutateDisplay: { _, _, _, _ in },
+                     discard: { _, _ in }, compare: { _, _ in })
+        c.injectRepack(
+            repack: { _, _ in "ATOM  ..." },
+            loadRepacked: { _, _, _ in events.append("topology-replace") })
+        c.injectScore { _, s in
+            MPNNModel.ScoreResult(
+                logProbs: Array(repeating: Array(repeating: -3, count: 21), count: s.count),
+                currentAALogProb: Array(repeating: -3, count: s.count))
+        }
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
+        XCTAssertTrue(c.showSidechains, "pre-condition: sidechains default on")
+        events.removeAll()
+
+        await c.applyMutationAwait(residueIndex: 1, aa: 9)
+
+        let ri = events.firstIndex(of: "topology-replace")
+        XCTAssertNotNil(ri, "loadRepacked (topology replace) must have been called")
+        if let ri {
+            XCTAssertTrue(events[ri...].contains { $0 == "show-all-m1_design" },
+                "after the topology replace the global show-all must be re-issued for " +
+                "the working object, or the design ends up with no sidechains visible")
         }
     }
 

--- a/swiftui/PyMOLViewerTests/DesignIOSPortTests.swift
+++ b/swiftui/PyMOLViewerTests/DesignIOSPortTests.swift
@@ -21,13 +21,12 @@ final class DesignIOSPortTests: XCTestCase {
     // clearError() must be the way it goes away (the banner's dismiss path).
     func testClearErrorResetsErrorText() async {
         let c = makeController()
-        c.injectRegion(designRegion: { _, _, _, _, _ in [] },   // wrong length → failure
-                       selectedIndices: { _, _, _, _ in [0, 1] })
+        c.injectRegion(designRegion: { _, _, _, _, _ in [] })   // wrong length → failure
         c.injectEdit(makeWorkingCopy: { $0 + "_design" },
                      mutateDisplay: { _, _, _, _ in },
                      discard: { _, _ in }, compare: { _, _ in })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
-        c.pickSelection("reg")
+        c.tapResidue(residueIndex: 0); c.tapResidue(residueIndex: 1)
 
         await c.redesignSelectionAwait()
         XCTAssertEqual(c.errorText, "Region redesign failed",
@@ -46,14 +45,13 @@ final class DesignIOSPortTests: XCTestCase {
         c.injectRegion(designRegion: { r, _, _, _, _ in
                            designCalls += 1
                            return Array(repeating: 0, count: r.count)
-                       },
-                       selectedIndices: { _, _, _, _ in [0, 1] })
+                       })
         c.injectEdit(makeWorkingCopy: { $0 + "_design" },
                      mutateDisplay: { _, _, _, _ in },
                      discard: { _, _ in }, compare: { _, _ in })
         c.sizeDecisionProvider = { _ in .refuse(maxFittingResidues: 500) }
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
-        c.pickSelection("reg")
+        c.tapResidue(residueIndex: 0); c.tapResidue(residueIndex: 1)
 
         await c.redesignSelectionAwait()
 
@@ -71,8 +69,7 @@ final class DesignIOSPortTests: XCTestCase {
         c.injectRegion(designRegion: { r, _, _, _, _ in
                            designCalls += 1
                            return Array(repeating: 0, count: r.count)
-                       },
-                       selectedIndices: { _, _, _, _ in [0, 1] })
+                       })
         c.injectEdit(makeWorkingCopy: { $0 + "_design" },
                      mutateDisplay: { _, _, _, _ in },
                      discard: { _, _ in }, compare: { _, _ in })
@@ -84,7 +81,7 @@ final class DesignIOSPortTests: XCTestCase {
         c.autosaveBeforeLargeRun = { autosaves += 1 }
         c.sizeDecisionProvider = { n in .warn(estimatedBytes: 3_000_000_000, availableBytes: 4_000_000_000) }
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
-        c.pickSelection("reg")
+        c.tapResidue(residueIndex: 0); c.tapResidue(residueIndex: 1)
 
         await c.redesignSelectionAwait()
         XCTAssertEqual(designCalls, 0, "warn must hold the run, not start it")
@@ -104,14 +101,13 @@ final class DesignIOSPortTests: XCTestCase {
         c.injectRegion(designRegion: { r, _, _, _, _ in
                            designCalls += 1
                            return Array(repeating: 0, count: r.count)
-                       },
-                       selectedIndices: { _, _, _, _ in [0, 1] })
+                       })
         c.injectEdit(makeWorkingCopy: { $0 + "_design" },
                      mutateDisplay: { _, _, _, _ in },
                      discard: { _, _ in }, compare: { _, _ in })
         c.sizeDecisionProvider = { _ in .warn(estimatedBytes: 3_000_000_000, availableBytes: 4_000_000_000) }
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
-        c.pickSelection("reg")
+        c.tapResidue(residueIndex: 0); c.tapResidue(residueIndex: 1)
 
         await c.redesignSelectionAwait()
         XCTAssertNotNil(c.pendingSizeWarning)
@@ -131,8 +127,7 @@ final class DesignIOSPortTests: XCTestCase {
         c.injectRegion(designRegion: { r, _, _, _, _ in
                            designCalls += 1
                            return Array(repeating: 0, count: r.count)
-                       },
-                       selectedIndices: { _, _, _, _ in [0, 1] })
+                       })
         c.injectEdit(makeWorkingCopy: { $0 + "_design" },
                      mutateDisplay: { _, _, _, _ in },
                      discard: { _, _ in }, compare: { _, _ in })
@@ -143,7 +138,7 @@ final class DesignIOSPortTests: XCTestCase {
         }
         c.sizeDecisionProvider = { _ in providerCalls += 1; return .ok }
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
-        c.pickSelection("reg")
+        c.tapResidue(residueIndex: 0); c.tapResidue(residueIndex: 1)
 
         await c.redesignSelectionAwait()
         XCTAssertNil(c.pendingSizeWarning)
@@ -156,7 +151,7 @@ final class DesignIOSPortTests: XCTestCase {
     //
     // Failure scenario (pre-fix):
     // 1. Run lands in warn band → pendingSizeWarning is set.
-    // 2. User clears the region (clearSelection does NOT clear pendingSizeWarning).
+    // 2. User clears the region (clearing does NOT clear pendingSizeWarning).
     // 3. User confirms the stale warning → confirmPendingWarning() sets
     //    suppressSizeGuardOnce=true and calls redesignSelectionAwait(), which
     //    immediately hits the "guard !selectedResidueIndices.isEmpty" early return
@@ -175,8 +170,7 @@ final class DesignIOSPortTests: XCTestCase {
         c.injectRegion(designRegion: { r, _, _, _, _ in
                            designCalls += 1
                            return Array(repeating: 0, count: r.count)
-                       },
-                       selectedIndices: { _, _, _, _ in [0, 1] })
+                       })
         c.injectEdit(makeWorkingCopy: { $0 + "_design" },
                      mutateDisplay: { _, _, _, _ in },
                      discard: { _, _ in }, compare: { _, _ in })
@@ -189,14 +183,14 @@ final class DesignIOSPortTests: XCTestCase {
         // Step 1: first redesign lands in the warn band — run is held.
         c.sizeDecisionProvider = { _ in .warn(estimatedBytes: 3_000_000_000, availableBytes: 4_000_000_000) }
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
-        c.pickSelection("reg")
+        c.tapResidue(residueIndex: 0); c.tapResidue(residueIndex: 1)
 
         await c.redesignSelectionAwait()
         XCTAssertNotNil(c.pendingSizeWarning, "warn band must set pendingSizeWarning")
         XCTAssertEqual(designCalls, 0, "warn band must hold the run")
 
         // Step 2: user clears the region while the warning is still pending.
-        c.clearSelection()
+        c.handleViewportHit(object: "", chain: "", resi: "", hasResidue: false)
 
         // Step 3: user confirms the (now stale) warning.
         // confirmPendingWarning() sets suppressSizeGuardOnce=true and calls
@@ -206,7 +200,7 @@ final class DesignIOSPortTests: XCTestCase {
         await c.confirmPendingWarning()
 
         // Step 4: re-establish a region and switch to a refuse provider.
-        c.pickSelection("reg")
+        c.tapResidue(residueIndex: 0); c.tapResidue(residueIndex: 1)
         c.sizeDecisionProvider = { _ in providerCalls += 1; return .refuse(maxFittingResidues: 0) }
 
         // Step 5: the next redesign must be refused.
@@ -303,8 +297,7 @@ final class DesignIOSPortTests: XCTestCase {
         c.injectRegion(designRegion: { r, _, _, _, _ in
                            order.append("design")
                            return Array(repeating: 0, count: r.count)
-                       },
-                       selectedIndices: { _, _, _, _ in [0, 1] })
+                       })
         c.injectEdit(makeWorkingCopy: { $0 + "_design" },
                      mutateDisplay: { _, _, _, _ in },
                      discard: { _, _ in }, compare: { _, _ in })
@@ -315,7 +308,7 @@ final class DesignIOSPortTests: XCTestCase {
         }
         c.injectReleaseModel { order.append("release"); done.fulfill() }
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
-        c.pickSelection("reg")
+        c.tapResidue(residueIndex: 0); c.tapResidue(residueIndex: 1)
 
         await c.redesignSelectionAwait()
         c.exit()
@@ -415,8 +408,7 @@ final class DesignIOSPortTests: XCTestCase {
         c.injectRegion(designRegion: { r, _, _, _, _ in
                            designCalls += 1
                            return Array(repeating: 0, count: r.count)
-                       },
-                       selectedIndices: { _, _, _, _ in [0, 1] })
+                       })
         c.injectEdit(makeWorkingCopy: { $0 + "_design" },
                      mutateDisplay: { _, _, _, _ in },
                      discard: { _, _ in }, compare: { _, _ in })
@@ -432,7 +424,7 @@ final class DesignIOSPortTests: XCTestCase {
         c.autoRepack = false
         c.setFocusForTest("m1", nativeSequence: Array(repeating: 5, count: count),
                           validFlags: allValid(count))
-        c.pickSelection("reg")   // selectedIndices returns [0]
+        c.tapResidue(residueIndex: 0); c.tapResidue(residueIndex: 1)
 
         await c.redesignSelectionAwait()
         XCTAssertNil(c.pendingSizeWarning,

--- a/swiftui/PyMOLViewerTests/DesignIOSPortTests.swift
+++ b/swiftui/PyMOLViewerTests/DesignIOSPortTests.swift
@@ -416,7 +416,7 @@ final class DesignIOSPortTests: XCTestCase {
                            designCalls += 1
                            return Array(repeating: 0, count: r.count)
                        },
-                       selectedIndices: { _, _, _, _ in [0] })
+                       selectedIndices: { _, _, _, _ in [0, 1] })
         c.injectEdit(makeWorkingCopy: { $0 + "_design" },
                      mutateDisplay: { _, _, _, _ in },
                      discard: { _, _ in }, compare: { _, _ in })

--- a/swiftui/PyMOLViewerTests/DesignIOSPortTests.swift
+++ b/swiftui/PyMOLViewerTests/DesignIOSPortTests.swift
@@ -1005,6 +1005,23 @@ final class DesignIOSPortTests: XCTestCase {
     //
     // No existing test covers this specific invariant — testReconcileSticksIsNoOpWhenShowSidechainsOn
     // tests the early-return guard (showSidechains == true), which is a separate path.
+    // An iOS tap that MISSES must reach the controller as an empty hit so it
+    // clears the selection. The old designPickResidue returned early on a miss,
+    // making empty-space taps silently inert.
+    func testEmptyHitClearsThroughTheSameRouting() {
+        let c = makeController()
+        var clearCalls = 0
+        c.injectSele(clearSele: { clearCalls += 1 })
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
+        c.tapResidue(residueIndex: 0)
+
+        c.handleViewportHit(object: "", chain: "", resi: "", hasResidue: false)
+
+        XCTAssertEqual(clearCalls, 1,
+                       "a miss must clear 'sele' through the injected closure")
+        XCTAssertEqual(c.focusObject, "m1", "a miss must not change focus")
+    }
+
     func testSticksNotOwnedByControllerAreNeverRemoved() {
         var hiddenResidue: [String] = []
         let c = makeController()

--- a/swiftui/PyMOLViewerTests/DesignRegionTests.swift
+++ b/swiftui/PyMOLViewerTests/DesignRegionTests.swift
@@ -297,5 +297,95 @@ final class DesignRegionTests: XCTestCase {
         await c.applyMutationAwait(residueIndex: 2, aa: 3)
         XCTAssertNil(c.redesignSnapshot)                    // revert invalidated by a manual edit
     }
+
+    // MARK: – 'sele' as the single source of truth
+
+    // No selection -> nothing active. This is the idle state the greyed propensity
+    // row renders.
+    func testSyncFromSeleWithNothingSelected() {
+        let c = makeController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: allValid(3))
+        XCTAssertEqual(c.syncFromSele(), 0)
+        XCTAssertNil(c.pinnedResidueIndex)
+        XCTAssertTrue(c.selectedResidueIndices.isEmpty)
+        XCTAssertFalse(c.regionModeActive)
+    }
+
+    // Exactly one selected residue must reproduce today's single-residue
+    // behaviour: pinned, and NOT region mode, so the propensity pills still show.
+    func testOneSelectedResiduePinsAndStaysOutOfRegionMode() {
+        let c = makeController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: allValid(3))
+        c.injectSele(seleState: { _, _, _ in (indices: [1], digest: "d1", total: 1) })
+        XCTAssertEqual(c.syncFromSele(), 1)
+        XCTAssertEqual(c.pinnedResidueIndex, 1)
+        XCTAssertTrue(c.selectedResidueIndices.isEmpty,
+                      "a single residue must not enter region mode")
+        XCTAssertFalse(c.regionModeActive)
+        XCTAssertNil(c.selectedSelectionName,
+                     "the region label belongs to region mode only")
+    }
+
+    // Two or more selected residues auto-designate the region and drop the pin,
+    // so the palette row replaces the propensity pills.
+    func testTwoSelectedResiduesEnterRegionMode() {
+        let c = makeController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: allValid(3))
+        c.injectSele(seleState: { _, _, _ in (indices: [0, 2], digest: "d2", total: 2) })
+        XCTAssertEqual(c.syncFromSele(), 2)
+        XCTAssertNil(c.pinnedResidueIndex,
+                     "region mode must clear the single-residue pin")
+        XCTAssertEqual(c.selectedResidueIndices, [0, 2])
+        XCTAssertTrue(c.regionModeActive)
+        XCTAssertEqual(c.selectedSelectionName, "sele",
+                       "a click-built region is labelled 'sele'")
+    }
+
+    // Non-designable positions (missing backbone) never count, so selecting one
+    // designable and one invalid residue is still single-residue mode.
+    func testInvalidResiduesAreDroppedFromTheCount() {
+        let c = makeController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: [true, false, true])
+        c.injectSele(seleState: { _, _, _ in (indices: [0, 1], digest: "d3", total: 2) })
+        XCTAssertEqual(c.syncFromSele(), 1,
+                       "index 1 is not designable and must not count")
+        XCTAssertEqual(c.pinnedResidueIndex, 0)
+        XCTAssertTrue(c.selectedResidueIndices.isEmpty)
+    }
+
+    // Out-of-range indices from a stale payload must not crash or leak in.
+    func testOutOfRangeIndicesAreIgnored() {
+        let c = makeController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: allValid(3))
+        c.injectSele(seleState: { _, _, _ in (indices: [1, 99, -1], digest: "d4", total: 3) })
+        XCTAssertEqual(c.syncFromSele(), 1)
+        XCTAssertEqual(c.pinnedResidueIndex, 1)
+    }
+
+    // Residues selected on OTHER structures are reported so the UI can say so
+    // instead of silently ignoring them.
+    func testOffFocusResiduesAreCounted() {
+        let c = makeController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: allValid(3))
+        c.injectSele(seleState: { _, _, _ in (indices: [0], digest: "d5", total: 3) })
+        c.syncFromSele()
+        XCTAssertEqual(c.seleResiduesOffFocus, 2)
+    }
+
+    // With no focus object there is nothing to resolve against; sync must reset
+    // rather than keep stale indices.
+    func testSyncWithoutFocusResets() {
+        let c = makeController()
+        c.injectSele(seleState: { _, _, _ in (indices: [0, 1], digest: "d6", total: 2) })
+        XCTAssertEqual(c.syncFromSele(), 0)
+        XCTAssertTrue(c.selectedResidueIndices.isEmpty)
+        XCTAssertNil(c.pinnedResidueIndex)
+    }
 }
 #endif

--- a/swiftui/PyMOLViewerTests/DesignRegionTests.swift
+++ b/swiftui/PyMOLViewerTests/DesignRegionTests.swift
@@ -16,36 +16,20 @@ final class DesignRegionTests: XCTestCase {
     }
     private func allValid(_ n: Int) -> [Bool] { Array(repeating: true, count: n) }
 
-    func testRegionModeTogglesWithSelection() {
-        let c = makeController()
-        c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 0, count: r.count) },
-                       selectedIndices: { _, _, _, _ in [0, 1] })
-        c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
-        XCTAssertFalse(c.regionModeActive)
-        c.pickSelection("reg")
-        XCTAssertTrue(c.regionModeActive)
-        XCTAssertEqual(c.selectedResidueIndices, [0, 1])
-        XCTAssertEqual(c.selectedSelectionName, "reg")
-        c.clearSelection()
-        XCTAssertFalse(c.regionModeActive)
-        XCTAssertNil(c.selectedSelectionName)
-    }
-
     func testSelectionFiltersInvalidResidues() {
         let c = makeController()
-        c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 0, count: r.count) },
-                       selectedIndices: { _, _, _, _ in [0, 1, 2] })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: [true, false, true])
-        c.pickSelection("reg")
+        c.injectSele(seleState: { _, _, _ in (indices: [0, 1, 2], digest: "d", off: 0) })
+        c.syncFromSele()
         XCTAssertEqual(c.selectedResidueIndices, [0, 2])   // idx 1 (invalid) dropped
     }
 
     // Click-built region under the count-driven rule: successive toggles accumulate
     // designable residues into a region, non-designable positions never count,
     // dropping back to ONE designable residue returns to single-residue pin mode
-    // (empty region), and removing the last one leaves nothing active. The label of
-    // a click-built region is "sele" — it IS the ordinary selection now, not a
-    // separate "custom" copy the controller keeps on the side.
+    // (empty region), and removing the last one leaves nothing active. The region
+    // IS the ordinary selection now, not a separate "custom" copy the controller
+    // keeps on the side.
     func testTapResidueBuildsAdHocRegion() {
         let c = makeController()
         c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 0, count: r.count) })
@@ -61,8 +45,6 @@ final class DesignRegionTests: XCTestCase {
         XCTAssertEqual(c.selectedResidueIndices, [1, 3])   // kept sorted
         XCTAssertTrue(c.regionModeActive)
         XCTAssertNil(c.pinnedResidueIndex, "region mode drops the pin")
-        XCTAssertEqual(c.selectedSelectionName, "sele",
-                       "a click-built region is labelled 'sele'")
 
         c.tapResidue(residueIndex: 2)             // invalid → never counts
         XCTAssertEqual(c.selectedResidueIndices, [1, 3])
@@ -71,11 +53,9 @@ final class DesignRegionTests: XCTestCase {
         XCTAssertTrue(c.selectedResidueIndices.isEmpty,
                       "one designable residue leaves region mode")
         XCTAssertEqual(c.pinnedResidueIndex, 3, "the survivor is pinned")
-        XCTAssertNil(c.selectedSelectionName)
 
         c.tapResidue(residueIndex: 3)             // remove last → nothing
         XCTAssertFalse(c.regionModeActive)
-        XCTAssertNil(c.selectedSelectionName)
         XCTAssertNil(c.pinnedResidueIndex)
     }
 
@@ -90,19 +70,6 @@ final class DesignRegionTests: XCTestCase {
         XCTAssertEqual(c.paletteAllowed.count, 20)
     }
 
-    func testRefreshSelectionsPopulatesList() {
-        let c = makeController()
-        c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 0, count: r.count) },
-                       listSelections: { _, _, _ in
-                           [DesignSelectionOption(name: "loopA", count: 12),
-                            DesignSelectionOption(name: "sele", count: 5)]
-                       })
-        c.setFocusForTest("m1", nativeSequence: [5, 5], validFlags: allValid(2))
-        c.refreshSelections()
-        XCTAssertEqual(c.availableSelections.map { $0.name }, ["loopA", "sele"])
-        XCTAssertEqual(c.availableSelections.first?.count, 12)
-    }
-
     // Stub score/edit closures used by every redesign test.
     private func wireEdit(_ c: DesignController) {
         c.injectEdit(makeWorkingCopy: { $0 + "_design" },
@@ -115,18 +82,21 @@ final class DesignRegionTests: XCTestCase {
         }
     }
 
-    // refreshSelections/pickSelection scope to the focus object AND its edit source,
-    // so selections made on the original still resolve once a working copy is focused.
-    func testSelectionScopingPassesSourceObjectWhenEditing() async {
+    // The 'sele' READ scopes to the focus object AND its edit source, so a selection
+    // made on the original still resolves once a working copy is focused. Python owns
+    // the scoping (see design_region.py); what Swift must guarantee is that
+    // `editSourceObject` actually reaches the reader.
+    func testSeleReadScopesToTheEditSourceObject() async {
         var srcSeen: [String?] = []
         let c = makeController(); wireEdit(c)
-        c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 9, count: r.count) },
-                       listSelections: { _, src, _ in srcSeen.append(src); return [] },
-                       selectedIndices: { _, _, _, _ in [0] })
+        c.injectSele(seleState: { _, src, _ in
+            srcSeen.append(src)
+            return (indices: [], digest: "d\(srcSeen.count)", off: 0)
+        })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
-        c.refreshSelections()                                  // pre-edit: no source
+        c.syncFromSele()                                       // pre-edit: no source
         await c.applyMutationAwait(residueIndex: 0, aa: 7)     // begins edit → editSourceObject "m1"
-        c.refreshSelections()                                  // post-edit: source is the original
+        c.syncFromSele()                                       // post-edit: source is the original
         XCTAssertEqual(srcSeen.count, 2)
         XCTAssertNil(srcSeen[0])
         XCTAssertEqual(srcSeen[1], "m1")
@@ -134,10 +104,9 @@ final class DesignRegionTests: XCTestCase {
 
     func testRedesignScattersOnlyIntoRegion() async {
         let c = makeController(); wireEdit(c)
-        c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 9, count: r.count) },
-                       selectedIndices: { _, _, _, _ in [1, 3] })
+        c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 9, count: r.count) })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5, 5, 5], validFlags: allValid(5))
-        c.pickSelection("reg")
+        c.tapResidue(residueIndex: 1); c.tapResidue(residueIndex: 3)
         await c.redesignSelectionAwait()
         XCTAssertEqual(c.editedSequence, [5, 9, 5, 9, 5])   // only free positions changed
     }
@@ -145,10 +114,9 @@ final class DesignRegionTests: XCTestCase {
     func testFixedPartitionIsComplementOfRegion() async {
         var capturedFixed: Set<Int>?
         let c = makeController(); wireEdit(c)
-        c.injectRegion(designRegion: { _, fixed, native, _, _ in capturedFixed = fixed; return native },
-                       selectedIndices: { _, _, _, _ in [0, 2] })
+        c.injectRegion(designRegion: { _, fixed, native, _, _ in capturedFixed = fixed; return native })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5, 5], validFlags: allValid(4))
-        c.pickSelection("reg")
+        c.tapResidue(residueIndex: 0); c.tapResidue(residueIndex: 2)
         await c.redesignSelectionAwait()
         XCTAssertEqual(capturedFixed, [1, 3])               // complement of free {0,2} over L=4
     }
@@ -158,9 +126,10 @@ final class DesignRegionTests: XCTestCase {
         let c = makeController(); wireEdit(c)
         c.injectRegion(designRegion: { _, fixed, native, _, _ in
             capturedFixed = fixed; capturedNative = native; return native
-        }, selectedIndices: { _, _, _, _ in [0, 2] })       // full idx 0,2 selected; idx 1 invalid
+        })
         c.setFocusForTest("m1", nativeSequence: [5, 6, 7], validFlags: [true, false, true])
-        c.pickSelection("reg")
+        // full idx 0,2 selected; idx 1 is invalid and never counts
+        c.tapResidue(residueIndex: 0); c.tapResidue(residueIndex: 2)
         await c.redesignSelectionAwait()
         // valid residues full {0,2} → valid-projected {0,1}; both selected → free {0,1}, fixed {}.
         XCTAssertEqual(capturedFixed, [])
@@ -169,10 +138,10 @@ final class DesignRegionTests: XCTestCase {
 
     func testScatterWithInvalidGap() async {
         let c = makeController(); wireEdit(c)
-        c.injectRegion(designRegion: { _, _, _, _, _ in [9, 8] },   // valid-projected result (L=2)
-                       selectedIndices: { _, _, _, _ in [0, 2] })   // full idx 0,2 → valid-projected 0,1
+        c.injectRegion(designRegion: { _, _, _, _, _ in [9, 8] })   // valid-projected result (L=2)
         c.setFocusForTest("m1", nativeSequence: [5, 6, 7], validFlags: [true, false, true])
-        c.pickSelection("reg")
+        // full idx 0,2 → valid-projected 0,1
+        c.tapResidue(residueIndex: 0); c.tapResidue(residueIndex: 2)
         await c.redesignSelectionAwait()
         // Both designed values must land on the correct side of the invalid gap:
         // full 0 ← result[0]==9, full 2 ← result[1]==8, and full 1 (no backbone)
@@ -183,11 +152,10 @@ final class DesignRegionTests: XCTestCase {
     func testNativeSequenceReflectsPriorEdits() async {
         var capturedNative: [Int]?
         let c = makeController(); wireEdit(c)
-        c.injectRegion(designRegion: { _, _, native, _, _ in capturedNative = native; return native },
-                       selectedIndices: { _, _, _, _ in [2, 3] })
+        c.injectRegion(designRegion: { _, _, native, _, _ in capturedNative = native; return native })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5, 5], validFlags: allValid(4))
         await c.applyMutationAwait(residueIndex: 0, aa: 7)  // earlier manual edit
-        c.pickSelection("reg")
+        c.tapResidue(residueIndex: 2); c.tapResidue(residueIndex: 3)
         await c.redesignSelectionAwait()
         XCTAssertEqual(capturedNative, [7, 5, 5, 5])        // manual edit carried into native
     }
@@ -195,10 +163,9 @@ final class DesignRegionTests: XCTestCase {
     func testOmitDerivedFromPalette() async {
         var capturedOmit: [Set<Int>]?
         let c = makeController(); wireEdit(c)
-        c.injectRegion(designRegion: { _, _, native, omit, _ in capturedOmit = omit; return native },
-                       selectedIndices: { _, _, _, _ in [1, 2] })
+        c.injectRegion(designRegion: { _, _, native, omit, _ in capturedOmit = omit; return native })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
-        c.pickSelection("reg")
+        c.tapResidue(residueIndex: 1); c.tapResidue(residueIndex: 2)
         c.togglePalette(4); c.togglePalette(12)
         await c.redesignSelectionAwait()
         XCTAssertEqual(capturedOmit?.count, 3)              // one per valid residue (L=3)
@@ -209,11 +176,10 @@ final class DesignRegionTests: XCTestCase {
     func testTemperaturePassedToDesign() async {
         var capturedTemp: Float?
         let c = makeController(); wireEdit(c)
-        c.injectRegion(designRegion: { _, _, native, _, temp in capturedTemp = temp; return native },
-                       selectedIndices: { _, _, _, _ in [1, 2] })
+        c.injectRegion(designRegion: { _, _, native, _, temp in capturedTemp = temp; return native })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
         c.designTemperature = 0.7
-        c.pickSelection("reg")
+        c.tapResidue(residueIndex: 1); c.tapResidue(residueIndex: 2)
         await c.redesignSelectionAwait()
         XCTAssertEqual(capturedTemp, 0.7)
     }
@@ -223,11 +189,10 @@ final class DesignRegionTests: XCTestCase {
     // redesign whose follow-up repack runs.
     func testBusyFlagsClearAfterSuccessfulRedesign() async {
         let c = makeController(); wireEdit(c)
-        c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 9, count: r.count) },
-                       selectedIndices: { _, _, _, _ in [1, 2] })
+        c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 9, count: r.count) })
         c.injectRepack(repack: { _, _ in "REPACKED" }, loadRepacked: { _, _, _ in })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
-        c.pickSelection("reg")
+        c.tapResidue(residueIndex: 1); c.tapResidue(residueIndex: 2)
         await c.redesignSelectionAwait()
         XCTAssertEqual(c.editedSequence, [5, 9, 9],
                        "the redesign must actually have run — without this the flag "
@@ -244,12 +209,11 @@ final class DesignRegionTests: XCTestCase {
     func testRedesignFlagDoesNotSpanRepackPhase() async {
         var flagDuringRepack: Bool?
         let c = makeController(); wireEdit(c)
-        c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 9, count: r.count) },
-                       selectedIndices: { _, _, _, _ in [1, 2] })
+        c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 9, count: r.count) })
         c.injectRepack(repack: { _, _ in "PDB" },
                        loadRepacked: { [weak c] _, _, _ in flagDuringRepack = c?.isRedesigning })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
-        c.pickSelection("reg")
+        c.tapResidue(residueIndex: 1); c.tapResidue(residueIndex: 2)
         await c.redesignSelectionAwait()
         XCTAssertEqual(flagDuringRepack, false,
                        "isRedesigning must already be clear once the repack phase runs — "
@@ -261,10 +225,9 @@ final class DesignRegionTests: XCTestCase {
     func testBusyFlagClearsWhenDesignThrows() async {
         struct Boom: Error {}
         let c = makeController(); wireEdit(c)
-        c.injectRegion(designRegion: { _, _, _, _, _ in throw Boom() },
-                       selectedIndices: { _, _, _, _ in [1, 2] })
+        c.injectRegion(designRegion: { _, _, _, _, _ in throw Boom() })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
-        c.pickSelection("reg")
+        c.tapResidue(residueIndex: 1); c.tapResidue(residueIndex: 2)
         await c.redesignSelectionAwait()
         XCTAssertFalse(c.isRedesigning, "a failed redesign must not strand the blocking overlay")
         XCTAssertNotNil(c.errorText)
@@ -272,10 +235,9 @@ final class DesignRegionTests: XCTestCase {
 
     func testBusyFlagClearsWhenDesignReturnsWrongLength() async {
         let c = makeController(); wireEdit(c)
-        c.injectRegion(designRegion: { _, _, _, _, _ in [1, 2, 3, 4, 5, 6, 7] },  // wrong length
-                       selectedIndices: { _, _, _, _ in [1, 2] })
+        c.injectRegion(designRegion: { _, _, _, _, _ in [1, 2, 3, 4, 5, 6, 7] })  // wrong length
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
-        c.pickSelection("reg")
+        c.tapResidue(residueIndex: 1); c.tapResidue(residueIndex: 2)
         await c.redesignSelectionAwait()
         XCTAssertEqual(c.errorText, "Region redesign failed",
                        "design() must actually have been called and rejected for its "
@@ -287,10 +249,9 @@ final class DesignRegionTests: XCTestCase {
     func testEmptyPaletteBlocksRedesign() async {
         var called = false
         let c = makeController(); wireEdit(c)
-        c.injectRegion(designRegion: { _, _, native, _, _ in called = true; return native },
-                       selectedIndices: { _, _, _, _ in [0, 1] })
+        c.injectRegion(designRegion: { _, _, native, _, _ in called = true; return native })
         c.setFocusForTest("m1", nativeSequence: [5, 5], validFlags: allValid(2))
-        c.pickSelection("reg")
+        c.tapResidue(residueIndex: 0); c.tapResidue(residueIndex: 1)
         // Pre-condition: without this, `called == false` also holds when the region
         // never designated at all — the assertion would pass for the wrong reason.
         XCTAssertTrue(c.regionModeActive, "pre-condition: a region must be designated")
@@ -301,12 +262,11 @@ final class DesignRegionTests: XCTestCase {
 
     func testRevertRestoresPreRedesignAndKeepsEarlierEdits() async {
         let c = makeController(); wireEdit(c)
-        c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 9, count: r.count) },
-                       selectedIndices: { _, _, _, _ in [2, 3] })
+        c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 9, count: r.count) })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5, 5], validFlags: allValid(4))
         await c.applyMutationAwait(residueIndex: 0, aa: 7)  // earlier manual edit
         let ec = c.editCount
-        c.pickSelection("reg")
+        c.tapResidue(residueIndex: 2); c.tapResidue(residueIndex: 3)
         await c.redesignSelectionAwait()
         XCTAssertEqual(c.editedSequence, [7, 5, 9, 9])
         XCTAssertNotNil(c.redesignSnapshot)
@@ -318,10 +278,9 @@ final class DesignRegionTests: XCTestCase {
 
     func testManualEditAfterRedesignClearsRevert() async {
         let c = makeController(); wireEdit(c)
-        c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 9, count: r.count) },
-                       selectedIndices: { _, _, _, _ in [1, 2] })
+        c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 9, count: r.count) })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
-        c.pickSelection("reg")
+        c.tapResidue(residueIndex: 1); c.tapResidue(residueIndex: 2)
         await c.redesignSelectionAwait()
         XCTAssertNotNil(c.redesignSnapshot)
         await c.applyMutationAwait(residueIndex: 2, aa: 3)
@@ -354,8 +313,6 @@ final class DesignRegionTests: XCTestCase {
         XCTAssertTrue(c.selectedResidueIndices.isEmpty,
                       "a single residue must not enter region mode")
         XCTAssertFalse(c.regionModeActive)
-        XCTAssertNil(c.selectedSelectionName,
-                     "the region label belongs to region mode only")
     }
 
     // Two or more selected residues auto-designate the region and drop the pin,
@@ -370,8 +327,6 @@ final class DesignRegionTests: XCTestCase {
                      "region mode must clear the single-residue pin")
         XCTAssertEqual(c.selectedResidueIndices, [0, 2])
         XCTAssertTrue(c.regionModeActive)
-        XCTAssertEqual(c.selectedSelectionName, "sele",
-                       "a click-built region is labelled 'sele'")
     }
 
     // Non-designable positions (missing backbone) never count, so selecting one
@@ -486,32 +441,15 @@ final class DesignRegionTests: XCTestCase {
                        "an unresolvable residue must not disturb the selection")
     }
 
-    // The lasso dropdown writes 'sele' and keeps its own label.
-    func testPickSelectionWritesSeleAndKeepsItsLabel() {
-        let c = makeController()
-        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
-                          validFlags: allValid(3))
-        c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 0, count: r.count) },
-                       selectedIndices: { _, _, _, _ in [0, 2] })
-        c.pickSelection("loop")
-        XCTAssertEqual(c.selectedResidueIndices, [0, 2])
-        XCTAssertEqual(c.selectedSelectionName, "loop")
-
-        // A subsequent click detaches from the named region.
-        c.tapResidue(residueIndex: 1)
-        XCTAssertEqual(c.selectedResidueIndices, [0, 1, 2])
-        XCTAssertEqual(c.selectedSelectionName, "sele")
-    }
-
-    // clearSelection empties 'sele' rather than only the mirrored array, so a
+    // The clear path empties 'sele' rather than only the mirrored array, so a
     // following sync cannot resurrect the region.
-    func testClearSelectionEmptiesSele() {
+    func testClearingEmptiesSeleNotJustTheMirror() {
         let c = makeController()
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
                           validFlags: allValid(3))
         c.tapResidue(residueIndex: 0)
         c.tapResidue(residueIndex: 1)
-        c.clearSelection()
+        c.handleViewportHit(object: "", chain: "", resi: "", hasResidue: false)
         XCTAssertTrue(c.selectedResidueIndices.isEmpty)
         XCTAssertEqual(c.syncFromSele(), 0, "'sele' itself must be empty, not just the mirror")
     }
@@ -640,44 +578,7 @@ final class DesignRegionTests: XCTestCase {
             XCTAssertEqual(c.selectedResidueIndices, [0, 2],
                            "\(path): 'sele' still holds both residues, so the region must survive")
             XCTAssertTrue(c.regionModeActive, "\(path): region mode must survive the teardown")
-            XCTAssertEqual(c.selectedSelectionName, "sele", "\(path): label re-derived")
         }
-    }
-
-    // The lasso name must not outlive the region it labels. Designate a named
-    // region, leave Design mode, then re-enter with 'sele' untouched: the region
-    // re-derives from 'sele' and is now click-built, so it must carry the "sele"
-    // label, not the stale lasso name. The focus-change path shares the same reset
-    // (both go through clearRegionState), so this covers it too.
-    func testStaleLassoNameDoesNotSurviveLeavingDesignMode() async {
-        let residues = (1...3).map { i in
-            DesignResidue(chain: "A", resi: "\(i)", resn: "ALA", aa: 5,
-                          backbone: MPNNModel.Residue(n: .zero, ca: .zero, c: .zero,
-                                                      o: .zero, chain: 0, resSeq: i),
-                          valid: true)
-        }
-        let c = DesignController(
-            enumerate: { obj, _ in
-                DesignResidueSet(object: obj, state: 1, residues: residues)
-            },
-            score: { _, _ in MPNNModel.ScoreResult(logProbs: [], currentAALogProb: []) },
-            applyColoring: { _, _, _, _, _, _, _ in },
-            dim: { _ in }, snapshot: { _ in }, restore: { })
-        c.allObjects = ["m1"]
-        c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 0, count: r.count) },
-                       selectedIndices: { _, _, _, _ in [0, 2] })
-        c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
-
-        c.pickSelection("loop")
-        XCTAssertEqual(c.selectedSelectionName, "loop", "pre-condition: named region")
-
-        c.exit()                      // must scrub the stale name
-        await c.focusAwait("m1")      // re-enter; 'sele' still holds both residues
-
-        XCTAssertEqual(c.selectedResidueIndices, [0, 2],
-                       "pre-condition: the region still derives from 'sele'")
-        XCTAssertEqual(c.selectedSelectionName, "sele",
-                       "the lasso name must not outlive the region it labelled")
     }
 
     // A refocus whose enumerate throws must leave 'sele' untouched. Writing anyway
@@ -821,32 +722,6 @@ final class DesignRegionTests: XCTestCase {
         }
     }
 
-    // M3: a named selection that resolves to exactly ONE designable residue pins
-    // (no region), so the branch that consumes the lasso label never runs — and the
-    // label must not survive to mislabel the NEXT region.
-    func testOneResidueNamedRegionDoesNotLabelTheNextRegion() {
-        let c = makeController()
-        c.setFocusForTest("m1", nativeSequence: [5, 5, 5, 5, 5], validFlags: allValid(5))
-        c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 0, count: r.count) },
-                       selectedIndices: { _, _, _, _ in [2] })   // ONE residue
-
-        c.pickSelection("hotspot")
-        XCTAssertEqual(c.pinnedResidueIndex, 2,
-                       "pre-condition: one designable residue pins rather than designating")
-        XCTAssertNil(c.selectedSelectionName, "pre-condition: no region, so no label")
-
-        // A 5-residue selection now arrives from outside Design mode (`select sele,
-        // resi 1-5` at the prompt) and reaches the controller through the poll.
-        c.injectSele(seleState: { _, _, _ in
-            (indices: [0, 1, 2, 3, 4], digest: "external", off: 0)
-        })
-        c.syncFromSeleIfChanged(digest: "external")
-
-        XCTAssertEqual(c.selectedResidueIndices, [0, 1, 2, 3, 4])
-        XCTAssertEqual(c.selectedSelectionName, "sele",
-                       "a click-built region must not inherit the stale lasso name")
-    }
-
     // M4: `refocusAndSelect` must check that the focus is still CURRENT, not merely
     // that the object exists. Two rapid clicks on two different non-focus objects
     // spawn two Tasks; if the loser resumes last its write lands while the winner
@@ -893,8 +768,8 @@ final class DesignRegionTests: XCTestCase {
     // MARK: – Design mode adopts a selection made before it opened
 
     // Goal 4's most visible consequence: an ordinary normal-mode selection is already
-    // a designated region the moment Design mode focuses a structure — no lasso, no
-    // re-clicking.
+    // a designated region the moment Design mode focuses a structure — no
+    // re-clicking, and nothing else to designate it with.
     func testEnteringDesignModeAdoptsAPreExistingSele() async {
         let residues = (1...5).map { i in
             DesignResidue(chain: "A", resi: "\(i)", resn: "ALA", aa: 5,
@@ -923,7 +798,6 @@ final class DesignRegionTests: XCTestCase {
         XCTAssertTrue(c.regionModeActive,
                       "\"Redesign selection · 3 res\" must be armed on entry")
         XCTAssertNil(c.pinnedResidueIndex, "3 residues is region mode, not a pin")
-        XCTAssertEqual(c.selectedSelectionName, "sele")
     }
 
     // The OTHER no-digest path: `focusObject` non-nil with no residue set for it.

--- a/swiftui/PyMOLViewerTests/DesignRegionTests.swift
+++ b/swiftui/PyMOLViewerTests/DesignRegionTests.swift
@@ -40,25 +40,43 @@ final class DesignRegionTests: XCTestCase {
         XCTAssertEqual(c.selectedResidueIndices, [0, 2])   // idx 1 (invalid) dropped
     }
 
-    // Shift-click region building: toggleRegionResidue adds/removes valid residues,
-    // ignores invalid ones, and detaches into a "custom" ad-hoc region.
+    // Click-built region under the count-driven rule: successive toggles accumulate
+    // designable residues into a region, non-designable positions never count,
+    // dropping back to ONE designable residue returns to single-residue pin mode
+    // (empty region), and removing the last one leaves nothing active. The label of
+    // a click-built region is "sele" — it IS the ordinary selection now, not a
+    // separate "custom" copy the controller keeps on the side.
     func testToggleRegionResidueBuildsAdHocRegion() {
         let c = makeController()
         c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 0, count: r.count) })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5, 5], validFlags: [true, true, false, true])
         XCTAssertFalse(c.regionModeActive)
+
         c.toggleRegionResidue(residueIndex: 3)
+        XCTAssertEqual(c.pinnedResidueIndex, 3,
+                       "one designable residue is single-residue mode, not a region")
+        XCTAssertFalse(c.regionModeActive)
+
         c.toggleRegionResidue(residueIndex: 1)
         XCTAssertEqual(c.selectedResidueIndices, [1, 3])   // kept sorted
         XCTAssertTrue(c.regionModeActive)
-        XCTAssertEqual(c.selectedSelectionName, "custom")
-        c.toggleRegionResidue(residueIndex: 2)             // invalid → ignored
+        XCTAssertNil(c.pinnedResidueIndex, "region mode drops the pin")
+        XCTAssertEqual(c.selectedSelectionName, "sele",
+                       "a click-built region is labelled 'sele'")
+
+        c.toggleRegionResidue(residueIndex: 2)             // invalid → never counts
         XCTAssertEqual(c.selectedResidueIndices, [1, 3])
-        c.toggleRegionResidue(residueIndex: 1)             // remove
-        XCTAssertEqual(c.selectedResidueIndices, [3])
-        c.toggleRegionResidue(residueIndex: 3)             // remove last → empty
+
+        c.toggleRegionResidue(residueIndex: 1)             // remove → one left
+        XCTAssertTrue(c.selectedResidueIndices.isEmpty,
+                      "one designable residue leaves region mode")
+        XCTAssertEqual(c.pinnedResidueIndex, 3, "the survivor is pinned")
+        XCTAssertNil(c.selectedSelectionName)
+
+        c.toggleRegionResidue(residueIndex: 3)             // remove last → nothing
         XCTAssertFalse(c.regionModeActive)
         XCTAssertNil(c.selectedSelectionName)
+        XCTAssertNil(c.pinnedResidueIndex)
     }
 
     func testTogglePalette() {
@@ -386,6 +404,173 @@ final class DesignRegionTests: XCTestCase {
         XCTAssertEqual(c.syncFromSele(), 0)
         XCTAssertTrue(c.selectedResidueIndices.isEmpty)
         XCTAssertNil(c.pinnedResidueIndex)
+    }
+
+    // MARK: – Gestures route through 'sele'
+
+    // Successive taps accumulate, exactly like normal-mode clicks: 1 -> pin,
+    // 2 -> region. This is the behaviour the whole change exists to deliver.
+    func testSuccessiveTapsAccumulateIntoARegion() {
+        let c = makeController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: allValid(3))
+
+        c.tapResidue(residueIndex: 1)
+        XCTAssertEqual(c.pinnedResidueIndex, 1)
+        XCTAssertFalse(c.regionModeActive)
+
+        c.tapResidue(residueIndex: 0)
+        XCTAssertEqual(c.selectedResidueIndices, [0, 1], "region stays sorted")
+        XCTAssertNil(c.pinnedResidueIndex)
+        XCTAssertTrue(c.regionModeActive)
+
+        c.tapResidue(residueIndex: 2)
+        XCTAssertEqual(c.selectedResidueIndices, [0, 1, 2])
+    }
+
+    // Tapping a selected residue removes it, matching pick_at's toggle.
+    func testTapOnSelectedResidueDeselects() {
+        let c = makeController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: allValid(3))
+        c.tapResidue(residueIndex: 1)
+        c.tapResidue(residueIndex: 2)
+        XCTAssertEqual(c.selectedResidueIndices, [1, 2])
+
+        c.tapResidue(residueIndex: 2)
+        XCTAssertEqual(c.pinnedResidueIndex, 1, "back to single-residue mode")
+        XCTAssertTrue(c.selectedResidueIndices.isEmpty)
+
+        c.tapResidue(residueIndex: 1)
+        XCTAssertNil(c.pinnedResidueIndex, "last residue removed -> nothing active")
+    }
+
+    // A click on empty space clears, as it does in normal mode. Focus is kept.
+    func testEmptySpaceHitClearsSelectionButKeepsFocus() {
+        let c = makeController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: allValid(3))
+        c.tapResidue(residueIndex: 0)
+        c.tapResidue(residueIndex: 1)
+        XCTAssertTrue(c.regionModeActive)
+
+        c.handleViewportHit(object: "", chain: "", resi: "", hasResidue: false)
+        XCTAssertTrue(c.selectedResidueIndices.isEmpty)
+        XCTAssertNil(c.pinnedResidueIndex)
+        XCTAssertEqual(c.focusObject, "m1", "clearing must not change focus")
+    }
+
+    // A hit on the focus object with no resolvable residue is a no-op, not a clear.
+    func testHitOnFocusObjectWithoutResidueIsNoOp() {
+        let c = makeController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: allValid(3))
+        c.tapResidue(residueIndex: 0)
+        c.handleViewportHit(object: "m1", chain: "A", resi: "99", hasResidue: true)
+        XCTAssertEqual(c.pinnedResidueIndex, 0,
+                       "an unresolvable residue must not disturb the selection")
+    }
+
+    // The lasso dropdown writes 'sele' and keeps its own label.
+    func testPickSelectionWritesSeleAndKeepsItsLabel() {
+        let c = makeController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: allValid(3))
+        c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 0, count: r.count) },
+                       selectedIndices: { _, _, _, _ in [0, 2] })
+        c.pickSelection("loop")
+        XCTAssertEqual(c.selectedResidueIndices, [0, 2])
+        XCTAssertEqual(c.selectedSelectionName, "loop")
+
+        // A subsequent click detaches from the named region.
+        c.tapResidue(residueIndex: 1)
+        XCTAssertEqual(c.selectedResidueIndices, [0, 1, 2])
+        XCTAssertEqual(c.selectedSelectionName, "sele")
+    }
+
+    // clearSelection empties 'sele' rather than only the mirrored array, so a
+    // following sync cannot resurrect the region.
+    func testClearSelectionEmptiesSele() {
+        let c = makeController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: allValid(3))
+        c.tapResidue(residueIndex: 0)
+        c.tapResidue(residueIndex: 1)
+        c.clearSelection()
+        XCTAssertTrue(c.selectedResidueIndices.isEmpty)
+        XCTAssertEqual(c.syncFromSele(), 0, "'sele' itself must be empty, not just the mirror")
+    }
+
+    // D3: reaching 2+ residues ARMS the Redesign button; it must never run MPNN
+    // on its own. Auto-running would burn an inference per click and throw away
+    // every intermediate result.
+    func testBuildingARegionNeverRunsInference() {
+        let c = makeController()
+        var designCalls = 0
+        c.injectRegion(designRegion: { r, _, _, _, _ in
+            designCalls += 1
+            return Array(repeating: 0, count: r.count)
+        })
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
+
+        c.tapResidue(residueIndex: 0)
+        c.tapResidue(residueIndex: 1)
+        c.tapResidue(residueIndex: 2)
+
+        XCTAssertTrue(c.regionModeActive, "3 residues must designate a region")
+        XCTAssertEqual(designCalls, 0,
+                       "designating a region must not run inference (D3)")
+    }
+
+    // D4: a hit on a NON-focus object retargets design AND selects that residue in
+    // one gesture, so the first click on another structure is never dead. The
+    // selection must be applied after the async focus completes, or it would be
+    // resolved against the previous object's residue set.
+    //
+    // Driven through the DEBUG `refocusAndSelectAwait` seam, which calls the SAME
+    // private method the synchronous `focusThenSelect` wraps in a Task. Awaiting the
+    // seam is deterministic; polling `focusObject` with a fixed number of
+    // `Task.yield()`s would not be, because `focusAwait` crosses a real
+    // DispatchQueue hop. That `handleViewportHit` routes a non-focus object into
+    // this path is covered by DesignIOSPortTests.testHandleViewportHitRefocusesOnDifferentObject.
+    func testHitOnOtherObjectRefocusesAndSelects() async {
+        let residues = (1...3).map { i in
+            DesignResidue(chain: "A", resi: "\(i)", resn: "ALA", aa: 5,
+                          backbone: MPNNModel.Residue(n: .zero, ca: .zero, c: .zero,
+                                                      o: .zero, chain: 0, resSeq: i),
+                          valid: true)
+        }
+        let c = DesignController(
+            enumerate: { obj, _ in
+                DesignResidueSet(object: obj, state: 1, residues: residues)
+            },
+            score: { _, _ in MPNNModel.ScoreResult(logProbs: [], currentAALogProb: []) },
+            applyColoring: { _, _, _, _, _, _, _ in },
+            dim: { _ in }, snapshot: { _ in }, restore: { })
+        c.allObjects = ["m1", "m2"]
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
+        c.tapResidue(residueIndex: 0)       // a residue selected on the OLD focus
+
+        await c.refocusAndSelectAwait(object: "m2", chain: "A", resi: "2", hasResidue: true)
+
+        XCTAssertEqual(c.focusObject, "m2", "the click must retarget design")
+        XCTAssertEqual(c.pinnedResidueIndex, 1,
+                       "the clicked residue must be selected by the same click (D4)")
+        XCTAssertTrue(c.selectedResidueIndices.isEmpty,
+                      "old-focus residues must not linger in the region")
+    }
+
+    // D2: leaving Design mode must NOT wipe the user's ordinary selection.
+    func testExitDoesNotClearSele() {
+        let c = makeController()
+        var cleared = false
+        c.injectSele(clearSele: { cleared = true })
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: allValid(3))
+        c.tapResidue(residueIndex: 0)
+        c.exit()
+        XCTAssertFalse(cleared,
+                       "exiting Design mode must leave 'sele' alone (D2)")
     }
 }
 #endif

--- a/swiftui/PyMOLViewerTests/DesignRegionTests.swift
+++ b/swiftui/PyMOLViewerTests/DesignRegionTests.swift
@@ -97,9 +97,17 @@ final class DesignRegionTests: XCTestCase {
         c.syncFromSele()                                       // pre-edit: no source
         await c.applyMutationAwait(residueIndex: 0, aa: 7)     // begins edit → editSourceObject "m1"
         c.syncFromSele()                                       // post-edit: source is the original
-        XCTAssertEqual(srcSeen.count, 2)
-        XCTAssertNil(srcSeen[0])
-        XCTAssertEqual(srcSeen[1], "m1")
+        // Assert the OBSERVED scopes, not how many times the reader ran: the count
+        // is an internal detail (any future syncFromSele inside the mutation path
+        // would change it) and says nothing about scoping.
+        guard let firstSrc = srcSeen.first, let lastSrc = srcSeen.last else {
+            return XCTFail("the 'sele' reader never ran, so nothing was scoped")
+        }
+        XCTAssertNil(firstSrc,
+                     "before an edit session there is no source object to scope to")
+        XCTAssertEqual(lastSrc, "m1",
+                       "once the focus moves to the working copy the read must carry "
+                     + "the original as its scope, or a selection made there is invisible")
     }
 
     func testRedesignScattersOnlyIntoRegion() async {
@@ -579,6 +587,47 @@ final class DesignRegionTests: XCTestCase {
                            "\(path): 'sele' still holds both residues, so the region must survive")
             XCTAssertTrue(c.regionModeActive, "\(path): region mode must survive the teardown")
         }
+    }
+
+    // Leaving Design mode and coming back must not lose the region: `exit()` wipes
+    // the derived state through `clearRegionState()` but deliberately does NOT touch
+    // 'sele' (D2), so the region has to be re-derived from the surviving selection on
+    // the next focus. Without that re-derive the user returns to pink markers on 2+
+    // residues with no Redesign button, and the digest-gated poll cannot rescue it —
+    // an unchanged 'sele' yields an identical digest, so the re-derive is skipped.
+    // The focus-change path shares the same reset (both go through
+    // clearRegionState), so this covers it too.
+    func testClickBuiltRegionSurvivesLeavingAndReenteringDesignMode() async {
+        let residues = (1...3).map { i in
+            DesignResidue(chain: "A", resi: "\(i)", resn: "ALA", aa: 5,
+                          backbone: MPNNModel.Residue(n: .zero, ca: .zero, c: .zero,
+                                                      o: .zero, chain: 0, resSeq: i),
+                          valid: true)
+        }
+        let c = DesignController(
+            enumerate: { obj, _ in
+                DesignResidueSet(object: obj, state: 1, residues: residues)
+            },
+            score: { _, _ in MPNNModel.ScoreResult(logProbs: [], currentAALogProb: []) },
+            applyColoring: { _, _, _, _, _, _, _ in },
+            dim: { _ in }, snapshot: { _ in }, restore: { })
+        c.allObjects = ["m1"]
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
+
+        c.tapResidue(residueIndex: 0)
+        c.tapResidue(residueIndex: 2)
+        XCTAssertEqual(c.selectedResidueIndices, [0, 2], "pre-condition: region designated")
+
+        c.exit()                      // wipes the derived state, keeps 'sele'
+        XCTAssertTrue(c.selectedResidueIndices.isEmpty,
+                      "pre-condition: exit() must actually have cleared the derived region")
+
+        await c.focusAwait("m1")      // re-enter; 'sele' still holds both residues
+
+        XCTAssertEqual(c.selectedResidueIndices, [0, 2],
+                       "the region must re-derive from the 'sele' that survived exit()")
+        XCTAssertTrue(c.regionModeActive, "2 residues means Redesign is armed again")
+        XCTAssertNil(c.pinnedResidueIndex, "a re-derived region carries no pin")
     }
 
     // A refocus whose enumerate throws must leave 'sele' untouched. Writing anyway

--- a/swiftui/PyMOLViewerTests/DesignRegionTests.swift
+++ b/swiftui/PyMOLViewerTests/DesignRegionTests.swift
@@ -708,5 +708,27 @@ final class DesignRegionTests: XCTestCase {
         XCTAssertFalse(cleared,
                        "exiting Design mode must leave 'sele' alone (D2)")
     }
+
+    // The poll must re-derive only when the digest actually changed, so a quiet
+    // 500 ms tick costs nothing.
+    func testSyncFromSeleRecordsTheDigestItResolved() {
+        let c = makeController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
+                          validFlags: [true, true, true])
+        c.injectSele(seleState: { _, _, _ in (indices: [0], digest: "abc123", total: 1) })
+        c.syncFromSele()
+        XCTAssertEqual(c.lastSeleDigest, "abc123",
+                       "the resolved digest must be recorded for poll gating")
+    }
+
+    // The panel payload's new field must be optional so an older bundled
+    // appkit_inspector.py still decodes (the whole panel would freeze otherwise).
+    func testPanelPayloadDecodesWithoutDesignSele() throws {
+        let json = """
+        {"objects":[],"selections":[],"enabled":[],"sel_counts":{}}
+        """.data(using: .utf8)!
+        let payload = try JSONDecoder().decode(PanelPayload.self, from: json)
+        XCTAssertNil(payload.design_sele)
+    }
 }
 #endif

--- a/swiftui/PyMOLViewerTests/DesignRegionTests.swift
+++ b/swiftui/PyMOLViewerTests/DesignRegionTests.swift
@@ -46,34 +46,34 @@ final class DesignRegionTests: XCTestCase {
     // (empty region), and removing the last one leaves nothing active. The label of
     // a click-built region is "sele" — it IS the ordinary selection now, not a
     // separate "custom" copy the controller keeps on the side.
-    func testToggleRegionResidueBuildsAdHocRegion() {
+    func testTapResidueBuildsAdHocRegion() {
         let c = makeController()
         c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 0, count: r.count) })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5, 5], validFlags: [true, true, false, true])
         XCTAssertFalse(c.regionModeActive)
 
-        c.toggleRegionResidue(residueIndex: 3)
+        c.tapResidue(residueIndex: 3)
         XCTAssertEqual(c.pinnedResidueIndex, 3,
                        "one designable residue is single-residue mode, not a region")
         XCTAssertFalse(c.regionModeActive)
 
-        c.toggleRegionResidue(residueIndex: 1)
+        c.tapResidue(residueIndex: 1)
         XCTAssertEqual(c.selectedResidueIndices, [1, 3])   // kept sorted
         XCTAssertTrue(c.regionModeActive)
         XCTAssertNil(c.pinnedResidueIndex, "region mode drops the pin")
         XCTAssertEqual(c.selectedSelectionName, "sele",
                        "a click-built region is labelled 'sele'")
 
-        c.toggleRegionResidue(residueIndex: 2)             // invalid → never counts
+        c.tapResidue(residueIndex: 2)             // invalid → never counts
         XCTAssertEqual(c.selectedResidueIndices, [1, 3])
 
-        c.toggleRegionResidue(residueIndex: 1)             // remove → one left
+        c.tapResidue(residueIndex: 1)             // remove → one left
         XCTAssertTrue(c.selectedResidueIndices.isEmpty,
                       "one designable residue leaves region mode")
         XCTAssertEqual(c.pinnedResidueIndex, 3, "the survivor is pinned")
         XCTAssertNil(c.selectedSelectionName)
 
-        c.toggleRegionResidue(residueIndex: 3)             // remove last → nothing
+        c.tapResidue(residueIndex: 3)             // remove last → nothing
         XCTAssertFalse(c.regionModeActive)
         XCTAssertNil(c.selectedSelectionName)
         XCTAssertNil(c.pinnedResidueIndex)

--- a/swiftui/PyMOLViewerTests/DesignRegionTests.swift
+++ b/swiftui/PyMOLViewerTests/DesignRegionTests.swift
@@ -291,9 +291,12 @@ final class DesignRegionTests: XCTestCase {
                        selectedIndices: { _, _, _, _ in [0, 1] })
         c.setFocusForTest("m1", nativeSequence: [5, 5], validFlags: allValid(2))
         c.pickSelection("reg")
+        // Pre-condition: without this, `called == false` also holds when the region
+        // never designated at all — the assertion would pass for the wrong reason.
+        XCTAssertTrue(c.regionModeActive, "pre-condition: a region must be designated")
         for i in 0..<20 where c.paletteAllowed.contains(i) { c.togglePalette(i) }
         await c.redesignSelectionAwait()
-        XCTAssertFalse(called)
+        XCTAssertFalse(called, "an empty palette must block the run")
     }
 
     func testRevertRestoresPreRedesignAndKeepsEarlierEdits() async {
@@ -574,11 +577,11 @@ final class DesignRegionTests: XCTestCase {
                 let idx = keys.enumerated().compactMap { sele.contains($0.element) ? $0.offset : nil }
                 return (indices: idx, digest: "\(sele.sorted())", total: sele.count)
             },
-            toggleSele: { _, chain, resi in
+            toggleSele: { _, chain, resi, _ in
                 let k = "\(chain)/\(resi)"
                 if sele.contains(k) { sele.remove(k) } else { sele.insert(k) }
             },
-            setSeleResidue: { [weak c] _, chain, resi in
+            setSeleResidue: { [weak c] _, chain, resi, _ in
                 // Record WHEN the write lands relative to the refocus. This is the
                 // load-bearing assertion: every state assertion below also passes
                 // if the two steps are swapped, because `focusAwait` ends with its
@@ -687,7 +690,7 @@ final class DesignRegionTests: XCTestCase {
             dim: { _ in }, snapshot: { _ in }, restore: { })
         c.allObjects = ["m1", "m2"]
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
-        c.injectSele(setSeleResidue: { _, _, _ in wrote = true },
+        c.injectSele(setSeleResidue: { _, _, _, _ in wrote = true },
                      clearSele: { wrote = true })
 
         await c.refocusAndSelectAwait(object: "m2", chain: "A", resi: "2", hasResidue: true)
@@ -719,6 +722,230 @@ final class DesignRegionTests: XCTestCase {
         c.syncFromSele()
         XCTAssertEqual(c.lastSeleDigest, "abc123",
                        "the resolved digest must be recorded for poll gating")
+    }
+
+    // MARK: – I1: 'sele' writes are scoped like 'sele' reads
+
+    // Inside an edit session the focus is the WORKING COPY while the selection still
+    // sits on the original's atoms, and every read resolves `sele ∩ scope(obj, src)`
+    // by (chain, resi) identity. A writer that never learns the source object
+    // therefore addresses a different atom set than the reader: the toggle finds no
+    // focus-object atoms in 'sele', so it ADDS instead of removing (the region
+    // member becomes un-removable and gets counted twice), and residues clicked
+    // mid-session lose their only membership when a repack replaces the working
+    // copy's topology. Python owns the scoping (see design_region.py); what Swift
+    // must guarantee is that `editSourceObject` actually reaches both writers.
+    func testSeleWritesCarryTheEditSourceScope() async {
+        var toggleSrc: [String?] = []
+        var setSrc: [String?] = []
+        let c = makeController(); wireEdit(c)
+        c.injectSele(toggleSele: { _, _, _, src in toggleSrc.append(src) },
+                     setSeleResidue: { _, _, _, src in setSrc.append(src) })
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
+
+        c.tapResidue(residueIndex: 0)
+        XCTAssertEqual(toggleSrc, [nil],
+                       "with no edit session open there is no source object to scope to")
+
+        await c.applyMutationAwait(residueIndex: 1, aa: 7)   // opens the edit session
+        XCTAssertTrue(c.editing, "pre-condition: an edit session must be open")
+        XCTAssertEqual(c.focusObject, "m1_design",
+                       "pre-condition: the focus must have moved to the working copy")
+
+        c.tapResidue(residueIndex: 2)
+        XCTAssertEqual(toggleSrc.last, "m1",
+                       "a toggle inside an edit session must carry the source object, "
+                     + "or it cannot remove a member selected on the original")
+
+        await c.refocusAndSelectAwait(object: "m1_design", chain: "A", resi: "3",
+                                     hasResidue: true)
+        XCTAssertEqual(setSrc.last, "m1",
+                       "the replace-with-one-residue write must be scoped too")
+    }
+
+    // MARK: – The panel-poll gate
+
+    // The gate itself, not just the digest bookkeeping: an unchanged digest must
+    // SKIP the re-derive (a quiet 500 ms tick costs nothing) and a changed one must
+    // trigger it.
+    func testPollGateReDerivesOnlyWhenTheDigestChanged() {
+        let c = makeController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
+        var reads = 0
+        c.injectSele(seleState: { _, _, _ in
+            reads += 1
+            return (indices: [0], digest: "d1", total: 1)
+        })
+
+        XCTAssertTrue(c.syncFromSeleIfChanged(digest: "d1"),
+                      "a digest never seen before must re-derive")
+        XCTAssertEqual(reads, 1)
+        XCTAssertEqual(c.pinnedResidueIndex, 0)
+
+        XCTAssertFalse(c.syncFromSeleIfChanged(digest: "d1"),
+                       "an unchanged digest must skip the re-derive")
+        XCTAssertEqual(reads, 1, "a quiet tick must not read 'sele' at all")
+
+        c.injectSele(seleState: { _, _, _ in
+            reads += 1
+            return (indices: [0, 2], digest: "d2", total: 2)
+        })
+        XCTAssertTrue(c.syncFromSeleIfChanged(digest: "d2"),
+                      "a changed digest must re-derive")
+        XCTAssertEqual(reads, 2)
+        XCTAssertEqual(c.selectedResidueIndices, [0, 2])
+    }
+
+    // M2: Design mode on with NO focus object (2+ objects loaded, so enter() does
+    // not auto-focus) and a non-empty 'sele'. syncFromSele cannot read a digest
+    // without an object to scope the read to, so the gate must adopt the digest the
+    // poll observed — otherwise every 500 ms tick re-derives forever, republishing
+    // four @Published properties and invalidating the design bar, compact panel and
+    // sequence strip twice a second for as long as the mode is open.
+    func testPollGateDoesNotSpinWithoutAFocusObject() {
+        let c = makeController()
+        c.allObjects = ["m1", "m2"]           // enter() must not auto-focus
+        c.enter()
+        XCTAssertNil(c.focusObject, "pre-condition: nothing is focused")
+
+        XCTAssertTrue(c.syncFromSeleIfChanged(digest: "py-digest"),
+                      "the first tick after entering may re-derive once")
+        for tick in 1...4 {
+            XCTAssertFalse(c.syncFromSeleIfChanged(digest: "py-digest"),
+                           "tick \(tick): an unchanged 'sele' must not re-derive "
+                         + "just because there is no focus object")
+        }
+    }
+
+    // M3: a named selection that resolves to exactly ONE designable residue pins
+    // (no region), so the branch that consumes the lasso label never runs — and the
+    // label must not survive to mislabel the NEXT region.
+    func testOneResidueNamedRegionDoesNotLabelTheNextRegion() {
+        let c = makeController()
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5, 5, 5], validFlags: allValid(5))
+        c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 0, count: r.count) },
+                       selectedIndices: { _, _, _, _ in [2] })   // ONE residue
+
+        c.pickSelection("hotspot")
+        XCTAssertEqual(c.pinnedResidueIndex, 2,
+                       "pre-condition: one designable residue pins rather than designating")
+        XCTAssertNil(c.selectedSelectionName, "pre-condition: no region, so no label")
+
+        // A 5-residue selection now arrives from outside Design mode (`select sele,
+        // resi 1-5` at the prompt) and reaches the controller through the poll.
+        c.injectSele(seleState: { _, _, _ in
+            (indices: [0, 1, 2, 3, 4], digest: "external", total: 5)
+        })
+        c.syncFromSeleIfChanged(digest: "external")
+
+        XCTAssertEqual(c.selectedResidueIndices, [0, 1, 2, 3, 4])
+        XCTAssertEqual(c.selectedSelectionName, "sele",
+                       "a click-built region must not inherit the stale lasso name")
+    }
+
+    // M4: `refocusAndSelect` must check that the focus is still CURRENT, not merely
+    // that the object exists. Two rapid clicks on two different non-focus objects
+    // spawn two Tasks; if the loser resumes last its write lands while the winner
+    // owns the focus, leaving 'sele' on a NON-focused object — pink markers plus
+    // "nothing selected", because every read is scoped to the focus object.
+    //
+    // The interleaving is made deterministic by having the loser's own `enumerate`
+    // move the focus, which is exactly where the competing task's `focusAwait` would
+    // land: after `focusObject = object` and before the 'sele' write.
+    func testRefocusDoesNotWriteSeleWhenAnotherObjectWonTheFocus() async {
+        var writes: [String] = []
+        var ctrl: DesignController?
+        let residues = (1...3).map { i in
+            DesignResidue(chain: "B", resi: "\(100 + i)", resn: "ALA", aa: 5,
+                          backbone: MPNNModel.Residue(n: .zero, ca: .zero, c: .zero,
+                                                      o: .zero, chain: 1, resSeq: 100 + i),
+                          valid: true)
+        }
+        let c = DesignController(
+            enumerate: { obj, _ in
+                if obj == "m2" { ctrl?.focusObject = "m3" }   // the winner takes over
+                return DesignResidueSet(object: obj, state: 1, residues: residues)
+            },
+            score: { _, _ in MPNNModel.ScoreResult(logProbs: [], currentAALogProb: []) },
+            applyColoring: { _, _, _, _, _, _, _ in },
+            dim: { _ in }, snapshot: { _ in }, restore: { })
+        ctrl = c
+        c.allObjects = ["m1", "m2", "m3"]
+        c.injectSele(setSeleResidue: { obj, _, resi, _ in writes.append("\(obj)/\(resi)") },
+                     clearSele: { writes.append("clear") })
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
+
+        await c.refocusAndSelectAwait(object: "m2", chain: "B", resi: "102",
+                                     hasResidue: true)
+
+        XCTAssertEqual(c.focusObject, "m3",
+                       "pre-condition: another object must have won the focus — "
+                     + "m2's residue set DOES exist, so existence alone is not enough")
+        XCTAssertTrue(writes.isEmpty,
+                      "a superseded refocus must not write 'sele' onto an object that "
+                    + "is no longer focused: \(writes)")
+    }
+
+    // MARK: – Design mode adopts a selection made before it opened
+
+    // Goal 4's most visible consequence: an ordinary normal-mode selection is already
+    // a designated region the moment Design mode focuses a structure — no lasso, no
+    // re-clicking.
+    func testEnteringDesignModeAdoptsAPreExistingSele() async {
+        let residues = (1...5).map { i in
+            DesignResidue(chain: "A", resi: "\(i)", resn: "ALA", aa: 5,
+                          backbone: MPNNModel.Residue(n: .zero, ca: .zero, c: .zero,
+                                                      o: .zero, chain: 0, resSeq: i),
+                          valid: true)
+        }
+        let c = DesignController(
+            enumerate: { obj, _ in
+                DesignResidueSet(object: obj, state: 1, residues: residues)
+            },
+            score: { _, _ in MPNNModel.ScoreResult(logProbs: [], currentAALogProb: []) },
+            applyColoring: { _, _, _, _, _, _, _ in },
+            dim: { _ in }, snapshot: { _ in }, restore: { })
+        c.allObjects = ["m1"]
+        // 'sele' already holds three residues, selected in normal mode.
+        c.injectSele(seleState: { _, _, _ in
+            (indices: [1, 2, 3], digest: "pre-existing", total: 3)
+        })
+
+        c.enter()                     // single object → auto-focus
+        await c.focusAwait("m1")      // the deterministic half of what enter() starts
+
+        XCTAssertEqual(c.selectedResidueIndices, [1, 2, 3],
+                       "the pre-existing selection must arm the region immediately")
+        XCTAssertTrue(c.regionModeActive,
+                      "\"Redesign selection · 3 res\" must be armed on entry")
+        XCTAssertNil(c.pinnedResidueIndex, "3 residues is region mode, not a pin")
+        XCTAssertEqual(c.selectedSelectionName, "sele")
+    }
+
+    // MARK: – M5: an unreadable pick payload must not destroy the selection
+
+    // `handleViewportHit(object: "")` CLEARS 'sele', so "I could not read the pick"
+    // and "the pick ran and missed" cannot share an encoding: the first must be a
+    // no-op, the second must clear (normal-mode parity).
+    func testDesignPickOutcomeSeparatesAMissFromAnUnreadablePayload() {
+        XCTAssertNil(PyMOLEngine.designPickOutcome(payload: nil),
+                     "no file / unparseable JSON: the tap must be a no-op")
+        XCTAssertNil(PyMOLEngine.designPickOutcome(payload: [:]),
+                     "a payload with no 'hit' key is not a pick result")
+
+        let miss = PyMOLEngine.designPickOutcome(
+            payload: ["hit": false, "obj": "m1", "chain": "A", "resi": "2"])
+        XCTAssertEqual(miss?.hit, false)
+        XCTAssertEqual(miss?.object, "",
+                       "a genuine miss must reach the controller as an empty object "
+                     + "so the empty-space tap clears 'sele'")
+
+        let hit = PyMOLEngine.designPickOutcome(
+            payload: ["hit": true, "obj": "m1", "chain": "A", "resi": "2"])
+        XCTAssertEqual(hit?.hit, true)
+        XCTAssertEqual(hit?.object, "m1")
+        XCTAssertEqual(hit?.chain, "A")
+        XCTAssertEqual(hit?.resi, "2")
     }
 
     // The panel payload's new field must be optional so an older bundled

--- a/swiftui/PyMOLViewerTests/DesignRegionTests.swift
+++ b/swiftui/PyMOLViewerTests/DesignRegionTests.swift
@@ -225,7 +225,7 @@ final class DesignRegionTests: XCTestCase {
         let c = makeController(); wireEdit(c)
         c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 9, count: r.count) },
                        selectedIndices: { _, _, _, _ in [1, 2] })
-        c.injectRepack(repack: { _, _ in "REPACKED" }, loadRepacked: { _, _ in })
+        c.injectRepack(repack: { _, _ in "REPACKED" }, loadRepacked: { _, _, _ in })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
         c.pickSelection("reg")
         await c.redesignSelectionAwait()
@@ -247,7 +247,7 @@ final class DesignRegionTests: XCTestCase {
         c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 9, count: r.count) },
                        selectedIndices: { _, _, _, _ in [1, 2] })
         c.injectRepack(repack: { _, _ in "PDB" },
-                       loadRepacked: { [weak c] _, _ in flagDuringRepack = c?.isRedesigning })
+                       loadRepacked: { [weak c] _, _, _ in flagDuringRepack = c?.isRedesigning })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
         c.pickSelection("reg")
         await c.redesignSelectionAwait()
@@ -348,7 +348,7 @@ final class DesignRegionTests: XCTestCase {
         let c = makeController()
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
                           validFlags: allValid(3))
-        c.injectSele(seleState: { _, _, _ in (indices: [1], digest: "d1", total: 1) })
+        c.injectSele(seleState: { _, _, _ in (indices: [1], digest: "d1", off: 0) })
         XCTAssertEqual(c.syncFromSele(), 1)
         XCTAssertEqual(c.pinnedResidueIndex, 1)
         XCTAssertTrue(c.selectedResidueIndices.isEmpty,
@@ -364,7 +364,7 @@ final class DesignRegionTests: XCTestCase {
         let c = makeController()
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
                           validFlags: allValid(3))
-        c.injectSele(seleState: { _, _, _ in (indices: [0, 2], digest: "d2", total: 2) })
+        c.injectSele(seleState: { _, _, _ in (indices: [0, 2], digest: "d2", off: 0) })
         XCTAssertEqual(c.syncFromSele(), 2)
         XCTAssertNil(c.pinnedResidueIndex,
                      "region mode must clear the single-residue pin")
@@ -380,7 +380,7 @@ final class DesignRegionTests: XCTestCase {
         let c = makeController()
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
                           validFlags: [true, false, true])
-        c.injectSele(seleState: { _, _, _ in (indices: [0, 1], digest: "d3", total: 2) })
+        c.injectSele(seleState: { _, _, _ in (indices: [0, 1], digest: "d3", off: 0) })
         XCTAssertEqual(c.syncFromSele(), 1,
                        "index 1 is not designable and must not count")
         XCTAssertEqual(c.pinnedResidueIndex, 0)
@@ -392,18 +392,21 @@ final class DesignRegionTests: XCTestCase {
         let c = makeController()
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
                           validFlags: allValid(3))
-        c.injectSele(seleState: { _, _, _ in (indices: [1, 99, -1], digest: "d4", total: 3) })
+        c.injectSele(seleState: { _, _, _ in (indices: [1, 99, -1], digest: "d4", off: 0) })
         XCTAssertEqual(c.syncFromSele(), 1)
         XCTAssertEqual(c.pinnedResidueIndex, 1)
     }
 
     // Residues selected on OTHER structures are reported so the UI can say so
-    // instead of silently ignoring them.
-    func testOffFocusResiduesAreCounted() {
+    // instead of silently ignoring them. The count is taken VERBATIM from the
+    // reader (Python computes it from the model names): deriving it here as
+    // "selected - in scope" double-counted a residue that an edit session
+    // legitimately marks on BOTH the working copy and the original.
+    func testOffFocusResiduesAreReportedNotDerived() {
         let c = makeController()
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
                           validFlags: allValid(3))
-        c.injectSele(seleState: { _, _, _ in (indices: [0], digest: "d5", total: 3) })
+        c.injectSele(seleState: { _, _, _ in (indices: [0], digest: "d5", off: 2) })
         c.syncFromSele()
         XCTAssertEqual(c.seleResiduesOffFocus, 2)
     }
@@ -412,7 +415,7 @@ final class DesignRegionTests: XCTestCase {
     // rather than keep stale indices.
     func testSyncWithoutFocusResets() {
         let c = makeController()
-        c.injectSele(seleState: { _, _, _ in (indices: [0, 1], digest: "d6", total: 2) })
+        c.injectSele(seleState: { _, _, _ in (indices: [0, 1], digest: "d6", off: 2) })
         XCTAssertEqual(c.syncFromSele(), 0)
         XCTAssertTrue(c.selectedResidueIndices.isEmpty)
         XCTAssertNil(c.pinnedResidueIndex)
@@ -575,7 +578,8 @@ final class DesignRegionTests: XCTestCase {
                     ? ["B/101", "B/102", "B/103"]
                     : ["A/1", "A/2", "A/3"]
                 let idx = keys.enumerated().compactMap { sele.contains($0.element) ? $0.offset : nil }
-                return (indices: idx, digest: "\(sele.sorted())", total: sele.count)
+                return (indices: idx, digest: "\(sele.sorted())",
+                        off: max(0, sele.count - idx.count))
             },
             toggleSele: { _, chain, resi, _ in
                 let k = "\(chain)/\(resi)"
@@ -718,7 +722,7 @@ final class DesignRegionTests: XCTestCase {
         let c = makeController()
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5],
                           validFlags: [true, true, true])
-        c.injectSele(seleState: { _, _, _ in (indices: [0], digest: "abc123", total: 1) })
+        c.injectSele(seleState: { _, _, _ in (indices: [0], digest: "abc123", off: 0) })
         c.syncFromSele()
         XCTAssertEqual(c.lastSeleDigest, "abc123",
                        "the resolved digest must be recorded for poll gating")
@@ -774,7 +778,7 @@ final class DesignRegionTests: XCTestCase {
         var reads = 0
         c.injectSele(seleState: { _, _, _ in
             reads += 1
-            return (indices: [0], digest: "d1", total: 1)
+            return (indices: [0], digest: "d1", off: 0)
         })
 
         XCTAssertTrue(c.syncFromSeleIfChanged(digest: "d1"),
@@ -788,7 +792,7 @@ final class DesignRegionTests: XCTestCase {
 
         c.injectSele(seleState: { _, _, _ in
             reads += 1
-            return (indices: [0, 2], digest: "d2", total: 2)
+            return (indices: [0, 2], digest: "d2", off: 0)
         })
         XCTAssertTrue(c.syncFromSeleIfChanged(digest: "d2"),
                       "a changed digest must re-derive")
@@ -834,7 +838,7 @@ final class DesignRegionTests: XCTestCase {
         // A 5-residue selection now arrives from outside Design mode (`select sele,
         // resi 1-5` at the prompt) and reaches the controller through the poll.
         c.injectSele(seleState: { _, _, _ in
-            (indices: [0, 1, 2, 3, 4], digest: "external", total: 5)
+            (indices: [0, 1, 2, 3, 4], digest: "external", off: 0)
         })
         c.syncFromSeleIfChanged(digest: "external")
 
@@ -908,7 +912,7 @@ final class DesignRegionTests: XCTestCase {
         c.allObjects = ["m1"]
         // 'sele' already holds three residues, selected in normal mode.
         c.injectSele(seleState: { _, _, _ in
-            (indices: [1, 2, 3], digest: "pre-existing", total: 3)
+            (indices: [1, 2, 3], digest: "pre-existing", off: 0)
         })
 
         c.enter()                     // single object → auto-focus
@@ -920,6 +924,85 @@ final class DesignRegionTests: XCTestCase {
                       "\"Redesign selection · 3 res\" must be armed on entry")
         XCTAssertNil(c.pinnedResidueIndex, "3 residues is region mode, not a pin")
         XCTAssertEqual(c.selectedSelectionName, "sele")
+    }
+
+    // The OTHER no-digest path: `focusObject` non-nil with no residue set for it.
+    // `focusAwait` sets `focusObject` BEFORE `enumerate`, and its catch only records
+    // `errorText` — so a failed focus leaves exactly that state, and gating on
+    // `focusObject == nil` would let the poll re-derive on every 500 ms tick
+    // forever, which is the symptom the gate exists to prevent.
+    func testPollGateDoesNotSpinAfterAFailedFocus() async {
+        struct Boom: Error {}
+        let c = DesignController(
+            enumerate: { _, _ in throw Boom() },
+            score: { _, _ in MPNNModel.ScoreResult(logProbs: [], currentAALogProb: []) },
+            applyColoring: { _, _, _, _, _, _, _ in },
+            dim: { _ in }, snapshot: { _ in }, restore: { })
+        c.allObjects = ["m1", "m2"]
+
+        await c.focusAwait("m1")
+        XCTAssertNotNil(c.errorText, "pre-condition: the focus must have failed")
+        XCTAssertEqual(c.focusObject, "m1",
+                       "pre-condition: focusObject is set even though enumerate threw")
+
+        XCTAssertTrue(c.syncFromSeleIfChanged(digest: "py-digest"),
+                      "the first tick may re-derive once")
+        for tick in 1...4 {
+            XCTAssertFalse(c.syncFromSeleIfChanged(digest: "py-digest"),
+                           "tick \(tick): an unchanged 'sele' must not re-derive just "
+                         + "because the focus object has no residue set")
+        }
+    }
+
+    // MARK: – Keeping edits must not leave an unclearable 'sele' membership
+
+    // A residue clicked mid-session is marked on BOTH the working copy and the
+    // original — that is what survives a repack. The Keep path RETAINS the copy but
+    // clears `editSourceObject`, so from then on no Design write can address the
+    // copy: without narrowing, clicking that region member off leaves it selected
+    // and pink there, with a spurious off-structure badge and no way to clear it.
+    // The Discard path needs no narrowing — deleting the copy takes its atoms with it.
+    func testKeepingEditsNarrowsSeleOffTheRetainedCopy() async {
+        for keep in [true, false] {
+            var dropped: [String] = []
+            let c = makeController(); wireEdit(c)
+            c.injectSele(dropObjectFromSele: { dropped.append($0) })
+            c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
+            c.tapResidue(residueIndex: 0)
+            await c.applyMutationAwait(residueIndex: 1, aa: 7)   // opens the session
+            XCTAssertEqual(c.workingObject, "m1_design",
+                           "pre-condition: a working copy must exist")
+
+            if keep { c.keepEdits() } else { c.discardEdits() }
+
+            if keep {
+                XCTAssertEqual(dropped, ["m1_design"],
+                               "Keep retains the copy, so 'sele' must be narrowed off it")
+            } else {
+                XCTAssertTrue(dropped.isEmpty,
+                              "Discard deletes the copy — nothing to narrow: \(dropped)")
+            }
+        }
+    }
+
+    // MARK: – The repack must be able to re-assert 'sele' where it is visible
+
+    // `load_repacked` deletes and renames the object, annihilating its 'sele' atoms;
+    // it re-asserts them on the replacement, and needs the edit scope to know which
+    // residues those are (the pre-session ones were only ever marked on the
+    // original, which the session disabled). Swift's job is to pass the source.
+    func testRepackCarriesTheEditSourceToLoadRepacked() async {
+        var srcSeen: [String?] = []
+        let c = makeController(); wireEdit(c)
+        c.injectRepack(repack: { _, _ in "PDBDATA" },
+                       loadRepacked: { _, _, src in srcSeen.append(src) })
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
+        await c.applyMutationAwait(residueIndex: 1, aa: 7)   // opens the session
+        await c.repackNowAwait()
+
+        XCTAssertEqual(srcSeen, ["m1"],
+                       "the repack must tell load_repacked which object the region's "
+                     + "selection can also live on")
     }
 
     // MARK: – M5: an unreadable pick payload must not destroy the selection
@@ -946,6 +1029,46 @@ final class DesignRegionTests: XCTestCase {
         XCTAssertEqual(hit?.object, "m1")
         XCTAssertEqual(hit?.chain, "A")
         XCTAssertEqual(hit?.resi, "2")
+    }
+
+    // The guard itself, at the level designPickResidue uses it: an unreadable
+    // payload file must deliver NOTHING to the controller (delivering an empty
+    // object would clear 'sele'), while a genuine miss must still be delivered.
+    func testRouteDesignPickDeliversNothingForAnUnreadablePayload() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("raymol-pick-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        var delivered: [(String, String, String, Bool)] = []
+        let sink: (String, String, String, Bool) -> Void = {
+            delivered.append(($0, $1, $2, $3))
+        }
+
+        // 1. No file at all (hover_design_at never ran, or the write failed).
+        PyMOLEngine.routeDesignPick(
+            payloadPath: dir.appendingPathComponent("missing.json").path, deliver: sink)
+        XCTAssertTrue(delivered.isEmpty, "a missing payload must not reach the controller")
+
+        // 2. Present but not JSON (a truncated or clobbered write).
+        let garbage = dir.appendingPathComponent("garbage.json")
+        try Data("{not json".utf8).write(to: garbage)
+        PyMOLEngine.routeDesignPick(payloadPath: garbage.path, deliver: sink)
+        XCTAssertTrue(delivered.isEmpty, "unparseable JSON must not reach the controller")
+
+        // 3. Valid JSON that is not a pick result.
+        let wrongShape = dir.appendingPathComponent("array.json")
+        try Data("[1, 2, 3]".utf8).write(to: wrongShape)
+        PyMOLEngine.routeDesignPick(payloadPath: wrongShape.path, deliver: sink)
+        XCTAssertTrue(delivered.isEmpty, "a non-object payload must not reach the controller")
+
+        // 4. A genuine miss MUST be delivered, as an empty object, so the tap clears.
+        let miss = dir.appendingPathComponent("miss.json")
+        try Data(#"{"hit": false, "obj": "m1", "chain": "A", "resi": "2"}"#.utf8).write(to: miss)
+        PyMOLEngine.routeDesignPick(payloadPath: miss.path, deliver: sink)
+        XCTAssertEqual(delivered.count, 1, "a real miss must reach the controller")
+        XCTAssertEqual(delivered.first?.0, "")
+        XCTAssertEqual(delivered.first?.3, false)
     }
 
     // The panel payload's new field must be optional so an older bundled

--- a/swiftui/PyMOLViewerTests/DesignRegionTests.swift
+++ b/swiftui/PyMOLViewerTests/DesignRegionTests.swift
@@ -229,6 +229,9 @@ final class DesignRegionTests: XCTestCase {
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
         c.pickSelection("reg")
         await c.redesignSelectionAwait()
+        XCTAssertEqual(c.editedSequence, [5, 9, 9],
+                       "the redesign must actually have run — without this the flag "
+                     + "assertions below pass vacuously on any early return")
         XCTAssertFalse(c.isRedesigning, "isRedesigning must clear after a successful redesign")
         XCTAssertFalse(c.isRepacking, "isRepacking must clear after the follow-up repack")
     }
@@ -274,6 +277,9 @@ final class DesignRegionTests: XCTestCase {
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
         c.pickSelection("reg")
         await c.redesignSelectionAwait()
+        XCTAssertEqual(c.errorText, "Region redesign failed",
+                       "design() must actually have been called and rejected for its "
+                     + "length — otherwise the rollback assertion below is vacuous")
         XCTAssertFalse(c.isRedesigning)
         XCTAssertEqual(c.editedSequence, [5, 5, 5])   // rolled back
     }
@@ -537,30 +543,66 @@ final class DesignRegionTests: XCTestCase {
     // DispatchQueue hop. That `handleViewportHit` routes a non-focus object into
     // this path is covered by DesignIOSPortTests.testHandleViewportHitRefocusesOnDifferentObject.
     func testHitOnOtherObjectRefocusesAndSelects() async {
-        let residues = (1...3).map { i in
-            DesignResidue(chain: "A", resi: "\(i)", resn: "ALA", aa: 5,
+        // m2's residues deliberately use DIFFERENT keys from m1's (which
+        // setFocusForTest builds as chain "A", resi "1"..."3"), so the two objects
+        // are not interchangeable and no future test can pass by accident.
+        let m2Residues = (1...3).map { i in
+            DesignResidue(chain: "B", resi: "\(100 + i)", resn: "ALA", aa: 5,
                           backbone: MPNNModel.Residue(n: .zero, ca: .zero, c: .zero,
-                                                      o: .zero, chain: 0, resSeq: i),
+                                                      o: .zero, chain: 1, resSeq: 100 + i),
                           valid: true)
         }
         let c = DesignController(
             enumerate: { obj, _ in
-                DesignResidueSet(object: obj, state: 1, residues: residues)
+                DesignResidueSet(object: obj, state: 1, residues: m2Residues)
             },
             score: { _, _ in MPNNModel.ScoreResult(logProbs: [], currentAALogProb: []) },
             applyColoring: { _, _, _, _, _, _, _ in },
             dim: { _ in }, snapshot: { _ in }, restore: { })
         c.allObjects = ["m1", "m2"]
+
+        // 'sele', modelled object-awarely: PyMOL resolves a selection against
+        // whichever object is in scope, so reading it while the OLD object is still
+        // focused yields the OLD object's indices. That is the hazard under test.
+        var sele: Set<String> = []
+        var focusWhenWritten: String?
+        c.injectSele(
+            seleState: { obj, _, _ in
+                let keys = (obj == "m2")
+                    ? ["B/101", "B/102", "B/103"]
+                    : ["A/1", "A/2", "A/3"]
+                let idx = keys.enumerated().compactMap { sele.contains($0.element) ? $0.offset : nil }
+                return (indices: idx, digest: "\(sele.sorted())", total: sele.count)
+            },
+            toggleSele: { _, chain, resi in
+                let k = "\(chain)/\(resi)"
+                if sele.contains(k) { sele.remove(k) } else { sele.insert(k) }
+            },
+            setSeleResidue: { [weak c] _, chain, resi in
+                // Record WHEN the write lands relative to the refocus. This is the
+                // load-bearing assertion: every state assertion below also passes
+                // if the two steps are swapped, because `focusAwait` ends with its
+                // own `syncFromSele()` and would re-derive the right indices anyway.
+                focusWhenWritten = c?.focusObject
+                sele = ["\(chain)/\(resi)"]
+            })
+
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
         c.tapResidue(residueIndex: 0)       // a residue selected on the OLD focus
+        XCTAssertEqual(c.pinnedResidueIndex, 0, "pre-condition: A/1 selected on m1")
 
-        await c.refocusAndSelectAwait(object: "m2", chain: "A", resi: "2", hasResidue: true)
+        await c.refocusAndSelectAwait(object: "m2", chain: "B", resi: "102", hasResidue: true)
 
+        XCTAssertEqual(focusWhenWritten, "m2",
+                       "the selection must be written AFTER the refocus completes — "
+                     + "writing it first resolves the new residue against the OLD "
+                     + "object's residue set and silently produces wrong indices")
         XCTAssertEqual(c.focusObject, "m2", "the click must retarget design")
         XCTAssertEqual(c.pinnedResidueIndex, 1,
                        "the clicked residue must be selected by the same click (D4)")
         XCTAssertTrue(c.selectedResidueIndices.isEmpty,
                       "old-focus residues must not linger in the region")
+        XCTAssertEqual(sele, ["B/102"], "'sele' holds exactly the clicked residue")
     }
 
     // Ending an edit session must leave the derived state agreeing with 'sele'.
@@ -593,6 +635,65 @@ final class DesignRegionTests: XCTestCase {
             XCTAssertTrue(c.regionModeActive, "\(path): region mode must survive the teardown")
             XCTAssertEqual(c.selectedSelectionName, "sele", "\(path): label re-derived")
         }
+    }
+
+    // The lasso name must not outlive the region it labels. Designate a named
+    // region, leave Design mode, then re-enter with 'sele' untouched: the region
+    // re-derives from 'sele' and is now click-built, so it must carry the "sele"
+    // label, not the stale lasso name. The focus-change path shares the same reset
+    // (both go through clearRegionState), so this covers it too.
+    func testStaleLassoNameDoesNotSurviveLeavingDesignMode() async {
+        let residues = (1...3).map { i in
+            DesignResidue(chain: "A", resi: "\(i)", resn: "ALA", aa: 5,
+                          backbone: MPNNModel.Residue(n: .zero, ca: .zero, c: .zero,
+                                                      o: .zero, chain: 0, resSeq: i),
+                          valid: true)
+        }
+        let c = DesignController(
+            enumerate: { obj, _ in
+                DesignResidueSet(object: obj, state: 1, residues: residues)
+            },
+            score: { _, _ in MPNNModel.ScoreResult(logProbs: [], currentAALogProb: []) },
+            applyColoring: { _, _, _, _, _, _, _ in },
+            dim: { _ in }, snapshot: { _ in }, restore: { })
+        c.allObjects = ["m1"]
+        c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 0, count: r.count) },
+                       selectedIndices: { _, _, _, _ in [0, 2] })
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
+
+        c.pickSelection("loop")
+        XCTAssertEqual(c.selectedSelectionName, "loop", "pre-condition: named region")
+
+        c.exit()                      // must scrub the stale name
+        await c.focusAwait("m1")      // re-enter; 'sele' still holds both residues
+
+        XCTAssertEqual(c.selectedResidueIndices, [0, 2],
+                       "pre-condition: the region still derives from 'sele'")
+        XCTAssertEqual(c.selectedSelectionName, "sele",
+                       "the lasso name must not outlive the region it labelled")
+    }
+
+    // A refocus whose enumerate throws must leave 'sele' untouched. Writing anyway
+    // would swap the user's selection for a residue that cannot be resolved against
+    // any residue set, leaving them with neither the old selection nor a usable new
+    // one.
+    func testFailedRefocusLeavesSeleUntouched() async {
+        struct Boom: Error {}
+        var wrote = false
+        let c = DesignController(
+            enumerate: { _, _ in throw Boom() },
+            score: { _, _ in MPNNModel.ScoreResult(logProbs: [], currentAALogProb: []) },
+            applyColoring: { _, _, _, _, _, _, _ in },
+            dim: { _ in }, snapshot: { _ in }, restore: { })
+        c.allObjects = ["m1", "m2"]
+        c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
+        c.injectSele(setSeleResidue: { _, _, _ in wrote = true },
+                     clearSele: { wrote = true })
+
+        await c.refocusAndSelectAwait(object: "m2", chain: "A", resi: "2", hasResidue: true)
+
+        XCTAssertNotNil(c.errorText, "pre-condition: the focus must actually have failed")
+        XCTAssertFalse(wrote, "a failed refocus must not touch 'sele'")
     }
 
     // D2: leaving Design mode must NOT wipe the user's ordinary selection.

--- a/swiftui/PyMOLViewerTests/DesignRegionTests.swift
+++ b/swiftui/PyMOLViewerTests/DesignRegionTests.swift
@@ -170,18 +170,21 @@ final class DesignRegionTests: XCTestCase {
     func testScatterWithInvalidGap() async {
         let c = makeController(); wireEdit(c)
         c.injectRegion(designRegion: { _, _, _, _, _ in [9, 8] },   // valid-projected result (L=2)
-                       selectedIndices: { _, _, _, _ in [2] })      // full idx 2 → valid-projected 1
+                       selectedIndices: { _, _, _, _ in [0, 2] })   // full idx 0,2 → valid-projected 0,1
         c.setFocusForTest("m1", nativeSequence: [5, 6, 7], validFlags: [true, false, true])
         c.pickSelection("reg")
         await c.redesignSelectionAwait()
-        XCTAssertEqual(c.editedSequence, [5, 6, 8])         // only full idx 2 changed → result[1]==8
+        // Both designed values must land on the correct side of the invalid gap:
+        // full 0 ← result[0]==9, full 2 ← result[1]==8, and full 1 (no backbone)
+        // is skipped entirely and keeps its native identity.
+        XCTAssertEqual(c.editedSequence, [9, 6, 8])
     }
 
     func testNativeSequenceReflectsPriorEdits() async {
         var capturedNative: [Int]?
         let c = makeController(); wireEdit(c)
         c.injectRegion(designRegion: { _, _, native, _, _ in capturedNative = native; return native },
-                       selectedIndices: { _, _, _, _ in [2] })
+                       selectedIndices: { _, _, _, _ in [2, 3] })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5, 5], validFlags: allValid(4))
         await c.applyMutationAwait(residueIndex: 0, aa: 7)  // earlier manual edit
         c.pickSelection("reg")
@@ -193,7 +196,7 @@ final class DesignRegionTests: XCTestCase {
         var capturedOmit: [Set<Int>]?
         let c = makeController(); wireEdit(c)
         c.injectRegion(designRegion: { _, _, native, omit, _ in capturedOmit = omit; return native },
-                       selectedIndices: { _, _, _, _ in [1] })
+                       selectedIndices: { _, _, _, _ in [1, 2] })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
         c.pickSelection("reg")
         c.togglePalette(4); c.togglePalette(12)
@@ -207,7 +210,7 @@ final class DesignRegionTests: XCTestCase {
         var capturedTemp: Float?
         let c = makeController(); wireEdit(c)
         c.injectRegion(designRegion: { _, _, native, _, temp in capturedTemp = temp; return native },
-                       selectedIndices: { _, _, _, _ in [1] })
+                       selectedIndices: { _, _, _, _ in [1, 2] })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
         c.designTemperature = 0.7
         c.pickSelection("reg")
@@ -221,7 +224,7 @@ final class DesignRegionTests: XCTestCase {
     func testBusyFlagsClearAfterSuccessfulRedesign() async {
         let c = makeController(); wireEdit(c)
         c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 9, count: r.count) },
-                       selectedIndices: { _, _, _, _ in [1] })
+                       selectedIndices: { _, _, _, _ in [1, 2] })
         c.injectRepack(repack: { _, _ in "REPACKED" }, loadRepacked: { _, _ in })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
         c.pickSelection("reg")
@@ -239,7 +242,7 @@ final class DesignRegionTests: XCTestCase {
         var flagDuringRepack: Bool?
         let c = makeController(); wireEdit(c)
         c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 9, count: r.count) },
-                       selectedIndices: { _, _, _, _ in [1] })
+                       selectedIndices: { _, _, _, _ in [1, 2] })
         c.injectRepack(repack: { _, _ in "PDB" },
                        loadRepacked: { [weak c] _, _ in flagDuringRepack = c?.isRedesigning })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
@@ -256,7 +259,7 @@ final class DesignRegionTests: XCTestCase {
         struct Boom: Error {}
         let c = makeController(); wireEdit(c)
         c.injectRegion(designRegion: { _, _, _, _, _ in throw Boom() },
-                       selectedIndices: { _, _, _, _ in [1] })
+                       selectedIndices: { _, _, _, _ in [1, 2] })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
         c.pickSelection("reg")
         await c.redesignSelectionAwait()
@@ -267,7 +270,7 @@ final class DesignRegionTests: XCTestCase {
     func testBusyFlagClearsWhenDesignReturnsWrongLength() async {
         let c = makeController(); wireEdit(c)
         c.injectRegion(designRegion: { _, _, _, _, _ in [1, 2, 3, 4, 5, 6, 7] },  // wrong length
-                       selectedIndices: { _, _, _, _ in [1] })
+                       selectedIndices: { _, _, _, _ in [1, 2] })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
         c.pickSelection("reg")
         await c.redesignSelectionAwait()
@@ -279,7 +282,7 @@ final class DesignRegionTests: XCTestCase {
         var called = false
         let c = makeController(); wireEdit(c)
         c.injectRegion(designRegion: { _, _, native, _, _ in called = true; return native },
-                       selectedIndices: { _, _, _, _ in [0] })
+                       selectedIndices: { _, _, _, _ in [0, 1] })
         c.setFocusForTest("m1", nativeSequence: [5, 5], validFlags: allValid(2))
         c.pickSelection("reg")
         for i in 0..<20 where c.paletteAllowed.contains(i) { c.togglePalette(i) }
@@ -307,7 +310,7 @@ final class DesignRegionTests: XCTestCase {
     func testManualEditAfterRedesignClearsRevert() async {
         let c = makeController(); wireEdit(c)
         c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 9, count: r.count) },
-                       selectedIndices: { _, _, _, _ in [1] })
+                       selectedIndices: { _, _, _, _ in [1, 2] })
         c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
         c.pickSelection("reg")
         await c.redesignSelectionAwait()
@@ -558,6 +561,38 @@ final class DesignRegionTests: XCTestCase {
                        "the clicked residue must be selected by the same click (D4)")
         XCTAssertTrue(c.selectedResidueIndices.isEmpty,
                       "old-focus residues must not linger in the region")
+    }
+
+    // Ending an edit session must leave the derived state agreeing with 'sele'.
+    // teardownEditSession calls clearRegionState(), which wipes the region, but the
+    // teardown never touches 'sele' — so without a re-derive the UI loses the
+    // Redesign button and palette row while the pink markers still show a
+    // multi-residue selection. The panel poll cannot rescue it: it is digest-gated,
+    // and an unchanged 'sele' produces an identical digest, so the re-derive is
+    // skipped and the wrong state persists until the user happens to click a
+    // residue. Both teardown paths (Keep and Discard) share the code, so both are
+    // exercised here.
+    func testEndingAnEditSessionKeepsTheRegionDerivedFromSele() async {
+        for keep in [true, false] {
+            let c = makeController(); wireEdit(c)
+            c.injectRegion(designRegion: { r, _, _, _, _ in Array(repeating: 9, count: r.count) })
+            c.setFocusForTest("m1", nativeSequence: [5, 5, 5], validFlags: allValid(3))
+            c.tapResidue(residueIndex: 0)
+            c.tapResidue(residueIndex: 2)
+            XCTAssertEqual(c.selectedResidueIndices, [0, 2], "pre-condition: region designated")
+
+            await c.applyMutationAwait(residueIndex: 1, aa: 7)   // begins the edit session
+            XCTAssertTrue(c.editing, "pre-condition: an edit session must be open")
+
+            if keep { c.keepEdits() } else { c.discardEdits() }
+
+            let path = keep ? "Keep" : "Discard"
+            XCTAssertFalse(c.editing, "\(path): the session must be closed")
+            XCTAssertEqual(c.selectedResidueIndices, [0, 2],
+                           "\(path): 'sele' still holds both residues, so the region must survive")
+            XCTAssertTrue(c.regionModeActive, "\(path): region mode must survive the teardown")
+            XCTAssertEqual(c.selectedSelectionName, "sele", "\(path): label re-derived")
+        }
     }
 
     // D2: leaving Design mode must NOT wipe the user's ordinary selection.

--- a/testing/tests/raymol/design_region.py
+++ b/testing/tests/raymol/design_region.py
@@ -138,3 +138,70 @@ class TestDesignRegion(testing.PyMOLTestCase):
             self.assertNotEqual(rd.sele_digest(), d1)
         finally:
             rd.set_design_active(0)   # never leak the flag into another test
+
+    def _sele_resis(self):
+        """Sorted resi strings of the guide residues currently in 'sele'."""
+        out = set()
+        cmd.iterate('(?sele) and polymer and guide',
+                    'out.add(resi)', space={'out': out})
+        return sorted(out, key=int)
+
+    def testToggleSeleResidueAddsThenRemoves(self):
+        obj = self._peptide()
+        from pymol import raymol_design as rd
+        self.assertEqual(rd.toggle_sele_residue(obj, '', '2'),
+                         'DESIGN_SELE_TOGGLE:on')
+        self.assertEqual(self._sele_resis(), ['2'])
+        rd.toggle_sele_residue(obj, '', '4')
+        self.assertEqual(self._sele_resis(), ['2', '4'])
+        # Same residue again -> removed, matching a normal-mode click.
+        self.assertEqual(rd.toggle_sele_residue(obj, '', '2'),
+                         'DESIGN_SELE_TOGGLE:off')
+        self.assertEqual(self._sele_resis(), ['4'])
+
+    def testSetSeleResidueReplaces(self):
+        obj = self._peptide()
+        from pymol import raymol_design as rd
+        rd.toggle_sele_residue(obj, '', '2')
+        rd.toggle_sele_residue(obj, '', '3')
+        rd.set_sele_residue(obj, '', '5')
+        self.assertEqual(self._sele_resis(), ['5'],
+                         'set must replace the selection, not extend it')
+
+    def testSetSeleFromSelectionCopiesNamedRegion(self):
+        obj = self._peptide()
+        cmd.select('loop', '%s and resi 2+3' % obj)
+        from pymol import raymol_design as rd
+        rd.set_sele_from_selection('loop')
+        self.assertEqual(self._sele_resis(), ['2', '3'])
+
+    def testSetSeleFromMissingSelectionEmpties(self):
+        obj = self._peptide()
+        from pymol import raymol_design as rd
+        rd.toggle_sele_residue(obj, '', '2')
+        # A name that does not exist must empty 'sele', never raise.
+        rd.set_sele_from_selection('nope')
+        self.assertEqual(self._sele_resis(), [])
+
+    def testToggleIsResidueScopedRegardlessOfMouseSelectionMode(self):
+        # D1: Design clicks always expand to RESIDUE scope. With
+        # mouse_selection_mode = 0 (atom) a normal-mode click would commit a single
+        # ATOM, which maps to zero guide residues -- a click that silently selects
+        # nothing. Design must ignore the setting entirely.
+        obj = self._peptide()
+        from pymol import raymol_design as rd
+        for mode in (0, 1, 2, 4):
+            cmd.set('mouse_selection_mode', mode)
+            rd.clear_sele()
+            rd.toggle_sele_residue(obj, '', '2')
+            self.assertEqual(self._sele_resis(), ['2'],
+                             'mouse_selection_mode %d must not change the scope '
+                             'of a Design-mode click' % mode)
+        cmd.set('mouse_selection_mode', 1)   # restore the default
+
+    def testClearSeleEmpties(self):
+        obj = self._peptide()
+        from pymol import raymol_design as rd
+        rd.toggle_sele_residue(obj, '', '2')
+        self.assertEqual(rd.clear_sele(), 'DESIGN_SELE_CLEAR:ok')
+        self.assertEqual(self._sele_resis(), [])

--- a/testing/tests/raymol/design_region.py
+++ b/testing/tests/raymol/design_region.py
@@ -205,3 +205,26 @@ class TestDesignRegion(testing.PyMOLTestCase):
         rd.toggle_sele_residue(obj, '', '2')
         self.assertEqual(rd.clear_sele(), 'DESIGN_SELE_CLEAR:ok')
         self.assertEqual(self._sele_resis(), [])
+
+    def testPollPanelCarriesDesignSeleDigest(self):
+        obj = self._peptide()
+        cmd.select('sele', '%s and resi 2' % obj)
+        from pymol import appkit_inspector as ai
+        from pymol import raymol_design as rd
+        rd.set_design_active(1)
+        try:
+            ai.poll_panel()
+            path = os.path.join(tempfile.gettempdir(),
+                                'pymol_objpanel_%d.json' % os.getpid())
+            with open(path) as f:
+                payload = json.load(f)
+            self.assertTrue(payload.get('design_sele'),
+                            "poll_panel must carry the digest while Design is active")
+            # And it must cost nothing once Design mode is off.
+            rd.set_design_active(0)
+            ai.poll_panel()
+            with open(path) as f:
+                payload = json.load(f)
+            self.assertEqual(payload.get('design_sele'), '')
+        finally:
+            rd.set_design_active(0)

--- a/testing/tests/raymol/design_region.py
+++ b/testing/tests/raymol/design_region.py
@@ -137,6 +137,23 @@ class TestDesignRegion(testing.PyMOLTestCase):
         self.assertEqual(rd.clear_sele(), 'DESIGN_SELE_CLEAR:ok')
         self.assertEqual(self._sele_resis(), [])
 
+    def testSelectingAMissingNameEmptiesSeleWithoutRaising(self):
+        # The '(?name)' form is how a NAMED selection reaches Design mode now that
+        # the picker is gone (the PYMOL_AUTODESIGN hook writes exactly this). A
+        # misspelled or deleted name must empty 'sele' rather than raise, because
+        # the caller reports "matched no designable residues" from the resulting
+        # empty selection — an exception would abort before that check.
+        obj = self._peptide()
+        from pymol import raymol_design as rd
+        rd.toggle_sele_residue(obj, '', '2')
+        self.assertEqual(self._sele_resis(), ['2'], 'pre-condition: something selected')
+        cmd.select('sele', '(?nope)', enable=1)          # must not raise
+        self.assertEqual(self._sele_resis(), [])
+        # ...and the real thing still works through the same expression.
+        cmd.select('loop', '%s and resi 2+3' % obj)
+        cmd.select('sele', '(?loop)', enable=1)
+        self.assertEqual(self._sele_resis(), ['2', '3'])
+
     def testPollPanelCarriesDesignSeleDigest(self):
         obj = self._peptide()
         cmd.select('sele', '%s and resi 2' % obj)

--- a/testing/tests/raymol/design_region.py
+++ b/testing/tests/raymol/design_region.py
@@ -228,3 +228,84 @@ class TestDesignRegion(testing.PyMOLTestCase):
             self.assertEqual(payload.get('design_sele'), '')
         finally:
             rd.set_design_active(0)
+
+    # ------------------------------------------------------------------
+    # I1: Design-mode 'sele' WRITES must resolve in the same scope the READS do.
+    #
+    # Inside an edit session the focus object is the working copy while the
+    # selection still lives on the ORIGINAL's atoms. sele_design_indices reads
+    # through _scope(obj, src) -- residue IDENTITY across both objects -- so a
+    # write that only touches the focus object's atoms disagrees with the read
+    # from the first mutation onward.
+    # ------------------------------------------------------------------
+
+    def _design_session(self):
+        """m1 plus the working copy that an edit session would focus."""
+        src = self._peptide()
+        work = '%s_design01' % src
+        cmd.create(work, src, zoom=0)
+        return src, work
+
+    def testToggleInEditSessionRemovesRegionMember(self):
+        src, work = self._design_session()
+        cmd.select('sele', '%s and resi 2+3+4' % src)   # region built pre-session
+        from pymol import raymol_design as rd
+        # The user clicks residue 4 again to drop it from the region.
+        rd.toggle_sele_residue(work, '', '4', src=src)
+        rd.sele_design_indices(work, 1, src=src)
+        data = self._sele_payload()
+        self.assertEqual(data['indices'], [1, 2],
+                         'a click inside an edit session must be able to REMOVE a '
+                         'region member -- an unscoped write re-adds it instead')
+        self.assertEqual(data['n_total'], 2,
+                         'the same residue on the working copy and the original is '
+                         'ONE residue -- double counting invents an off-structure count')
+
+    def testToggleInEditSessionAddsResidueExactlyOnce(self):
+        src, work = self._design_session()
+        cmd.select('sele', '%s and resi 2+3' % src)
+        from pymol import raymol_design as rd
+        rd.toggle_sele_residue(work, '', '5', src=src)   # a NEW residue, mid-session
+        rd.sele_design_indices(work, 1, src=src)
+        data = self._sele_payload()
+        self.assertEqual(data['indices'], [1, 2, 4])
+        self.assertEqual(data['n_total'], 3,
+                         'n_total must count residues, not (object, residue) pairs')
+
+    def testRepackKeepsResiduesSelectedDuringTheSession(self):
+        # autoRepack defaults ON, so every Redesign ends in load_repacked -- a
+        # topology replace of the working copy. Residues clicked DURING the session
+        # must not lose their region membership when that happens.
+        src, work = self._design_session()
+        cmd.select('sele', '%s and resi 2+3' % src)
+        from pymol import raymol_design as rd
+        rd.toggle_sele_residue(work, '', '5', src=src)
+        rd.load_repacked(work, cmd.get_pdbstr(work))
+        rd.sele_design_indices(work, 1, src=src)
+        self.assertEqual(self._sele_payload()['indices'], [1, 2, 4],
+                         'a repack must not silently shrink the region')
+
+    def testSetSeleResidueInEditSessionIsVisibleToTheRead(self):
+        src, work = self._design_session()
+        from pymol import raymol_design as rd
+        rd.set_sele_residue(work, '', '3', src=src)
+        rd.sele_design_indices(work, 1, src=src)
+        data = self._sele_payload()
+        self.assertEqual(data['indices'], [2])
+        self.assertEqual(data['n_total'], 1,
+                         'one residue selected in scope must read as one residue')
+
+    def testSeleDigestAgreesWithSeleIndicesPayload(self):
+        # The poll gate compares rd.sele_digest() against the digest the Swift side
+        # recorded from sele_design_indices. If the two ever diverge the poll either
+        # never fires or fires on every 500 ms tick.
+        obj = self._peptide()
+        cmd.select('sele', '%s and resi 2+4' % obj)
+        from pymol import raymol_design as rd
+        rd.set_design_active(1)
+        try:
+            rd.sele_design_indices(obj, 1)
+            self.assertEqual(rd.sele_digest(), self._sele_payload()['digest'],
+                             'the two producers of the gating digest must agree')
+        finally:
+            rd.set_design_active(0)

--- a/testing/tests/raymol/design_region.py
+++ b/testing/tests/raymol/design_region.py
@@ -16,62 +16,6 @@ class TestDesignRegion(testing.PyMOLTestCase):
         cmd.fab('AAAAA', 'm1')          # 5-residue poly-Ala with full backbone
         return 'm1'
 
-    def testSelectedIndicesMapInGuideOrder(self):
-        obj = self._peptide()
-        cmd.select('reg', '%s and resi 2+4' % obj)
-        from pymol import raymol_design as rd
-        marker = rd.selected_design_indices(obj, 'reg', 1)
-        self.assertTrue(marker.startswith('DESIGN_SELECTED:'))
-        with open(os.path.join(tempfile.gettempdir(),
-                               'raymol_design_selected.json')) as f:
-            data = json.load(f)
-        # resi 2 and 4 → 0-based guide-order indices 1 and 3.
-        self.assertEqual(data['indices'], [1, 3])
-
-    def testListSelectionsCountsAndFilters(self):
-        obj = self._peptide()
-        cmd.select('reg', '%s and resi 2+3+4' % obj)
-        cmd.select('empty', 'resn HOH')          # matches nothing on m1
-        from pymol import raymol_design as rd
-        rd.list_design_selections(obj, 1)
-        with open(os.path.join(tempfile.gettempdir(),
-                               'raymol_design_selections.json')) as f:
-            data = json.load(f)
-        names = {d['name']: d['n'] for d in data['selections']}
-        self.assertEqual(names.get('reg'), 3)
-        self.assertNotIn('empty', names)         # zero-intersection selection filtered out
-
-    def testExcludesInternalSelections(self):
-        obj = self._peptide()
-        cmd.select('reg', '%s and resi 2+3' % obj)
-        cmd.select('_preselect', '%s and resi 1' % obj)   # PyMOL-internal style name
-        from pymol import raymol_design as rd
-        rd.list_design_selections(obj, 1)
-        with open(os.path.join(tempfile.gettempdir(),
-                               'raymol_design_selections.json')) as f:
-            data = json.load(f)
-        names = {d['name'] for d in data['selections']}
-        self.assertIn('reg', names)
-        self.assertNotIn('_preselect', names)    # internal '_' selections hidden
-
-    def testSourceScopingResolvesOriginalSelection(self):
-        # A selection made on the original resolves onto the focused working copy
-        # (identical residues) when src is supplied — object-membership vs identity.
-        obj = self._peptide()
-        cmd.create('%s_design' % obj, obj, zoom=0)   # working copy
-        cmd.select('loop', '%s and resi 2+4' % obj)  # selection on the ORIGINAL
-        from pymol import raymol_design as rd
-        # Focus = working copy; without src the original selection doesn't intersect.
-        rd.selected_design_indices('%s_design' % obj, 'loop', 1)
-        with open(os.path.join(tempfile.gettempdir(),
-                               'raymol_design_selected.json')) as f:
-            self.assertEqual(json.load(f)['indices'], [])
-        # With src = original, it maps by (chain, resi) to the copy's guide order.
-        rd.selected_design_indices('%s_design' % obj, 'loop', 1, src=obj)
-        with open(os.path.join(tempfile.gettempdir(),
-                               'raymol_design_selected.json')) as f:
-            self.assertEqual(json.load(f)['indices'], [1, 3])
-
     def _sele_payload(self):
         with open(os.path.join(tempfile.gettempdir(),
                                'raymol_design_sele.json')) as f:
@@ -169,21 +113,6 @@ class TestDesignRegion(testing.PyMOLTestCase):
         rd.set_sele_residue(obj, '', '5')
         self.assertEqual(self._sele_resis(), ['5'],
                          'set must replace the selection, not extend it')
-
-    def testSetSeleFromSelectionCopiesNamedRegion(self):
-        obj = self._peptide()
-        cmd.select('loop', '%s and resi 2+3' % obj)
-        from pymol import raymol_design as rd
-        rd.set_sele_from_selection('loop')
-        self.assertEqual(self._sele_resis(), ['2', '3'])
-
-    def testSetSeleFromMissingSelectionEmpties(self):
-        obj = self._peptide()
-        from pymol import raymol_design as rd
-        rd.toggle_sele_residue(obj, '', '2')
-        # A name that does not exist must empty 'sele', never raise.
-        rd.set_sele_from_selection('nope')
-        self.assertEqual(self._sele_resis(), [])
 
     def testToggleIsResidueScopedRegardlessOfMouseSelectionMode(self):
         # D1: Design clicks always expand to RESIDUE scope. With

--- a/testing/tests/raymol/design_region.py
+++ b/testing/tests/raymol/design_region.py
@@ -103,8 +103,10 @@ class TestDesignRegion(testing.PyMOLTestCase):
         from pymol import raymol_design as rd
         rd.sele_design_indices('m1', 1)
         data = self._sele_payload()
-        # Only m1's residue is designable here; m2's still counts toward n_total.
+        # Only m1's residue is designable here; m2's is reported as off-scope so the
+        # UI can say so rather than silently dropping it.
         self.assertEqual(data['indices'], [1])
+        self.assertEqual(data['n_off'], 1)
         self.assertEqual(data['n_total'], 2)
 
     def testSeleIndicesResolveOriginalOntoWorkingCopy(self):
@@ -240,11 +242,23 @@ class TestDesignRegion(testing.PyMOLTestCase):
     # ------------------------------------------------------------------
 
     def _design_session(self):
-        """m1 plus the working copy that an edit session would focus."""
+        """m1 plus the working copy an edit session would focus.
+
+        Built through make_working_copy rather than cmd.create, so the original ends
+        up DISABLED exactly as it does in a real session — which is what makes
+        "the selection must be on the visible object" a meaningful assertion.
+        """
         src = self._peptide()
-        work = '%s_design01' % src
-        cmd.create(work, src, zoom=0)
+        from pymol import raymol_design as rd
+        work = rd.make_working_copy(src).split(':', 1)[1]
         return src, work
+
+    def _sele_resis_on(self, obj):
+        """Sorted resi strings of `obj`'s own guide residues in 'sele'."""
+        out = set()
+        cmd.iterate('(%s) and (?sele) and polymer and guide' % obj,
+                    'out.add(resi)', space={'out': out})
+        return sorted(out, key=int)
 
     def testToggleInEditSessionRemovesRegionMember(self):
         src, work = self._design_session()
@@ -257,9 +271,9 @@ class TestDesignRegion(testing.PyMOLTestCase):
         self.assertEqual(data['indices'], [1, 2],
                          'a click inside an edit session must be able to REMOVE a '
                          'region member -- an unscoped write re-adds it instead')
-        self.assertEqual(data['n_total'], 2,
-                         'the same residue on the working copy and the original is '
-                         'ONE residue -- double counting invents an off-structure count')
+        self.assertEqual(data['n_off'], 0,
+                         'a residue in scope on BOTH the working copy and the '
+                         'original is not on "another structure"')
 
     def testToggleInEditSessionAddsResidueExactlyOnce(self):
         src, work = self._design_session()
@@ -269,8 +283,11 @@ class TestDesignRegion(testing.PyMOLTestCase):
         rd.sele_design_indices(work, 1, src=src)
         data = self._sele_payload()
         self.assertEqual(data['indices'], [1, 2, 4])
-        self.assertEqual(data['n_total'], 3,
-                         'n_total must count residues, not (object, residue) pairs')
+        self.assertEqual(data['n_off'], 0,
+                         'everything selected is inside the scope, so nothing is '
+                         'off-structure -- n_total counts (object, residue) keys and '
+                         'legitimately sees the mid-session residue on both objects')
+        self.assertEqual(data['n_total'], 4)
 
     def testRepackKeepsResiduesSelectedDuringTheSession(self):
         # autoRepack defaults ON, so every Redesign ends in load_repacked -- a
@@ -280,10 +297,18 @@ class TestDesignRegion(testing.PyMOLTestCase):
         cmd.select('sele', '%s and resi 2+3' % src)
         from pymol import raymol_design as rd
         rd.toggle_sele_residue(work, '', '5', src=src)
-        rd.load_repacked(work, cmd.get_pdbstr(work))
+        self.assertNotIn(src, cmd.get_names('objects', 1),
+                         'pre-condition: a session disables the original, so pink '
+                         'markers on it alone would draw nothing')
+        rd.load_repacked(work, cmd.get_pdbstr(work), src=src)
         rd.sele_design_indices(work, 1, src=src)
         self.assertEqual(self._sele_payload()['indices'], [1, 2, 4],
                          'a repack must not silently shrink the region')
+        # ... and the membership must be on the object the user can SEE. The replace
+        # annihilates the working copy's atoms, so without re-assertion the region
+        # stays armed while nothing is drawn.
+        self.assertEqual(self._sele_resis_on(work), ['2', '3', '5'],
+                         'the replaced (visible) object must carry the selection')
 
     def testSetSeleResidueInEditSessionIsVisibleToTheRead(self):
         src, work = self._design_session()
@@ -292,8 +317,38 @@ class TestDesignRegion(testing.PyMOLTestCase):
         rd.sele_design_indices(work, 1, src=src)
         data = self._sele_payload()
         self.assertEqual(data['indices'], [2])
-        self.assertEqual(data['n_total'], 1,
-                         'one residue selected in scope must read as one residue')
+        self.assertEqual(data['n_off'], 0,
+                         'the residue is in scope, so it is not off-structure')
+
+    def testDropObjectFromSeleClearsAKeptWorkingCopy(self):
+        # A residue clicked during a session is marked on BOTH the copy and the
+        # original (that is what survives a repack). The Keep path retains the copy
+        # but clears the source, so nothing can address the copy again — the
+        # membership must be narrowed off it at teardown or it can never be cleared.
+        src, work = self._design_session()
+        from pymol import raymol_design as rd
+        rd.toggle_sele_residue(work, '', '3', src=src)
+        self.assertEqual(self._sele_resis_on(work), ['3'],
+                         'pre-condition: the scoped write marks the working copy too')
+
+        rd.drop_object_from_sele(work)
+        self.assertEqual(self._sele_resis_on(work), [],
+                         "no 'sele' membership may survive on a kept working copy")
+        self.assertEqual(self._sele_resis_on(src), ['3'],
+                         'the addressable original keeps it')
+        # And the post-Keep scope (no src) can now remove it for good.
+        rd.toggle_sele_residue(src, '', '3')
+        self.assertEqual(self._sele_resis(), [])
+
+    def testDropObjectFromSeleNeverLeavesAnEnabledEmptySele(self):
+        # An enabled EMPTY 'sele' would suppress every other selection.
+        src, work = self._design_session()
+        from pymol import raymol_design as rd
+        rd.set_sele_residue(work, '', '3')      # unscoped: only on the copy
+        rd.drop_object_from_sele(work)
+        self.assertEqual(self._sele_resis(), [])
+        self.assertNotIn('sele', cmd.get_names('selections', 1) or [],
+                         "an emptied 'sele' must not be left enabled")
 
     def testSeleDigestAgreesWithSeleIndicesPayload(self):
         # The poll gate compares rd.sele_digest() against the digest the Swift side
@@ -307,5 +362,27 @@ class TestDesignRegion(testing.PyMOLTestCase):
             rd.sele_design_indices(obj, 1)
             self.assertEqual(rd.sele_digest(), self._sele_payload()['digest'],
                              'the two producers of the gating digest must agree')
+        finally:
+            rd.set_design_active(0)
+
+    def testDigestSeparatesIndependentSimilarlyNamedObjects(self):
+        # Two independent structures whose names merely LOOK like a working-copy
+        # pair ('foo' and 'foo_design') are an ordinary thing to have loaded in a
+        # design workflow. Selecting the same chain/resi on each in turn must change
+        # the digest, or the poll skips the re-derive and the region never arms:
+        # the user is left with a selected structure and a dead Redesign button.
+        cmd.reinitialize()
+        cmd.fab('AAAAA', 'foo')
+        cmd.fab('AAAAA', 'foo_design')      # NOT a working copy of foo
+        from pymol import raymol_design as rd
+        rd.set_design_active(1)
+        try:
+            cmd.select('sele', 'foo_design and resi 2+3')
+            d1 = rd.sele_digest()
+            cmd.select('sele', 'foo and resi 2+3')
+            d2 = rd.sele_digest()
+            self.assertNotEqual(d1, d2,
+                                'the digest must distinguish the same residues on two '
+                                'different objects, whatever they are named')
         finally:
             rd.set_design_active(0)

--- a/testing/tests/raymol/design_region.py
+++ b/testing/tests/raymol/design_region.py
@@ -71,3 +71,70 @@ class TestDesignRegion(testing.PyMOLTestCase):
         with open(os.path.join(tempfile.gettempdir(),
                                'raymol_design_selected.json')) as f:
             self.assertEqual(json.load(f)['indices'], [1, 3])
+
+    def _sele_payload(self):
+        with open(os.path.join(tempfile.gettempdir(),
+                               'raymol_design_sele.json')) as f:
+            return json.load(f)
+
+    def testSeleIndicesMapInGuideOrder(self):
+        obj = self._peptide()
+        cmd.select('sele', '%s and resi 2+4' % obj)
+        from pymol import raymol_design as rd
+        marker = rd.sele_design_indices(obj, 1)
+        self.assertTrue(marker.startswith('DESIGN_SELE:'))
+        data = self._sele_payload()
+        # resi 2 and 4 -> 0-based guide-order indices 1 and 3.
+        self.assertEqual(data['indices'], [1, 3])
+        self.assertEqual(data['n_total'], 2)
+
+    def testSeleIndicesEmptyWithoutSele(self):
+        obj = self._peptide()          # reinitialize() in _peptide drops any 'sele'
+        from pymol import raymol_design as rd
+        rd.sele_design_indices(obj, 1)
+        data = self._sele_payload()
+        self.assertEqual(data['indices'], [])
+        self.assertEqual(data['n_total'], 0)
+
+    def testSeleIndicesScopeToFocusObject(self):
+        obj = self._peptide()
+        cmd.fab('AAAAA', 'm2')
+        cmd.select('sele', '(m1 and resi 2) or (m2 and resi 3)')
+        from pymol import raymol_design as rd
+        rd.sele_design_indices('m1', 1)
+        data = self._sele_payload()
+        # Only m1's residue is designable here; m2's still counts toward n_total.
+        self.assertEqual(data['indices'], [1])
+        self.assertEqual(data['n_total'], 2)
+
+    def testSeleIndicesResolveOriginalOntoWorkingCopy(self):
+        obj = self._peptide()
+        cmd.create('%s_design' % obj, obj, zoom=0)
+        cmd.select('sele', '%s and resi 2+4' % obj)   # selection on the ORIGINAL
+        from pymol import raymol_design as rd
+        # Focus = working copy, no src: the original's selection does not intersect.
+        rd.sele_design_indices('%s_design' % obj, 1)
+        self.assertEqual(self._sele_payload()['indices'], [])
+        # With src = original it maps by (chain, resi) onto the copy's guide order.
+        rd.sele_design_indices('%s_design' % obj, 1, src=obj)
+        self.assertEqual(self._sele_payload()['indices'], [1, 3])
+
+    def testSeleDigestIsGatedOnDesignActive(self):
+        obj = self._peptide()
+        cmd.select('sele', '%s and resi 2' % obj)
+        from pymol import raymol_design as rd
+        rd.set_design_active(0)
+        self.assertEqual(rd.sele_digest(), '',
+                         'digest must cost nothing while Design mode is off')
+        rd.set_design_active(1)
+        try:
+            d1 = rd.sele_digest()
+            self.assertTrue(d1)
+            # Re-selecting the SAME residues must not change the digest.
+            cmd.select('sele', '%s and resi 2' % obj)
+            self.assertEqual(rd.sele_digest(), d1)
+            # A different residue set must change it.
+            cmd.select('sele', '%s and resi 2+3' % obj)
+            self.assertNotEqual(rd.sele_digest(), d1)
+        finally:
+            rd.set_design_active(0)   # never leak the flag into another test


### PR DESCRIPTION
Closes #281, closes #282.

## #281 — inserting no longer kicks you out of the editor

`insertPendingView`, `insertMetalScreenshot`, `insertResidueSummary`, and `insertMeasurementSummary` each ended with `isPreviewing = true`, so any Insert action interrupted typing. Those lines are gone; the mode stays a user choice (the Preview/Edit picker and `.raymolPerformToggleNotePreview` still change it). Search submit and the heading outline keep theirs, as the issue suggested.

## #282 — optional thumbnail bound to a camera/scene link

- **Prompt:** the name alert became a small sheet (alerts can't host a `Toggle`) with the name field plus **Include image of the view**, default on, remembered via `@AppStorage`.
- **Markdown:** a linked image — `[![title](raymol-asset://<asset>)](raymol-view://<bookmark>)`. `addViewBookmark(insertsMarkdown:)` registers the bookmark without a marker; `addScreenshot(linkedBookmarkID:)` writes the wrapped form. If the render can't be filed, it falls back to the bare link via the new `appendViewLink(_:)`.
- **Preview:** new `AnalysisNotePreviewBlock.linkedImage(asset, bookmark)`; the thumbnail renders with the link name as caption inside a `Button` that calls the same `restore(_:)` path as the text link.
- **Round-trip:** `cleanMarkdown` and the exporter's `readable()` collapse the wrapped marker to `**Camera view:** title` / `Scene view: title`. HTML/PDF already matched the asset id, so they embed the figure as before.

## Verification

`xcodebuild test -scheme UnitTests_macOS -only-testing:PyMOLViewerTests/AnalysisNotesStoreTests` — 15/15 pass, including 4 new cases (wrapped marker + cleanMarkdown, `appendViewLink`, parser recognising linked vs. plain thumbnails, exporter fallback when the asset is missing). Both `PyMOLViewer_macOS` and `PyMOLViewer_iOS` build.

Functionally driven in a disposable macOS VM: Insert → Image from Current View left the pane in Edit with the marker appended; the Camera Link sheet showed the checked box; the inserted thumbnail's tooltip read "Restore camera view: Camera 1" and clicking it restored a deliberately rotated camera; unchecking produced a bare `[Camera 2](raymol-view://…)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)