### PR TITLE
refactor(predict): collapse the duplicated pythonLiteral onto InferenceJob

### DIFF
--- a/swiftui/PyMOLViewer/Shared/InferenceJob.swift
+++ b/swiftui/PyMOLViewer/Shared/InferenceJob.swift
@@ -311,12 +311,19 @@ enum InferenceJob {
         }
     }
 
-    /// A Python string literal for an arbitrary path. Paths come from our own temp dir,
-    /// but building source text without quoting is how injection bugs start.
+    /// A Python string literal for an arbitrary path or object name. Paths come from our
+    /// own temp dir, but building source text without quoting is how injection bugs start.
     /// PyMOL's text parser does not strip quotes from a `"..."` token, so an object name
     /// has to be escaped exactly this way or a name with an apostrophe breaks the call.
-    /// Private: both callers are right here.
-    private static func pythonLiteral(_ value: String) -> String {
+    ///
+    /// Newlines are DELETED, not escaped: every value that reaches here is a single token
+    /// (a path, an object name, a predictor id), and a stray newline would end the
+    /// statement mid-call. A multi-line payload must not be passed through this.
+    ///
+    /// Internal, and the only copy: PredictController and ProgressTray each carried a
+    /// byte-identical private one, which is three chances to fix a quoting bug in two
+    /// places.
+    static func pythonLiteral(_ value: String) -> String {
         "'" + value
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "'", with: "\\'")

--- a/swiftui/PyMOLViewer/Shared/PredictController.swift
+++ b/swiftui/PyMOLViewer/Shared/PredictController.swift
@@ -38,14 +38,6 @@ struct PredictSizeWarning: Equatable {
 
 extension PredictController {
 
-    /// A Python single-quoted string literal. Matches InferenceJob.pythonLiteral.
-    nonisolated static func pythonLiteral(_ value: String) -> String {
-        "'" + value
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "'", with: "\\'")
-            .replacingOccurrences(of: "\n", with: "") + "'"
-    }
-
     /// `from pymol import cmd as _c\n_c.predict(...)`. Optional args are omitted when
     /// nil so predict applies its own defaults (notably: no seed → a fresh seed per
     /// run). `msa` is passed only on the literal-sequence path; object inputs let
@@ -54,14 +46,15 @@ extension PredictController {
                               recyclingSteps: Int, diffusionSteps: Int,
                               seed: Int?, msaDepth: Int?, name: String?,
                               msa: String?) -> String {
-        var args = ["\(pythonLiteral(predictor)), \(pythonLiteral(input))"]
+        var args = ["\(InferenceJob.pythonLiteral(predictor)), "
+                    + "\(InferenceJob.pythonLiteral(input))"]
         args.append("n_models=\(nModels)")
         args.append("recycling_steps=\(recyclingSteps)")
         args.append("diffusion_steps=\(diffusionSteps)")
         if let seed { args.append("seed=\(seed)") }
         if let msaDepth { args.append("msa_depth=\(msaDepth)") }
-        if let name, !name.isEmpty { args.append("name=\(pythonLiteral(name))") }
-        if let msa, !msa.isEmpty { args.append("msa=\(pythonLiteral(msa))") }
+        if let name, !name.isEmpty { args.append("name=\(InferenceJob.pythonLiteral(name))") }
+        if let msa, !msa.isEmpty { args.append("msa=\(InferenceJob.pythonLiteral(msa))") }
         return "from pymol import cmd as _c\n_c.predict(\(args.joined(separator: ", ")))"
     }
 
@@ -69,12 +62,12 @@ extension PredictController {
     /// object path); a literal sequence lands the alignment unattached under `name`.
     nonisolated static func msaSearchPython(sequence: String, name: String, target: String,
                                 chain: String, mode: String, server: String) -> String {
-        var args = ["\(pythonLiteral(sequence))"]
-        args.append("name=\(pythonLiteral(name))")
-        if !target.isEmpty { args.append("target=\(pythonLiteral(target))") }
-        if !chain.isEmpty { args.append("chain=\(pythonLiteral(chain))") }
-        args.append("mode=\(pythonLiteral(mode))")
-        if !server.isEmpty { args.append("server=\(pythonLiteral(server))") }
+        var args = ["\(InferenceJob.pythonLiteral(sequence))"]
+        args.append("name=\(InferenceJob.pythonLiteral(name))")
+        if !target.isEmpty { args.append("target=\(InferenceJob.pythonLiteral(target))") }
+        if !chain.isEmpty { args.append("chain=\(InferenceJob.pythonLiteral(chain))") }
+        args.append("mode=\(InferenceJob.pythonLiteral(mode))")
+        if !server.isEmpty { args.append("server=\(InferenceJob.pythonLiteral(server))") }
         return "from pymol import cmd as _c\n_c.msa_search(\(args.joined(separator: ", ")))"
     }
 
@@ -376,7 +369,7 @@ final class PredictController: ObservableObject {
 
     func cancel() {
         for name in plannedNames.values {
-            runPythonSeam("from pymol import cmd as _c\n_c.msa_cancel(\(PredictController.pythonLiteral(name)))")
+            runPythonSeam("from pymol import cmd as _c\n_c.msa_cancel(\(InferenceJob.pythonLiteral(name)))")
         }
         plannedNames = [:]
         phase = .idle

--- a/swiftui/PyMOLViewer/Shared/ProgressTray.swift
+++ b/swiftui/PyMOLViewer/Shared/ProgressTray.swift
@@ -153,16 +153,7 @@ struct ProgressItem: Identifiable, Equatable {
     /// the statement, and an unusual one cannot shadow something a user's
     /// `~/.raymolrc.py` put there.
     private static func pythonCall(_ function: String, _ name: String) -> String {
-        "from pymol import cmd as _c\n_c.\(function)(\(pythonLiteral(name)))"
-    }
-
-    /// A Python single-quoted string literal for an arbitrary object name.
-    /// Matches the escaping in InferenceJob.pythonLiteral(_:).
-    private static func pythonLiteral(_ value: String) -> String {
-        "'" + value
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "'", with: "\\'")
-            .replacingOccurrences(of: "\n", with: "") + "'"
+        "from pymol import cmd as _c\n_c.\(function)(\(InferenceJob.pythonLiteral(name)))"
     }
 
     /// Everything the tray should show, in order.

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -2534,7 +2534,7 @@ final class PyMOLEngine: ObservableObject {
             pc.runPythonSeam = { [weak self] code in self?.runPython(code) }
             // Trigger the tempfile-JSON feed; PREDICT_FORM:ready routes back below.
             pc.refreshTrigger = { [weak self] input in
-                let lit = PredictController.pythonLiteral(input)
+                let lit = InferenceJob.pythonLiteral(input)
                 self?.runPython("from pymol import appkit_predict as _ap\n_ap.emit(\(lit))")
             }
             // Drive the search→predict state machine off the object poll's published state.


### PR DESCRIPTION
`PredictController` and `ProgressTray` each carried a byte-identical private copy of `InferenceJob.pythonLiteral(_:)` — the same four lines, down to the whitespace, each with a doc comment pointing at the other one (*"Matches InferenceJob.pythonLiteral"*). A comment is not a link. A quoting bug found in one copy is a bug fixed in one of three places, and the two left wrong are the ones on the paths a user actually types into: the predict form's input field, and an object name in the progress tray.

This was deliberately left out of the #342 design-trajectory PR so that change wouldn't touch two shipped controllers.

## What changed

- `InferenceJob.pythonLiteral(_:)` widens from `private` to internal — the one copy.
- `PredictController.pythonLiteral` deleted; its 11 call sites (10 bare + `cancel()`'s qualified one) now call `InferenceJob.pythonLiteral`.
- `ProgressTray.pythonLiteral` deleted; `pythonCall(_:_:)` calls `InferenceJob.pythonLiteral`.
- `PyMOLEngine`'s `refreshTrigger` moves off `PredictController.pythonLiteral` — it was the only external user of the now-deleted copy.

**No behaviour change.** The three bodies were byte-identical, so every generated Python statement is byte-for-byte what it was. `predictPython` / `msaSearchPython` — the two functions `PredictControllerTests` pins — are unchanged apart from the qualification.

## The newline contract, now written down

The escaping contract lives where the one copy lives, including the part that reads like a bug: **newlines are DELETED, not escaped**. Every value that reaches here is a single token — a path, an object name, a predictor id, a chain — and a newline mid-statement would end the call early. A multi-line payload must not be passed through this function.

Audited every rewired call site against that: `predictor`, `name`, `msa`, `target`, `chain`, `mode`, `server`, the tray's job id, and `InferenceJob`'s own `outPath` / `objectName` are all single tokens. The one value that *could* carry a newline is the predict form's `input` (a pasted literal sequence), and it already had newline-deletion applied on this exact path before this PR — unchanged, not newly introduced. No PDB-sized payload goes through here.

## One correction to the premise

The task named a **fourth** copy at `DesignBackboneController.swift`. It is real, but it does not exist on `master` — it arrives with `claude/issue-342-rfd3`'s later, still-unpushed commits (the "Design Backbone as a docked bar and a mode" refactor). The pushed tip of that branch, `dfcec9557`, has neither the file nor a widened `pythonLiteral`; the widening and the fourth copy both live in commits that have not reached the remote.

So this PR collapses the three copies that exist on `master`. The fourth is collapsed in a follow-up commit prepared on top of a rebase of that branch onto this one — held back rather than pushed, because the branch is checked out in another worktree that is actively committing.

`InferenceJob.pythonMultilineLiteral` — the separate multi-line escaper for PDB payloads — likewise arrives with that branch, not with `master`. Nothing here conflates the two: everything rewired in this PR is a single-line token.

## Verification

No CI job compiles Swift, so both slices were compiled by hand:

- **macOS** — `xcodebuild test -scheme UnitTests_macOS -destination 'platform=macOS'`: `** TEST SUCCEEDED **`, 437 tests, 4 skipped, **0 failures**. (The scheme builds `PyMOLViewer_macOS` as its `TEST_HOST`, so the macOS app target compiled.)
- **iOS** — `xcodebuild build -scheme PyMOLViewer_iOS -destination 'generic/platform=iOS Simulator'`: `** BUILD SUCCEEDED **`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

