### PR TITLE
fix(predict): settle a Protenix job instead of discarding it first

### DIFF
--- a/swiftui/PyMOLViewer/Shared/ProtenixJobManager.swift
+++ b/swiftui/PyMOLViewer/Shared/ProtenixJobManager.swift
@@ -58,9 +58,8 @@ final class ProtenixJobManager: InferenceRuntime {
     /// Refuse or accept a submitted request. Runs on the MAIN thread.
     func submit(_ request: InferenceJob.Request) {
         if let failure = Self.preflight(request) {
-            InferenceJob.discardPlaceholder(request)
-            try? InferenceJob.writeStatus(
-                failure, to: URL(fileURLWithPath: request.statusPath))
+            InferenceJob.settle(request, failure,
+                                to: URL(fileURLWithPath: request.statusPath))
             return
         }
         queue.async { self.run(request) }
@@ -117,6 +116,26 @@ final class ProtenixJobManager: InferenceRuntime {
                                     peakBytes: peak, elapsedSeconds: elapsed),
                 to: statusURL)
         }
+        /// A TERMINAL status, written BEFORE the placeholder comes down.
+        ///
+        /// Not `report` with a terminal state: the two differ in ORDER, not in payload.
+        /// `report` only writes; this writes and then discards, and the sequence is the
+        /// whole point -- `discard_pending` re-reads the status file to decide whether to
+        /// retain a failure card, so a discard that lands first strands the failure where
+        /// nothing can observe it and an eleven-minute run that died explains nothing.
+        ///
+        /// Mirrors `BoltzJobManager.run`'s own local `settle` and routes through the shared
+        /// `InferenceJob.settle`, so there is ONE implementation of the ordering rather than
+        /// a hand-rolled copy per manager -- which is exactly what this manager had, and
+        /// what got it backwards at all four of its terminal paths.
+        func settle(_ state: String, _ phase: String, error: String? = nil) {
+            InferenceJob.settle(
+                request,
+                InferenceJob.Status(state: state, phase: phase, fraction: 0,
+                                    error: error, resultPath: nil,
+                                    peakBytes: peak, elapsedSeconds: elapsed),
+                to: statusURL)
+        }
         func isCancelled() -> Bool {
             stateQueue.sync { cancelled.contains(request.jobID) }
         }
@@ -136,8 +155,7 @@ final class ProtenixJobManager: InferenceRuntime {
                 name: request.objectName ?? "prediction")
 
             if isCancelled() {
-                InferenceJob.discardPlaceholder(request)
-                report("cancelled", "featurize", 0); return
+                settle("cancelled", "featurize"); return
             }
 
             report("running", "load", 0.05)
@@ -194,11 +212,9 @@ final class ProtenixJobManager: InferenceRuntime {
             InferenceJob.loadResult(request)
             report("done", "done", 1.0, result: request.outPath)
         } catch ProtenixError.cancelled {
-            InferenceJob.discardPlaceholder(request)
-            report("cancelled", "inference", 0)
+            settle("cancelled", "inference")
         } catch {
-            InferenceJob.discardPlaceholder(request)
-            report("failed", "inference", 0,
+            settle("failed", "inference",
                    error: (error as? LocalizedError)?.errorDescription
                        ?? error.localizedDescription)
         }

--- a/swiftui/PyMOLViewerTests/ProtenixRuntimeTests.swift
+++ b/swiftui/PyMOLViewerTests/ProtenixRuntimeTests.swift
@@ -44,6 +44,77 @@ final class ProtenixRuntimeTests: XCTestCase {
         return try InferenceJob.parseRequest(at: url)
     }
 
+    // MARK: - settle ordering
+
+    /// The status file must be on disk BEFORE the placeholder is taken down.
+    ///
+    /// `predicting.discard_pending` re-reads the status FRESH to decide whether to retain a
+    /// failure card in `_RECENT` -- and it can, because nothing deletes the status file. So
+    /// a discard that lands first records the failure after `_PENDING`, the only map that
+    /// could observe it, has already been popped: the card silently vanishes and a refused
+    /// or failed run explains nothing.
+    ///
+    /// The Boltz path has had this test since #291. Protenix did not, and did the two steps
+    /// inline in the wrong order at all four of its terminal paths -- #346 moved them onto
+    /// `InferenceJob` but preserved the ordering, so extracting the shared shell did not by
+    /// itself fix them.
+    func testARefusalWritesStatusBeforeDiscardingThePlaceholder() throws {
+        var order: [String] = []
+        InferenceJob.settleTap = { order.append($0) }
+        defer { InferenceJob.settleTap = nil }
+
+        // 100k residues: far past any machine's fitting size, so preflight refuses without
+        // touching MLX or reading a weight pack.
+        let request = try writeRequest(
+            job: "settle-order",
+            chains: [("A", String(repeating: "A", count: 100_000))],
+            runtime: ProtenixJobManager.runtimeName)
+        ProtenixJobManager.shared.submit(request)
+
+        XCTAssertEqual(order, ["write", "discard"],
+                       "status must be written before the placeholder is discarded")
+        let status = try JSONDecoder().decode(
+            InferenceJob.Status.self,
+            from: Data(contentsOf: URL(fileURLWithPath: request.statusPath)))
+        XCTAssertEqual(status.state, "failed")
+        XCTAssertNotNil(status.error)
+    }
+
+    /// Every terminal path goes through the ordered helper -- checked STRUCTURALLY, because
+    /// three of the four cannot be reached from a unit test.
+    ///
+    /// `submit`'s refusal is testable (above). The three inside `run` are not: they need a
+    /// real 214 MB pack and a real MLX fold to reach. They are also where the ordering
+    /// actually bites, and the reason is threading: `discardPlaceholder` hops to the MAIN
+    /// queue while the status write is synchronous on the calling thread. From `submit`,
+    /// which runs on the main thread, that hop is deferred past the write and the wrong
+    /// order is accidentally harmless. From `run`, which is on a background queue, the main
+    /// thread can pick the discard up while the write is still in flight.
+    ///
+    /// So a grep is the honest guard: no direct `discardPlaceholder` call may remain in this
+    /// manager. Same discipline as
+    /// `predict_api.testEveryMessageHelperUsedByPredictingExists`, which greps its source
+    /// rather than trying to take every branch.
+    func testNoTerminalPathDiscardsThePlaceholderItself() throws {
+        let source = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()          // PyMOLViewerTests
+            .deletingLastPathComponent()          // swiftui
+            .appendingPathComponent("PyMOLViewer/Shared/ProtenixJobManager.swift")
+        let text = try String(contentsOf: source, encoding: .utf8)
+        for (number, line) in text.split(separator: "\n").enumerated() {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("//") { continue }
+            XCTAssertFalse(line.contains("discardPlaceholder"),
+                           "ProtenixJobManager.swift:\(number + 1) discards the placeholder "
+                           + "directly; route it through InferenceJob.settle so the status "
+                           + "is written first: \(trimmed)")
+        }
+        // And it does still settle -- so the assertion above cannot be satisfied by simply
+        // deleting the teardown.
+        XCTAssertTrue(text.contains("InferenceJob.settle("),
+                      "the manager must settle its jobs through the shared helper")
+    }
+
     // MARK: - Wire format
 
     func testRequestCarriesItsRuntime() throws {


### PR DESCRIPTION
Re-lands #344, whose fix was lost when that PR was closed as superseded by #346. Only the rename survived.

## The bug

All four of `ProtenixJobManager`'s terminal paths take the placeholder down **before** writing the terminal status:

```swift
InferenceJob.discardPlaceholder(request)
try? InferenceJob.writeStatus(failure, to: …)
```

`predicting.discard_pending` re-reads the status file *fresh* to decide whether to retain a failure card in `_RECENT` — it can, because nothing deletes that file. Discarding first records the failure after `_PENDING`, the only map that could observe it, has already been popped. The card silently vanishes and a fold that died after eleven minutes explains nothing.

#346 did not fix this and was not expected to — it moved these calls from `BoltzJobManager.discardPlaceholder` to `InferenceJob.discardPlaceholder` and preserved the order they were in. But the shell it extracted is what makes the fix small: `InferenceJob.settle` writes then discards, with a DEBUG `settleTap` pinning the sequence.

## Where it actually bites

`discardPlaceholder` hops to the **main queue** while the status write is synchronous on the calling thread.

| path | thread | effect |
|---|---|---|
| `submit` refusal | main | hop deferred past the write — wrong order, accidentally harmless |
| `run` cancel-during-featurize | background | **live race** |
| `run` `catch .cancelled` | background | **live race** |
| `run` `catch` (failure) | background | **live race** |

So the three that matter are inside `run`, and they are the ones covering a failed or cancelled fold rather than a refused one.

## The fix

`submit`'s refusal calls `InferenceJob.settle`; `run` gets the same local `settle(_:_:error:)` helper `BoltzJobManager.run` already has, used at its three terminal paths. No manager hand-rolls the two steps any more — a second copy of an ordering is a second chance to get it backwards.

## Tests

Both fail against the code as it was — the ordering one with `[] != ["write", "discard"]`, the structural one naming all four sites by line number:

- `testARefusalWritesStatusBeforeDiscardingThePlaceholder` drives the one terminal path a unit test can reach, through `settleTap`.
- `testNoTerminalPathDiscardsThePlaceholderItself` greps the manager's own source, because the other three need a 214 MB pack and a real MLX fold to reach. It also asserts the manager still settles, so it can't be satisfied by deleting the teardown.

Verified: **437 Swift tests, 0 failures**; both macOS and iOS slices compiled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)