### PR TITLE
fix(predict): write a Protenix job's terminal status before discarding its placeholder

### DIFF
--- a/swiftui/PyMOLViewer/Shared/BoltzJobManager.swift
+++ b/swiftui/PyMOLViewer/Shared/BoltzJobManager.swift
@@ -285,7 +285,11 @@ final class BoltzJobManager {
     /// run that failed used to just make its object vanish.
     ///
     /// One function rather than six call-pairs so a seventh exit cannot get it wrong.
-    private static func settle(_ request: Request, _ status: Status, to url: URL) {
+    /// Internal rather than private: `ProtenixJobManager` settles its own jobs and must use
+    /// THIS function rather than a second copy of the ordering. That is the whole point --
+    /// a second copy is a second chance to get it backwards, which is exactly what had
+    /// happened at all four of that manager's terminal paths.
+    static func settle(_ request: Request, _ status: Status, to url: URL) {
         try? writeStatus(status, to: url)
         #if DEBUG
         settleTap?("write")

--- a/swiftui/PyMOLViewer/Shared/ProtenixJobManager.swift
+++ b/swiftui/PyMOLViewer/Shared/ProtenixJobManager.swift
@@ -52,9 +52,8 @@ final class ProtenixJobManager {
     /// Refuse or accept a submitted request. Runs on the MAIN thread.
     func submit(_ request: BoltzJobManager.Request) {
         if let failure = Self.preflight(request) {
-            BoltzJobManager.discardPlaceholder(request)
-            try? BoltzJobManager.writeStatus(
-                failure, to: URL(fileURLWithPath: request.statusPath))
+            BoltzJobManager.settle(request, failure,
+                                   to: URL(fileURLWithPath: request.statusPath))
             return
         }
         queue.async { self.run(request) }
@@ -114,6 +113,23 @@ final class ProtenixJobManager {
         func isCancelled() -> Bool {
             stateQueue.sync { cancelled.contains(request.jobID) }
         }
+        /// A TERMINAL status, written before the placeholder comes down.
+        ///
+        /// Not `report` with a different state: the two differ in ORDER, not in payload.
+        /// `report` only writes; this writes and then discards, and the sequence is what
+        /// matters -- `discard_pending` re-reads the status file to decide whether to
+        /// retain a failure card, so a discard that lands first strands the failure where
+        /// nothing can observe it. Mirrors `BoltzJobManager.run`'s own local `settle`, and
+        /// routes through the shared `BoltzJobManager.settle` so there is one
+        /// implementation of the ordering rather than two.
+        func settle(_ state: String, _ phase: String, error: String? = nil) {
+            BoltzJobManager.settle(
+                request,
+                BoltzJobManager.Status(state: state, phase: phase, fraction: 0,
+                                       error: error, resultPath: nil,
+                                       peakBytes: peak, elapsedSeconds: elapsed),
+                to: statusURL)
+        }
 
         report("running", "featurize", 0.0)
         do {
@@ -130,8 +146,7 @@ final class ProtenixJobManager {
                 name: request.objectName ?? "prediction")
 
             if isCancelled() {
-                BoltzJobManager.discardPlaceholder(request)
-                report("cancelled", "featurize", 0); return
+                settle("cancelled", "featurize"); return
             }
 
             report("running", "load", 0.05)
@@ -188,11 +203,9 @@ final class ProtenixJobManager {
             BoltzJobManager.loadResult(request)
             report("done", "done", 1.0, result: request.outPath)
         } catch ProtenixError.cancelled {
-            BoltzJobManager.discardPlaceholder(request)
-            report("cancelled", "inference", 0)
+            settle("cancelled", "inference")
         } catch {
-            BoltzJobManager.discardPlaceholder(request)
-            report("failed", "inference", 0,
+            settle("failed", "inference",
                    error: (error as? LocalizedError)?.errorDescription
                        ?? error.localizedDescription)
         }

--- a/swiftui/PyMOLViewerTests/ProtenixRuntimeTests.swift
+++ b/swiftui/PyMOLViewerTests/ProtenixRuntimeTests.swift
@@ -44,6 +44,76 @@ final class ProtenixRuntimeTests: XCTestCase {
         return try BoltzJobManager.parseRequest(at: url)
     }
 
+    // MARK: - settle ordering
+
+    /// The status file must be on disk BEFORE the placeholder is taken down.
+    ///
+    /// `predicting.discard_pending` re-reads the status FRESH to decide whether to retain a
+    /// failure card in `_RECENT` -- and it can, because nothing deletes the status file. So
+    /// a discard that lands first records the failure after `_PENDING`, the only map that
+    /// could observe it, has already been popped: the card silently vanishes and a refused
+    /// or failed run explains nothing.
+    ///
+    /// The Boltz path has had this test since #291
+    /// (`testPreflightRefusalWritesStatusBeforeDiscardingPlaceholder`). Protenix did not,
+    /// and all four of its terminal paths did the two steps inline, in the wrong order.
+    func testARefusalWritesStatusBeforeDiscardingThePlaceholder() throws {
+        var order: [String] = []
+        BoltzJobManager.settleTap = { order.append($0) }
+        defer { BoltzJobManager.settleTap = nil }
+
+        // 100k residues: far past any machine's fitting size, so preflight refuses without
+        // touching MLX or reading a weight pack.
+        let request = try writeRequest(
+            job: "settle-order",
+            chains: [("A", String(repeating: "A", count: 100_000))],
+            runtime: ProtenixJobManager.runtimeName)
+        ProtenixJobManager.shared.submit(request)
+
+        XCTAssertEqual(order, ["write", "discard"],
+                       "status must be written before the placeholder is discarded")
+        let status = try JSONDecoder().decode(
+            BoltzJobManager.Status.self,
+            from: Data(contentsOf: URL(fileURLWithPath: request.statusPath)))
+        XCTAssertEqual(status.state, "failed")
+        XCTAssertNotNil(status.error)
+    }
+
+    /// Every terminal path goes through the ordered helper -- checked STRUCTURALLY, because
+    /// three of the four cannot be reached from a unit test.
+    ///
+    /// `submit`'s refusal is testable (above). The three inside `run` are not: they need a
+    /// real 214 MB pack and a real MLX fold to reach. They are also where the ordering
+    /// actually bites, and the reason is the threading: `discardPlaceholder` hops to the
+    /// MAIN queue while the status write is synchronous on the calling thread. From
+    /// `submit`, which runs on the main thread, that hop is deferred past the write and the
+    /// wrong order is accidentally harmless. From `run`, which is on a background queue,
+    /// the main thread can pick the discard up while the write is still in flight.
+    ///
+    /// So a grep is the honest guard: no `discardPlaceholder` call may remain in this
+    /// manager at all. The same discipline as
+    /// `predict_api.testEveryMessageHelperUsedByPredictingExists`, which greps its source
+    /// rather than trying to take every branch.
+    func testNoTerminalPathDiscardsThePlaceholderItself() throws {
+        let source = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()          // PyMOLViewerTests
+            .deletingLastPathComponent()          // swiftui
+            .appendingPathComponent("PyMOLViewer/Shared/ProtenixJobManager.swift")
+        let text = try String(contentsOf: source, encoding: .utf8)
+        for (number, line) in text.split(separator: "\n").enumerated() {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("//") || trimmed.hasPrefix("///") { continue }
+            XCTAssertFalse(line.contains("discardPlaceholder"),
+                           "ProtenixJobManager.swift:\(number + 1) discards the placeholder "
+                           + "directly; route it through BoltzJobManager.settle so the "
+                           + "status is written first: \(trimmed)")
+        }
+        // And it does still settle -- so the assertion above cannot be satisfied by simply
+        // deleting the teardown.
+        XCTAssertTrue(text.contains("BoltzJobManager.settle("),
+                      "the manager must settle its jobs through the shared helper")
+    }
+
     // MARK: - Wire format
 
     func testRequestCarriesItsRuntime() throws {


### PR DESCRIPTION
`predicting.discard_pending` re-reads the status file **fresh** to decide whether to retain a
failure card in `_RECENT` — it can, because nothing ever deletes that file. So the order is
load-bearing: a discard that lands first pops `_PENDING`, the only map that could observe the
outcome, and the failure is stranded. The card silently vanishes and a run that produced
nothing explains nothing.

`BoltzJobManager.settle` exists to encode that order and has had a test since #291.
`ProtenixJobManager` never used it — all four of its terminal paths did the two steps inline,
discard first.

## Three of the four are a real race, and it isn't the one that looks worst

`discardPlaceholder` hops to the **main** queue while `writeStatus` is synchronous on the
calling thread. That makes the threading decisive:

| site | thread | effect today |
|---|---|---|
| `submit` refusal | main | hop is deferred past the write — accidentally harmless |
| `run` cancel-during-featurize | background | main thread can take the discard mid-write |
| `run` `catch .cancelled` | background | same |
| `run` `catch` (failure) | background | same |

So: a latent hazard at the one site that reads worst, and a live race at the three that
carry a cancellation or a failure *after minutes of folding* — precisely when a card saying
why is worth having.

The fix is the same at all four: route them through the shared helper instead of repeating
the sequence. A second copy of an ordering is a second chance to get it backwards, which is
what happened here. `run` gains a local `settle(_ state:_ phase:error:)` mirroring
`BoltzJobManager.run`'s own, so the two managers now settle identically.
`BoltzJobManager.settle` drops `private` and gains no new behaviour.

## Tests

Both were confirmed to **fail against the unfixed code** before the fix went in — 6 failures
naming all four call sites:

- `testARefusalWritesStatusBeforeDiscardingThePlaceholder` — drives `submit` with a
  100k-residue request (refused before MLX or any weight read) and asserts the `settleTap`
  sequence is exactly `["write", "discard"]`. Against the old code the tap recorded `[]`:
  the manager never entered `settle` at all, which is the finding stated as an assertion.
- `testNoTerminalPathDiscardsThePlaceholderItself` — greps the manager's own source for
  zero direct `discardPlaceholder` calls, plus at least one `settle` so it can't be
  satisfied by deleting the teardown. A grep because the three paths inside `run` need a
  real 214 MB pack and a real fold to reach; same discipline as
  `predict_api.testEveryMessageHelperUsedByPredictingExists`.

**431 Swift tests, 0 failures.** Both slices compiled (macOS + iOS) — no CI job compiles
Swift.

The regenerated `project.pbxproj` is deliberately **not** included: no files were added, so
its only diff was fresh random UUIDs.

## Note for whoever merges second

This widens `BoltzJobManager.settle` from `private static` to `static`. #343 edits the same
declaration line (making it `static` **and** adding `pythonModule: String = "predicting"`),
so whichever lands second gets a one-line textual conflict. The resolution is always #343's
signature — it is a superset. Everything else here is in `ProtenixJobManager.swift` and
`ProtenixRuntimeTests.swift`, which #343 does not touch.

Noticed while implementing #342 and kept out of #343 so that change did not touch a shipped
predictor's behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
