### PR TITLE
fix(predict): unwedge a weight fetch cancelled during the unpack

### DIFF
--- a/modules/pymol/predicting.py
+++ b/modules/pymol/predicting.py
@@ -1706,6 +1706,17 @@ NOTES
     the application's progress sheet. Stop a running fetch with
     "predict_weights_cancel".
 
+    A bundle is fetched ONCE however many callers ask for it, so download=1 while a
+    transfer is already in flight joins that transfer instead of starting a second
+    one. It says so on the console and reports it as joined=True rather than looking
+    like a call that did nothing.
+
+RETURNS
+
+    dict: predictor id -> {'cached', 'path', 'bundle', 'joined', 'fetch'}, where
+    'fetch' is the live transfer's state (or None) and 'joined' says whether this
+    call attached to a transfer that was already running.
+
 SEE ALSO
 
     predict, predict_weights_cancel
@@ -1722,7 +1733,8 @@ SEE ALSO
         predictor_obj = registry.get(pid)
         bundle = predictor_obj.weight_bundle
         if bundle is None:
-            out[pid] = {'cached': True, 'path': None, 'bundle': None}
+            out[pid] = {'cached': True, 'path': None, 'bundle': None,
+                        'joined': False, 'fetch': None}
             continue
         # A BULK fetch downloads only what this build could actually run. Asking for one
         # predictor BY NAME still downloads it -- that is someone pre-warming a cache
@@ -1734,19 +1746,48 @@ SEE ALSO
         if int(download) and not predictor and not _can_run(predictor_obj):
             out[pid] = {'cached': bool(cache.is_cached(bundle)),
                         'path': cache.path_for(bundle),
-                        'bundle': bundle.id}
+                        'bundle': bundle.id,
+                        'joined': False, 'fetch': None}
             if not int(quiet):
                 colorprinting.parrot(
                     ' predict: %s cannot run in this build; not fetching its weights'
                     % pid)
             continue
+        joined = False
         if int(download) and not cache.is_cached(bundle):
-            fetching.start(bundle, cache)
+            # Identity, not a flag from start(): start() joins an in-flight transfer
+            # on purpose (one bundle, one download, however many callers), and the
+            # only way to tell "joined" from "began" is that it handed back the
+            # record that was already there.
+            before = fetching.get(bundle.id)
+            started = fetching.start(bundle, cache)
+            joined = started is before and before is not None
+            if joined and started.state == 'running':
+                snap = started.snapshot()
+                # Warned regardless of `quiet`, for the same reason predict() warns
+                # when it defers: this call deliberately started nothing, and saying
+                # nothing about it is indistinguishable from "download=1 is broken".
+                # That silence is what sent the reported bug looking for a .part file
+                # that was never going to appear.
+                colorprinting.warning(
+                    ' predict: a fetch of %s weights is already in flight (%s %d%%);'
+                    ' this call joined it rather than starting a second download.'
+                    ' Stop it with "predict_weights_cancel %s".'
+                    % (bundle.id, snap['phase'],
+                       int(round(snap['fraction'] * 100)), pid))
             if wait:
                 _wait_for_fetch(bundle, quiet)
+        live = fetching.get(bundle.id)
         out[pid] = {'cached': bool(cache.is_cached(bundle)),
                     'path': cache.path_for(bundle),
-                    'bundle': bundle.id}
+                    'bundle': bundle.id,
+                    # Whether this call joined a transfer already running rather than
+                    # starting one, and what that transfer is doing. Reported in the
+                    # return value as well as on the console so a script can tell a
+                    # deliberate join from a failure instead of reading cached=False
+                    # as "nothing happened".
+                    'joined': joined,
+                    'fetch': live.snapshot() if live is not None else None}
         if not int(quiet):
             colorprinting.parrot(' predict: %s weights cached=%s at %s' % (
                 pid, out[pid]['cached'], out[pid]['path']))

--- a/modules/pymol/predictors/fetching.py
+++ b/modules/pymol/predictors/fetching.py
@@ -83,9 +83,10 @@ class Fetch:
                 'state': self.state,
                 'phase': self.phase,
                 'fraction': self.fraction,
-                # Bytes only make sense while downloading: during extraction the
-                # fraction counts archive members, and a byte count derived from it
-                # would be a plausible-looking lie.
+                # Bytes only make sense while downloading. The extract fraction is
+                # a share of the archive's UNCOMPRESSED size, so scaling `total` --
+                # which is the size of the compressed download -- by it would be a
+                # plausible-looking lie.
                 'received': int(self.fraction * total) if (
                     self.phase == 'download' and total) else 0,
                 'total': total,
@@ -115,8 +116,14 @@ def start(bundle, cache, on_marker=None):
         # somewhere else would leave the caller waiting on a cache it never fills.
         # A finished fetch is always replaced, so a failed or cancelled attempt can be
         # retried simply by asking again.
+        #
+        # _is_live is the third condition rather than trusting `state == 'running'`
+        # alone: a record whose worker is gone without having settled reads exactly
+        # like one mid-transfer, and sharing it is permanent -- forget() skips running
+        # records too, so nothing can clear it and every later download=1 hands back
+        # the same dead handle and starts nothing. That was the reported wedge.
         if (existing is not None and existing.state == 'running'
-                and existing.cache.root == cache.root):
+                and existing.cache.root == cache.root and _is_live(existing)):
             return existing
 
     # Weights that ship inside the app, and weights already on disk, both resolve with no
@@ -135,16 +142,48 @@ def start(bundle, cache, on_marker=None):
         return fetch
 
     fetch = Fetch(bundle, cache)
-    with _LOCK:
-        _FETCHES[bundle.id] = fetch
-    fetch.thread = threading.Thread(
-        target=_run, args=(fetch, on_marker),
-        name='raymol-weights-%s' % bundle.id, daemon=True)
     # daemon=True so a quit during a download does not hang the process on join. The
     # partial file is scratch under .incoming and the sentinel is written last, so an
     # abandoned transfer leaves nothing a later run would mistake for a valid cache.
-    fetch.thread.start()
+    #
+    # Built BEFORE the record is published, so a concurrent start() never sees a
+    # running record with no thread on it -- _is_live would read that as wedged and
+    # start a second transfer for the same bundle, which is the very thing the
+    # publish-then-start order exists to prevent.
+    fetch.thread = threading.Thread(
+        target=_run, args=(fetch, on_marker),
+        name='raymol-weights-%s' % bundle.id, daemon=True)
+    with _LOCK:
+        _FETCHES[bundle.id] = fetch
+    try:
+        fetch.thread.start()
+    except BaseException as exc:
+        # Nothing will ever settle this record now, and a record stuck on 'running'
+        # is worse than a failed one: forget() skips it and start() shares it, so the
+        # bundle becomes permanently un-fetchable for the life of the process. Settle
+        # it here instead, and drop the thread so shutdown() does not try to join a
+        # thread that was never started.
+        with _LOCK:
+            fetch.thread = None
+            fetch.state = 'error'
+            fetch.error = 'could not start the download thread: %s' % (
+                str(exc) or exc.__class__.__name__)
+        _emit(fetch, on_marker, force=True)
     return fetch
+
+
+def _is_live(fetch):
+    """True if `fetch` still has a worker that can settle it.
+
+    Call with `_LOCK` held. `ident` is None until Thread.start() has been called and
+    stays set once it has, so `ident and not is_alive()` means "it ran and is gone"
+    -- a record that will never settle itself. Testing is_alive() alone would
+    misread the window between publishing the record and starting its thread.
+    """
+    thread = fetch.thread
+    if thread is None:
+        return False
+    return thread.ident is None or thread.is_alive()
 
 
 def get(bundle_id):
@@ -188,11 +227,38 @@ def join(bundle_id, timeout=None):
 
 
 def forget(bundle_id=''):
-    """Drop finished records. Tests use it; nothing in normal operation needs it."""
+    """Drop fetch records so the next start() begins a fresh transfer.
+
+    Two deliberately different behaviours, because the two callers want opposite
+    things:
+
+    `forget()` with no id is the broom -- it clears out finished records and leaves
+    anything still transferring alone. Aborting a live half-gigabyte download as a
+    side effect of tidying up would be a nasty surprise.
+
+    `forget(bundle_id)` names one bundle, which is only ever asked by someone trying
+    to get UNSTUCK, so it drops the record whatever state it is in. The old
+    "settled records only" rule made this the one thing that could not help: a
+    record reading 'running' is exactly the one that needs clearing, because
+    start() shares it and so every retry silently starts nothing.
+
+    A live record dropped this way is cancelled on the way out. It owns a
+    half-written staging directory and would otherwise still publish it, landing on
+    top of the very fetch this call exists to permit -- and the worker is a daemon
+    with no other way to be told its result is no longer wanted.
+
+    Returns the ids dropped.
+    """
     with _LOCK:
-        for key in [k for k, f in _FETCHES.items()
-                    if f.state != 'running' and (not bundle_id or k == bundle_id)]:
-            _FETCHES.pop(key, None)
+        if bundle_id:
+            keys = [bundle_id] if bundle_id in _FETCHES else []
+        else:
+            keys = [k for k, f in _FETCHES.items() if f.state != 'running']
+        for key in keys:
+            fetch = _FETCHES.pop(key, None)
+            if fetch is not None and fetch.state == 'running':
+                fetch.cancelled = True
+    return keys
 
 
 def shutdown(timeout=5.0):
@@ -240,24 +306,45 @@ def _run(fetch, on_marker):
 
     _emit(fetch, on_marker, force=True)
     try:
-        path = fetch.cache.ensure(bundle, progress=progress,
-                                  should_cancel=should_cancel)
-    except WeightDownloadCancelled:
+        try:
+            path = fetch.cache.ensure(bundle, progress=progress,
+                                      should_cancel=should_cancel)
+        except WeightDownloadCancelled:
+            with _LOCK:
+                fetch.state = 'cancelled'
+        except Exception as exc:
+            # Deliberately broad: this runs on a thread with no caller to propagate
+            # to, so an unclassified failure has to become readable state rather than
+            # a traceback on stderr that the app would never show.
+            with _LOCK:
+                fetch.state = 'error'
+                fetch.error = str(exc) or exc.__class__.__name__
+        except BaseException as exc:
+            # And broader still, for the same reason. Nothing ensure() raises today
+            # lands here, but letting one through would leave the record on 'running'
+            # -- which forget() skips and start() shares, so the bundle becomes
+            # un-fetchable for the life of the process and the app's tray card sits on
+            # a stale fraction with no terminal marker coming. Re-raising would only
+            # print a traceback into a stderr the app never shows, on a daemon thread
+            # with nobody above it to catch anything.
+            with _LOCK:
+                fetch.state = 'error'
+                fetch.error = str(exc) or exc.__class__.__name__
+        else:
+            with _LOCK:
+                fetch.state = 'done'
+                fetch.fraction = 1.0
+                fetch.path = path
+    finally:
+        # Backstop for the handlers themselves, so that "this worker always settles
+        # its record and always emits a terminal marker" holds no matter what -- the
+        # one invariant the app's tray card and forget() both depend on.
         with _LOCK:
-            fetch.state = 'cancelled'
-    except Exception as exc:
-        # Deliberately broad: this runs on a thread with no caller to propagate to, so
-        # an unclassified failure has to become readable state rather than a traceback
-        # on stderr that the app would never show.
-        with _LOCK:
-            fetch.state = 'error'
-            fetch.error = str(exc) or exc.__class__.__name__
-    else:
-        with _LOCK:
-            fetch.state = 'done'
-            fetch.fraction = 1.0
-            fetch.path = path
-    _emit(fetch, on_marker, force=True)
+            if fetch.state == 'running':
+                fetch.state = 'error'
+                fetch.error = (fetch.error
+                               or 'the weight fetch ended without a result')
+        _emit(fetch, on_marker, force=True)
 
 
 def _emit(fetch, on_marker, force=False):

--- a/modules/pymol/predictors/weights.py
+++ b/modules/pymol/predictors/weights.py
@@ -37,6 +37,14 @@ _sleep = time.sleep
 #: and must never be buffered whole.
 CHUNK_BYTES = 1 << 20
 
+#: Write size during extraction, and therefore how often cancellation and progress
+#: are observed while unpacking. It has to be a chunk rather than a whole member
+#: because every shipping pack is three members of which model.safetensors IS the
+#: payload: a check that only ran between members ran twice on a few bytes of JSON
+#: and then not again for hundreds of MB, which pinned the progress marker at 2/3
+#: and made Cancel look dead for the whole unpack.
+EXTRACT_CHUNK_BYTES = 1 << 20
+
 DEFAULT_TIMEOUT = 30.0
 
 #: Hard ceiling on transfer attempts for one bundle. Two budgets rather than one
@@ -434,21 +442,65 @@ class WeightCache:
         return received, digest
 
     def _extract(self, bundle, part, staging, progress, should_cancel=None):
-        """Extract to staging, then assert the layout is exactly what was declared."""
+        """Extract to staging, then assert the layout is exactly what was declared.
+
+        Written as an explicit chunked copy rather than one ZipFile.extract() per
+        member so that BOTH cancellation and progress are observed WITHIN a member.
+        Per-member was the bug behind the "stuck on Unpacking... 67%" report: the
+        packs are three members -- config.json, manifest.json, model.safetensors --
+        so 2/3 of the checks happened on a few bytes of JSON and the third ran only
+        after the entire multi-hundred-MB tensor file had been written. For that
+        whole stretch the marker never moved (so the app's tray card could not
+        resolve, and still showed a stale 67%) and the cancel flag was never looked
+        at (so Cancel did nothing at all).
+
+        The fraction is byte-based for the same reason: counting members makes the
+        bar jump 0 -> 33 -> 67 -> 100 with the entire wait sitting inside one step.
+        """
         _rmtree(staging)
         try:
             os.makedirs(staging)
             with zipfile.ZipFile(part) as archive:
-                names = archive.namelist()
+                infos = archive.infolist()
+                names = [info.filename for info in infos]
                 if set(names) != set(bundle.members):
                     raise WeightBundleLayoutError(
                         'bundle %s contains %s, expected %s'
                         % (bundle.id, sorted(names), sorted(bundle.members)))
-                for index, name in enumerate(names):
-                    archive.extract(name, staging)
-                    if progress:
-                        progress('extract', float(index + 1) / len(names))
+                # Guard the destination path explicitly. ZipFile.extract() sanitised
+                # member names itself; the copy below does not, so dropping that call
+                # would otherwise turn a declared "../x" into a write outside staging.
+                for name in names:
+                    if (not name or os.path.isabs(name)
+                            or name != os.path.basename(name)
+                            or name in (os.curdir, os.pardir)):
+                        raise WeightBundleLayoutError(
+                            'bundle %s member %r is not a plain file name'
+                            % (bundle.id, name))
+                # `or 1` guards a bundle of empty files; the final progress call
+                # below is what reports completion in that case.
+                total = sum(info.file_size for info in infos) or 1
+                done = 0
+                last = -1.0
+                for info in infos:
+                    dest = os.path.join(staging, info.filename)
+                    with archive.open(info) as src, open(dest, 'wb') as handle:
+                        while True:
+                            chunk = src.read(EXTRACT_CHUNK_BYTES)
+                            if not chunk:
+                                break
+                            handle.write(chunk)
+                            done += len(chunk)
+                            if progress:
+                                last = min(1.0, float(done) / total)
+                                progress('extract', last)
+                            _raise_if_cancelled(should_cancel, bundle)
+                    # Per chunk AND per member, so "cancellation is observed at least
+                    # once per member" still holds for a zero-byte one, whose copy
+                    # loop above never runs a single iteration.
                     _raise_if_cancelled(should_cancel, bundle)
+                if progress and last < 1.0:
+                    progress('extract', 1.0)
         except zipfile.BadZipFile as exc:
             raise WeightBundleLayoutError(
                 'bundle %s is not a readable zip: %s' % (bundle.id, exc))

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -49,9 +49,10 @@ struct WeightsFetchState: Codable, Equatable {
     /// download | extract | cached
     let phase: String
     let fraction: Double
-    /// Bytes so far, and the bundle's total. Both 0 outside the download phase:
-    /// during extraction the fraction counts archive members, and a byte count
-    /// derived from it would be a plausible-looking lie.
+    /// Bytes so far, and the bundle's total. `received` is 0 outside the download
+    /// phase: the extract fraction is a share of the archive's UNCOMPRESSED size,
+    /// so scaling `total` -- the compressed download's size -- by it would be a
+    /// plausible-looking lie.
     let received: Int
     let total: Int
     /// Seconds since the transfer began. Optional so a payload from an older Python

--- a/swiftui/PyMOLViewerTests/WeightsFetchStateTests.swift
+++ b/swiftui/PyMOLViewerTests/WeightsFetchStateTests.swift
@@ -36,9 +36,10 @@ final class WeightsFetchStateTests: XCTestCase {
         """)
         XCTAssertTrue(state.isExtracting)
         XCTAssertTrue(state.isRunning)
-        // Bytes are deliberately zero outside the download phase: the fraction counts
-        // archive members there, so a byte count derived from it would be a lie. The
-        // overlay must fall back to its "Unpacking…" label rather than show "0 MB of".
+        // Bytes are deliberately zero outside the download phase: the extract
+        // fraction is a share of the archive's UNCOMPRESSED size, so scaling the
+        // compressed `total` by it would be a lie. The overlay must fall back to its
+        // "Unpacking…" label rather than show "0 MB of".
         XCTAssertEqual(state.received, 0)
     }
 
@@ -109,8 +110,8 @@ final class WeightsFetchStateTests: XCTestCase {
         """)
         XCTAssertNil(early.secondsRemaining)
 
-        // Extraction counts archive members, not bytes — a byte-derived ETA there
-        // would be meaningless.
+        // The extract fraction is a share of the UNCOMPRESSED archive, not of the
+        // compressed download — a byte-derived ETA there would be meaningless.
         let extracting = try decode("""
         {"id":"b","state":"running","phase":"extract","fraction":0.5,\
         "received":0,"total":524288000,"elapsed":60.0,"error":null}
@@ -125,5 +126,69 @@ final class WeightsFetchStateTests: XCTestCase {
         XCTAssertEqual(ProgressCard.formatRemaining(45), "45 sec left")
         XCTAssertEqual(ProgressCard.formatRemaining(240), "4 min left")
         XCTAssertEqual(ProgressCard.formatRemaining(9000), "over an hour left")
+    }
+
+    // -- the fetch must always reach a terminal marker ------------------------
+    //
+    // Reported bug: cancelling while the tray read "Unpacking… 67%" left the card up
+    // for good. The card is kept while the state is running or error and dropped on
+    // anything else, so a card that never goes away means a terminal marker that
+    // never arrived. The Python side now guarantees one from the extract phase too;
+    // these pin the Swift half of that contract.
+
+    func testACancelFromTheExtractPhaseIsTerminalSoTheCardIsDropped() throws {
+        let state = try decode("""
+        {"id":"protenix-v2-mlx-int8","state":"cancelled","phase":"extract",\
+        "fraction":0.6666666666666666,"received":0,"total":299351203,\
+        "elapsed":48.5,"error":null}
+        """)
+        // Exactly the predicate parseWeightsFeedback applies: neither running nor
+        // error, so `weightsFetch` is cleared and the card goes away.
+        XCTAssertFalse(state.isRunning)
+        XCTAssertFalse(state.isError)
+        XCTAssertTrue(state.isExtracting)
+    }
+
+    func testTheExtractFractionCanLandBetweenMemberBoundaries() throws {
+        // The 3-member packs used to report only 0.333/0.667/1.0, with the entire
+        // wait inside the last step. Byte-based extraction progress means the
+        // decoder has to accept anything in between, and still show no ETA.
+        let state = try decode("""
+        {"id":"protenix-v2-mlx-int8","state":"running","phase":"extract",\
+        "fraction":0.7391304347826086,"received":0,"total":299351203,\
+        "elapsed":51.0,"error":null}
+        """)
+        XCTAssertTrue(state.isRunning)
+        XCTAssertTrue(state.isExtracting)
+        XCTAssertEqual(state.fraction, 0.7391304347826086, accuracy: 1e-12)
+        XCTAssertEqual(state.received, 0)
+        XCTAssertNil(state.secondsRemaining)
+        XCTAssertEqual(WeightDownloadDetail.text(state), "Unpacking… 74%")
+    }
+
+    func testAWorkerThatEndedWithoutAResultIsReportedAsAnError() throws {
+        // The backstop marker for a worker that unwound without settling. It must
+        // read as an error -- a record left on "running" is what wedged the tray,
+        // and the card has to offer Dismiss rather than pretend work continues.
+        let state = try decode("""
+        {"id":"protenix-v2-mlx-int8","state":"error","phase":"extract",\
+        "fraction":0.6666666666666666,"received":0,"total":299351203,\
+        "elapsed":61.2,"error":"the weight fetch ended without a result"}
+        """)
+        XCTAssertTrue(state.isError)
+        XCTAssertFalse(state.isRunning)
+        // The card shows the reason, not a stale "Unpacking… 67%".
+        XCTAssertEqual(WeightDownloadDetail.text(state),
+                       "the weight fetch ended without a result")
+    }
+
+    func testAThreadThatCouldNotStartIsAnErrorNotAStalledDownload() throws {
+        let state = try decode("""
+        {"id":"stub","state":"error","phase":"download","fraction":0.0,\
+        "received":0,"total":223,"elapsed":0.001,\
+        "error":"could not start the download thread: can't start new thread"}
+        """)
+        XCTAssertTrue(state.isError)
+        XCTAssertEqual(ProgressItem.weights(state).buttonTitle, "Dismiss")
     }
 }

--- a/testing/tests/predict/predict_weights_async.py
+++ b/testing/tests/predict/predict_weights_async.py
@@ -30,7 +30,7 @@ if _HERE not in sys.path:
     sys.path.insert(0, _HERE)
 
 from predict_api import StubJob, install_stub          # noqa: E402
-from predict_weights_download import make_zip          # noqa: E402
+from predict_weights_download import FakeResponse, make_zip   # noqa: E402
 
 
 class GatedResponse:
@@ -106,6 +106,22 @@ class captured_markers:
         return out
 
 
+def registry_bundle(predictor='stub'):
+    """The stub predictor's bundle, as the command path resolves it."""
+    from pymol.predictors import registry
+    return registry.get(predictor).weight_bundle
+
+
+def predicting_cache():
+    """The same WeightCache the commands use, so cache.root matches theirs.
+
+    start() only shares a fetch that lands in the SAME root, so a test that built
+    its own cache would exercise the not-shared branch by accident.
+    """
+    from pymol import predicting
+    return predicting.weight_cache()
+
+
 class AsyncFetchTest(testing.PyMOLTestCase):
 
     def setUp(self):
@@ -178,7 +194,6 @@ class AsyncFetchTest(testing.PyMOLTestCase):
     def testASettledFetchAlwaysEmitsATerminalMarker(self):
         """A dropped terminal marker would leave the app's sheet up forever."""
         from pymol.predictors import fetching
-        from predict_weights_download import FakeResponse
         with patch('pymol.predictors.weights._urlopen',
                    return_value=FakeResponse(self.data)):
             with captured_markers() as cap:
@@ -207,7 +222,6 @@ class AsyncFetchTest(testing.PyMOLTestCase):
     def testPumpSubmitsTheJobOnceTheWeightsLand(self):
         from pymol import predicting
         from pymol.predictors import fetching
-        from predict_weights_download import FakeResponse
         with patch('pymol.predictors.weights._urlopen',
                    return_value=FakeResponse(self.data)):
             job = cmd.predict('stub', 'AA', name='async_test')
@@ -326,3 +340,238 @@ class AsyncFetchTest(testing.PyMOLTestCase):
 
     def testCancelIsRegisteredAsACommandKeyword(self):
         self.assertIn('predict_weights_cancel', cmd.keyword)
+
+    # -- a fetch record must never wedge ------------------------------------
+    #
+    # Reported symptom: cancelling while the tray said "Unpacking... 67%" left the
+    # card on screen forever, `fetching.forget(<id>)` refused to drop the record,
+    # and every later `predict_weights <p>, download=1` silently did nothing --
+    # no new .incoming/.part -- because start() kept handing back the same entry.
+    # Only popping _FETCHES by hand recovered it.
+    #
+    # All three follow from ONE state: a record still reading `running`. forget()
+    # skips running records by design and start() shares them by design, so a
+    # record that stops making progress disables both retry and cleanup with no
+    # way out. These pin the escape hatches.
+
+    def _gate_inside_extract(self, member='model.bin'):
+        """(patcher, reached, gate) that holds the worker inside ONE member.
+
+        Gates on the member's own read() rather than on a chunk count, so it can
+        only ever trip during extraction -- a count would have to guess how many
+        checks the download phase made first.
+        """
+        import zipfile
+        real_open = zipfile.ZipFile.open
+        reached = threading.Event()
+        gate = threading.Event()
+
+        class _Held:
+            def __init__(self, inner):
+                self._inner = inner
+                self._reads = 0
+
+            def read(self, size=-1):
+                self._reads += 1
+                if self._reads == 2:
+                    reached.set()
+                    gate.wait(10)
+                return self._inner.read(size)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                self._inner.close()
+                return False
+
+        def opener(zself, name, mode='r', *args, **kwargs):
+            handle = real_open(zself, name, mode, *args, **kwargs)
+            if getattr(name, 'filename', name) == member:
+                return _Held(handle)
+            return handle
+        return patch.object(zipfile.ZipFile, 'open', opener), reached, gate
+
+    def _big_stub(self, size=256 * 1024):
+        """Re-install the stub with a model.bin big enough to span many chunks."""
+        self.data, self.digest = make_zip(
+            (('config.json', '{}'), ('model.bin', 'x' * size)))
+        install_stub(self.root, self.digest, len(self.data))
+
+    def testCancellingDuringExtractEmitsATerminalMarker(self):
+        """THE reported bug: the tray card must resolve, not freeze on a stale %.
+
+        The card is kept while the state is running or error and dropped on any
+        terminal state, so "the card never went away" means "no terminal marker
+        ever arrived". It has to arrive from the extract phase too.
+        """
+        from pymol.predictors import fetching
+        self._big_stub()
+        patcher, reached, gate = self._gate_inside_extract()
+        with patch('pymol.predictors.weights.EXTRACT_CHUNK_BYTES', 4096), \
+                patch('pymol.predictors.weights._urlopen',
+                      return_value=FakeResponse(self.data)), patcher:
+            with captured_markers() as cap:
+                cmd.predict_weights('stub', download=1, async_=1)
+                self.assertTrue(reached.wait(10), 'never reached extract')
+                mid = fetching.get('stub').snapshot()
+                self.assertEqual(mid['phase'], 'extract')
+                cmd.predict_weights_cancel('stub')
+                gate.set()
+                fetching.join('stub', timeout=10)
+                markers = cap.markers()
+        self.assertEqual(fetching.get('stub').snapshot()['state'], 'cancelled')
+        self.assertTrue(markers, 'no markers at all')
+        self.assertEqual(markers[-1]['state'], 'cancelled',
+                         'the last marker was not terminal, so the tray card would '
+                         'sit on a stale running fraction forever')
+        self.assertEqual(markers[-1]['phase'], 'extract')
+
+    def testExtractProgressIsVisibleWhileOneBigMemberIsWritten(self):
+        """A marker has to move DURING the unpack, or the bar looks hung."""
+        from pymol.predictors import fetching
+        self._big_stub()
+        with patch('pymol.predictors.weights.EXTRACT_CHUNK_BYTES', 4096), \
+                patch('pymol.predictors.weights._urlopen',
+                      return_value=FakeResponse(self.data)):
+            with captured_markers() as cap:
+                cmd.predict_weights('stub', download=1, async_=1)
+                fetching.join('stub', timeout=10)
+                extracting = [m['fraction'] for m in cap.markers()
+                              if m['phase'] == 'extract' and m['state'] == 'running']
+        self.assertGreater(len(set(extracting)), 1,
+                           'only one extract fraction was ever published (%r), so a '
+                           'pack whose last member is the payload shows a frozen bar'
+                           % (extracting,))
+
+    def testForgetDropsALiveRecordSoARetryCanStart(self):
+        """(a) forget(<id>) must actually drop it -- that is the whole point.
+
+        It also has to cancel what it abandons: the worker owns a half-written
+        staging dir and would otherwise still publish it, racing the fresh fetch
+        that forget() exists to permit.
+        """
+        from pymol.predictors import fetching
+        held = GatedResponse(self.data)
+        # A fresh body for the retry, so this asserts the replacement transfer
+        # actually COMPLETES -- the whole point of being able to forget the old one.
+        responses = [held, FakeResponse(self.data)]
+        with patch('pymol.predictors.weights._urlopen',
+                   side_effect=lambda *a, **k: responses.pop(0)):
+            first = fetching.start(registry_bundle(), predicting_cache())
+            self.assertTrue(held.serving.wait(5))
+            self.assertEqual(first.snapshot()['state'], 'running')
+            self.assertEqual(fetching.forget('stub'), ['stub'])
+            self.assertNotIn('stub', list(fetching._FETCHES),
+                             'forget() left the record in place, so every retry is '
+                             'still a silent no-op')
+            self.assertTrue(first.cancelled,
+                            'the abandoned worker was not asked to stop; it can '
+                            'still publish over the fetch that replaces it')
+            held.gate.set()
+            # Let the abandoned worker unwind before retrying: it still holds the
+            # cache lock for this bundle, and releases it as it goes.
+            if first.thread is not None:
+                first.thread.join(10)
+            self.assertEqual(first.snapshot()['state'], 'cancelled')
+            second = fetching.start(registry_bundle(), predicting_cache())
+            self.assertIsNot(second, first, 'retry rejoined the forgotten fetch')
+            fetching.join('stub', timeout=10)
+        self.assertEqual(second.snapshot()['state'], 'done')
+        self.assertTrue(predicting_cache().is_cached(registry_bundle()))
+
+    def testForgetWithNoIdStillOnlyDropsSettledRecords(self):
+        """The bulk broom must stay a broom: it may not abort live transfers."""
+        from pymol.predictors import fetching
+        response = GatedResponse(self.data)
+        with patch('pymol.predictors.weights._urlopen', return_value=response):
+            fetch = fetching.start(registry_bundle(), predicting_cache())
+            self.assertTrue(response.serving.wait(5))
+            fetching.forget()
+            self.assertIn('stub', list(fetching._FETCHES))
+            self.assertFalse(fetch.cancelled)
+            response.gate.set()
+            fetching.join('stub', timeout=10)
+        fetching.forget()
+        self.assertNotIn('stub', list(fetching._FETCHES))
+
+    def testARecordWhoseWorkerDiedDoesNotBlockEveryRetryForever(self):
+        """A 'running' record with a dead thread is wedged, not live.
+
+        This is the state the report was stuck in. Sharing it forever is what made
+        `predict_weights ..., download=1` a no-op with no .part to show for it.
+        """
+        from pymol.predictors import fetching
+        bundle, cache = registry_bundle(), predicting_cache()
+        wedged = fetching.Fetch(bundle, cache)
+        dead = threading.Thread(target=lambda: None)
+        dead.start()
+        dead.join()
+        wedged.thread = dead              # ran, exited, never settled its state
+        with fetching._LOCK:
+            fetching._FETCHES[bundle.id] = wedged
+        self.assertEqual(wedged.state, 'running')
+        with patch('pymol.predictors.weights._urlopen',
+                   return_value=FakeResponse(self.data)):
+            fresh = fetching.start(bundle, cache)
+            self.assertIsNot(fresh, wedged, 'retry rejoined a dead fetch')
+            fetching.join(bundle.id, timeout=10)
+        self.assertEqual(fetching.get(bundle.id).snapshot()['state'], 'done')
+
+    def testAWorkerThatCannotStartSettlesInsteadOfStrandingARunningRecord(self):
+        """If the thread never starts, nothing will ever settle the record."""
+        from pymol.predictors import fetching
+        bundle, cache = registry_bundle(), predicting_cache()
+        with patch.object(threading.Thread, 'start',
+                          side_effect=RuntimeError("can't start new thread")):
+            with captured_markers() as cap:
+                fetch = fetching.start(bundle, cache)
+                markers = cap.markers()
+        self.assertEqual(fetch.snapshot()['state'], 'error')
+        self.assertTrue(fetch.snapshot()['error'])
+        self.assertTrue(markers and markers[-1]['state'] == 'error',
+                        'no terminal marker, so the tray card would never clear')
+        # And the record must not block the next attempt.
+        with patch('pymol.predictors.weights._urlopen',
+                   return_value=FakeResponse(self.data)):
+            again = fetching.start(bundle, cache)
+            self.assertIsNot(again, fetch)
+            fetching.join(bundle.id, timeout=10)
+        self.assertEqual(fetching.get(bundle.id).snapshot()['state'], 'done')
+
+    def testTheWorkerSettlesEvenIfEnsureRaisesSomethingOutsideException(self):
+        """`except Exception` is not enough: a BaseException strands the record.
+
+        Nothing in ensure() raises one today. This asserts the invariant rather
+        than the current call graph, because the cost of being wrong is a record
+        that can never be forgotten and a tray card that never clears.
+        """
+        from pymol.predictors import fetching
+        from pymol.predictors.weights import WeightCache
+        bundle, cache = registry_bundle(), predicting_cache()
+        with patch.object(WeightCache, 'ensure',
+                          side_effect=KeyboardInterrupt('boom')):
+            with captured_markers() as cap:
+                fetching.start(bundle, cache)
+                fetching.join(bundle.id, timeout=10)
+                markers = cap.markers()
+        snap = fetching.get(bundle.id).snapshot()
+        self.assertEqual(snap['state'], 'error')
+        self.assertTrue(snap['error'])
+        self.assertTrue(markers and markers[-1]['state'] == 'error')
+
+    def testPredictWeightsSaysSoWhenItJoinsAFetchAlreadyInFlight(self):
+        """(c) A download=1 that starts nothing must say why, not look like a no-op."""
+        from pymol.predictors import fetching
+        response = GatedResponse(self.data)
+        with patch('pymol.predictors.weights._urlopen', return_value=response):
+            cmd.predict_weights('stub', download=1, async_=1)
+            self.assertTrue(response.serving.wait(5))
+            out = cmd.predict_weights('stub', download=1, async_=1)
+            self.assertIn('fetch', out['stub'],
+                          'the second call reported nothing about the transfer it '
+                          'silently joined')
+            self.assertEqual(out['stub']['fetch']['state'], 'running')
+            self.assertTrue(out['stub']['joined'])
+            response.gate.set()
+            fetching.join('stub', timeout=10)

--- a/testing/tests/predict/predict_weights_download.py
+++ b/testing/tests/predict/predict_weights_download.py
@@ -381,3 +381,105 @@ class TestEnsure(testing.PyMOLTestCase):
         self.assertEqual(seen[-1], ('extract', 1.0))
         for _, frac in seen:
             self.assertTrue(0.0 <= frac <= 1.0, seen)
+
+    # -- cancellation and progress INSIDE one archive member ------------------
+    #
+    # These pin the fix for the "stuck at Unpacking... 67%" report. Every shipping
+    # pack has the same shape -- three members, of which model.safetensors IS
+    # essentially the whole bundle -- so a check that only runs BETWEEN members
+    # runs exactly twice on something tiny and then not again for hundreds of MB.
+    # For protenix-v2-mlx-int8 (285 MB, 3 members) that pinned the progress marker
+    # at 2/3 = 67% and made Cancel do nothing at all for the whole unpack.
+
+    def testExtractProgressMovesWithinASingleMember(self):
+        """The bar must move while ONE big member is being written, not only between.
+
+        Asserted as "more extract callbacks than there are members": with a
+        per-member check the count can never exceed len(members), which is what
+        froze the tray at 67%.
+        """
+        from pymol.predictors.weights import WeightCache
+        big = ('model.bin', 'x' * (300 * 1024))
+        data, digest = make_zip((('config.json', '{}'), big))
+        bundle = bundle_for(data, digest)
+        fractions = []
+        with testing.mkdtemp() as root:
+            with patch('pymol.predictors.weights.EXTRACT_CHUNK_BYTES', 4096), \
+                 patch('pymol.predictors.weights._urlopen',
+                       return_value=FakeResponse(data)):
+                WeightCache(root).ensure(
+                    bundle,
+                    progress=lambda phase, frac: (
+                        fractions.append(frac) if phase == 'extract' else None))
+        self.assertGreater(
+            len(fractions), len(bundle.members),
+            'extract progress was only reported between members, so a bundle whose '
+            'last member is the whole payload reports nothing for the whole unpack')
+        self.assertEqual(fractions, sorted(fractions), 'fraction went backwards')
+        self.assertEqual(fractions[-1], 1.0)
+        for frac in fractions:
+            self.assertTrue(0.0 <= frac <= 1.0, fractions)
+
+    def testCancelDuringOneBigMemberDoesNotWaitForItToFinish(self):
+        """Cancel must be observed mid-member, not after the whole member lands."""
+        from pymol.predictors.errors import WeightDownloadCancelled
+        from pymol.predictors.weights import WeightCache
+        # ~75 chunks at the patched chunk size, so "finished the member anyway"
+        # is loudly distinguishable from "stopped at the first check".
+        data, digest = make_zip((('config.json', '{}'),
+                                 ('model.bin', 'x' * (300 * 1024))))
+        bundle = bundle_for(data, digest)
+        calls = []
+
+        def should_cancel():
+            calls.append(1)
+            return len(calls) > 2      # let it start, then pull the plug
+        with testing.mkdtemp() as root:
+            with patch('pymol.predictors.weights.EXTRACT_CHUNK_BYTES', 4096), \
+                 patch('pymol.predictors.weights._urlopen',
+                       return_value=FakeResponse(data)):
+                self.assertRaises(
+                    WeightDownloadCancelled,
+                    WeightCache(root).ensure, bundle, should_cancel=should_cancel)
+        self.assertLess(len(calls), 20,
+                        'cancel was not noticed until the member was fully written')
+
+    def testACancelledExtractLeavesNoCache(self):
+        from pymol.predictors.errors import WeightDownloadCancelled
+        from pymol.predictors.weights import WeightCache
+        data, digest = make_zip((('config.json', '{}'),
+                                 ('model.bin', 'x' * (64 * 1024))))
+        bundle = bundle_for(data, digest)
+        with testing.mkdtemp() as root:
+            cache = WeightCache(root)
+            with patch('pymol.predictors.weights.EXTRACT_CHUNK_BYTES', 4096), \
+                 patch('pymol.predictors.weights._urlopen',
+                       return_value=FakeResponse(data)):
+                self.assertRaises(
+                    WeightDownloadCancelled, cache.ensure, bundle,
+                    should_cancel=lambda: True)
+            self.assertFalse(cache.is_cached(bundle))
+            self.assertEqual(os.listdir(cache._incoming()), [])
+
+    def testExtractStillRejectsAMemberThatIsNotAPlainFileName(self):
+        """The chunked extract must not become a path-traversal seam.
+
+        WeightCache no longer routes through ZipFile.extract (which sanitises names
+        itself), so the guard has to be here. The layout check catches this too --
+        this asserts it is caught even if a name somehow matches the declaration.
+        """
+        import io
+        import zipfile
+        from pymol.predictors.errors import WeightBundleLayoutError
+        from pymol.predictors.weights import WeightCache
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, 'w') as archive:
+            archive.writestr('../escape.bin', 'nope')
+        data = buf.getvalue()
+        digest = hashlib.sha256(data).hexdigest()
+        bundle = bundle_for(data, digest, members=('../escape.bin',))
+        with testing.mkdtemp() as root:
+            with patch('pymol.predictors.weights._urlopen',
+                       return_value=FakeResponse(data)):
+                self.assertRaises(WeightBundleLayoutError,
+                                  WeightCache(root).ensure, bundle)


### PR DESCRIPTION
## The bug

Cancelling a weights download while it was unpacking left the ProgressTray card stuck on
**"Downloading model weights — Unpacking… 67%"** for good. `fetching.forget(<id>)` refused
to drop the record, and every later `predict_weights <p>, download=1` silently did nothing
— no new `.incoming/.part` — because `start()` kept handing back the same entry. Only
popping `_FETCHES` by hand recovered it.

## Root cause

**The 67% was literally 2/3.** Every shipping pack is three zip members — `config.json`,
`manifest.json`, `model.safetensors` — and the last one *is* the payload
(`protenix-v2-mlx-int8` is 299,351,203 B). `WeightCache._extract` called
`ZipFile.extract()` per member and only then reported progress and looked at the cancel
flag, so two checks fired on a few bytes of JSON and the third not until the entire tensor
file had been written. Measured: the fraction sits at exactly `0.6667` for that whole
stretch, during which no marker moves and Cancel does nothing at all.

**All three symptoms then follow from ONE state: a record still reading `running`.**

* The tray keeps the card while `running` or `error`, and `WeightDownloadDetail.text`
  renders `Unpacking… NN%` only when `!isError && isExtracting` — so a card reading
  "Unpacking… 67%" *proves* the Python record was `running`. (Handy when triaging from a
  screenshot.)
* `forget()` skipped `running` records **by design** — so the one call that could have
  helped was the one that refused.
* `start()` shares any live `running` record with a matching `cache.root` **by design**
  (one bundle, one download, however many callers) — so every retry got the dead handle
  back, and under `async_=1` nothing was printed to say so.

Auditing for how a record reaches that state *permanently* found two more paths, both
closed here:

1. `start()` published into `_FETCHES` **before** creating/starting the thread — a failed
   `Thread.start()` stranded the record on `running` with `thread=None` forever.
2. `_run` caught `Exception`, not `BaseException`.

## The fix

**`weights.py`** — `_extract` is now an explicit chunked copy (`EXTRACT_CHUNK_BYTES`,
1 MiB) via `archive.open(info)`, checking cancellation per chunk **and** per member, with
a **byte-based** fraction (`sum(info.file_size)`) so the bar advances through a big member
instead of jumping 0 → 33 → 67 → 100 with the whole wait inside one step.

> Reviewer note: dropping `ZipFile.extract()` also drops its built-in member-name
> sanitisation, so there is now an explicit plain-basename guard. Please don't remove it —
> a declared `../x` would otherwise write outside `staging`. It has its own test.

**`fetching.py`** — `_is_live()` so a record whose worker is gone is treated as wedged
rather than shared; `forget(<id>)` drops the record whatever its state and cancels what it
abandons, while bare `forget()` stays the settled-only broom; `_run` settles in a
`finally`, so "always settles, always emits a terminal marker" — the invariant the tray
card and `forget()` both rest on — holds unconditionally.

> Why cancelling on `forget` is safe rather than a publish race: `ensure`'s `finally`
> rmtrees `staging` and unlinks `part` *before* releasing the cache lock, and the
> pid-keyed scratch token is **identical** for two fetches in the same process — so that
> ordering is exactly what lets the replacement fetch proceed without collision.

**`predicting.py`** — `predict_weights` reports `joined` and `fetch` in its return value,
and warns regardless of `quiet` when it joins a transfer already in flight (same precedent
as `predict()`'s deferral warning) instead of looking like a no-op:

```
predict: a fetch of stub weights is already in flight (extract 2%); this call joined it
rather than starting a second download. Stop it with "predict_weights_cancel stub".
```

## Behaviour, end to end

```
>>> tray shows: Unpacking... 2%                     # fraction now advances mid-member
>>> predict_weights stub, download=1, async_=1
>>> returned joined=True fetch.state='running'      # was: silent, cached=False
>>> predict_weights_cancel stub
>>> final fetch state: 'cancelled'                  # terminal marker -> card clears
>>> forget() drops it: ['stub'] -> _FETCHES=[]      # was: refused
```

## Coverage

* `predict_weights_download.py` **+5** — intra-member progress, mid-member cancel,
  cancelled extract leaves no cache, the basename guard.
* `predict_weights_async.py` **+8** — terminal marker from the extract phase,
  `forget(<id>)` drops a live record *and the replacement completes*, bare `forget()`
  stays a broom, a dead-worker record doesn't block retries, a thread that can't start
  settles, a `BaseException` still settles, and `predict_weights` reports the join.
* `WeightsFetchStateTests.swift` **+4** — extract-phase cancel is terminal, an
  inter-member fraction decodes and renders `Unpacking… 74%`, and both new error markers.

Every one was confirmed **red first**: `forget()` leaving the record, the `BaseException`
strand, and the silent no-op all failed before the fix.

## Verification

* Full CI embedded list (extracted from `raymol-embedded-tests.yml` with `yaml.safe_load`
  and executed, rather than hand-copied): **663 tests, OK, 0 failures**.
* Swift `UnitTests_macOS`: **425 tests, 0 failures**.
* Both re-run **after** rebasing onto #336, which also touches `predicting.py`. The rebase
  was textually clean and I checked it semantically too: #336 scopes the *prediction*
  card's ETA and explicitly leaves `format_remaining`/`formatRemaining` alone because
  their other caller is the weight-download card — no interaction with the extract
  fraction. `secondsRemaining` still guards on `phase == "download"`.

Two notes for the reviewer:

* I did **not** run an iOS build. The only Swift source change here is a doc comment in
  `PyMOLEngine.swift`; the new tests are in the macOS-only test target. There is no symbol
  change that could trip the shared-ContentView iOS boundary.
* I saw `msa_e2e.py::testThePollLandsAFinishedSearchAndShowsItInTheSameTick` fail once in
  ~6 full-list runs and pass 4/4 in isolation. It never touches `fetching`; it looks like
  a pre-existing timing flake in a poll-ordering test and I left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
