### PR TITLE
fix(predict): key the placeholder tables on the object's real name

### DIFF
--- a/modules/pymol/predicting.py
+++ b/modules/pymol/predicting.py
@@ -123,6 +123,32 @@ def default_object_name(sequence, predictor_id=''):
     return '%s_%s' % (method, stem) if method else stem
 
 
+def _legal_object_name(name, _self=cmd):
+    """The object name PyMOL will actually use for `name`.
+
+    Creating an object LEGALISES its name -- an apostrophe, a space and a forward slash
+    all become underscores -- and nothing tells the caller. So a name chosen here and the
+    object that actually exists are two different strings, and every table keyed on the
+    chosen one then addresses an object that is not there: the placeholder is not deleted
+    by `discard_pending`, `session_save` does not recognise it and writes it into the
+    .pse, and `record_run` files metrics against a name nothing answers to.
+
+    `cmd.get_legal_name` rather than a local rewrite: it is the same C++ rule
+    (`ObjectMakeValidName`) that creation itself applies, so the two cannot drift. That
+    rule is subtler than replacing three characters -- it strips a trailing `)`, yields one
+    underscore per BYTE of a multi-byte character, and leaves `+`, `-` and `.` alone.
+    It is idempotent, so applying it twice on one path is harmless.
+
+    Applied on EVERY public entry point that takes an object name, `pending_info`
+    included. In production its callers pass keys that came out of these tables, so the
+    call is a no-op there -- but a rule of "some of these legalise and some do not" is one
+    a caller has to know, and the cost of not needing to know it was measured at 0.82 us
+    per call: 0.016 ms for twenty placeholders on a 500 ms poll tick, 0.003% of it.
+    """
+    return _self.get_legal_name(str(name))
+
+
+
 def job_ids():
     """Ids of every job submitted this session, newest last.
 
@@ -160,6 +186,13 @@ def pending_info(name, _self=cmd):
     if this throws, which freezes the object panel on a stale list.
     """
     import time
+    try:
+        name = _legal_object_name(name, _self=_self)
+    except Exception:
+        # Guarded because of the "never raises" contract above, and only here: a lookup
+        # under the name as given misses and returns None, which the panel renders as
+        # "pending" -- where letting this out would write no panel file at all.
+        pass
     job_ids = _PENDING.get(name)
     if not job_ids:
         return _RECENT.get(name)
@@ -425,6 +458,7 @@ def register_pending(name, job_id, _self=cmd):
     Recording only the newest would clear the pending mark on the first delivery while
     later models were still running.
     """
+    name = _legal_object_name(name, _self=_self)
     if name not in _self.get_names('objects'):
         _self.create(name, 'none')
     _PENDING.setdefault(name, []).append(job_id)
@@ -454,6 +488,7 @@ def discard_pending(name, _self=cmd):
     #
     # NOT on the poll path: discard_pending runs once per placeholder teardown, so
     # this does not add a per-tick status read.
+    name = _legal_object_name(name, _self=_self)
     fresh = None
     try:
         fresh = pending_info(name, _self=_self)
@@ -893,6 +928,7 @@ def deliver_result(path, name, seed=None, _self=cmd):
     # Read BEFORE the finally block pops it: this is the job whose model is landing,
     # and it is what says which predictor, which options and which alignment produced
     # the coordinates about to be loaded.
+    name = _legal_object_name(name, _self=_self)
     landing = (_PENDING.get(name) or [None])[0]
     try:
         _self.load(path, name, zoom=0)
@@ -1497,6 +1533,11 @@ SEE ALSO
     # the job immediately rather than after the first poll.
     object_name = (str(name) if name else
                    default_object_name(sequence, predictor_obj.id))
+    # Legalised HERE, once, rather than left for `create` to do silently: this string is
+    # the placeholder's key, the name the host is handed and echoes back to
+    # `deliver_result`, and what the metric run is filed against. Any of those differing
+    # from the object that actually exists is a silent no-op somewhere downstream.
+    object_name = _legal_object_name(object_name, _self=_self)
     # PredictionSpec is a __slots__ class, not a namedtuple: assign, don't _replace.
     spec.name = object_name
 
@@ -1672,6 +1713,7 @@ SEE ALSO
     if not path:
         raise PredictionError('job %s produced no structure' % job_id)
     object_name = name or getattr(job.spec, 'name', None) or job_id
+    object_name = _legal_object_name(object_name, _self=_self)
     _self.load(path, object_name)
     if not int(quiet):
         colorprinting.parrot(' predict: loaded %s' % object_name)
@@ -1915,7 +1957,7 @@ SEE ALSO
     """
     pump(_self=_self)
     if name:
-        removed = _RECENT.pop(name, None) is not None
+        removed = _RECENT.pop(_legal_object_name(name, _self=_self), None) is not None
     else:
         removed = bool(_RECENT)
         _RECENT.clear()

--- a/testing/tests/predict/predict_autoload.py
+++ b/testing/tests/predict/predict_autoload.py
@@ -234,6 +234,35 @@ class TestPlaceholder(testing.PyMOLTestCase):
         self.assertNotIn('my_test', cmd.get_names('objects'))
         self.assertNotIn('my_test', predicting.pending_objects())
 
+    # -- Names PyMOL rewrites on creation ------------------------------------
+    #
+    # `cmd.create` LEGALISES an object name: an apostrophe, a space and a forward slash
+    # all become underscores, and nothing tells the caller. A placeholder keyed on the
+    # name that was asked for therefore names an object that does not exist.
+
+    def testAPlaceholderIsKeyedUnderTheNameTheObjectActuallyHas(self):
+        from pymol import predicting
+        self._submit(name='my structure')
+        real = cmd.get_legal_name('my structure')
+        self.assertNotEqual(real, 'my structure', 'pre-condition: PyMOL rewrites this')
+        self.assertIn(real, cmd.get_names('objects'))
+        # The invariant session_save and the discard both depend on.
+        self.assertIn(real, predicting.pending_objects())
+
+    def testCleanupRemovesARewrittenNamePlaceholder(self):
+        # The leak: discard deletes the object only if it can find it. Keyed on the raw
+        # name it finds nothing, drops the record, and leaves a zero-atom object behind
+        # with no job and no card to dismiss it from.
+        from pymol import predicting
+        self._submit(name='my structure')
+        real = cmd.get_legal_name('my structure')
+        self.assertEqual(cmd.count_atoms(real), 0, 'pre-condition: an empty placeholder')
+        predicting.discard_pending(real)
+        self.assertNotIn(real, cmd.get_names('objects'))
+        # The WHOLE table: keyed otherwise the record is orphaned rather than removed,
+        # and the object stays listed as pending for the rest of the session.
+        self.assertEqual(predicting.pending_objects(), {})
+
     def testCleanupKeepsAnObjectThatAlreadyHasAtoms(self):
         """A completed job's object must never be deleted by late cleanup."""
         self._submit(name='my_test')
@@ -359,6 +388,24 @@ class TestSessionExclusion(testing.PyMOLTestCase):
         names = [e[0] for e in session['names'] if e]
         self.assertIn('keep_me', names)
         self.assertNotIn('pending_one', names)
+
+    def testARewrittenNamePlaceholderIsAlsoStrippedFromTheSession(self):
+        """session_save matches on the name the SESSION carries -- the object's real one.
+
+        Keyed on anything else it never matches, so the zero-atom placeholder this
+        function exists to drop is written into the .pse and reloads as an object that
+        can never fill.
+        """
+        from pymol import predicting
+        cmd.pseudoatom('keep_me')
+        predicting.register_pending('pending one', 'jobX')
+        real = cmd.get_legal_name('pending one')
+        self.assertNotEqual(real, 'pending one', 'pre-condition: PyMOL rewrites this')
+        session = cmd.get_session()
+        predicting.session_save(session)
+        names = [e[0] for e in session['names'] if e]
+        self.assertIn('keep_me', names)
+        self.assertNotIn(real, names)
 
     def testStructuralNoneEntriesArePreserved(self):
         """PyMOL's names list carries None entries; dropping them corrupts the session."""

--- a/testing/tests/predict/predict_progress.py
+++ b/testing/tests/predict/predict_progress.py
@@ -586,38 +586,38 @@ class TestPendingInfo(testing.PyMOLTestCase):
             except Exception:
                 pass
 
-    def testDismissSpaceNameViaDirectApi(self):
-        """cmd.predict_dismiss('my pred') works; cmd.do passes quotes as literals.
+    def testDismissSpaceNameViaDirectApiAndViaCmdDo(self):
+        """Dismissing a space-containing name, through both entry points.
 
-        FINDING: parsing.STRICT does NOT strip surrounding double-quotes from
-        arguments -- cmd.do('predict_dismiss "my pred"') passes the argument as
-        '"my pred"' (quotes included), not 'my pred'. Verified by sentinel-key
-        probe: only the literal-quoted key was removed, not 'my pred' itself.
+        A prediction asked for as 'my pred' IS the object `my_pred`: creation legalises
+        the name, so that is the key the retained card is filed under. Both dismissal
+        routes legalise what they are given, so both reach it.
 
-        The Swift error card must therefore avoid spaces in derived object names,
-        OR call the Python API directly rather than through cmd.do, OR strip its
-        own quotes before dispatching. The direct-API path is what every test in
-        this suite (and testDismissRemovesARetainedCard above) uses, and it works
-        for space-containing names.
+        FINDING, still true and still worth pinning: parsing.STRICT does NOT strip
+        surrounding double-quotes, so cmd.do('predict_dismiss "my pred"') passes the
+        argument as '"my pred"', quotes included. That used to mean the card survived --
+        the quoted key was popped and 'my pred' was not. It no longer does, because
+        legalisation maps '"my pred"' and 'my pred' onto the same `my_pred`: the quotes
+        are stripped as invalid characters. So the Swift error card may now dispatch a
+        spaced name through cmd.do, which it previously could not.
         """
+        real = self.cmd.get_legal_name('my pred')
+        self.assertEqual(real, 'my_pred', 'pre-condition: the name PyMOL actually uses')
         self.register('my pred', [[{'state': 'failed', 'phase': 'inference',
                                     'fraction': 0.0, 'error': 'x'}]])
         self.predicting.pending_info('my pred', _self=self.cmd)
         self.predicting.discard_pending('my pred', _self=self.cmd)
-        self.assertIsNotNone(self.predicting._RECENT.get('my pred'),
+        # Retained under the object's real name, which is what the panel lists.
+        self.assertIsNotNone(self.predicting._RECENT.get(real),
                              'pre-condition: failure must be retained')
-        # Direct API: works fine for space names.
         self.cmd.predict_dismiss('my pred')
-        self.assertIsNone(self.predicting._RECENT.get('my pred'),
+        self.assertIsNone(self.predicting._RECENT.get(real),
                           'direct API must dismiss space-containing name')
-        # cmd.do with quotes: STRICT passes the argument with the quotes as
-        # literal characters, not stripped -- 'my pred' is NOT matched.
-        self.predicting._RECENT['my pred'] = {'state': 'failed'}
+        # cmd.do: the argument still arrives quoted, and now still lands on the card.
+        self.predicting._RECENT[real] = {'state': 'failed'}
         self.cmd.do('predict_dismiss "my pred"')
-        # The key '"my pred"' (with quotes) would be popped, not 'my pred'.
-        # Assert the actual behaviour so a future Swift fix is caught immediately.
-        self.assertIsNotNone(self.predicting._RECENT.get('my pred'),
-                             'cmd.do with quoted arg does NOT strip quotes in STRICT mode')
+        self.assertIsNone(self.predicting._RECENT.get(real),
+                          'legalising the argument strips the quotes STRICT left on')
 
     # -- Measured diffusion progress and the phase-local ETA (increment 3) -----
 


### PR DESCRIPTION
## The bug

`register_pending` creates the placeholder with `cmd.create(name, 'none')`, which **legalises** the name — an apostrophe, a space and a forward slash all become underscores — but `_PENDING`/`_TRACK` were keyed on the name as given. Nothing reports the difference.

For `cmd.predict(..., name='my structure')` the object is `my_structure` while the tables say `my structure`. Measured:

```
object created as : 'my_structure'
_PENDING keyed as : ['my structure']
session_save keeps: ['my_structure']   *** persisted into the .pse ***
after discard     : objects=['my_structure']   *** LEAKED ***
```

Three consequences, all silent:

- **The placeholder leaks.** `discard_pending` deletes the object only if it can find it. Keyed otherwise it drops the record and leaves a zero-atom object with no job behind it and no card to dismiss it from.
- **`session_save` writes it into the `.pse`.** It matches `entry[0] in _PENDING` against the name the *session* carries — the object's real one — so it never matches. That is precisely the "object that can never fill on reload" the function exists to keep out.
- **`record_run` files metrics against a name nothing answers to.**

## The fix

Legalise the name where it is **chosen** (`predict()`), so one string is the placeholder key, the name the host is handed and echoes back to `deliver_result`, and what metrics attach to — plus on every public entry point taking an object name (`register_pending`, `discard_pending`, `pending_info`, `deliver_result`, `predict_result`, `predict_dismiss`), so a name from the prompt, a script or Swift lands on the same key.

Via `cmd.get_legal_name`, which is the same C++ `ObjectMakeValidName` that creation applies, so the two cannot drift. Worth not hand-rolling: the rule strips a trailing `)`, emits one underscore per *byte* of a multi-byte character, and leaves `+`, `-`, `.` alone.

`pending_info` is included rather than skipped on poll-path grounds. In production its callers pass table keys, so it is a no-op — but "some of these legalise and some don't" is a rule every caller must then know, and the existing suite already contained a caller passing a raw name. Measured before deciding: **0.82 µs/call — 0.016 ms for twenty placeholders on a 500 ms tick, 0.003% of it.** Its "never raises" contract is preserved by guarding just that call.

## One existing test rewritten (please look at this)

`testDismissSpaceNameViaDirectApi` asserted the **old** keying, so it could not survive unchanged. Its subject is unchanged and its STRICT finding still holds — `cmd.do` does not strip surrounding quotes — but its *conclusion has flipped*: `'"my pred"'` and `'my pred'` both legalise to `my_pred`, so the quotes are stripped as invalid characters and the card is now reached. The Swift error card may therefore dispatch a spaced name through `cmd.do`, which that docstring said it could not.

## Verification

- 3 new tests in `predict_autoload.py` covering the keying, the leak and the `.pse` persistence.
- A/B control: **4 fail** with the source reverted to `origin/master`, all pass with it.
- Full predict suite: **399 tests, OK**. Full CI list: **666 tests, exit 0**.

## Scope

The identical bug on the design path is fixed separately on the `claude/issue-342-rfd3` branch, where that code lives. Kept out of here deliberately — it is not master's code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)