### PR TITLE
refactor(predict): extract the shared job shell out of BoltzJobManager (#345)

### DIFF
--- a/docs/predictors.md
+++ b/docs/predictors.md
@@ -60,6 +60,10 @@ The distinction has to be on the wire because weights and featurizer are method-
 Running one method's request on another's backend does not fail; it tokenizes with the
 wrong featurizer and returns a confident wrong structure. So:
 
+- `InferenceRouter` owns the `PREDICT:` marker and one table of every runtime this build
+  links. `submit` and `cancel` read the **same** table, which is what makes "routable" and
+  "cancellable" the same property — a runtime that could be started but not stopped is a
+  job the user cannot cancel.
 - `BoltzJobManager` implements `boltz` and **refuses** any other in `preflight`, before it
   applies its size model — which is fitted to Boltz's measured peaks and would be
   meaningless applied to another method's request even as a refusal.
@@ -72,6 +76,26 @@ wrong featurizer and returns a confident wrong structure. So:
 
 That default is also the trap: a new predictor that forgets to pass `runtime=` is silently
 dispatched to Boltz. `predict_runtime.py` asserts every registered predictor names one.
+
+### Adding a runtime
+
+The Swift side is three pieces, and only the third is method-specific:
+
+| | |
+|---|---|
+| `InferenceJob` | the wire (`Request`, `Status`, `Chain`, `Alignment`) and the job shell: `parseRequest`, atomic `writeStatus`, `settle`, `refusal`, `discardPlaceholder`, `loadResult`, `StepThrottle`. Neutral — it imports no inference package and knows no method. |
+| `InferenceRuntime` | the three members a manager must have: `static var runtimeName`, `submit(_:)`, `cancel(jobID:)`. |
+| your manager | the featurizer, the weights, the size model, the result writer. |
+
+Conform your manager to `InferenceRuntime` and add its singleton to
+`InferenceRouter.runtimes`. That one line makes it both routable and cancellable; there is
+no second place to remember. Use `InferenceJob`'s helpers rather than reimplementing them —
+"the status file went missing on a cancelled job" is the class of bug you only find in
+production, and `settle`'s write-then-discard ordering in particular is load-bearing (see
+`predicting.discard_pending`, which re-reads the status to decide whether to keep a failure
+card).
+
+`submit` runs on the MAIN thread: refuse there, then hand the work to your own queue.
 
 `boltz2-bf16` subclasses `Boltz2Predictor` and overrides nothing but `weight_bundle`, which
 is what "two predictors, one runtime" looks like in practice. It needs boltz-mlx >= 0.2.0.

--- a/modules/pymol/predicting.py
+++ b/modules/pymol/predicting.py
@@ -448,7 +448,7 @@ def discard_pending(name, _self=cmd):
     # background queue -> settle() writes the terminal status file -> the discard is
     # hopped to the main queue and runs within milliseconds, LONG before the next
     # poll. Trusting the cache therefore retains nothing on the only path that
-    # matters. Nothing deletes the status file (BoltzJobManager has no removeItem
+    # matters. Nothing deletes the status file (InferenceJob has no removeItem
     # on statusPath), so re-reading it here is what actually sees the failure;
     # _LAST_INFO stays as the fallback for a job that vanished from _PENDING first.
     #

--- a/modules/pymol/predictors/host.py
+++ b/modules/pymol/predictors/host.py
@@ -10,7 +10,7 @@ SETTINGS:ready use. Payloads go through files because the feedback line caps at
 Because cmd.predict returns a job handle, nothing here needs a synchronous return
 value from Swift: status and result are files this module polls.
 
-The JSON keys below are a contract with BoltzJobManager.Request / .Status.
+The JSON keys below are a contract with InferenceJob.Request / .Status.
 """
 import json
 import os
@@ -200,7 +200,7 @@ def submit(spec, options, weights_path, runtime=DEFAULT_RUNTIME, knobs=None):
         # instead of a refusal that names the missing runtime.
         'runtime': runtime,
         'weights_dir': weights_path or '',
-        # Objects, not pairs: BoltzJobManager.Chain is a Codable struct with named
+        # Objects, not pairs: InferenceJob.Chain is a Codable struct with named
         # keys, so a positional array would fail to decode.
         'chains': [{'chain': chain, 'sequence': sequence}
                    for chain, sequence in spec.chains],

--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		575E4E4792DE4C46A70ECE01 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 10CCAA289EA2934B267C337A /* PrivacyInfo.xcprivacy */; };
 		57B2D711FAEB98EBCAD11CBC /* PredictScreenAwake.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4847B7F5C09AD3E9412C3EB /* PredictScreenAwake.swift */; };
 		57E2333020DE9DC8910BDC3E /* InteractionModeExitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43E4051E6410834AAAA4047 /* InteractionModeExitTests.swift */; };
+		59414471A1C1412AF869074D /* InferenceJob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87825A30DE5C455B6270187F /* InferenceJob.swift */; };
 		598C60D5EA54B317DA845A5D /* PredictControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60E5CB80464F5616064A91C /* PredictControllerTests.swift */; };
 		5992346BC7D06026A673BA71 /* ObjectPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A73267D4D7B506E647B7A995 /* ObjectPanel.swift */; };
 		5A20A6D21AA3CFAE2394BAB4 /* dylib-Info-template.plist in Resources */ = {isa = PBXBuildFile; fileRef = 57E9E81F5C4757D03AAF7ABD /* dylib-Info-template.plist */; };
@@ -119,6 +120,7 @@
 		7F9C46E519B7180C507053BB /* MLXRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AD9869000B548D9F7CDF9DE /* MLXRuntimeTests.swift */; };
 		809165FC9A0F411860956BD6 /* PredictAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0825BFE369DAF40A6F3AA5D4 /* PredictAvailabilityTests.swift */; };
 		8206A8EA7F51F473C168C9D0 /* whatsnew-1100-msa.png in Resources */ = {isa = PBXBuildFile; fileRef = 727EA43D6A4FCC275ABC49D0 /* whatsnew-1100-msa.png */; };
+		82DADD44C2ED6C0A534EBD26 /* InferenceJob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87825A30DE5C455B6270187F /* InferenceJob.swift */; };
 		82F6B1E5C339BCC6545AA222 /* whatsnew-1100-predict-progress.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = C5D633C399E993EE52877C82 /* whatsnew-1100-predict-progress.mp4 */; };
 		8471766417221874246F5252 /* WhatsNewLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3753EB4AA7EC91E685E36B84 /* WhatsNewLogic.swift */; };
 		848682B247E00ECDD720FF73 /* DesignResidues.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFE9998F68625C92B8BCD710 /* DesignResidues.swift */; };
@@ -133,6 +135,7 @@
 		90F5E063444FBF4FF3770118 /* MCPStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1304C662D9011F7C4505FC /* MCPStatusView.swift */; };
 		917ABB57816FDCD8B1D1E9CE /* DesignSizeGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3CAE980896763CAAAF2034 /* DesignSizeGuardTests.swift */; };
 		946A8CF4D62A7AFFFA6E39A9 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 10CCAA289EA2934B267C337A /* PrivacyInfo.xcprivacy */; };
+		966C6886E3CE816365256220 /* InferenceRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71574A2074A14803B91ED695 /* InferenceRouter.swift */; };
 		979AB10150CC62EE5E7962F9 /* MetalViewport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E9F8D36908E3216D1C8F893 /* MetalViewport.swift */; };
 		97F0B5805CD3B11723C7B43B /* whatsnew-152-timeline.png in Resources */ = {isa = PBXBuildFile; fileRef = 55094A33AFF9AEF5561CFD96 /* whatsnew-152-timeline.png */; };
 		983BCF8F1E0F251E82C1CF0E /* DesignController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4FB7F151982A2927D612F0 /* DesignController.swift */; };
@@ -146,6 +149,7 @@
 		A76B8F620DCFED6F7AD69FEE /* ProtenixRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7845A3EB6A6BF8A14F090062 /* ProtenixRuntime.swift */; };
 		AA00B9355E30A51B8F4C207B /* AppBuildInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525F338CAB2EE18987CD1701 /* AppBuildInfo.swift */; };
 		AA36D034CEC68207CFC82340 /* WhatsNewModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4D170B35BCCF683A6B3D655 /* WhatsNewModal.swift */; };
+		AC4CB915ECB531A4406CF387 /* InferenceRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71574A2074A14803B91ED695 /* InferenceRouter.swift */; };
 		ACBE8F70B980BCCE6730141A /* MovieBuilderSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ED5BFF3FEE9D6621BB40AE5 /* MovieBuilderSheet.swift */; };
 		AF7D82103248D30E0CD32311 /* ProgressTray.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4857D1284B60EB0C750C02F /* ProgressTray.swift */; };
 		B238B98768632BEFAD9327E4 /* MLXRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86E93358875495F499780A00 /* MLXRuntime.swift */; };
@@ -169,6 +173,7 @@
 		C2FE6360EC57133D61DC3FAD /* CopyRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CC639810B19E8F5E637E93 /* CopyRouting.swift */; };
 		C89E138879C40C8FB6C0478A /* OpenFilesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2C1E1633D1E93E9914BEC3 /* OpenFilesTests.swift */; };
 		C97C087311C3D159E74FA96A /* MLX in Frameworks */ = {isa = PBXBuildFile; productRef = 69935BE3EFD2F08B88D4AEE9 /* MLX */; };
+		C98E23FB46AC666B6D1B5A72 /* InferenceRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3E224EA1BE94147B322332 /* InferenceRouterTests.swift */; };
 		CAC9B9F8A93BC4B71C3DB0D6 /* KeyBindingDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF072CB363743CAF805155E /* KeyBindingDispatchTests.swift */; };
 		CCA9FAAAD0E59CE43443B7DA /* PyMOLGestureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8EE6573045A81CF52A9CDF5 /* PyMOLGestureUITests.swift */; };
 		CCC5944AB82CA9D946A60F10 /* whatsnew-190-redesign.png in Resources */ = {isa = PBXBuildFile; fileRef = 137F4EFE6CA3B90DE4765559 /* whatsnew-190-redesign.png */; };
@@ -288,6 +293,7 @@
 		6C07F661E0541060409A09F7 /* PredictSizeGuard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictSizeGuard.swift; sourceTree = "<group>"; };
 		6E2FC2AD1A8FEE912986DF9D /* whatsnew-161-hover.mp4 */ = {isa = PBXFileReference; path = "whatsnew-161-hover.mp4"; sourceTree = "<group>"; };
 		6ECDA98647B184340BC7934F /* DesignIOSPortTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignIOSPortTests.swift; sourceTree = "<group>"; };
+		71574A2074A14803B91ED695 /* InferenceRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InferenceRouter.swift; sourceTree = "<group>"; };
 		727EA43D6A4FCC275ABC49D0 /* whatsnew-1100-msa.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "whatsnew-1100-msa.png"; sourceTree = "<group>"; };
 		75F059BB95517CE91BD3E26E /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7845A3EB6A6BF8A14F090062 /* ProtenixRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtenixRuntime.swift; sourceTree = "<group>"; };
@@ -299,6 +305,7 @@
 		82BCB731F0C74F642D78D450 /* PyMOLBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PyMOLBridge.h; sourceTree = "<group>"; };
 		85B66833BF167209A47B9C15 /* ThemeStudioPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStudioPanel.swift; sourceTree = "<group>"; };
 		86E93358875495F499780A00 /* MLXRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLXRuntime.swift; sourceTree = "<group>"; };
+		87825A30DE5C455B6270187F /* InferenceJob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InferenceJob.swift; sourceTree = "<group>"; };
 		8B0D207800BE2DDAF04598C1 /* PredictController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictController.swift; sourceTree = "<group>"; };
 		8FE79EC8844C681A41A1E54A /* MovieExportSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieExportSheet.swift; sourceTree = "<group>"; };
 		9371B6FFB30D6166234C678B /* RayMolMain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RayMolMain.swift; sourceTree = "<group>"; };
@@ -313,6 +320,7 @@
 		A63406B360384F3C62E511E1 /* RayMolPython.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RayMolPython.entitlements; sourceTree = "<group>"; };
 		A73267D4D7B506E647B7A995 /* ObjectPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectPanel.swift; sourceTree = "<group>"; };
 		AA4C108E3D04FD75288859DA /* GizmoOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GizmoOverlay.swift; sourceTree = "<group>"; };
+		AD3E224EA1BE94147B322332 /* InferenceRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InferenceRouterTests.swift; sourceTree = "<group>"; };
 		B158150C93613716ED3CE572 /* KeyboardDismissUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardDismissUITests.swift; sourceTree = "<group>"; };
 		B45634C95AE991CC91CFBA75 /* DesignInferenceSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignInferenceSmokeTests.swift; sourceTree = "<group>"; };
 		B47211EDB3E34DF3B0CFE8BB /* PanelLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelLayout.swift; sourceTree = "<group>"; };
@@ -356,7 +364,7 @@
 		F7E41DCBB427678A8F018B0E /* DesignControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignControllerTests.swift; sourceTree = "<group>"; };
 		FB1304C662D9011F7C4505FC /* MCPStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPStatusView.swift; sourceTree = "<group>"; };
 		FF4FB7F151982A2927D612F0 /* DesignController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignController.swift; sourceTree = "<group>"; };
-		"TEMP_6E6D2056-B3D8-4BDE-BD35-B66641BB30D6" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
+		"TEMP_ECE7A689-BD6F-4587-BA1E-27EB02D1331A" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -496,6 +504,8 @@
 				EEC5AE545F97DF175BFE0462 /* DesignScoreCache.swift */,
 				9E69AA2C12DC2D1583FBF8C8 /* DesignSizeGuard.swift */,
 				AA4C108E3D04FD75288859DA /* GizmoOverlay.swift */,
+				87825A30DE5C455B6270187F /* InferenceJob.swift */,
+				71574A2074A14803B91ED695 /* InferenceRouter.swift */,
 				3697F74BD2283492B5A7790C /* KeyRouting.swift */,
 				1A18D8A6B0FB56FCD3C31211 /* MCPBridge.swift */,
 				786939619F7871E32E2BB123 /* MCPDesktopInstaller.swift */,
@@ -548,6 +558,7 @@
 				48EDC39F7E7F250CFC4F7D0D /* DesignResiduesTests.swift */,
 				D0BCB2A867C3554FB56A7299 /* DesignScoreCacheTests.swift */,
 				EE3CAE980896763CAAAF2034 /* DesignSizeGuardTests.swift */,
+				AD3E224EA1BE94147B322332 /* InferenceRouterTests.swift */,
 				F43E4051E6410834AAAA4047 /* InteractionModeExitTests.swift */,
 				1FF072CB363743CAF805155E /* KeyBindingDispatchTests.swift */,
 				F61B9A042E88CAE1E21BC506 /* KeyRoutingTests.swift */,
@@ -589,10 +600,10 @@
 			path = Bridge;
 			sourceTree = "<group>";
 		};
-		"TEMP_B76D0A75-F994-4D72-9AFB-225E61A2475F" /* swiftui */ = {
+		"TEMP_B4B7BF10-A05C-4BC3-A0FC-767151C4BA0F" /* swiftui */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_6E6D2056-B3D8-4BDE-BD35-B66641BB30D6" /* PyMOLBridge.xcconfig */,
+				"TEMP_ECE7A689-BD6F-4587-BA1E-27EB02D1331A" /* PyMOLBridge.xcconfig */,
 			);
 			path = swiftui;
 			sourceTree = "<group>";
@@ -1274,6 +1285,7 @@
 				52B5620BEF26DEB8E3A700C1 /* DesignResiduesTests.swift in Sources */,
 				6EAC8947F66B8D7AD29BF3B8 /* DesignScoreCacheTests.swift in Sources */,
 				917ABB57816FDCD8B1D1E9CE /* DesignSizeGuardTests.swift in Sources */,
+				C98E23FB46AC666B6D1B5A72 /* InferenceRouterTests.swift in Sources */,
 				57E2333020DE9DC8910BDC3E /* InteractionModeExitTests.swift in Sources */,
 				CAC9B9F8A93BC4B71C3DB0D6 /* KeyBindingDispatchTests.swift in Sources */,
 				EF9A088B19E39220CC72469D /* KeyRoutingTests.swift in Sources */,
@@ -1313,6 +1325,8 @@
 				2E559E9581421DDC00C8BBB8 /* DesignScoreCache.swift in Sources */,
 				65CE08E50C85C8ACDAC92D07 /* DesignSizeGuard.swift in Sources */,
 				8C04C5D4AB27F2D9BEF79561 /* GizmoOverlay.swift in Sources */,
+				59414471A1C1412AF869074D /* InferenceJob.swift in Sources */,
+				AC4CB915ECB531A4406CF387 /* InferenceRouter.swift in Sources */,
 				2C2D4B24DF4807FA1407582D /* KeyRouting.swift in Sources */,
 				B33C0620EDD48195A59B7DD8 /* MCPBridge.swift in Sources */,
 				55F78301BAF8CD914D86069D /* MCPConnectSheet.swift in Sources */,
@@ -1376,6 +1390,8 @@
 				6C8AA3C224C1B2106FBF4881 /* DesignScoreCache.swift in Sources */,
 				1A580F6792CD440D91FA9F45 /* DesignSizeGuard.swift in Sources */,
 				8F71359FAD68AE5D09416C1B /* GizmoOverlay.swift in Sources */,
+				82DADD44C2ED6C0A534EBD26 /* InferenceJob.swift in Sources */,
+				966C6886E3CE816365256220 /* InferenceRouter.swift in Sources */,
 				768E23FCAB4D2B27205900B6 /* KeyRouting.swift in Sources */,
 				42D3395698D37E4BF7055EEA /* MCPBridge.swift in Sources */,
 				E777A44381A854B382874738 /* MCPConnectSheet.swift in Sources */,
@@ -1600,7 +1616,7 @@
 		};
 		76B7E9DB75E073D1E60928FA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_6E6D2056-B3D8-4BDE-BD35-B66641BB30D6" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_ECE7A689-BD6F-4587-BA1E-27EB02D1331A" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1707,7 +1723,7 @@
 		};
 		D8F44FDFF036013D2F03BA83 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_6E6D2056-B3D8-4BDE-BD35-B66641BB30D6" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_ECE7A689-BD6F-4587-BA1E-27EB02D1331A" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/swiftui/PyMOLViewer/Shared/BoltzJobManager.swift
+++ b/swiftui/PyMOLViewer/Shared/BoltzJobManager.swift
@@ -3,18 +3,19 @@ import BoltzMLX
 import Foundation
 import os
 
-/// Runs Boltz predictions on behalf of Python.
+/// Runs the `boltz` inference runtime: Boltz predictions on behalf of Python, and the
+/// runtime a request that names none is routed to.
 ///
-/// RayMol has no Python→Swift call path: `PyMOLBridge.h` is one-directional and no Swift
-/// function carries a C symbol. So `cmd.predict` writes a request JSON and prints a
-/// `PREDICT:` marker, which `PyMOLEngine.pollFeedback()` already scans on a 100 ms timer
-/// — exactly how `OBJPANEL:` and `SETTINGS:ready` work. Payloads travel as tempfiles
-/// because the feedback line caps at ~1 KB.
+/// The job SHELL — the wire format, atomic status writes, the write-then-discard settle
+/// ordering, placeholder discard and result autoload — is ``InferenceJob``, and the
+/// `PREDICT:` marker is ``InferenceRouter``'s. Both used to live in here, which made the
+/// other manager a dependent of this one for nothing it needed from it. What remains is
+/// only what is Boltz's: its featurizer, its weights, its size model and its metrics.
 ///
 /// Because the Python API is a job handle, nothing here needs to return a value to
 /// Python: status and result are files that Python polls. That is what makes the missing
-/// bridge direction unnecessary rather than something to build.
-final class BoltzJobManager {
+/// Python→Swift bridge direction unnecessary rather than something to build.
+final class BoltzJobManager: InferenceRuntime {
 
     static let shared = BoltzJobManager()
 
@@ -23,7 +24,7 @@ final class BoltzJobManager {
     /// `PyMOLBridge` advertises in `RAYMOL_PREDICT_RUNTIMES` — that variable is what lets
     /// a predictor whose backend is NOT linked here refuse in `check_available` instead
     /// of submitting a job that only gets refused after a weight download.
-    static let boltzRuntime = "boltz"
+    static let runtimeName = "boltz"
 
     /// MLX must never run on the main thread. `cmd.predict` from the console arrives ON
     /// the main thread, which is exactly why submit is fire-and-forget.
@@ -66,336 +67,62 @@ final class BoltzJobManager {
         stateQueue.sync { cancelled.removeAll(); runningTasks.removeAll() }
     }
 
-    // MARK: - Marker parsing
+    // MARK: - InferenceRuntime
 
-    enum Verb: String { case submit, cancel }
-    struct Marker: Equatable { let verb: Verb; let jobID: String }
-
-    static func parseMarker(_ line: String) -> Marker? {
-        guard line.hasPrefix("PREDICT:") else { return nil }
-        let body = line.dropFirst("PREDICT:".count)
-        let parts = body.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
-        guard parts.count == 2,
-              let verb = Verb(rawValue: String(parts[0])),
-              !parts[1].isEmpty else { return nil }
-        return Marker(verb: verb, jobID: String(parts[1]))
-    }
-
-    // MARK: - Wire format (must match modules/pymol/predictors/host.py)
-
-    struct Chain: Codable { let chain: String; let sequence: String }
-
-    /// One chain's multiple-sequence alignment, as a PATH to an a3m.
+    /// Refuse or accept a submitted request. Runs on the MAIN thread, called by
+    /// ``InferenceRouter``.
     ///
-    /// A path rather than inline text because an alignment is megabytes — the barnase
-    /// one boltz-mlx tests against is ~1.3 MB — and base64 inside a JSON this decodes in
-    /// one gulp buys nothing over a file that is read once and dropped. Python writes
-    /// each file BEFORE the request that names it, so a request that decodes has its
-    /// alignments already complete on disk.
-    struct Alignment: Codable {
-        let chain: String
-        let a3mPath: String
-
-        enum CodingKeys: String, CodingKey { case chain, a3mPath = "a3m_path" }
+    /// Nothing here decides which runtime a request belongs to any more: the router does
+    /// that, and reaching this method means either the request named `boltz`, named nothing
+    /// (which means `boltz`), or named a runtime this build does not carry. `preflight`
+    /// still refuses the third case BY NAME — that is how a Python side offering a method
+    /// this build did not link gets a real error instead of a job that never reports.
+    func submit(_ request: InferenceJob.Request) {
+        if let failure = Self.preflight(request) {
+            // Refused before any work: the placeholder Python just created will never
+            // be filled, so drop it rather than leaving an empty stub behind.
+            InferenceJob.settle(request, failure,
+                                to: URL(fileURLWithPath: request.statusPath))
+            return
+        }
+        queue.async { self.run(request) }
     }
 
-    struct Request: Codable {
-        let jobID: String
-        let weightsDir: String
-        let chains: [Chain]
-        /// Which backend must run this job. OPTIONAL, absent meaning ``boltzRuntime`` —
-        /// every Python side that predates a second runtime wrote no such key, and the
-        /// only runtime that existed then was this one. A request naming a runtime this
-        /// build does not carry is REFUSED in `preflight`, never run here: the weights and
-        /// the featurizer are method-specific, so running one method's request on
-        /// another's backend would not fail, it would return a confident wrong answer.
-        let runtime: String?
-        let recyclingSteps: Int
-        let diffusionSteps: Int
-        let seed: UInt64
-        let outPath: String
-        let statusPath: String
-        /// Per-chain alignments. OPTIONAL, so a request written by a Python side that
-        /// predates #297 still decodes — the same reasoning as `objectName` below.
-        ///
-        /// PARTIAL by design: a chain that is absent gets upstream's depth-1 dummy MSA
-        /// (`BoltzFeaturizer` falls back to `MSAAlignment.singleSequence`), which is
-        /// exactly the designed-binder case — a real alignment for the target, none for
-        /// the binder, because a designed binder has no homologs to align.
-        let alignments: [Alignment]?
-        /// Rows to read from each a3m, from the top. Optional for the same reason.
-        let msaDepth: Int?
-        /// Object the finished structure is loaded into. Python creates an empty
-        /// placeholder under this name at submit time; loading into it lands at state 1,
-        /// and a repeat prediction of the same sequence appends model 2, 3, ...
-        ///
-        /// OPTIONAL on purpose. Absent means "do not auto-load" — a legitimate state, and
-        /// it keeps the wire backward compatible: a non-optional field would turn any
-        /// Python/Swift skew into a hard "malformed request" failure instead of simply
-        /// falling back to the explicit `predict_result` flow. Same reasoning as the
-        /// object panel's optional `groups`/`pending` fields.
-        let objectName: String?
-        /// Where to write what this run MEASURED, as a `pymol.metrics` document (#308).
-        ///
-        /// The confidence numbers exist only in here: pLDDT rounded into a B-factor
-        /// column was the only one that used to survive, and `ScoredStructure.pae` and
-        /// `interfaceScores()` were computed on every run and thrown away. A PAE matrix
-        /// is per residue PAIR and an interface score is per run, so neither fits in
-        /// the PDB — hence a second file rather than more columns.
-        ///
-        /// Optional for the reason `objectName` is: absent simply means the Python side
-        /// predates this and records the run without them, rather than the whole request
-        /// failing to decode.
-        let metricsPath: String?
-
-        enum CodingKeys: String, CodingKey {
-            case jobID = "job_id", weightsDir = "weights_dir", chains, runtime
-            case recyclingSteps = "recycling_steps", diffusionSteps = "diffusion_steps"
-            case seed, outPath = "out_path", statusPath = "status_path"
-            case objectName = "object_name", metricsPath = "metrics_path"
-            case alignments, msaDepth = "msa_depth"
+    /// Note a cancel. Idempotent, and safe for a job id this manager never had — the
+    /// marker carries no runtime, so cancels are broadcast to every runtime and each
+    /// keeps only its own.
+    ///
+    /// Cancels the live TASK, because that is what actually interrupts compute, and
+    /// records the request for the coarse phase checks (a cancel can arrive before the
+    /// task is registered). Cancels for jobs already in a terminal state are ignored, so
+    /// `cancelled` cannot grow without bound from stray or post-completion markers.
+    func cancel(jobID: String) {
+        stateQueue.sync {
+            if let task = runningTasks[jobID] {
+                cancelled.insert(jobID)
+                task.cancel()
+            } else if !InferenceJob.hasTerminalStatus(jobID: jobID) {
+                cancelled.insert(jobID)
+            }
         }
     }
 
-    struct Status: Codable {
-        let state: String        // queued | running | done | failed | cancelled
-        let phase: String
-        let fraction: Double
-        let error: String?
-        let resultPath: String?
-        /// MLX's peak-memory high-water mark for THIS prediction, in bytes. Nil until the
-        /// run finishes. Reported because process RSS does not attribute MLX's Metal
-        /// allocations at all -- sampling RSS during a 250-residue run showed ~9 MB of
-        /// growth against a multi-GB actual -- so this is the only honest instrument, and
-        /// it is what `PredictSizeGuard`'s constants must be fitted against.
-        let peakBytes: Int?
-        /// The MAXIMUM `phys_footprint` this process reached during the run, in bytes,
-        /// sampled every 200 ms (see ``FootprintSampler``). Nil until the run finishes.
-        ///
-        /// **Not a duplicate of ``peakBytes``, and the difference is the point.** MLX's
-        /// high-water mark EXCLUDES its own buffer cache
-        /// (mlx-swift/Source/MLX/Memory.swift:171-178), so it under-reports what the
-        /// system sees. `phys_footprint` is the quantity **jetsam kills on** and the one
-        /// `os_proc_available_memory()` is denominated in — so on iOS it, not `peakBytes`,
-        /// is what ``PredictSizeGuard``'s estimate is actually racing.
-        ///
-        /// The comment above about RSS being useless refers to `resident_size`, which
-        /// omits compressed and IOKit-mapped pages and therefore misses Metal allocations
-        /// entirely. `phys_footprint` includes them; the two are different instruments and
-        /// only one of them was tried.
-        ///
-        /// Recorded rather than derived because the gap between the two is not a constant:
-        /// it is whatever the cache happens to be holding, which is exactly the thing a
-        /// fitted model cannot know.
-        var footprintBytes: Int? = nil
-        /// Wall time for the inference itself, excluding the one-time model load.
-        let elapsedSeconds: Double?
-        /// Steps completed within the CURRENT phase, and that phase's total --
-        /// e.g. diffusion step 84 of 200. `fraction` is the same thing as a ratio;
-        /// these are carried as well because "step 84 of 200" is a far more
-        /// legible sentence than "42%", and because the ETA wants the raw counts.
-        ///
-        /// `var … = nil` rather than `let`: a default keeps the memberwise
-        /// initialiser's existing call sites (and their tests) compiling, and
-        /// Optional keeps a status file written before this field existed -- or by
-        /// any phase that reports no steps at all -- decoding cleanly.
-        var step: Int? = nil
-        var totalSteps: Int? = nil
+    // MARK: - Preflight
 
-        enum CodingKeys: String, CodingKey {
-            case state, phase, fraction, error, resultPath = "result_path"
-            case peakBytes = "peak_bytes", footprintBytes = "footprint_bytes"
-            case elapsedSeconds = "elapsed_s"
-            case step, totalSteps = "total_steps"
-        }
-    }
-
-    /// Rate-limits the status writes driven by boltz-mlx's per-step callback.
-    ///
-    /// Same policy, and the same two constants, as the weight fetcher's marker
-    /// throttle (`modules/pymol/predictors/fetching.py:38-41` --
-    /// `MARKER_INTERVAL = 0.15`, `MARKER_FRACTION_STEP = 0.01`, applied in `_emit`
-    /// at `:261-276`): skip a write only when BOTH too little time has passed AND
-    /// the bar would not visibly move, and never skip a stage's final step. A
-    /// 200-step run on a small input steps in milliseconds, and one status file
-    /// per step would be 200 atomic writes in a burst.
-    ///
-    /// `@unchecked Sendable` with its own lock, and pointedly NOT `stateQueue`:
-    /// the callback runs synchronously inside the sampling loop on the actor's
-    /// executor, while `stateQueue` is entered from the MAIN thread on every
-    /// cancel and is held for the ~10 s model build. Blocking the sampling loop
-    /// behind that would stall inference itself.
-    final class StepThrottle: @unchecked Sendable {
-        /// Floor on the gap between two writes.
-        static let interval: Double = 0.15
-        /// ...but always write when the bar would visibly move.
-        static let fractionStep: Double = 0.01
-
-        private let lock = NSLock()
-        private var lastStage = ""
-        private var lastTime: Double = 0
-        private var lastFraction: Double = 0
-
-        /// `now` is injected rather than read here so the policy is testable
-        /// without sleeping. Callers pass a MONOTONIC clock
-        /// (`ProcessInfo.processInfo.systemUptime`), not wall time.
-        func shouldEmit(stage: String, fraction: Double, isFinal: Bool,
-                        now: Double) -> Bool {
-            lock.lock()
-            defer { lock.unlock() }
-            // A stage change is itself news: the phase NAME the card shows
-            // changes, which no fraction comparison would catch.
-            let forced = isFinal || stage != lastStage
-            if !forced,
-               now - lastTime < Self.interval,
-               abs(fraction - lastFraction) < Self.fractionStep {
-                return false
-            }
-            lastStage = stage
-            lastTime = now
-            lastFraction = fraction
-            return true
-        }
-    }
-
-    static func parseRequest(at url: URL) throws -> Request {
-        try JSONDecoder().decode(Request.self, from: try Data(contentsOf: url))
-    }
-
-    /// Atomic, so a poller never reads a half-written status.
-    static func writeStatus(_ status: Status, to url: URL) throws {
-        let data = try JSONEncoder().encode(status)
-        let temp = url.appendingPathExtension("tmp")
-        try data.write(to: temp)
-        _ = try FileManager.default.replaceItemAt(url, withItemAt: temp)
-    }
-
-    #if DEBUG
-    /// Test seam: receives "write" then "discard" for each terminal settle. Same
-    /// pattern as PyMOLEngine's pythonTap -- `settle`'s ordering is the whole point
-    /// of the function and is otherwise invisible, because discardPlaceholder is a
-    /// main-queue hop into PyMOLEngine.shared that a unit test cannot observe.
-    static var settleTap: ((String) -> Void)?
-    #endif
-
-    /// Record a terminal status, THEN take the placeholder down. Order is
-    /// load-bearing: `discard_pending` pops `_PENDING`, the map every Python-derived
-    /// progress view is built from, so discarding first records the failure after the
-    /// only thing that could observe it has been deleted -- which is why an 11-minute
-    /// run that failed used to just make its object vanish.
-    ///
-    /// One function rather than six call-pairs so a seventh exit cannot get it wrong.
-    private static func settle(_ request: Request, _ status: Status, to url: URL) {
-        try? writeStatus(status, to: url)
-        #if DEBUG
-        settleTap?("write")
-        #endif
-        discardPlaceholder(request)
-        #if DEBUG
-        settleTap?("discard")
-        #endif
-    }
-
-    // MARK: - Entry point from pollFeedback()
-
-    func handle(marker line: String) {
-        guard let marker = Self.parseMarker(line) else { return }
-        switch marker.verb {
-        case .cancel:
-            // Cancel the live task so compute actually stops, and record the request for
-            // the coarse phase checks (a cancel can arrive before the task is registered).
-            // Ignore cancels for jobs already in a terminal state, so `cancelled` cannot
-            // grow without bound from stray or post-completion markers.
-            stateQueue.sync {
-                if let task = runningTasks[marker.jobID] {
-                    cancelled.insert(marker.jobID)
-                    task.cancel()
-                } else if !Self.hasTerminalStatus(jobID: marker.jobID) {
-                    cancelled.insert(marker.jobID)
-                }
-            }
-            // Broadcast: a cancel marker carries only a job id, so there is nothing in it
-            // to route on. Every manager keeps only its own ids, and a cancel for a job
-            // this one never had is a no-op. macOS only because Protenix is: iOS links
-            // no second manager, so there is nothing to broadcast to.
-            #if os(macOS)
-            ProtenixJobManager.shared.cancel(jobID: marker.jobID)
-            #endif
-        case .submit:
-            let url = URL(fileURLWithPath: NSTemporaryDirectory())
-                .appendingPathComponent("raymol_predict_req_\(marker.jobID).json")
-            let request: Request
-            do {
-                request = try Self.parseRequest(at: url)
-            } catch {
-                // Without this, an unparseable request returns silently and Python polls
-                // `queued` forever — asymmetric with preflight, which does write `failed`.
-                // The status path follows host.py's naming convention, so it is derivable
-                // even when the payload is not.
-                try? Self.writeStatus(
-                    Status(state: "failed", phase: "request", fraction: 0,
-                           error: "malformed prediction request: "
-                                + error.localizedDescription,
-                           resultPath: nil, peakBytes: nil, elapsedSeconds: nil),
-                    to: Self.statusURL(jobID: marker.jobID))
-                return
-            }
-            // Routed BEFORE preflight, because preflight below is Boltz's: its size model
-            // is fitted to Boltz's peaks, and its runtime check exists to refuse backends
-            // nothing implements. A protenix request is not that -- it has a manager.
-            //
-            // This manager owns the marker only because it was here first. When a third
-            // runtime lands, lift the parse-and-route out into a dispatcher rather than
-            // adding another branch here.
-            //
-            // macOS only, and the iOS arm needs no fallback branch: PyMOLBridge.mm
-            // advertises "boltz" alone there, so host.require_runtime refuses a protenix
-            // request in Python before any marker is printed. If one somehow arrived, it
-            // would fall through to Self.preflight below, whose runtime check refuses
-            // exactly this case with an accurate message.
-            #if os(macOS)
-            if request.runtime == ProtenixJobManager.runtimeName {
-                ProtenixJobManager.shared.submit(request)
-                return
-            }
-            #endif
-            if let failure = Self.preflight(request) {
-                // Refused before any work: the placeholder Python just created will never
-                // be filled, so drop it rather than leaving an empty stub behind.
-                Self.settle(request, failure, to: URL(fileURLWithPath: request.statusPath))
-                return
-            }
-            queue.async { self.run(request) }
-        }
-    }
-
-    /// host.py's naming convention, so a status can be reported even for a request that
-    /// could not be decoded.
-    static func statusURL(jobID: String) -> URL {
-        URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("raymol_predict_status_\(jobID).json")
-    }
-
-    /// True when a status file already records a terminal state, i.e. cancelling is moot.
-    static func hasTerminalStatus(jobID: String) -> Bool {
-        guard let data = try? Data(contentsOf: statusURL(jobID: jobID)),
-              let status = try? JSONDecoder().decode(Status.self, from: data)
-        else { return false }
-        return ["done", "failed", "cancelled"].contains(status.state)
-    }
 
     /// Refuse before allocating anything. Returns nil when the run may proceed.
     ///
     /// Sees only what the REQUEST says, because it runs on the main thread from
     /// `pollFeedback`: the alignment's real depth costs a parse of the a3m, which
     /// belongs on the inference queue. `alignmentPreflight` makes that second check.
-    static func preflight(_ request: Request) -> Status? {
+    static func preflight(_ request: InferenceJob.Request) -> InferenceJob.Status? {
         // Runtime first, before any sizing: the size model below is Boltz's, fitted to
         // Boltz's measured peaks, so applying it to another method's request would be
-        // meaningless even as a refusal. Absent means Boltz, per `Request.runtime`.
-        if let runtime = request.runtime, runtime != boltzRuntime {
-            return refusal("this build of RayMol does not carry the '\(runtime)' "
-                         + "inference runtime")
+        // meaningless even as a refusal. Absent means Boltz, per
+        // `InferenceJob.Request.runtime`.
+        if let runtime = request.runtime, runtime != runtimeName {
+            return InferenceJob.refusal(
+                "this build of RayMol does not carry the '\(runtime)' inference runtime")
         }
         let tokens = request.chains.reduce(0) { $0 + $1.sequence.count }
         switch PredictSizeGuard.decide(tokens: tokens,
@@ -404,7 +131,7 @@ final class BoltzJobManager {
             // Unreachable: this call passes no depth, so it defaults to 1. Handled
             // rather than defaulted away so that adding a depth here cannot silently
             // become "proceed".
-            return refusal("the alignment is too large for this machine")
+            return InferenceJob.refusal("the alignment is too large for this machine")
         case .ok, .warn:
             // `.warn` deliberately proceeds, so `okFraction` has no effect on this path
             // today — the tier is not yet surfaced anywhere. It is kept rather than
@@ -415,8 +142,9 @@ final class BoltzJobManager {
             // `.warn` there rather than reviving it here.
             return nil
         case let .refuse(maxFittingTokens):
-            return refusal("input of \(tokens) residues is too large for this machine; "
-                         + "at most about \(maxFittingTokens) fit")
+            return InferenceJob.refusal(
+                "input of \(tokens) residues is too large for this machine; "
+                + "at most about \(maxFittingTokens) fit")
         }
     }
 
@@ -427,8 +155,10 @@ final class BoltzJobManager {
     /// deep alignment is charged as though both chains carried it — and it is the one
     /// that cannot license a run that then dies, which is the only direction that
     /// matters here.
-    static func alignmentPreflight(_ request: Request,
-                                   alignments: [String: MSAAlignment]) -> Status? {
+    static func alignmentPreflight(_ request: InferenceJob.Request,
+                                   alignments: [String: MSAAlignment])
+        -> InferenceJob.Status?
+    {
         guard let deepest = alignments.values.map(\.depth).max(), deepest > 1 else {
             return nil
         }
@@ -438,43 +168,20 @@ final class BoltzJobManager {
         case .ok, .warn:
             return nil
         case let .refuseDepth(maxFittingDepth):
-            return refusal(
+            return InferenceJob.refusal(
                 maxFittingDepth >= 1
                     ? "an alignment \(deepest) rows deep is too large for this machine "
                     + "at \(tokens) residues; retry with msa_depth=\(maxFittingDepth)"
                     : "\(tokens) residues with an alignment is too large for this "
                     + "machine")
         case let .refuse(maxFittingTokens):
-            return refusal("input of \(tokens) residues is too large for this machine; "
-                         + "at most about \(maxFittingTokens) fit")
+            return InferenceJob.refusal(
+                "input of \(tokens) residues is too large for this machine; "
+                + "at most about \(maxFittingTokens) fit")
         }
     }
 
-    /// Both refusals read the same to a caller; only the advice differs.
-    static func refusal(_ message: String) -> Status {
-        Status(state: "failed", phase: "preflight", fraction: 0, error: message,
-               resultPath: nil, peakBytes: nil, elapsedSeconds: nil)
-    }
-
-    // MARK: - Handing the result back to Python
-
-    /// Hands the finished structure to Python, which loads it into the placeholder and
-    /// retires the pending mark in one step.
-    ///
-    /// One Python entry point rather than a load plus a bookkeeping call: a name left
-    /// marked pending after a successful load would be stripped from every subsequent
-    /// session save. `deliver_result` also pins `zoom=0` -- a prediction can land many
-    /// minutes after submit, and moving the camera then would interrupt the user.
-    static func loadResult(_ request: Request) {
-        guard let objectName = request.objectName, !objectName.isEmpty else { return }
-        let path = pythonLiteral(request.outPath)
-        let name = pythonLiteral(objectName)
-        DispatchQueue.main.async {
-            PyMOLEngine.shared.runPython(
-                "from pymol import predicting as _p; "
-                + "_p.deliver_result(\(path), \(name), seed=\(request.seed))")
-        }
-    }
+    // MARK: - Metrics
 
     /// (chain, resi) for every residue, numbered exactly as the PDB written beside it.
     ///
@@ -505,7 +212,8 @@ final class BoltzJobManager {
     /// Best effort by construction. A prediction that folded must not be reported as
     /// failed because its metrics could not be serialized, so every failure here is
     /// swallowed and the run is simply recorded without them.
-    private static func writeMetrics(request: Request, scored: ScoredStructure,
+    private static func writeMetrics(request: InferenceJob.Request,
+                                     scored: ScoredStructure,
                                      canonical: CanonicalStructure) {
         guard let path = request.metricsPath, !path.isEmpty else { return }
         let index = residueIndex(canonical)
@@ -576,26 +284,6 @@ final class BoltzJobManager {
         _ = try? FileManager.default.replaceItemAt(url, withItemAt: temp)
     }
 
-    /// A Python string literal for an arbitrary path. Paths come from our own temp dir,
-    /// but building source text without quoting is how injection bugs start.
-    private static func pythonLiteral(_ value: String) -> String {
-        "'" + value
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "'", with: "\\'")
-            .replacingOccurrences(of: "\n", with: "") + "'"
-    }
-
-    /// Drops the placeholder when a job will never produce a structure. Python only
-    /// deletes it if it is still empty, so this cannot destroy a completed result.
-    static func discardPlaceholder(_ request: Request) {
-        guard let objectName = request.objectName, !objectName.isEmpty else { return }
-        DispatchQueue.main.async {
-            PyMOLEngine.shared.runPython(
-                "from pymol import predicting as _p; "
-                + "_p.discard_pending(\(pythonLiteral(objectName)))")
-        }
-    }
-
     // MARK: - Inference
 
     /// Records one step of a running phase, from inside boltz-mlx's callback.
@@ -610,14 +298,15 @@ final class BoltzJobManager {
     /// loop, so everything it does is on inference's critical path.
     private static func reportStep(to url: URL, phase: String, fraction: Double,
                                    step: Int, totalSteps: Int) {
-        try? writeStatus(Status(state: "running", phase: phase, fraction: fraction,
+        try? InferenceJob.writeStatus(
+            InferenceJob.Status(state: "running", phase: phase, fraction: fraction,
                                 error: nil, resultPath: nil, peakBytes: nil,
                                 elapsedSeconds: nil,
                                 step: step, totalSteps: totalSteps),
-                         to: url)
+            to: url)
     }
 
-    private func run(_ request: Request) {
+    private func run(_ request: InferenceJob.Request) {
         let statusURL = URL(fileURLWithPath: request.statusPath)
         // Captured by report() below; filled in once inference completes.
         var peak: Int? = nil
@@ -625,22 +314,24 @@ final class BoltzJobManager {
         var elapsed: Double? = nil
         func report(_ state: String, _ phase: String, _ fraction: Double,
                     error: String? = nil, result: String? = nil) {
-            try? Self.writeStatus(Status(state: state, phase: phase, fraction: fraction,
-                                         error: error, resultPath: result,
-                                         peakBytes: peak, footprintBytes: footprint,
-                                         elapsedSeconds: elapsed),
-                                  to: statusURL)
+            try? InferenceJob.writeStatus(
+                InferenceJob.Status(state: state, phase: phase, fraction: fraction,
+                                    error: error, resultPath: result,
+                                    peakBytes: peak, footprintBytes: footprint,
+                                    elapsedSeconds: elapsed),
+                to: statusURL)
         }
         func isCancelled() -> Bool {
             stateQueue.sync { cancelled.contains(request.jobID) }
         }
         func settle(_ state: String, _ phase: String, error: String? = nil) {
-            Self.settle(request,
-                        Status(state: state, phase: phase, fraction: 0,
-                               error: error, resultPath: nil,
-                               peakBytes: peak, footprintBytes: footprint,
-                               elapsedSeconds: elapsed),
-                        to: statusURL)
+            InferenceJob.settle(
+                request,
+                InferenceJob.Status(state: state, phase: phase, fraction: 0,
+                                    error: error, resultPath: nil,
+                                    peakBytes: peak, footprintBytes: footprint,
+                                    elapsedSeconds: elapsed),
+                to: statusURL)
         }
 
         report("running", "featurize", 0.0)
@@ -684,7 +375,7 @@ final class BoltzJobManager {
                 // settle, not discard-then-write: discard_pending pops _PENDING, the map
                 // every progress view reads, so discarding first records the refusal
                 // after the only thing that could show it is gone.
-                Self.settle(request, failure, to: statusURL)
+                InferenceJob.settle(request, failure, to: statusURL)
                 return
             }
             let features = try BoltzFeaturizer().featurize(canonical,
@@ -726,7 +417,7 @@ final class BoltzJobManager {
             // recycling and diffusion sampling -- so a reported step is a step that
             // has genuinely been computed, not one merely queued into MLX's lazy
             // graph.
-            let throttle = StepThrottle()
+            let throttle = InferenceJob.StepThrottle()
             let onProgress: @Sendable (BoltzProgress) -> Void = { progress in
                 // "trunk" / "diffusion" EXACTLY: predictors/boltz2.py declares a
                 // band under each of those names. Spelled out here rather than
@@ -793,7 +484,7 @@ final class BoltzJobManager {
             // Load BEFORE reporting done: predict_status returning done should already
             // imply the object is populated, or a script that polls then reads the object
             // races the load.
-            Self.loadResult(request)
+            InferenceJob.loadResult(request)
             report("done", "done", 1.0, result: request.outPath)
         } catch is CancellationError {
             settle("cancelled", "inference")
@@ -826,7 +517,9 @@ final class BoltzJobManager {
     /// inert for locally generated files. Marking a multimer's rows as paired without
     /// one would assert co-evolution across the very interface an interface score
     /// measures — and that fails by reading HIGH rather than by crashing.
-    static func loadAlignments(_ request: Request) throws -> [String: MSAAlignment] {
+    static func loadAlignments(_ request: InferenceJob.Request) throws
+        -> [String: MSAAlignment]
+    {
         guard let entries = request.alignments, !entries.isEmpty else { return [:] }
         // Nil only for a request written before #297, which also carries no alignments —
         // so this fallback is for a hand-written request, and it is upstream's own cap.

--- a/swiftui/PyMOLViewer/Shared/InferenceJob.swift
+++ b/swiftui/PyMOLViewer/Shared/InferenceJob.swift
@@ -1,0 +1,327 @@
+#if os(macOS) || os(iOS)
+import Foundation
+
+/// The job SHELL every inference runtime shares: the wire format it speaks with Python,
+/// and the file-based plumbing that carries a job from a marker to a settled status.
+///
+/// RayMol has no Python→Swift call path: `PyMOLBridge.h` is one-directional and no Swift
+/// function carries a C symbol. So `cmd.predict` writes a request JSON and prints a
+/// `PREDICT:` marker, which `PyMOLEngine.pollFeedback()` already scans on a 100 ms timer
+/// — exactly how `OBJPANEL:` and `SETTINGS:ready` work. Payloads travel as tempfiles
+/// because the feedback line caps at ~1 KB.
+///
+/// Because the Python API is a job handle, nothing here needs to return a value to Python:
+/// status and result are files that Python polls. That is what makes the missing bridge
+/// direction unnecessary rather than something to build.
+///
+/// **Neutral by construction.** Nothing in here knows a method: no featurizer, no weights,
+/// no size model, and no `import` of any inference package. That is the point — this used
+/// to live inside ``BoltzJobManager``, which made every other runtime a dependent of the
+/// runtime that happened to be written first. A runtime added tomorrow uses this shell
+/// without acquiring that dependency.
+enum InferenceJob {
+
+    // MARK: - Wire format (must match modules/pymol/predictors/host.py)
+
+    struct Chain: Codable { let chain: String; let sequence: String }
+
+    /// One chain's multiple-sequence alignment, as a PATH to an a3m.
+    ///
+    /// A path rather than inline text because an alignment is megabytes — the barnase
+    /// one boltz-mlx tests against is ~1.3 MB — and base64 inside a JSON this decodes in
+    /// one gulp buys nothing over a file that is read once and dropped. Python writes
+    /// each file BEFORE the request that names it, so a request that decodes has its
+    /// alignments already complete on disk.
+    struct Alignment: Codable {
+        let chain: String
+        let a3mPath: String
+
+        enum CodingKeys: String, CodingKey { case chain, a3mPath = "a3m_path" }
+    }
+
+    /// One job, as Python wrote it.
+    ///
+    /// **EVERY OPTIONAL FIELD HERE IS OPTIONAL ON PURPOSE.** A non-optional turns any
+    /// Python/Swift version skew into "malformed prediction request" for *every* runtime at
+    /// once, instead of a request that decodes and is refused by name. That property is
+    /// what lets a Python side which predates a field keep working, and it is worth more
+    /// than the type-level guarantee a non-optional would buy — the fields that must be
+    /// present are checked by the manager that claims the runtime, which can say what is
+    /// missing.
+    struct Request: Codable {
+        let jobID: String
+        let weightsDir: String
+        let chains: [Chain]
+        /// Which backend must run this job. OPTIONAL, absent meaning
+        /// ``BoltzJobManager/runtimeName`` — every Python side that predates a second
+        /// runtime wrote no such key, and the only runtime that existed then was that one.
+        /// A request naming a runtime this build does not carry reaches the default
+        /// runtime's `preflight`, which REFUSES IT BY NAME: the weights and the featurizer
+        /// are method-specific, so running one method's request on another's backend would
+        /// not fail, it would return a confident wrong answer.
+        let runtime: String?
+        let recyclingSteps: Int
+        let diffusionSteps: Int
+        let seed: UInt64
+        let outPath: String
+        let statusPath: String
+        /// Per-chain alignments. OPTIONAL, so a request written by a Python side that
+        /// predates #297 still decodes — the same reasoning as `objectName` below.
+        ///
+        /// PARTIAL by design: a chain that is absent gets upstream's depth-1 dummy MSA
+        /// (`BoltzFeaturizer` falls back to `MSAAlignment.singleSequence`), which is
+        /// exactly the designed-binder case — a real alignment for the target, none for
+        /// the binder, because a designed binder has no homologs to align.
+        let alignments: [Alignment]?
+        /// Rows to read from each a3m, from the top. Optional for the same reason.
+        let msaDepth: Int?
+        /// Object the finished structure is loaded into. Python creates an empty
+        /// placeholder under this name at submit time; loading into it lands at state 1,
+        /// and a repeat prediction of the same sequence appends model 2, 3, ...
+        ///
+        /// OPTIONAL on purpose. Absent means "do not auto-load" — a legitimate state, and
+        /// it keeps the wire backward compatible: a non-optional field would turn any
+        /// Python/Swift skew into a hard "malformed request" failure instead of simply
+        /// falling back to the explicit `predict_result` flow. Same reasoning as the
+        /// object panel's optional `groups`/`pending` fields.
+        let objectName: String?
+        /// Where to write what this run MEASURED, as a `pymol.metrics` document (#308).
+        ///
+        /// The confidence numbers exist only in here: pLDDT rounded into a B-factor
+        /// column was the only one that used to survive, and `ScoredStructure.pae` and
+        /// `interfaceScores()` were computed on every run and thrown away. A PAE matrix
+        /// is per residue PAIR and an interface score is per run, so neither fits in
+        /// the PDB — hence a second file rather than more columns.
+        ///
+        /// Optional for the reason `objectName` is: absent simply means the Python side
+        /// predates this and records the run without them, rather than the whole request
+        /// failing to decode.
+        let metricsPath: String?
+        enum CodingKeys: String, CodingKey {
+            case jobID = "job_id", weightsDir = "weights_dir", chains, runtime
+            case recyclingSteps = "recycling_steps", diffusionSteps = "diffusion_steps"
+            case seed, outPath = "out_path", statusPath = "status_path"
+            case objectName = "object_name", metricsPath = "metrics_path"
+            case alignments, msaDepth = "msa_depth"
+        }
+    }
+
+    struct Status: Codable {
+        let state: String        // queued | running | done | failed | cancelled
+        let phase: String
+        let fraction: Double
+        let error: String?
+        let resultPath: String?
+        /// MLX's peak-memory high-water mark for THIS prediction, in bytes. Nil until the
+        /// run finishes. Reported because process RSS does not attribute MLX's Metal
+        /// allocations at all -- sampling RSS during a 250-residue run showed ~9 MB of
+        /// growth against a multi-GB actual -- so this is the only honest instrument, and
+        /// it is what `PredictSizeGuard`'s constants must be fitted against.
+        let peakBytes: Int?
+        /// The MAXIMUM `phys_footprint` this process reached during the run, in bytes,
+        /// sampled every 200 ms (see ``BoltzJobManager/FootprintSampler``). Nil until the
+        /// run finishes.
+        ///
+        /// **Not a duplicate of ``peakBytes``, and the difference is the point.** MLX's
+        /// high-water mark EXCLUDES its own buffer cache
+        /// (mlx-swift/Source/MLX/Memory.swift:171-178), so it under-reports what the
+        /// system sees. `phys_footprint` is the quantity **jetsam kills on** and the one
+        /// `os_proc_available_memory()` is denominated in — so on iOS it, not `peakBytes`,
+        /// is what ``PredictSizeGuard``'s estimate is actually racing.
+        ///
+        /// The comment above about RSS being useless refers to `resident_size`, which
+        /// omits compressed and IOKit-mapped pages and therefore misses Metal allocations
+        /// entirely. `phys_footprint` includes them; the two are different instruments and
+        /// only one of them was tried.
+        ///
+        /// Recorded rather than derived because the gap between the two is not a constant:
+        /// it is whatever the cache happens to be holding, which is exactly the thing a
+        /// fitted model cannot know.
+        var footprintBytes: Int? = nil
+        /// Wall time for the inference itself, excluding the one-time model load.
+        let elapsedSeconds: Double?
+        /// Steps completed within the CURRENT phase, and that phase's total --
+        /// e.g. diffusion step 84 of 200. `fraction` is the same thing as a ratio;
+        /// these are carried as well because "step 84 of 200" is a far more
+        /// legible sentence than "42%", and because the ETA wants the raw counts.
+        ///
+        /// `var … = nil` rather than `let`: a default keeps the memberwise
+        /// initialiser's existing call sites (and their tests) compiling, and
+        /// Optional keeps a status file written before this field existed -- or by
+        /// any phase that reports no steps at all -- decoding cleanly.
+        var step: Int? = nil
+        var totalSteps: Int? = nil
+
+        enum CodingKeys: String, CodingKey {
+            case state, phase, fraction, error, resultPath = "result_path"
+            case peakBytes = "peak_bytes", footprintBytes = "footprint_bytes"
+            case elapsedSeconds = "elapsed_s"
+            case step, totalSteps = "total_steps"
+        }
+    }
+
+    // MARK: - Progress throttling
+
+    /// Rate-limits the status writes driven by a runtime's per-step callback.
+    ///
+    /// Same policy, and the same two constants, as the weight fetcher's marker
+    /// throttle (`modules/pymol/predictors/fetching.py:38-41` --
+    /// `MARKER_INTERVAL = 0.15`, `MARKER_FRACTION_STEP = 0.01`, applied in `_emit`
+    /// at `:261-276`): skip a write only when BOTH too little time has passed AND
+    /// the bar would not visibly move, and never skip a stage's final step. A
+    /// 200-step run on a small input steps in milliseconds, and one status file
+    /// per step would be 200 atomic writes in a burst.
+    ///
+    /// `@unchecked Sendable` with **its own lock**, and pointedly NOT a manager's
+    /// `stateQueue`: the callback runs synchronously inside the sampling loop on the
+    /// actor's executor, while `stateQueue` is entered from the MAIN thread on every
+    /// cancel and is held for the ~10 s model build. Blocking the sampling loop
+    /// behind that would stall inference itself. Living out here rather than inside
+    /// one manager must not tempt anyone to share a queue with one.
+    final class StepThrottle: @unchecked Sendable {
+        /// Floor on the gap between two writes.
+        static let interval: Double = 0.15
+        /// ...but always write when the bar would visibly move.
+        static let fractionStep: Double = 0.01
+
+        private let lock = NSLock()
+        private var lastStage = ""
+        private var lastTime: Double = 0
+        private var lastFraction: Double = 0
+
+        /// `now` is injected rather than read here so the policy is testable
+        /// without sleeping. Callers pass a MONOTONIC clock
+        /// (`ProcessInfo.processInfo.systemUptime`), not wall time.
+        func shouldEmit(stage: String, fraction: Double, isFinal: Bool,
+                        now: Double) -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            // A stage change is itself news: the phase NAME the card shows
+            // changes, which no fraction comparison would catch.
+            let forced = isFinal || stage != lastStage
+            if !forced,
+               now - lastTime < Self.interval,
+               abs(fraction - lastFraction) < Self.fractionStep {
+                return false
+            }
+            lastStage = stage
+            lastTime = now
+            lastFraction = fraction
+            return true
+        }
+    }
+
+    // MARK: - Request and status files
+
+    static func parseRequest(at url: URL) throws -> Request {
+        try JSONDecoder().decode(Request.self, from: try Data(contentsOf: url))
+    }
+
+    /// Atomic, so a poller never reads a half-written status.
+    static func writeStatus(_ status: Status, to url: URL) throws {
+        let data = try JSONEncoder().encode(status)
+        let temp = url.appendingPathExtension("tmp")
+        try data.write(to: temp)
+        _ = try FileManager.default.replaceItemAt(url, withItemAt: temp)
+    }
+
+    /// host.py's naming convention, so a status can be reported even for a request that
+    /// could not be decoded.
+    static func statusURL(jobID: String) -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("raymol_predict_status_\(jobID).json")
+    }
+
+    /// True when a status file already records a terminal state, i.e. cancelling is moot.
+    static func hasTerminalStatus(jobID: String) -> Bool {
+        guard let data = try? Data(contentsOf: statusURL(jobID: jobID)),
+              let status = try? JSONDecoder().decode(Status.self, from: data)
+        else { return false }
+        return ["done", "failed", "cancelled"].contains(status.state)
+    }
+
+    /// A refusal, in the one shape every runtime's preflight returns. Both refusals read
+    /// the same to a caller; only the advice differs.
+    static func refusal(_ message: String) -> Status {
+        Status(state: "failed", phase: "preflight", fraction: 0, error: message,
+               resultPath: nil, peakBytes: nil, elapsedSeconds: nil)
+    }
+
+    // MARK: - Settling a job
+
+    #if DEBUG
+    /// Test seam: receives "write" then "discard" for each terminal settle. Same
+    /// pattern as PyMOLEngine's pythonTap -- `settle`'s ordering is the whole point
+    /// of the function and is otherwise invisible, because discardPlaceholder is a
+    /// main-queue hop into PyMOLEngine.shared that a unit test cannot observe.
+    static var settleTap: ((String) -> Void)?
+    #endif
+
+    /// Record a terminal status, THEN take the placeholder down. Order is
+    /// load-bearing: `discard_pending` pops `_PENDING`, the map every Python-derived
+    /// progress view is built from, so discarding first records the failure after the
+    /// only thing that could observe it has been deleted -- which is why an 11-minute
+    /// run that failed used to just make its object vanish.
+    ///
+    /// One function rather than six call-pairs so a seventh exit cannot get it wrong.
+    /// `discard_pending` reads the status FRESH to decide whether to retain a failure
+    /// card, so the reverse order strands the failure where nothing can observe it.
+    ///
+    /// Internal rather than private: it moved out of the manager that used to own it, so
+    /// every runtime now reaches it from outside. The ordering is the whole point of the
+    /// function, and a second copy of it is a second chance to get it backwards.
+    static func settle(_ request: Request, _ status: Status, to url: URL) {
+        try? writeStatus(status, to: url)
+        #if DEBUG
+        settleTap?("write")
+        #endif
+        discardPlaceholder(request)
+        #if DEBUG
+        settleTap?("discard")
+        #endif
+    }
+
+    // MARK: - Handing the result back to Python
+
+    /// Hands the finished structure to Python, which loads it into the placeholder and
+    /// retires the pending mark in one step.
+    ///
+    /// One Python entry point rather than a load plus a bookkeeping call: a name left
+    /// marked pending after a successful load would be stripped from every subsequent
+    /// session save. `deliver_result` also pins `zoom=0` -- a prediction can land many
+    /// minutes after submit, and moving the camera then would interrupt the user.
+    static func loadResult(_ request: Request) {
+        guard let objectName = request.objectName, !objectName.isEmpty else { return }
+        let path = pythonLiteral(request.outPath)
+        let name = pythonLiteral(objectName)
+        DispatchQueue.main.async {
+            PyMOLEngine.shared.runPython(
+                "from pymol import predicting as _p; "
+                + "_p.deliver_result(\(path), \(name), seed=\(request.seed))")
+        }
+    }
+
+    /// Drops the placeholder when a job will never produce a structure. Python only
+    /// deletes it if it is still empty, so this cannot destroy a completed result.
+    static func discardPlaceholder(_ request: Request) {
+        guard let objectName = request.objectName, !objectName.isEmpty else { return }
+        DispatchQueue.main.async {
+            PyMOLEngine.shared.runPython(
+                "from pymol import predicting as _p; "
+                + "_p.discard_pending(\(pythonLiteral(objectName)))")
+        }
+    }
+
+    /// A Python string literal for an arbitrary path. Paths come from our own temp dir,
+    /// but building source text without quoting is how injection bugs start.
+    /// PyMOL's text parser does not strip quotes from a `"..."` token, so an object name
+    /// has to be escaped exactly this way or a name with an apostrophe breaks the call.
+    /// Private: both callers are right here.
+    private static func pythonLiteral(_ value: String) -> String {
+        "'" + value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "'", with: "\\'")
+            .replacingOccurrences(of: "\n", with: "") + "'"
+    }
+}
+#endif

--- a/swiftui/PyMOLViewer/Shared/InferenceRouter.swift
+++ b/swiftui/PyMOLViewer/Shared/InferenceRouter.swift
@@ -1,0 +1,144 @@
+#if os(macOS) || os(iOS)
+import Foundation
+
+/// What a manager must be for the router to reach it.
+///
+/// Exists to kill a naming drift that had already started: the first manager called its
+/// wire name `boltzRuntime`, the second called its `runtimeName`, and nothing enforced a
+/// shape because each new runtime was wired in by hand at the call site. A protocol makes
+/// the table uniform, which is what lets ``InferenceRouter`` dispatch by loop instead of by
+/// a branch per runtime — and a branch per runtime is exactly how a runtime ends up
+/// routable but not cancellable.
+///
+/// Deliberately three members and no more. Everything method-specific — the featurizer, the
+/// weights, the size model, the result writer — is the conformer's own business; the router
+/// only needs to know a runtime's name and how to start and stop a job.
+protocol InferenceRuntime: AnyObject {
+    /// This runtime's name as it appears on the wire, in `Request.runtime`. Kept in step
+    /// with the Python side's `RUNTIME` constant and with what `PyMOLBridge` advertises in
+    /// `RAYMOL_PREDICT_RUNTIMES` — that variable is what lets a method whose backend is NOT
+    /// linked here refuse in `check_available` instead of submitting a job that only gets
+    /// refused after a weight download.
+    static var runtimeName: String { get }
+
+    /// Refuse or accept a submitted request. Runs on the MAIN thread, so it must not block:
+    /// the app drains PyMOL's feedback buffer from a main-run-loop timer, and a blocked main
+    /// thread cannot deliver even the messages describing why it is blocked.
+    func submit(_ request: InferenceJob.Request)
+
+    /// Note a cancel. Must be idempotent, and safe for a job id this runtime never had — a
+    /// cancel marker carries only a job id, so it is broadcast to every runtime and each
+    /// keeps only its own.
+    func cancel(jobID: String)
+}
+
+/// Owns the `PREDICT:` marker and the table of runtimes it can reach.
+///
+/// The dispatcher lives here rather than inside one of its own targets. It used to be a
+/// branch inside ``BoltzJobManager/handle(marker:)``, which made the two managers a cycle:
+/// Protenix reached in for the wire types and the shell, and Boltz reached back out to
+/// route and to broadcast cancels. Boltz owned the marker only because it was written
+/// first, and the note at that branch asked for exactly this — "when a third runtime
+/// lands, lift the parse-and-route out into a dispatcher rather than adding another branch
+/// here". Doing it now rather than then means the third runtime arrives as a peer instead
+/// of being added to a cycle.
+enum InferenceRouter {
+
+    // MARK: - Marker parsing
+
+    enum Verb: String { case submit, cancel }
+    struct Marker: Equatable { let verb: Verb; let jobID: String }
+
+    static func parseMarker(_ line: String) -> Marker? {
+        guard line.hasPrefix("PREDICT:") else { return nil }
+        let body = line.dropFirst("PREDICT:".count)
+        let parts = body.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+        guard parts.count == 2,
+              let verb = Verb(rawValue: String(parts[0])),
+              !parts[1].isEmpty else { return nil }
+        return Marker(verb: verb, jobID: String(parts[1]))
+    }
+
+    // MARK: - The table
+
+    /// The runtime a request that names NO runtime is handed to.
+    ///
+    /// `nil` means Boltz, per ``InferenceJob/Request/runtime``: every Python side that
+    /// predates a second runtime wrote no such key, and the only runtime that existed then
+    /// was this one.
+    ///
+    /// It is also where a request naming a runtime this build does not carry lands — see
+    /// ``runtime(for:)``.
+    static let defaultRuntime: any InferenceRuntime = BoltzJobManager.shared
+
+    /// Every runtime this build links.
+    ///
+    /// ONE list, read by both `submit` and `cancel`. That is the point of it: when the two
+    /// were written out separately, keeping them in step was a thing a human had to
+    /// remember, and a runtime that is routable but not cancellable is a job the user
+    /// cannot stop. Adding a third runtime is now one line, and it cannot be added to one
+    /// path and forgotten in the other.
+    ///
+    /// A runtime is claimed by exactly one entry because the weights and the featurizer are
+    /// method-specific: running one method's request on another's backend does not fail, it
+    /// tokenizes with the wrong featurizer and returns a confident wrong answer.
+    ///
+    /// iOS carries the Boltz runtime alone (see PyMOLBridge.mm), so nothing else is linked
+    /// there and a foreign runtime must reach Boltz's refusal rather than be silently
+    /// accepted.
+    static let runtimes: [any InferenceRuntime] = {
+        var table: [any InferenceRuntime] = [BoltzJobManager.shared]
+        #if os(macOS)
+        table.append(ProtenixJobManager.shared)
+        #endif
+        return table
+    }()
+
+    /// The runtime that claims `name`, or the default.
+    ///
+    /// An unclaimed runtime deliberately falls through to the default, whose `preflight`
+    /// refuses it BY NAME. That is how a Python side offering a method this build did not
+    /// link gets a real error instead of a job that never reports.
+    private static func runtime(for name: String?) -> any InferenceRuntime {
+        guard let name else { return defaultRuntime }
+        return runtimes.first { type(of: $0).runtimeName == name } ?? defaultRuntime
+    }
+
+    // MARK: - Entry point from pollFeedback()
+
+    /// Dispatch one `PREDICT:` marker. The single entry point `PyMOLEngine.pollFeedback()`
+    /// calls, for every job.
+    static func handle(marker line: String) {
+        guard let marker = parseMarker(line) else { return }
+        switch marker.verb {
+        case .cancel:
+            // Broadcast: a cancel marker carries only a job id, so there is nothing in it
+            // to route on. Every runtime keeps only its own ids, and a cancel for a job
+            // this one never had is a no-op.
+            for runtime in runtimes { runtime.cancel(jobID: marker.jobID) }
+        case .submit:
+            let url = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("raymol_predict_req_\(marker.jobID).json")
+            let request: InferenceJob.Request
+            do {
+                request = try InferenceJob.parseRequest(at: url)
+            } catch {
+                // Without this, an unparseable request returns silently and Python polls
+                // `queued` forever — asymmetric with preflight, which does write `failed`.
+                // The status path follows host.py's naming convention, so it is derivable
+                // even when the payload is not. `writeStatus` rather than `settle`: there
+                // is no decoded request, so there is no object name to discard.
+                try? InferenceJob.writeStatus(
+                    InferenceJob.Status(state: "failed", phase: "request", fraction: 0,
+                                        error: "malformed prediction request: "
+                                             + error.localizedDescription,
+                                        resultPath: nil, peakBytes: nil,
+                                        elapsedSeconds: nil),
+                    to: InferenceJob.statusURL(jobID: marker.jobID))
+                return
+            }
+            runtime(for: request.runtime).submit(request)
+        }
+    }
+}
+#endif

--- a/swiftui/PyMOLViewer/Shared/PredictController.swift
+++ b/swiftui/PyMOLViewer/Shared/PredictController.swift
@@ -38,7 +38,7 @@ struct PredictSizeWarning: Equatable {
 
 extension PredictController {
 
-    /// A Python single-quoted string literal. Matches BoltzJobManager.pythonLiteral.
+    /// A Python single-quoted string literal. Matches InferenceJob.pythonLiteral.
     nonisolated static func pythonLiteral(_ value: String) -> String {
         "'" + value
             .replacingOccurrences(of: "\\", with: "\\\\")

--- a/swiftui/PyMOLViewer/Shared/ProgressTray.swift
+++ b/swiftui/PyMOLViewer/Shared/ProgressTray.swift
@@ -157,7 +157,7 @@ struct ProgressItem: Identifiable, Equatable {
     }
 
     /// A Python single-quoted string literal for an arbitrary object name.
-    /// Matches the escaping in BoltzJobManager.pythonLiteral(_:).
+    /// Matches the escaping in InferenceJob.pythonLiteral(_:).
     private static func pythonLiteral(_ value: String) -> String {
         "'" + value
             .replacingOccurrences(of: "\\", with: "\\\\")

--- a/swiftui/PyMOLViewer/Shared/ProtenixJobManager.swift
+++ b/swiftui/PyMOLViewer/Shared/ProtenixJobManager.swift
@@ -5,12 +5,12 @@ import ProtenixMLX
 
 /// Runs the `protenix` inference runtime: the second backend behind `cmd.predict`.
 ///
-/// The job SHELL is shared with ``BoltzJobManager`` — marker parsing, request decoding,
-/// atomic status writes, placeholder discard and result autoload are its static helpers,
-/// used here rather than reimplemented, because "the status file went missing on a
-/// cancelled job" is the class of bug you only find in production. What is not shared is
-/// everything inside `run`: the featurizer, the weights and the network are
-/// method-specific, which is the whole reason a request has to name its runtime.
+/// The job SHELL is ``InferenceJob`` — request decoding, atomic status writes, placeholder
+/// discard and result autoload are its static helpers, used here rather than reimplemented,
+/// because "the status file went missing on a cancelled job" is the class of bug you only
+/// find in production. What is not shared is everything inside `run`: the featurizer, the
+/// weights and the network are method-specific, which is the whole reason a request has to
+/// name its runtime.
 ///
 /// Three differences from the Boltz path are worth knowing:
 ///
@@ -24,7 +24,7 @@ import ProtenixMLX
 ///   cancellation points at all.
 /// * **Progress is real.** `FoldProgress.fraction` is weighted by measured phase cost, so
 ///   the reported fraction tracks the wall clock instead of jumping at phase boundaries.
-final class ProtenixJobManager {
+final class ProtenixJobManager: InferenceRuntime {
 
     static let shared = ProtenixJobManager()
 
@@ -47,13 +47,19 @@ final class ProtenixJobManager {
 
     private init() {}
 
-    // MARK: Entry points, called by BoltzJobManager's marker routing
+    /// Test seam, matching ``BoltzJobManager``'s. UNGATED for the same reason those are:
+    /// `InferenceRouterTests` reads it to prove the cancel broadcast reaches a runtime
+    /// that is neither the first table entry nor the default, and a `#if DEBUG` here would
+    /// not compile against a Release app host.
+    var cancelRequestedForTesting: Set<String> { stateQueue.sync { cancelled } }
+
+    // MARK: InferenceRuntime
 
     /// Refuse or accept a submitted request. Runs on the MAIN thread.
-    func submit(_ request: BoltzJobManager.Request) {
+    func submit(_ request: InferenceJob.Request) {
         if let failure = Self.preflight(request) {
-            BoltzJobManager.discardPlaceholder(request)
-            try? BoltzJobManager.writeStatus(
+            InferenceJob.discardPlaceholder(request)
+            try? InferenceJob.writeStatus(
                 failure, to: URL(fileURLWithPath: request.statusPath))
             return
         }
@@ -61,17 +67,17 @@ final class ProtenixJobManager {
     }
 
     /// Note a cancel. Idempotent, and safe for a job id this manager never had — the
-    /// marker carries no runtime, so cancels are broadcast to every manager and each
+    /// marker carries no runtime, so cancels are broadcast to every runtime and each
     /// keeps only its own.
     func cancel(jobID: String) {
         stateQueue.sync {
-            guard !BoltzJobManager.hasTerminalStatus(jobID: jobID) else { return }
+            guard !InferenceJob.hasTerminalStatus(jobID: jobID) else { return }
             cancelled.insert(jobID)
         }
     }
 
     /// Refuse before allocating anything, on what the request alone says.
-    static func preflight(_ request: BoltzJobManager.Request) -> BoltzJobManager.Status? {
+    static func preflight(_ request: InferenceJob.Request) -> InferenceJob.Status? {
         let tokens = request.chains.reduce(0) { $0 + $1.sequence.count }
         // The variant, not just the length: v2 costs ~35% more than base at 60 residues
         // and ~22% more at 250, so sizing it against base's curve is optimistic, which
@@ -81,14 +87,14 @@ final class ProtenixJobManager {
         switch ProtenixSizeGuard.decide(tokens: tokens, variant: variant,
                                         availableBytes: PredictSizeGuard.availableBytes) {
         case .refuse(let maxFitting):
-            return BoltzJobManager.refusal(
+            return InferenceJob.refusal(
                 "\(tokens) residues is too large for this machine; at most "
                 + "\(maxFitting) fit")
         case .refuseDepth:
             // Unreachable: Protenix declares no msa_depth, so no request carries one.
             // Handled rather than defaulted away so that adding alignments later cannot
             // silently become "proceed".
-            return BoltzJobManager.refusal("alignments are not supported by protenix")
+            return InferenceJob.refusal("alignments are not supported by protenix")
         case .ok, .warn:
             // `.warn` proceeds, matching the Boltz path: the tier is not surfaced
             // anywhere yet, and inventing a caution channel for it here would be
@@ -99,16 +105,16 @@ final class ProtenixJobManager {
 
     // MARK: Inference
 
-    private func run(_ request: BoltzJobManager.Request) {
+    private func run(_ request: InferenceJob.Request) {
         let statusURL = URL(fileURLWithPath: request.statusPath)
         var peak: Int? = nil
         var elapsed: Double? = nil
         @Sendable func report(_ state: String, _ phase: String, _ fraction: Double,
                               error: String? = nil, result: String? = nil) {
-            try? BoltzJobManager.writeStatus(
-                BoltzJobManager.Status(state: state, phase: phase, fraction: fraction,
-                                       error: error, resultPath: result,
-                                       peakBytes: peak, elapsedSeconds: elapsed),
+            try? InferenceJob.writeStatus(
+                InferenceJob.Status(state: state, phase: phase, fraction: fraction,
+                                    error: error, resultPath: result,
+                                    peakBytes: peak, elapsedSeconds: elapsed),
                 to: statusURL)
         }
         func isCancelled() -> Bool {
@@ -130,7 +136,7 @@ final class ProtenixJobManager {
                 name: request.objectName ?? "prediction")
 
             if isCancelled() {
-                BoltzJobManager.discardPlaceholder(request)
+                InferenceJob.discardPlaceholder(request)
                 report("cancelled", "featurize", 0); return
             }
 
@@ -185,13 +191,13 @@ final class ProtenixJobManager {
                            atomically: true, encoding: .utf8)
             // Load BEFORE reporting done, so a script that polls then reads the object
             // does not race the load.
-            BoltzJobManager.loadResult(request)
+            InferenceJob.loadResult(request)
             report("done", "done", 1.0, result: request.outPath)
         } catch ProtenixError.cancelled {
-            BoltzJobManager.discardPlaceholder(request)
+            InferenceJob.discardPlaceholder(request)
             report("cancelled", "inference", 0)
         } catch {
-            BoltzJobManager.discardPlaceholder(request)
+            InferenceJob.discardPlaceholder(request)
             report("failed", "inference", 0,
                    error: (error as? LocalizedError)?.errorDescription
                        ?? error.localizedDescription)

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -3216,7 +3216,9 @@ final class PyMOLEngine: ObservableObject {
                 } else if line.hasPrefix("PREDICT:") {
                     // Structure prediction (#224). cmd.predict writes a request JSON to
                     // the temp dir and prints this marker; there is no Python->Swift call
-                    // path, so this poll IS the invocation. Deliberately NOT inside the
+                    // path, so this poll IS the invocation. The ROUTER picks the runtime
+                    // from the request, so no manager sees a job that is not its own.
+                    // Deliberately NOT inside the
                     // MAS-restricted #if used for MCP: below -- prediction ships in every
                     // build, on both platforms. No #if at all now: on iOS the marker can
                     // only be printed if cmd.predict got past host.available(), which is
@@ -3224,7 +3226,7 @@ final class PyMOLEngine: ObservableObject {
                     // does not in the Simulator. The platform gate lives there and in
                     // PredictAvailability, so a guard here would only be a third place to
                     // forget.
-                    BoltzJobManager.shared.handle(marker: line)
+                    InferenceRouter.handle(marker: line)
                 } else if line.hasPrefix("PREDICT_FORM:ready") {
                     parsePredictFormFeedback()
                 } else if line.hasPrefix("PREDICT_FORM:err") {

--- a/swiftui/PyMOLViewerTests/BoltzJobManagerMSATests.swift
+++ b/swiftui/PyMOLViewerTests/BoltzJobManagerMSATests.swift
@@ -71,7 +71,7 @@ final class BoltzJobManagerMSATests: XCTestCase {
     /// request" failure instead of a single-sequence run.
     func testARequestWithoutAlignmentsStillDecodes() throws {
         let url = try writeRequest(job: "old", chains: [("A", "MKTAY")])
-        let parsed = try BoltzJobManager.parseRequest(at: url)
+        let parsed = try InferenceJob.parseRequest(at: url)
         XCTAssertNil(parsed.alignments)
         XCTAssertNil(parsed.msaDepth)
     }
@@ -81,7 +81,7 @@ final class BoltzJobManagerMSATests: XCTestCase {
         let url = try writeRequest(job: "a1", chains: [("A", "MKTAY")],
                                    alignments: [["chain": "A", "a3m_path": path]],
                                    msaDepth: 16_384)
-        let parsed = try BoltzJobManager.parseRequest(at: url)
+        let parsed = try InferenceJob.parseRequest(at: url)
         XCTAssertEqual(parsed.alignments?.map(\.chain), ["A"])
         XCTAssertEqual(parsed.alignments?.first?.a3mPath, path)
         XCTAssertEqual(parsed.msaDepth, 16_384)
@@ -96,7 +96,7 @@ final class BoltzJobManagerMSATests: XCTestCase {
                                    alignments: [["chain": "A", "a3m_path": a],
                                                 ["chain": "B", "a3m_path": b]])
         let loaded = try BoltzJobManager.loadAlignments(
-            try BoltzJobManager.parseRequest(at: url))
+            try InferenceJob.parseRequest(at: url))
         XCTAssertEqual(Set(loaded.keys), ["A", "B"])
         XCTAssertEqual(loaded["A"]?.depth, 3)
         XCTAssertEqual(loaded["B"]?.depth, 5)
@@ -110,14 +110,14 @@ final class BoltzJobManagerMSATests: XCTestCase {
         let url = try writeRequest(job: "a3", chains: [("A", "MKTAY"), ("B", "GSHMA")],
                                    alignments: [["chain": "A", "a3m_path": a]])
         let loaded = try BoltzJobManager.loadAlignments(
-            try BoltzJobManager.parseRequest(at: url))
+            try InferenceJob.parseRequest(at: url))
         XCTAssertEqual(Array(loaded.keys), ["A"])
     }
 
     func testNoAlignmentsMeansAnEmptyMapNotAFailure() throws {
         let url = try writeRequest(job: "a4", chains: [("A", "MKTAY")])
         XCTAssertEqual(try BoltzJobManager.loadAlignments(
-            try BoltzJobManager.parseRequest(at: url)).count, 0)
+            try InferenceJob.parseRequest(at: url)).count, 0)
     }
 
     /// The depth lever is applied by the PARSER, which counts rows after deduplication
@@ -129,7 +129,7 @@ final class BoltzJobManagerMSATests: XCTestCase {
                                    alignments: [["chain": "A", "a3m_path": path]],
                                    msaDepth: 4)
         let loaded = try BoltzJobManager.loadAlignments(
-            try BoltzJobManager.parseRequest(at: url))
+            try InferenceJob.parseRequest(at: url))
         XCTAssertEqual(loaded["A"]?.depth, 4)
     }
 
@@ -138,7 +138,7 @@ final class BoltzJobManagerMSATests: XCTestCase {
             job: "a6", chains: [("A", "MKTAY")],
             alignments: [["chain": "A",
                           "a3m_path": dir.appendingPathComponent("gone.a3m").path]])
-        let request = try BoltzJobManager.parseRequest(at: url)
+        let request = try InferenceJob.parseRequest(at: url)
         XCTAssertThrowsError(try BoltzJobManager.loadAlignments(request))
     }
 
@@ -150,7 +150,7 @@ final class BoltzJobManagerMSATests: XCTestCase {
         let url = try writeRequest(job: "a7", chains: [("A", "MKTAY")],
                                    alignments: [["chain": "A", "a3m_path": path]])
         let loaded = try BoltzJobManager.loadAlignments(
-            try BoltzJobManager.parseRequest(at: url))
+            try InferenceJob.parseRequest(at: url))
         XCTAssertEqual(loaded["A"]?.depth, 3)
         XCTAssertEqual(BoltzInputLimits.desktop.maximumMSADepth, 16_384)
     }
@@ -238,13 +238,13 @@ final class BoltzJobManagerMSATests: XCTestCase {
         ]
         try JSONSerialization.data(withJSONObject: payload).write(to: requestURL)
 
-        BoltzJobManager.shared.handle(marker: "PREDICT:submit:\(job)")
+        InferenceRouter.handle(marker: "PREDICT:submit:\(job)")
 
         let settled = expectation(description: "job settles")
         let poll = DispatchQueue(label: "poll")
         func check(_ attempt: Int) {
             if let data = try? Data(contentsOf: statusURL),
-               let status = try? JSONDecoder().decode(BoltzJobManager.Status.self,
+               let status = try? JSONDecoder().decode(InferenceJob.Status.self,
                                                       from: data),
                status.state != "queued" {
                 return settled.fulfill()
@@ -256,7 +256,7 @@ final class BoltzJobManagerMSATests: XCTestCase {
         wait(for: [settled], timeout: 40)
 
         let data = try Data(contentsOf: statusURL)
-        let status = try JSONDecoder().decode(BoltzJobManager.Status.self, from: data)
+        let status = try JSONDecoder().decode(InferenceJob.Status.self, from: data)
         XCTAssertEqual(status.state, "failed")
         let error = try XCTUnwrap(status.error)
         XCTAssertTrue(error.contains("chain A"), error)

--- a/swiftui/PyMOLViewerTests/BoltzJobManagerTests.swift
+++ b/swiftui/PyMOLViewerTests/BoltzJobManagerTests.swift
@@ -68,7 +68,7 @@ final class BoltzJobManagerTests: XCTestCase {
 
     func testDecodesARequestWrittenInHostPysFormat() throws {
         let url = try writeRequest(job: "j1", chains: [("A", "AG"), ("B", "W")])
-        let parsed = try BoltzJobManager.parseRequest(at: url)
+        let parsed = try InferenceJob.parseRequest(at: url)
         XCTAssertEqual(parsed.jobID, "j1")
         XCTAssertEqual(parsed.chains.map(\.chain), ["A", "B"])
         XCTAssertEqual(parsed.chains.map(\.sequence), ["AG", "W"])
@@ -91,7 +91,7 @@ final class BoltzJobManagerTests: XCTestCase {
             "object_name": "prediction_deadbeef",
         ]
         try JSONSerialization.data(withJSONObject: payload).write(to: url)
-        XCTAssertEqual(try BoltzJobManager.parseRequest(at: url).objectName,
+        XCTAssertEqual(try InferenceJob.parseRequest(at: url).objectName,
                        "prediction_deadbeef")
     }
 
@@ -99,7 +99,7 @@ final class BoltzJobManagerTests: XCTestCase {
     /// a strict field would turn Python/Swift skew into a hard failure.
     func testRequestWithoutAnObjectNameStillDecodes() throws {
         let url = try writeRequest(job: "noname", chains: [("A", "AG")])
-        let parsed = try BoltzJobManager.parseRequest(at: url)
+        let parsed = try InferenceJob.parseRequest(at: url)
         XCTAssertNil(parsed.objectName)
     }
 
@@ -114,12 +114,12 @@ final class BoltzJobManagerTests: XCTestCase {
             "out_path": "/tmp/o.pdb", "status_path": "/tmp/s.json",
         ]
         try JSONSerialization.data(withJSONObject: payload).write(to: url)
-        XCTAssertThrowsError(try BoltzJobManager.parseRequest(at: url))
+        XCTAssertThrowsError(try InferenceJob.parseRequest(at: url))
     }
 
     func testStatusRoundTripsWithSnakeCaseKeys() throws {
         let path = dir.appendingPathComponent("raymol_predict_status_j2.json")
-        try BoltzJobManager.writeStatus(
+        try InferenceJob.writeStatus(
             .init(state: "running", phase: "inference", fraction: 0.5,
                   error: nil, resultPath: "/tmp/x.pdb", peakBytes: nil,
                   elapsedSeconds: nil), to: path)
@@ -128,14 +128,14 @@ final class BoltzJobManagerTests: XCTestCase {
             with: try Data(contentsOf: path)) as? [String: Any]
         XCTAssertEqual(raw?["state"] as? String, "running")
         XCTAssertEqual(raw?["result_path"] as? String, "/tmp/x.pdb")
-        let decoded = try JSONDecoder().decode(BoltzJobManager.Status.self,
+        let decoded = try JSONDecoder().decode(InferenceJob.Status.self,
                                                from: try Data(contentsOf: path))
         XCTAssertEqual(decoded.fraction, 0.5)
     }
 
     func testStatusCarriesPeakMemoryAndElapsedWithSnakeCaseKeys() throws {
         let path = dir.appendingPathComponent("raymol_predict_status_j6.json")
-        try BoltzJobManager.writeStatus(
+        try InferenceJob.writeStatus(
             .init(state: "done", phase: "done", fraction: 1.0, error: nil,
                   resultPath: "/tmp/x.pdb", peakBytes: 4_294_967_296,
                   elapsedSeconds: 65.3), to: path)
@@ -143,7 +143,7 @@ final class BoltzJobManagerTests: XCTestCase {
             with: try Data(contentsOf: path)) as? [String: Any]
         XCTAssertEqual(raw?["peak_bytes"] as? Int, 4_294_967_296)
         XCTAssertEqual(raw?["elapsed_s"] as? Double, 65.3)
-        let decoded = try JSONDecoder().decode(BoltzJobManager.Status.self,
+        let decoded = try JSONDecoder().decode(InferenceJob.Status.self,
                                                from: try Data(contentsOf: path))
         XCTAssertEqual(decoded.peakBytes, 4_294_967_296)
     }
@@ -151,10 +151,10 @@ final class BoltzJobManagerTests: XCTestCase {
     /// Absent while a job is still running -- Python's queued fallback mirrors that.
     func testPeakMemoryIsNilBeforeCompletion() throws {
         let path = dir.appendingPathComponent("raymol_predict_status_j7.json")
-        try BoltzJobManager.writeStatus(
+        try InferenceJob.writeStatus(
             .init(state: "running", phase: "inference", fraction: 0.2, error: nil,
                   resultPath: nil, peakBytes: nil, elapsedSeconds: nil), to: path)
-        let decoded = try JSONDecoder().decode(BoltzJobManager.Status.self,
+        let decoded = try JSONDecoder().decode(InferenceJob.Status.self,
                                                from: try Data(contentsOf: path))
         XCTAssertNil(decoded.peakBytes)
         XCTAssertNil(decoded.elapsedSeconds)
@@ -165,7 +165,7 @@ final class BoltzJobManagerTests: XCTestCase {
     /// spelling is the contract, not the Swift property name.
     func testStatusCarriesStepCountsWithSnakeCaseKeys() throws {
         let path = dir.appendingPathComponent("raymol_predict_status_j8.json")
-        try BoltzJobManager.writeStatus(
+        try InferenceJob.writeStatus(
             .init(state: "running", phase: "diffusion", fraction: 0.42, error: nil,
                   resultPath: nil, peakBytes: nil, elapsedSeconds: nil,
                   step: 84, totalSteps: 200), to: path)
@@ -174,7 +174,7 @@ final class BoltzJobManagerTests: XCTestCase {
         XCTAssertEqual(raw?["phase"] as? String, "diffusion")
         XCTAssertEqual(raw?["step"] as? Int, 84)
         XCTAssertEqual(raw?["total_steps"] as? Int, 200)
-        let decoded = try JSONDecoder().decode(BoltzJobManager.Status.self,
+        let decoded = try JSONDecoder().decode(InferenceJob.Status.self,
                                                from: try Data(contentsOf: path))
         XCTAssertEqual(decoded.step, 84)
         XCTAssertEqual(decoded.totalSteps, 200)
@@ -189,7 +189,7 @@ final class BoltzJobManagerTests: XCTestCase {
         {"state":"running","phase":"load","fraction":0.1,"error":null,
          "result_path":null,"peak_bytes":null,"elapsed_s":null}
         """.utf8).write(to: path)
-        let decoded = try JSONDecoder().decode(BoltzJobManager.Status.self,
+        let decoded = try JSONDecoder().decode(InferenceJob.Status.self,
                                                from: try Data(contentsOf: path))
         XCTAssertEqual(decoded.phase, "load")
         XCTAssertNil(decoded.step)
@@ -201,7 +201,7 @@ final class BoltzJobManagerTests: XCTestCase {
     /// A 200-step run on a small input steps in milliseconds. Unthrottled that is
     /// 200 atomic status writes in a burst, on inference's own critical path.
     func testTheThrottleSkipsStepsThatAreNeitherTimelyNorVisible() {
-        let throttle = BoltzJobManager.StepThrottle()
+        let throttle = InferenceJob.StepThrottle()
         XCTAssertTrue(throttle.shouldEmit(stage: "diffusion", fraction: 0.0,
                                           isFinal: false, now: 0),
                       "the first step of a stage is always news")
@@ -213,14 +213,14 @@ final class BoltzJobManagerTests: XCTestCase {
     /// Either threshold alone is enough — the same OR that fetching.py's `_emit`
     /// applies to the WEIGHTS: marker.
     func testTheThrottleEmitsOnAOnePercentMoveEvenWhenNoTimeHasPassed() {
-        let throttle = BoltzJobManager.StepThrottle()
+        let throttle = InferenceJob.StepThrottle()
         _ = throttle.shouldEmit(stage: "diffusion", fraction: 0.0, isFinal: false, now: 0)
         XCTAssertTrue(throttle.shouldEmit(stage: "diffusion", fraction: 0.01,
                                           isFinal: false, now: 0.001))
     }
 
     func testTheThrottleEmitsOnTheIntervalEvenWhenTheBarHasNotMoved() {
-        let throttle = BoltzJobManager.StepThrottle()
+        let throttle = InferenceJob.StepThrottle()
         _ = throttle.shouldEmit(stage: "diffusion", fraction: 0.5, isFinal: false, now: 0)
         XCTAssertFalse(throttle.shouldEmit(stage: "diffusion", fraction: 0.5,
                                            isFinal: false, now: 0.14))
@@ -231,7 +231,7 @@ final class BoltzJobManagerTests: XCTestCase {
     /// A dropped final step would leave the card parked one step short forever,
     /// because nothing follows it inside the stage.
     func testTheThrottleAlwaysEmitsAStagesFinalStep() {
-        let throttle = BoltzJobManager.StepThrottle()
+        let throttle = InferenceJob.StepThrottle()
         _ = throttle.shouldEmit(stage: "diffusion", fraction: 0.995, isFinal: false, now: 0)
         XCTAssertTrue(throttle.shouldEmit(stage: "diffusion", fraction: 1.0,
                                           isFinal: true, now: 0.001),
@@ -243,7 +243,7 @@ final class BoltzJobManagerTests: XCTestCase {
     /// would catch: trunk ends at 1.0 and diffusion's first step can also be 1.0
     /// of 1 in the degenerate case.
     func testTheThrottleAlwaysEmitsTheFirstStepOfANewStage() {
-        let throttle = BoltzJobManager.StepThrottle()
+        let throttle = InferenceJob.StepThrottle()
         _ = throttle.shouldEmit(stage: "trunk", fraction: 0.75, isFinal: false, now: 0)
         XCTAssertTrue(throttle.shouldEmit(stage: "diffusion", fraction: 0.75,
                                           isFinal: false, now: 0.001))
@@ -254,7 +254,7 @@ final class BoltzJobManagerTests: XCTestCase {
     /// is the deliberate floor: it is the rate at which the bar visibly moves,
     /// and it is exactly the ceiling fetching.py accepts for the WEIGHTS: marker.
     func testAFastTwoHundredStepRunIsThrottledBelowOneWritePerStep() {
-        let throttle = BoltzJobManager.StepThrottle()
+        let throttle = InferenceJob.StepThrottle()
         var emitted = 0
         for step in 1...200 {
             // 200 steps in 100 ms: every step is well inside the interval, and
@@ -272,7 +272,7 @@ final class BoltzJobManagerTests: XCTestCase {
 
     func testStatusWriteIsAtomicLeavingNoTempBehind() throws {
         let path = dir.appendingPathComponent("raymol_predict_status_j5.json")
-        try BoltzJobManager.writeStatus(
+        try InferenceJob.writeStatus(
             .init(state: "done", phase: "done", fraction: 1.0,
                   error: nil, resultPath: nil, peakBytes: nil,
                   elapsedSeconds: nil), to: path)
@@ -285,27 +285,27 @@ final class BoltzJobManagerTests: XCTestCase {
     // MARK: - Marker parsing
 
     func testParsesSubmitAndCancelVerbs() {
-        XCTAssertEqual(BoltzJobManager.parseMarker("PREDICT:submit:j1")?.verb, .submit)
-        XCTAssertEqual(BoltzJobManager.parseMarker("PREDICT:cancel:j1")?.verb, .cancel)
-        XCTAssertEqual(BoltzJobManager.parseMarker("PREDICT:submit:j1")?.jobID, "j1")
+        XCTAssertEqual(InferenceRouter.parseMarker("PREDICT:submit:j1")?.verb, .submit)
+        XCTAssertEqual(InferenceRouter.parseMarker("PREDICT:cancel:j1")?.verb, .cancel)
+        XCTAssertEqual(InferenceRouter.parseMarker("PREDICT:submit:j1")?.jobID, "j1")
     }
 
     func testRejectsUnknownVerbsAndForeignPrefixes() {
-        XCTAssertNil(BoltzJobManager.parseMarker("PREDICT:frobnicate:j1"))
-        XCTAssertNil(BoltzJobManager.parseMarker("OBJPANEL:ready"))
-        XCTAssertNil(BoltzJobManager.parseMarker("PREDICT:submit:"))
-        XCTAssertNil(BoltzJobManager.parseMarker("PREDICT:submit"))
-        XCTAssertNil(BoltzJobManager.parseMarker(""))
+        XCTAssertNil(InferenceRouter.parseMarker("PREDICT:frobnicate:j1"))
+        XCTAssertNil(InferenceRouter.parseMarker("OBJPANEL:ready"))
+        XCTAssertNil(InferenceRouter.parseMarker("PREDICT:submit:"))
+        XCTAssertNil(InferenceRouter.parseMarker("PREDICT:submit"))
+        XCTAssertNil(InferenceRouter.parseMarker(""))
     }
 
     /// A job id containing a colon must survive, since maxSplits caps the split at one.
     func testJobIdMayContainAColon() {
-        XCTAssertEqual(BoltzJobManager.parseMarker("PREDICT:cancel:a:b")?.jobID, "a:b")
+        XCTAssertEqual(InferenceRouter.parseMarker("PREDICT:cancel:a:b")?.jobID, "a:b")
     }
 
     func testAMarkerWithNoRequestFileIsIgnored() {
         // Must not crash or throw out of the feedback pump.
-        BoltzJobManager.shared.handle(marker: "PREDICT:submit:definitely-missing")
+        InferenceRouter.handle(marker: "PREDICT:submit:definitely-missing")
     }
 
     // MARK: - Preflight
@@ -313,7 +313,7 @@ final class BoltzJobManagerTests: XCTestCase {
     func testOversizedInputIsRefusedBeforeAnyAllocation() throws {
         let long = String(repeating: "A", count: PredictSizeGuard.maximumTokens + 10)
         let url = try writeRequest(job: "j3", chains: [("A", long)])
-        let request = try BoltzJobManager.parseRequest(at: url)
+        let request = try InferenceJob.parseRequest(at: url)
         let status = BoltzJobManager.preflight(request)
         XCTAssertEqual(status?.state, "failed")
         XCTAssertEqual(status?.phase, "preflight")
@@ -322,7 +322,7 @@ final class BoltzJobManagerTests: XCTestCase {
 
     func testReasonableInputPassesPreflight() throws {
         let url = try writeRequest(job: "j4", chains: [("A", String(repeating: "A", count: 40))])
-        let request = try BoltzJobManager.parseRequest(at: url)
+        let request = try InferenceJob.parseRequest(at: url)
         XCTAssertNil(BoltzJobManager.preflight(request),
                      "a 40-residue chain must not be refused on any supported Mac")
     }
@@ -343,7 +343,7 @@ final class BoltzJobManagerTests: XCTestCase {
         BoltzJobManager.shared.registerTaskForTesting(task, jobID: "cx1")
         wait(for: [started], timeout: 5)
 
-        BoltzJobManager.shared.handle(marker: "PREDICT:cancel:cx1")
+        InferenceRouter.handle(marker: "PREDICT:cancel:cx1")
 
         wait(for: [observed], timeout: 5)
         XCTAssertTrue(task.isCancelled)
@@ -353,20 +353,20 @@ final class BoltzJobManagerTests: XCTestCase {
     /// A cancel can legitimately arrive before the task is registered, so the flag must
     /// still be recorded for the coarse phase checks in run().
     func testCancelBeforeRegistrationIsStillRecorded() {
-        BoltzJobManager.shared.handle(marker: "PREDICT:cancel:cx2")
+        InferenceRouter.handle(marker: "PREDICT:cancel:cx2")
         XCTAssertTrue(BoltzJobManager.shared.cancelRequestedForTesting.contains("cx2"))
     }
 
     /// ...but a cancel for a job that already finished is moot and must NOT accumulate.
     func testCancelForATerminalJobIsIgnoredSoTheSetStaysBounded() throws {
         let jobID = "cx3"
-        try BoltzJobManager.writeStatus(
+        try InferenceJob.writeStatus(
             .init(state: "done", phase: "done", fraction: 1.0, error: nil,
                   resultPath: "/tmp/x.pdb", peakBytes: 1, elapsedSeconds: 1),
-            to: BoltzJobManager.statusURL(jobID: jobID))
-        defer { try? FileManager.default.removeItem(at: BoltzJobManager.statusURL(jobID: jobID)) }
+            to: InferenceJob.statusURL(jobID: jobID))
+        defer { try? FileManager.default.removeItem(at: InferenceJob.statusURL(jobID: jobID)) }
 
-        BoltzJobManager.shared.handle(marker: "PREDICT:cancel:\(jobID)")
+        InferenceRouter.handle(marker: "PREDICT:cancel:\(jobID)")
         XCTAssertFalse(BoltzJobManager.shared.cancelRequestedForTesting.contains(jobID))
     }
 
@@ -379,16 +379,16 @@ final class BoltzJobManagerTests: XCTestCase {
         let req = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("raymol_predict_req_\(jobID).json")
         try Data("{ not json at all".utf8).write(to: req)
-        let statusPath = BoltzJobManager.statusURL(jobID: jobID)
+        let statusPath = InferenceJob.statusURL(jobID: jobID)
         defer {
             try? FileManager.default.removeItem(at: req)
             try? FileManager.default.removeItem(at: statusPath)
         }
 
-        BoltzJobManager.shared.handle(marker: "PREDICT:submit:\(jobID)")
+        InferenceRouter.handle(marker: "PREDICT:submit:\(jobID)")
 
         let decoded = try JSONDecoder().decode(
-            BoltzJobManager.Status.self, from: try Data(contentsOf: statusPath))
+            InferenceJob.Status.self, from: try Data(contentsOf: statusPath))
         XCTAssertEqual(decoded.state, "failed")
         XCTAssertEqual(decoded.phase, "request")
         XCTAssertNotNil(decoded.error)
@@ -403,18 +403,18 @@ final class BoltzJobManagerTests: XCTestCase {
         try Data("""
         {"job_id":"\(jobID)","weights_dir":"/tmp","chains":[{"chain":"A","sequence":"AG"}],
          "recycling_steps":3,"diffusion_steps":1000000000000000000000000000000,"seed":0,
-         "out_path":"/tmp/o.pdb","status_path":"\(BoltzJobManager.statusURL(jobID: jobID).path)"}
+         "out_path":"/tmp/o.pdb","status_path":"\(InferenceJob.statusURL(jobID: jobID).path)"}
         """.utf8).write(to: req)
-        let statusPath = BoltzJobManager.statusURL(jobID: jobID)
+        let statusPath = InferenceJob.statusURL(jobID: jobID)
         defer {
             try? FileManager.default.removeItem(at: req)
             try? FileManager.default.removeItem(at: statusPath)
         }
 
-        BoltzJobManager.shared.handle(marker: "PREDICT:submit:\(jobID)")
+        InferenceRouter.handle(marker: "PREDICT:submit:\(jobID)")
 
         let decoded = try JSONDecoder().decode(
-            BoltzJobManager.Status.self, from: try Data(contentsOf: statusPath))
+            InferenceJob.Status.self, from: try Data(contentsOf: statusPath))
         XCTAssertEqual(decoded.state, "failed")
     }
     // MARK: - settle ordering
@@ -424,8 +424,8 @@ final class BoltzJobManagerTests: XCTestCase {
     /// discarding first strands the error where nothing can observe it.
     func testPreflightRefusalWritesStatusBeforeDiscardingPlaceholder() throws {
         var order: [String] = []
-        BoltzJobManager.settleTap = { order.append($0) }
-        defer { BoltzJobManager.settleTap = nil }
+        InferenceJob.settleTap = { order.append($0) }
+        defer { InferenceJob.settleTap = nil }
 
         // 100k residues: far past any machine's fitting size, so preflight refuses
         // without touching MLX.
@@ -433,7 +433,7 @@ final class BoltzJobManagerTests: XCTestCase {
         try writeRequest(job: jobID,
                          chains: [("A", String(repeating: "A", count: 100_000))],
                          diffusionSteps: 200)
-        BoltzJobManager.shared.handle(marker: "PREDICT:submit:\(jobID)")
+        InferenceRouter.handle(marker: "PREDICT:submit:\(jobID)")
 
         XCTAssertEqual(order, ["write", "discard"],
                        "status must be written before the placeholder is discarded")
@@ -441,7 +441,7 @@ final class BoltzJobManagerTests: XCTestCase {
         let statusURL = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("raymol_predict_status_\(jobID).json")
         let status = try JSONDecoder().decode(
-            BoltzJobManager.Status.self, from: Data(contentsOf: statusURL))
+            InferenceJob.Status.self, from: Data(contentsOf: statusURL))
         XCTAssertEqual(status.state, "failed")
         XCTAssertNotNil(status.error)
     }
@@ -454,7 +454,7 @@ final class BoltzJobManagerTests: XCTestCase {
     func testCancelArrivingBeforeRegistrationStillCancelsTheTask() {
         let jobID = "prereg"
         // Cancel first — no task exists yet, so only the flag is recorded.
-        BoltzJobManager.shared.handle(marker: "PREDICT:cancel:\(jobID)")
+        InferenceRouter.handle(marker: "PREDICT:cancel:\(jobID)")
         XCTAssertTrue(BoltzJobManager.shared.cancelRequestedForTesting.contains(jobID))
 
         let observed = expectation(description: "task saw the cancellation")

--- a/swiftui/PyMOLViewerTests/InferenceRouterTests.swift
+++ b/swiftui/PyMOLViewerTests/InferenceRouterTests.swift
@@ -1,0 +1,117 @@
+#if os(macOS)
+import XCTest
+@testable import RayMol
+
+/// The dispatcher, now that it is neutral ground rather than a static on one of its own
+/// targets.
+///
+/// Two properties here were previously carried by nothing but the shape of a hand-written
+/// branch per runtime:
+///
+/// * **Routable implies cancellable.** `submit` and `cancel` read the SAME table, so a
+///   runtime cannot be added to one path and forgotten in the other. A runtime that is
+///   routable but not cancellable is a job the user cannot stop.
+/// * **An unrouted runtime is refused BY NAME**, not silently accepted and not left
+///   reporting `queued` forever. That is how a Python side offering a method this build did
+///   not link gets a real error.
+final class InferenceRouterTests: XCTestCase {
+
+    private var dir: URL!
+
+    override func setUpWithError() throws {
+        dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("inference-router-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: dir)
+    }
+
+    private func name(of runtime: any InferenceRuntime) -> String {
+        type(of: runtime).runtimeName
+    }
+
+    // MARK: The table
+
+    /// `Request.runtime` is optional and absent means Boltz — every Python side that
+    /// predates a second runtime wrote no such key.
+    func testARequestNamingNoRuntimeMeansBoltz() {
+        XCTAssertEqual(name(of: InferenceRouter.defaultRuntime),
+                       BoltzJobManager.runtimeName)
+    }
+
+    /// The default must ALSO be a table entry, or a cancel for the commonest kind of job —
+    /// one that named no runtime at all — would never be broadcast to the manager running
+    /// it.
+    func testTheDefaultRuntimeIsItselfInTheTable() {
+        XCTAssertTrue(
+            InferenceRouter.runtimes.contains { $0 === InferenceRouter.defaultRuntime },
+            "the default runtime is reachable by submit but not by cancel")
+    }
+
+    /// Two entries sharing a name would make routing depend on table order, which nothing
+    /// declares.
+    func testEveryLinkedRuntimeHasADistinctName() {
+        let names = InferenceRouter.runtimes.map(name(of:))
+        XCTAssertEqual(names.count, Set(names).count, "duplicate runtime name in \(names)")
+    }
+
+    /// What this macOS build actually links. Fails when a runtime is added to the app and
+    /// not to the table — the state in which it is neither routable nor cancellable.
+    func testTheTableCarriesEveryRuntimeThisBuildLinks() {
+        XCTAssertEqual(Set(InferenceRouter.runtimes.map(name(of:))),
+                       ["boltz", "protenix"])
+    }
+
+    // MARK: Cancel reaches the whole table
+
+    /// A cancel marker carries only a job id, so there is nothing in it to route on: it
+    /// must reach EVERY runtime, not just the first or the default.
+    ///
+    /// Asserted through `protenix`, which is neither — so a broadcast that stopped after
+    /// the default would fail here.
+    func testACancelMarkerReachesARuntimeThatIsNotTheDefault() {
+        let jobID = "router-cancel-\(UUID().uuidString.prefix(8))"
+        XCTAssertFalse(ProtenixJobManager.shared.cancelRequestedForTesting.contains(jobID))
+
+        InferenceRouter.handle(marker: "PREDICT:cancel:\(jobID)")
+
+        XCTAssertTrue(ProtenixJobManager.shared.cancelRequestedForTesting.contains(jobID),
+                      "the cancel broadcast stopped before reaching every runtime")
+        // ...and the default saw it too, from the same one loop.
+        XCTAssertTrue(BoltzJobManager.shared.cancelRequestedForTesting.contains(jobID))
+    }
+
+    // MARK: Refusals
+
+    /// A runtime nothing implements must reach a refusal that NAMES it. Refused inside
+    /// Boltz's preflight, which runs before any sizing and before MLX is touched, so this
+    /// test costs nothing.
+    func testARuntimeThisBuildDoesNotCarryIsRefusedByName() throws {
+        let jobID = "router-unknown-\(UUID().uuidString.prefix(8))"
+        let statusPath = dir.appendingPathComponent("\(jobID).json")
+        // No `object_name`: a refusal for a job with a placeholder would hop into
+        // PyMOLEngine, which a unit test must not do.
+        let payload: [String: Any] = [
+            "job_id": jobID, "weights_dir": dir.path, "chains": [],
+            "runtime": "nosuchruntime",
+            "recycling_steps": 1, "diffusion_steps": 1, "seed": 0,
+            "out_path": dir.appendingPathComponent("\(jobID).pdb").path,
+            "status_path": statusPath.path,
+        ]
+        let requestURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("raymol_predict_req_\(jobID).json")
+        try JSONSerialization.data(withJSONObject: payload).write(to: requestURL)
+        defer { try? FileManager.default.removeItem(at: requestURL) }
+
+        InferenceRouter.handle(marker: "PREDICT:submit:\(jobID)")
+
+        let status = try JSONDecoder().decode(
+            InferenceJob.Status.self, from: Data(contentsOf: statusPath))
+        XCTAssertEqual(status.state, "failed")
+        XCTAssertTrue(status.error?.contains("nosuchruntime") ?? false,
+                      "the refusal must name the runtime: \(status.error ?? "nil")")
+    }
+}
+#endif

--- a/swiftui/PyMOLViewerTests/ProtenixRuntimeTests.swift
+++ b/swiftui/PyMOLViewerTests/ProtenixRuntimeTests.swift
@@ -27,7 +27,7 @@ final class ProtenixRuntimeTests: XCTestCase {
     }
 
     private func writeRequest(job: String, chains: [(String, String)],
-                              runtime: String?) throws -> BoltzJobManager.Request {
+                              runtime: String?) throws -> InferenceJob.Request {
         let url = dir.appendingPathComponent("raymol_predict_req_\(job).json")
         var payload: [String: Any] = [
             "job_id": job,
@@ -41,7 +41,7 @@ final class ProtenixRuntimeTests: XCTestCase {
         ]
         if let runtime { payload["runtime"] = runtime }
         try JSONSerialization.data(withJSONObject: payload).write(to: url)
-        return try BoltzJobManager.parseRequest(at: url)
+        return try InferenceJob.parseRequest(at: url)
     }
 
     // MARK: - Wire format

--- a/testing/tests/msa/msa_e2e.py
+++ b/testing/tests/msa/msa_e2e.py
@@ -527,7 +527,7 @@ class SwiftWireContractTest(MSAEndToEndTestCase):
 
     #: The struct whose CodingKeys must cover the request Python writes.
     SWIFT_SOURCE = os.path.join('swiftui', 'PyMOLViewer', 'Shared',
-                                'BoltzJobManager.swift')
+                                'InferenceJob.swift')
 
     def swift_wire_names(self, after):
         """Wire names in the first `enum CodingKeys` following `after` in the source."""


### PR DESCRIPTION
Closes #345.

**Now targets `master`, not #343** — see "Ordering" at the bottom.

## The cycle, on master

`ProtenixJobManager` reaches into `BoltzJobManager` for the wire types and the whole job
shell; `BoltzJobManager.handle(marker:)` reaches back out to route submits and to broadcast
cancels. That is a cycle, and the shell it is built around — the protocol RayMol speaks with
Python — sits inside one of its two ends for no reason but that Boltz was written first.

The note at that routing branch said it out loud:

> This manager owns the marker only because it was here first. When a third runtime lands,
> lift the parse-and-route out into a dispatcher rather than adding another branch here.

Doing it **before** the third runtime lands means #343 arrives as a peer instead of being
added to a cycle.

## What moved

Two new files, both lifted verbatim out of `BoltzJobManager`:

| | |
|---|---|
| `InferenceJob` | the wire (`Request`, `Status`, `Chain`, `Alignment`) and the shell (`parseRequest`, `writeStatus`, `statusURL`, `hasTerminalStatus`, `refusal`, `settle`, `discardPlaceholder`, `loadResult`, `pythonLiteral`, `StepThrottle`, the DEBUG `settleTap`). Imports Foundation and nothing else. |
| `InferenceRouter` | `Verb`, `Marker`, `parseMarker`, `handle(marker:)` — plus `InferenceRuntime` and the one table of runtimes. |

`PyMOLEngine.swift` now calls `InferenceRouter.handle(marker:)` instead of routing through a
manager that may not own the job.

What did **not** move: everything method-specific. Boltz keeps `preflight`,
`alignmentPreflight`, `loadAlignments`, `message`, `writeMetrics`, `FootprintSampler`,
`memoryPlanner` and its inference loop.

## The bit that is more than a rename

`InferenceRuntime` (`static var runtimeName`, `submit(_:)`, `cancel(jobID:)`) retires the
naming drift — `boltzRuntime` → `runtimeName` — but its real job is letting the router
dispatch over **one** table that both `submit` and `cancel` read:

```swift
static let runtimes: [any InferenceRuntime] = {
    var table: [any InferenceRuntime] = [BoltzJobManager.shared]
    #if os(macOS)
    table.append(ProtenixJobManager.shared)
    #endif
    return table
}()
```

Keeping a route branch and a broadcast branch in step used to be something a human had to
remember. It is now a property of the code: a runtime that is routable but not cancellable —
a job the user cannot stop — can no longer be constructed. Adding `rfd3` is one line.

## Invariants, held

| # | how |
|---|---|
| `settle` writes the status **then** discards the placeholder | moved verbatim; `testPreflightRefusalWritesStatusBeforeDiscardingPlaceholder` re-pointed at `InferenceJob.settle` and still asserts `["write", "discard"]` |
| `StepThrottle` keeps its **own** `NSLock`, never a manager's `stateQueue` | moved verbatim; the doc comment now says explicitly that living outside a manager must not tempt anyone to share a queue |
| every `Request` field stays Optional | byte-identical struct |
| `nil` runtime means `boltz`; an unrouted runtime reaches a refusal that **names** it | `InferenceRouter.runtime(for:)` falls back to `defaultRuntime`, whose `preflight` does the refusing exactly as before. New `testARuntimeThisBuildDoesNotCarryIsRefusedByName` drives this end-to-end through `handle` and asserts the status file |
| the cancel broadcast covers every routable runtime | structural now — one table. New `testACancelMarkerReachesARuntimeThatIsNotTheDefault` asserts it through `protenix`, which is neither the first entry nor the default |

The wire is untouched: every `CodingKeys` spelling and every optionality is identical.
`msa_e2e.SwiftWireContractTest` reads the struct out of the Swift source; its `SWIFT_SOURCE`
now points at `InferenceJob.swift` and **all three of its tests run rather than skip**, so
the Python↔Swift key contract is still genuinely checked (a silent skip there would have
looked exactly like a pass).

## Two deliberate non-mechanical changes

- `InferenceJob.settle` widens from `private` — the move puts every caller outside it.
- `ProtenixJobManager` gains an ungated `cancelRequestedForTesting`, matching
  `BoltzJobManager`'s seams. `InferenceRouterTests` reads it, and a `#if DEBUG` in a test
  file does not compile against a Release app host.

## Verification

- **macOS suite: 435 tests, 4 skipped, 0 failures.** Master's baseline is 429 (measured on a
  clean tree, same command); the 6 added are `InferenceRouterTests`.
- **Both slices hand-compiled** (`PyMOLViewer_macOS`, `PyMOLViewer_iOS`, Debug) — no CI job
  compiles Swift, and the shared target has broken each platform from the other three times
  (#174, #226/#238).
- **Embedded Python CI list: `Ran 663 tests`, `OK`** — the full `--run` list out of
  `raymol-embedded-tests.yml`, parsed from the YAML rather than retyped.

The regenerated `project.pbxproj` **is** included: three files were added, and its diff is
exactly those.

## Ordering

Originally opened stacked **on top of** #343, because #345 is written against the
three-manager world. Reversed at your request: this now sits on `master` and #343 rebases on
top of it.

Two consequences worth knowing:

- On master the cycle is two managers, not three, so this is the smaller version of #345 —
  no `DesignResidue`/`DesignAtom`, no `target`/`hotspots`/`design_*` fields, and `settle` /
  `loadResult` / `discardPlaceholder` take no `pythonModule:` parameter yet. Those are #343's
  and arrive with it.
- `docs/generators.md` does not exist on master, so that half of #345's docs acceptance
  lands with #343 too. `docs/predictors.md` is updated here.

#344 was closed unmerged, so `ProtenixJobManager`'s discard-then-write ordering is left
exactly as it is — changing it here would not be "no behaviour change".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
