### PR TITLE
feat(viewport): hover readout chip scoped to the selection level (#359)

### DIFF
--- a/modules/pymol/metal_pick.py
+++ b/modules/pymol/metal_pick.py
@@ -54,6 +54,53 @@ _DRAWN_REPS = ('rep spheres or rep sticks or rep lines or rep nb_spheres or '
 # committed color always wins on overlap.
 _PRESELECT = '_preselect'
 
+# Payload file the top-right hover readout (issue #359) reads back: the identity
+# of whatever sits under the cursor, at the CURRENT mouse_selection_mode. The
+# hover pick already computes this to build the '_preselect' highlight — the
+# readout just keeps it instead of discarding it. Swift formats the text (see
+# HoverReadout.text); Python stays a dumb reporter so the formatting rules are
+# unit-testable without a live core.
+_HOVER_INFO_JSON = 'pymol_hover_info.json'
+
+
+def _hover_info_path():
+    import os, tempfile
+    return os.path.join(tempfile.gettempdir(), _HOVER_INFO_JSON)
+
+
+def _write_hover_info(out):
+    """Write the hover-readout payload. The reader (Swift) calls this through a
+    SYNCHRONOUS runPython on its own thread and reads the file immediately after,
+    so there is no writer/reader race to guard against — same contract as
+    hover_design_at's payload."""
+    import json
+    try:
+        with open(_hover_info_path(), 'w') as f:
+            json.dump(out, f)
+    except Exception:
+        pass
+
+
+def _hover_payload(best, mode):
+    """Identity of a _pick_atom hit, plus the selection level it was picked at.
+
+    `nstates` lets the readout drop the state component for the single-state
+    objects that are the common case; `state` is the DISPLAYED state, which is
+    also the one _pick_atom projected against."""
+    from pymol import cmd
+    _, obj, chain, resi, resn, segi, name, _sx, _sy = best
+    try:
+        nstates = int(cmd.count_states(obj))
+    except Exception:
+        nstates = 1
+    try:
+        state = int(cmd.get_state())
+    except Exception:
+        state = 1
+    return {"hit": True, "obj": obj, "chain": chain, "resi": resi, "resn": resn,
+            "segi": segi, "name": name, "mode": int(mode),
+            "state": state, "nstates": nstates}
+
 
 def _pickdbg(ndc_x, ndc_y, aspect, best, ncand):
     """Append a pick diagnostic line to PYMOL_PICKDEBUG (debug harness only).
@@ -570,7 +617,7 @@ def pick_info_at(ndc_x, ndc_y, aspect):
         pass
 
 
-def hover_preview_at(ndc_x, ndc_y, aspect):
+def hover_preview_at(ndc_x, ndc_y, aspect, preview=1, info=0):
     """Hover PREVIEW (issue #165): highlight what a click WOULD select, without
     committing anything. Runs the same pick + mouse_selection_mode expansion as
     pick_at, but writes the result to the transient '_preselect' selection
@@ -579,10 +626,23 @@ def hover_preview_at(ndc_x, ndc_y, aspect):
     Deliberately touches ONLY '_preselect' — never 'sele' or 'pk1' — so the
     committed selection is untouched as the pointer moves. The renderer draws
     '_preselect' in a distinct color/size BEFORE the committed pink pass, so an
-    already-selected residue keeps its committed color under the cursor."""
+    already-selected residue keeps its committed color under the cursor.
+
+    Two independently toggleable features ride on this ONE pick (the projection
+    over every drawn atom is the expensive part, so it must not run twice):
+      preview=1  update the '_preselect' highlight   (Mouse / Hover)
+      info=1     write the top-right readout payload (issue #359) to
+                 <tmpdir>/pymol_hover_info.json for Swift to format
+    The caller passes whichever its user has left on; with both off it should not
+    call at all.
+    """
     from pymol import cmd
     try:
         best = _pick_atom(ndc_x, ndc_y, aspect)
+        try:
+            mode = int(cmd.get_setting_int('mouse_selection_mode'))
+        except Exception:
+            mode = 1
         if best is None:
             # Empty space: clear the preview (leave 'sele' untouched). enable=0:
             # NEVER enable '_preselect' — cmd.enable is exclusive for selections
@@ -590,18 +650,25 @@ def hover_preview_at(ndc_x, ndc_y, aspect):
             # (the atoms stay in 'sele', which is why a click still appended).
             # The renderer draws '_preselect' by atom membership regardless of
             # its enabled flag, so the cyan preview still shows.
-            cmd.select(_PRESELECT, 'none', enable=0)
+            if preview:
+                cmd.select(_PRESELECT, 'none', enable=0)
+            if info:
+                _write_hover_info({"hit": False})
             return
 
-        try:
-            mode = int(cmd.get_setting_int('mouse_selection_mode'))
-        except Exception:
-            mode = 1
         # enable=0 and NO cmd.enable — see the note above: enabling '_preselect'
         # would deselect the committed 'sele'. The C++ preselect pass renders it
         # by name/membership regardless of enabled state.
-        cmd.select(_PRESELECT, _mode_expr(best, mode), enable=0)
+        if preview:
+            cmd.select(_PRESELECT, _mode_expr(best, mode), enable=0)
+        if info:
+            _write_hover_info(_hover_payload(best, mode))
     except Exception as e:
+        # A failed pick must not leave the LAST hit's payload on disk: the reader
+        # cannot tell a stale file from a fresh one, so the chip would keep naming
+        # a residue the cursor left long ago.
+        if info:
+            _write_hover_info({"hit": False})
         print('metal_pick hover error: %s' % e)
 
 

--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		68AB212502F00E7E297F8208 /* ProtenixSizeGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EE8A26A41F551AB296B2F8E /* ProtenixSizeGuard.swift */; };
 		6A1DB5F97E3738FD1819FF6E /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3E805AC2D63B01AB7EE29C /* Theme.swift */; };
 		6A3892FDD5939A57DC9FFCCE /* CopyRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0B47016374F32C7BB13017 /* CopyRoutingTests.swift */; };
+		FE667ADF3DAD102C12DC4DA2 /* HoverReadoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF1264ED4865B293F313315 /* HoverReadoutTests.swift */; };
 		6C028EE83C8A29A4FDCF2222 /* BoltzJobManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 193D4D739151970412BB6EDF /* BoltzJobManagerTests.swift */; };
 		6C8AA3C224C1B2106FBF4881 /* DesignScoreCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC5AE545F97DF175BFE0462 /* DesignScoreCache.swift */; };
 		6D67CAB3F655837D48E68AF3 /* PredictController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0D207800BE2DDAF04598C1 /* PredictController.swift */; };
@@ -127,11 +128,13 @@
 		86F8E58F4BAA9E8B03380DBB /* TransportBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C562306A5AD1EEDDBA931B98 /* TransportBar.swift */; };
 		8852A9FA93BDAAB188D4103C /* PyMOLEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33D6A753E4525628B96C259C /* PyMOLEngine.swift */; };
 		8C04C5D4AB27F2D9BEF79561 /* GizmoOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4C108E3D04FD75288859DA /* GizmoOverlay.swift */; };
+		12A3993A3E181A358E00AF0A /* HoverReadout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80137B4E6E0FA24F011D7E87 /* HoverReadout.swift */; };
 		8CDF44341FE9E9CB053BFC76 /* TransportBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C562306A5AD1EEDDBA931B98 /* TransportBar.swift */; };
 		8DC572A1863238F8B919ED70 /* WhatsNewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5377EE69A856479317FD61 /* WhatsNewModel.swift */; };
 		8E33AC50510ECB1DA4277904 /* RayMol.svg in Resources */ = {isa = PBXBuildFile; fileRef = F16058D96E2773BE9A24C323 /* RayMol.svg */; };
 		8F33D1DB927644308CEF0C5B /* WhatsNew.json in Resources */ = {isa = PBXBuildFile; fileRef = 689CDE512811C244D4BA931B /* WhatsNew.json */; };
 		8F71359FAD68AE5D09416C1B /* GizmoOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4C108E3D04FD75288859DA /* GizmoOverlay.swift */; };
+		32061FAD7CD7E949C8C6A7BF /* HoverReadout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80137B4E6E0FA24F011D7E87 /* HoverReadout.swift */; };
 		90F5E063444FBF4FF3770118 /* MCPStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1304C662D9011F7C4505FC /* MCPStatusView.swift */; };
 		917ABB57816FDCD8B1D1E9CE /* DesignSizeGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3CAE980896763CAAAF2034 /* DesignSizeGuardTests.swift */; };
 		946A8CF4D62A7AFFFA6E39A9 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 10CCAA289EA2934B267C337A /* PrivacyInfo.xcprivacy */; };
@@ -320,6 +323,7 @@
 		A63406B360384F3C62E511E1 /* RayMolPython.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RayMolPython.entitlements; sourceTree = "<group>"; };
 		A73267D4D7B506E647B7A995 /* ObjectPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectPanel.swift; sourceTree = "<group>"; };
 		AA4C108E3D04FD75288859DA /* GizmoOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GizmoOverlay.swift; sourceTree = "<group>"; };
+		80137B4E6E0FA24F011D7E87 /* HoverReadout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverReadout.swift; sourceTree = "<group>"; };
 		AD3E224EA1BE94147B322332 /* InferenceRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InferenceRouterTests.swift; sourceTree = "<group>"; };
 		B158150C93613716ED3CE572 /* KeyboardDismissUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardDismissUITests.swift; sourceTree = "<group>"; };
 		B45634C95AE991CC91CFBA75 /* DesignInferenceSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignInferenceSmokeTests.swift; sourceTree = "<group>"; };
@@ -330,6 +334,7 @@
 		B9EC978B16F58D988575E206 /* MCPDrivingBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPDrivingBanner.swift; sourceTree = "<group>"; };
 		BB5ABD1A8C45E5BC97AB0B80 /* RayMol.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = RayMol.icon; sourceTree = "<group>"; };
 		BF0B47016374F32C7BB13017 /* CopyRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyRoutingTests.swift; sourceTree = "<group>"; };
+		3BF1264ED4865B293F313315 /* HoverReadoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverReadoutTests.swift; sourceTree = "<group>"; };
 		C2C2F36B9B6E660DD0256EC2 /* PredictCompactPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictCompactPanel.swift; sourceTree = "<group>"; };
 		C3F3410F7C0D3C85783B985F /* AppVersionFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionFooter.swift; sourceTree = "<group>"; };
 		C562306A5AD1EEDDBA931B98 /* TransportBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportBar.swift; sourceTree = "<group>"; };
@@ -504,6 +509,7 @@
 				EEC5AE545F97DF175BFE0462 /* DesignScoreCache.swift */,
 				9E69AA2C12DC2D1583FBF8C8 /* DesignSizeGuard.swift */,
 				AA4C108E3D04FD75288859DA /* GizmoOverlay.swift */,
+				80137B4E6E0FA24F011D7E87 /* HoverReadout.swift */,
 				87825A30DE5C455B6270187F /* InferenceJob.swift */,
 				71574A2074A14803B91ED695 /* InferenceRouter.swift */,
 				3697F74BD2283492B5A7790C /* KeyRouting.swift */,
@@ -546,6 +552,7 @@
 				1A75842F74BFC453CE7BA777 /* BoltzJobManagerMSATests.swift */,
 				193D4D739151970412BB6EDF /* BoltzJobManagerTests.swift */,
 				BF0B47016374F32C7BB13017 /* CopyRoutingTests.swift */,
+				3BF1264ED4865B293F313315 /* HoverReadoutTests.swift */,
 				2345D7E2703CF29D4A2AA277 /* DesignAvailabilityTests.swift */,
 				1B045EA1D04163863BD9DA94 /* DesignColorTests.swift */,
 				F7E41DCBB427678A8F018B0E /* DesignControllerTests.swift */,
@@ -1273,6 +1280,7 @@
 				238B6F24D467D70AE012E2CB /* BoltzJobManagerMSATests.swift in Sources */,
 				6C028EE83C8A29A4FDCF2222 /* BoltzJobManagerTests.swift in Sources */,
 				6A3892FDD5939A57DC9FFCCE /* CopyRoutingTests.swift in Sources */,
+				FE667ADF3DAD102C12DC4DA2 /* HoverReadoutTests.swift in Sources */,
 				B88942D786AB0D1CDC354C1F /* DesignAvailabilityTests.swift in Sources */,
 				42BC62ABCFB3CDB9C2CE3518 /* DesignColorTests.swift in Sources */,
 				FCB5A40892C6D7239E49791A /* DesignControllerTests.swift in Sources */,
@@ -1325,6 +1333,7 @@
 				2E559E9581421DDC00C8BBB8 /* DesignScoreCache.swift in Sources */,
 				65CE08E50C85C8ACDAC92D07 /* DesignSizeGuard.swift in Sources */,
 				8C04C5D4AB27F2D9BEF79561 /* GizmoOverlay.swift in Sources */,
+				12A3993A3E181A358E00AF0A /* HoverReadout.swift in Sources */,
 				59414471A1C1412AF869074D /* InferenceJob.swift in Sources */,
 				AC4CB915ECB531A4406CF387 /* InferenceRouter.swift in Sources */,
 				2C2D4B24DF4807FA1407582D /* KeyRouting.swift in Sources */,
@@ -1390,6 +1399,7 @@
 				6C8AA3C224C1B2106FBF4881 /* DesignScoreCache.swift in Sources */,
 				1A580F6792CD440D91FA9F45 /* DesignSizeGuard.swift in Sources */,
 				8F71359FAD68AE5D09416C1B /* GizmoOverlay.swift in Sources */,
+				32061FAD7CD7E949C8C6A7BF /* HoverReadout.swift in Sources */,
 				82DADD44C2ED6C0A534EBD26 /* InferenceJob.swift in Sources */,
 				966C6886E3CE816365256220 /* InferenceRouter.swift in Sources */,
 				768E23FCAB4D2B27205900B6 /* KeyRouting.swift in Sources */,

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -272,6 +272,9 @@ enum SceneCatalog {
         // special-case) and persisted across launches. Same control as Mouse ▸ Hover.
         SceneParam(setting: "hover_indicator", label: "Hover indicator", kind: .toggle, group: "Canvas",
                    help: "Highlight the residue under the cursor (nearest Cα) before you click, in a distinct cyan — without changing the selection. Also on the Mouse panel; persists across launches."),
+        // Also not a PyMOL setting — bound to engine.hoverReadoutEnabled (#359).
+        SceneParam(setting: "hover_readout", label: "Hover readout", kind: .toggle, group: "Canvas",
+                   help: "Name whatever the cursor is over in the viewport's top-right corner, at the current selection level — object, chain, segment, residue or atom. Persists across launches."),
 
         // --- Camera: viewpoint + lens ---
         SceneParam(setting: "field_of_view", label: "Lens (mm)", kind: .slider, min: 12, max: 135, step: 0.5, decimals: 0, group: "Camera",
@@ -3069,6 +3072,13 @@ struct SceneParamRow: View {
                     ToggleSetting(value: engine.hoverPreviewEnabled ? 1 : 0) { on in
                         engine.hoverPreviewEnabled = on
                         if !on { engine.clearHoverPreview() }
+                    }
+                } else if p.setting == "hover_readout" {
+                    // Likewise app-level (#359): gates the top-right identity chip.
+                    // Turning it off clears the chip via the property's didSet; the
+                    // hover pick itself keeps running only if the indicator is on.
+                    ToggleSetting(value: engine.hoverReadoutEnabled ? 1 : 0) { on in
+                        engine.hoverReadoutEnabled = on
                     }
                 } else {
                     ToggleSetting(value: v) { on in engine.runCommand("set \(p.setting), \(on ? 1 : 0)") }

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -382,6 +382,20 @@ struct ContentView: View {
         .allowsHitTesting(true)
     }
 
+    // Live hover readout chip (issue #359): names whatever the cursor is over, at
+    // the current selection level. Shared by the macOS and iOS viewports. Empty
+    // space (or the setting off) publishes nil, so the chip disappears rather
+    // than going stale. Animated so a sweep across the structure reads as the
+    // text updating, not as flicker.
+    @ViewBuilder private var hoverReadoutOverlay: some View {
+        if let readout = engine.hoverReadout, engine.hoverReadoutEnabled {
+            HoverReadoutChip(text: readout)
+                .padding(10)
+                .transition(.opacity)
+                .animation(.easeOut(duration: 0.12), value: readout)
+        }
+    }
+
     // MARK: - macOS: HSplitView with sidebar
 
     #if os(macOS)
@@ -965,6 +979,11 @@ struct ContentView: View {
                                          hovered: engine.hoveredHandle)
                 }
             }
+            // Live hover readout (issue #359), top-trailing. Only ever populated
+            // in viewing mode — the hover pick bails out under move/measure and
+            // Design mode runs its own hover path — so it can never collide with
+            // the mode bars that occupy the top edge above.
+            .overlay(alignment: .topTrailing) { hoverReadoutOverlay }
             // Mouse-mode legend as a compact floating card at the bottom-trailing
             // corner, so it's reachable even when the right column is collapsed
             // (where MousePanel used to live). Minimizable to free up the view.
@@ -2648,6 +2667,13 @@ struct ContentView: View {
                 // Keep the help button clear of the floating transport (timeline mode
                 // docks the panel elsewhere, so the viewport is clear then).
                 .padding(.bottom, 0)
+            }
+            // Live hover readout (issue #359). iOS only ever populates this from a
+            // trackpad / Apple Pencil hover (UIHoverGestureRecognizer never fires
+            // for a finger), so pure-touch use never sees the chip. Pushed clear
+            // of the floating top rail, which owns the same corner.
+            .overlay(alignment: .topTrailing) {
+                hoverReadoutOverlay.padding(.top, 44)
             }
             // Test-only hook (PYMOL_UITEST=1): surface the live selection size
             // so XCUITest can assert tap-to-select / clear behavior. Invisible

--- a/swiftui/PyMOLViewer/Shared/HoverReadout.swift
+++ b/swiftui/PyMOLViewer/Shared/HoverReadout.swift
@@ -1,0 +1,138 @@
+import SwiftUI
+
+/// Identity of whatever the pointer is currently over, as reported by
+/// `metal_pick.hover_preview_at(..., info=1)` (issue #359).
+///
+/// The hover pick already resolves all of this to build the `_preselect`
+/// highlight; the readout keeps it instead of discarding it.
+struct HoverIdentity: Equatable {
+    var object: String
+    var chain: String
+    var resi: String
+    var resn: String
+    var segi: String
+    var name: String
+    /// `mouse_selection_mode` AT PICK TIME — 0 atom, 1 residue, 2 chain,
+    /// 3 segment, 4 object, 5 molecule, 6 C-α. Carried in the payload rather
+    /// than read from the Swift-side scene mirror, which only refreshes on the
+    /// ~500 ms poll: right after a Tab (cycle level) the mirror is a level
+    /// behind, and the chip would name a scope the click no longer commits.
+    var mode: Int
+    /// Displayed state (the one `_pick_atom` projected against) and how many
+    /// states the object has — the readout names the state only when there is
+    /// more than one to be confused about.
+    var state: Int
+    var stateCount: Int
+}
+
+/// Turns a hover pick into the one-line chip text. A pure function of
+/// (pick result, selection level), so the whole formatting contract is
+/// testable headlessly — no engine, no gesture layer (see HoverReadoutTests).
+enum HoverReadout {
+
+    private static let separator = " / "
+
+    /// Decode a `pymol_hover_info.json` payload.
+    ///
+    /// Returns nil for BOTH "unreadable" and "the pick missed": either way there
+    /// is nothing to name, and unlike the design-pick payload (where a miss must
+    /// clear the selection) neither outcome has a side effect beyond hiding the
+    /// chip.
+    static func decode(payload: [String: Any]?) -> HoverIdentity? {
+        guard let root = payload, (root["hit"] as? Bool) == true else { return nil }
+        return HoverIdentity(
+            object: root["obj"] as? String ?? "",
+            chain: root["chain"] as? String ?? "",
+            resi: root["resi"] as? String ?? "",
+            resn: root["resn"] as? String ?? "",
+            segi: root["segi"] as? String ?? "",
+            name: root["name"] as? String ?? "",
+            mode: root["mode"] as? Int ?? 1,
+            state: root["state"] as? Int ?? 1,
+            stateCount: root["nstates"] as? Int ?? 1)
+    }
+
+    /// The chip text, or nil when there is nothing nameable (no object).
+    ///
+    /// The readout stops exactly where the selection would: at Object level it
+    /// names the object and no more, and at Chain/Segment level with a blank
+    /// chain/segi it falls back to the object — mirroring `_mode_expr`, which
+    /// expands those to the whole object. Naming a residue there would advertise
+    /// a scope a click does not commit.
+    static func text(for id: HoverIdentity) -> String? {
+        let object = id.object.trimmingCharacters(in: .whitespaces)
+        guard !object.isEmpty else { return nil }
+
+        var parts = [object]
+        if id.stateCount > 1 { parts.append("state \(id.state)") }
+
+        let chain = id.chain.trimmingCharacters(in: .whitespaces)
+        let segi = id.segi.trimmingCharacters(in: .whitespaces)
+
+        switch id.mode {
+        case 4:                                             // object
+            return parts.joined(separator: separator)
+        case 2:                                             // chain
+            if !chain.isEmpty { parts.append("chain \(chain)") }
+            return parts.joined(separator: separator)
+        case 3:                                             // segment
+            guard !segi.isEmpty else { return parts.joined(separator: separator) }
+            if !chain.isEmpty { parts.append("chain \(chain)") }
+            parts.append("seg \(segi)")
+            return parts.joined(separator: separator)
+        default:
+            break
+        }
+
+        if !chain.isEmpty { parts.append("chain \(chain)") }
+        let residue = [id.resn.trimmingCharacters(in: .whitespaces),
+                       id.resi.trimmingCharacters(in: .whitespaces)]
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+
+        switch id.mode {
+        case 0:                                             // atom
+            if !residue.isEmpty { parts.append(residue) }
+            let atom = id.name.trimmingCharacters(in: .whitespaces)
+            if !atom.isEmpty { parts.append(atom) }
+        case 5:
+            // Molecule level commits the whole connected component (`bymol`).
+            // Name it by the residue the pick anchored on — for the het groups
+            // and ligands this level exists to grab, that residue IS the
+            // molecule's name (HEM 501). The "mol" tag keeps it from reading as
+            // a residue-level pick.
+            if !residue.isEmpty { parts.append("mol \(residue)") }
+        default:                                            // 1 residue, 6 C-α
+            if !residue.isEmpty { parts.append(residue) }
+        }
+        return parts.joined(separator: separator)
+    }
+
+    /// Payload → chip text in one step (what the engine calls).
+    static func text(payload: [String: Any]?) -> String? {
+        guard let id = decode(payload: payload) else { return nil }
+        return text(for: id)
+    }
+}
+
+/// The chip itself: a small, non-interactive text pill pinned to the viewport's
+/// top-trailing corner. Never hit-testable — it floats over the Metal view and
+/// must not swallow a click meant for the structure under it.
+struct HoverReadoutChip: View {
+    let text: String
+    @EnvironmentObject var themeManager: ThemeManager
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 11, weight: .medium, design: .monospaced))
+            .foregroundColor(themeManager.active.panelText.color)
+            .lineLimit(1)
+            .truncationMode(.head)          // keep the finest scope (the atom) visible
+            .padding(.horizontal, 9)
+            .padding(.vertical, 5)
+            .background(.ultraThinMaterial, in: Capsule())
+            .overlay(Capsule().strokeBorder(Color.white.opacity(0.08), lineWidth: 0.5))
+            .allowsHitTesting(false)
+            .accessibilityIdentifier("hoverReadout")
+    }
+}

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -261,6 +261,22 @@ final class PyMOLEngine: ObservableObject {
         didSet { UserDefaults.standard.set(hoverPreviewEnabled, forKey: PyMOLEngine.hoverDefaultsKey) }
     }
     static let hoverDefaultsKey = "raymol.hoverPreviewEnabled"
+    // Hover READOUT (issue #359): a chip in the viewport's top-trailing corner
+    // naming whatever is under the cursor, at the current selection level. Rides
+    // on the SAME hover pick as the preview above but is independently
+    // toggleable — some users want the highlight without the text, or the text
+    // without the highlight. Persisted across launches; default on.
+    @Published var hoverReadoutEnabled: Bool =
+        (UserDefaults.standard.object(forKey: PyMOLEngine.hoverReadoutDefaultsKey) as? Bool ?? true) {
+        didSet {
+            UserDefaults.standard.set(hoverReadoutEnabled, forKey: PyMOLEngine.hoverReadoutDefaultsKey)
+            if !hoverReadoutEnabled { hoverReadout = nil }
+        }
+    }
+    static let hoverReadoutDefaultsKey = "raymol.hoverReadoutEnabled"
+    // The formatted chip text, or nil when the pointer is over empty space (or
+    // the readout is off) — so the chip never lingers with a stale identity.
+    @Published var hoverReadout: String? = nil
     // Full settings catalog for the searchable Settings panel (loaded on demand).
     @Published var settingsCatalog: [SettingItem] = []
     // The single detail view that is currently open (accordion: at most one).
@@ -2837,7 +2853,10 @@ final class PyMOLEngine: ObservableObject {
     /// tracks CONTINUOUSLY while the pointer sweeps — a pure trailing debounce
     /// only fired once the pointer paused, which read as "hover doesn't work".
     func hoverPreview(_ ndcX: Float, _ ndcY: Float, _ aspect: Float) {
-        guard isReady, hoverPreviewEnabled else { return }
+        // Either output is reason enough to pick: the highlight (#165) and the
+        // top-right readout (#359) are separately toggleable but share this one
+        // pick, so only BOTH being off makes hovering free.
+        guard isReady, hoverPreviewEnabled || hoverReadoutEnabled else { return }
         if let last = lastHoverNDC {
             let dx = ndcX - last.0, dy = ndcY - last.1
             if abs(dx) < kHoverMinNDC && abs(dy) < kHoverMinNDC { return }
@@ -2847,9 +2866,13 @@ final class PyMOLEngine: ObservableObject {
         let fire: () -> Void = { [weak self] in
             guard let self = self else { return }
             self.lastHoverFire = Date()
+            let wantsPreview = self.hoverPreviewEnabled
+            let wantsInfo = self.hoverReadoutEnabled
             self.runPython(
                 "from pymol import metal_pick as _mp; "
-                + "_mp.hover_preview_at(\(ndcX), \(ndcY), \(aspect))")
+                + "_mp.hover_preview_at(\(ndcX), \(ndcY), \(aspect), "
+                + "\(wantsPreview ? 1 : 0), \(wantsInfo ? 1 : 0))")
+            if wantsInfo { self.readHoverInfo() }
         }
         let elapsed = Date().timeIntervalSince(lastHoverFire)
         if elapsed >= kHoverInterval {
@@ -2869,6 +2892,11 @@ final class PyMOLEngine: ObservableObject {
         hoverWork?.cancel()
         hoverWork = nil
         lastHoverNDC = nil
+        // Drop the readout here too (not only when a pick reports empty space):
+        // this is the mouse-exit / drag-start path, where no further pick runs
+        // and the chip would otherwise keep naming whatever was last under the
+        // cursor.
+        if hoverReadout != nil { hoverReadout = nil }
         #if RAYMOL_MPNN
         designHoverWork?.cancel()
         designHoverWork = nil
@@ -2880,6 +2908,24 @@ final class PyMOLEngine: ObservableObject {
         // and would disable the committed 'sele', hiding its markers. (The
         // renderer draws '_preselect' by membership regardless of enabled state.)
         runPython("from pymol import cmd as _c; _c.select('_preselect', 'none', enable=0)")
+    }
+
+    /// Read back the payload the hover pick just wrote and publish the formatted
+    /// chip text. Called immediately after the pick on the same thread —
+    /// `runPython` runs the interpreter inline, so the file on disk is this
+    /// hover's result, not the previous one (same contract readDesignHoverHit
+    /// relies on).
+    ///
+    /// An unreadable payload resolves to nil (chip hidden) rather than being
+    /// ignored: keeping the last text on screen would name a residue the cursor
+    /// has already left, which is worse than showing nothing.
+    private func readHoverInfo() {
+        let path = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("pymol_hover_info.json")
+        let data = FileManager.default.contents(atPath: path)
+        let root = data.flatMap { try? JSONSerialization.jsonObject(with: $0) } as? [String: Any]
+        let text = HoverReadout.text(payload: root)
+        if hoverReadout != text { hoverReadout = text }
     }
 
     #if RAYMOL_MPNN

--- a/swiftui/PyMOLViewerTests/HoverReadoutTests.swift
+++ b/swiftui/PyMOLViewerTests/HoverReadoutTests.swift
@@ -1,0 +1,154 @@
+import XCTest
+@testable import RayMol
+
+/// Coverage for `HoverReadout` — the hover-identity chip in the viewport's
+/// top-right corner (#359).
+///
+/// The whole point of keeping the formatter a pure function of
+/// (pick payload, selection level) is that these rules can be pinned down
+/// without a live core, a camera, or a gesture: the readout must name exactly
+/// the scope a click at the current `mouse_selection_mode` would commit —
+/// no finer (it would promise a precision the click doesn't have) and no
+/// coarser (it would be useless for "which residue am I about to click?").
+final class HoverReadoutTests: XCTestCase {
+
+    /// A hit on `1abc / chain J / TYR 42 / CA`, single-state, segment A1.
+    private func hit(mode: Int,
+                     chain: String = "J",
+                     segi: String = "A1",
+                     stateCount: Int = 1,
+                     state: Int = 1) -> HoverIdentity {
+        HoverIdentity(object: "1abc", chain: chain, resi: "42", resn: "TYR",
+                      segi: segi, name: "CA", mode: mode,
+                      state: state, stateCount: stateCount)
+    }
+
+    // MARK: - One readout per selection level
+
+    func testObjectLevelNamesOnlyTheObject() {
+        XCTAssertEqual(HoverReadout.text(for: hit(mode: 4)), "1abc",
+                       "Object level commits the whole object — naming its chain "
+                       + "or residue would advertise a scope the click never selects")
+    }
+
+    func testChainLevelStopsAtTheChain() {
+        XCTAssertEqual(HoverReadout.text(for: hit(mode: 2)), "1abc / chain J")
+    }
+
+    func testSegmentLevelNamesChainAndSegment() {
+        XCTAssertEqual(HoverReadout.text(for: hit(mode: 3)), "1abc / chain J / seg A1")
+    }
+
+    func testResidueLevelNamesTheResidue() {
+        XCTAssertEqual(HoverReadout.text(for: hit(mode: 1)), "1abc / chain J / TYR 42")
+    }
+
+    func testAtomLevelAppendsTheAtomName() {
+        XCTAssertEqual(HoverReadout.text(for: hit(mode: 0)), "1abc / chain J / TYR 42 / CA")
+    }
+
+    func testMoleculeLevelTagsTheAnchorResidue() {
+        // mouse_selection_mode 5 commits `bymol` — the whole connected
+        // component. The "mol" tag is what keeps it from being misread as a
+        // residue-level pick of the same residue.
+        XCTAssertEqual(HoverReadout.text(for: hit(mode: 5)), "1abc / chain J / mol TYR 42")
+    }
+
+    func testCAlphaLevelReadsLikeResidueLevel() {
+        // Mode 6 expands to the residue in `_mode_expr`, so the readout has to
+        // agree with it rather than inventing a Cα-specific scope.
+        XCTAssertEqual(HoverReadout.text(for: hit(mode: 6)), "1abc / chain J / TYR 42")
+    }
+
+    // MARK: - State component
+
+    func testStateOmittedForSingleStateObject() {
+        XCTAssertEqual(HoverReadout.text(for: hit(mode: 1, stateCount: 1)),
+                       "1abc / chain J / TYR 42",
+                       "a single-state object has no state worth naming — the chip "
+                       + "stays short")
+    }
+
+    func testStateShownForMultiStateObject() {
+        XCTAssertEqual(HoverReadout.text(for: hit(mode: 1, stateCount: 20, state: 7)),
+                       "1abc / state 7 / chain J / TYR 42",
+                       "an NMR/trajectory hit must say WHICH state it picked — the "
+                       + "pick projects the displayed state, not state 1")
+    }
+
+    func testStateShownAtEveryLevelIncludingObject() {
+        XCTAssertEqual(HoverReadout.text(for: hit(mode: 4, stateCount: 20, state: 7)),
+                       "1abc / state 7")
+    }
+
+    // MARK: - Missing fields degrade instead of showing empty components
+
+    func testBlankChainIsDroppedNotRenderedEmpty() {
+        XCTAssertEqual(HoverReadout.text(for: hit(mode: 1, chain: "")),
+                       "1abc / TYR 42",
+                       "a chainless atom must not produce a dangling \"chain \"")
+    }
+
+    func testChainLevelWithNoChainFallsBackToTheObject() {
+        // `_mode_expr` selects the whole object when the atom carries no chain;
+        // the readout has to fall back the same way.
+        XCTAssertEqual(HoverReadout.text(for: hit(mode: 2, chain: "")), "1abc")
+    }
+
+    func testSegmentLevelWithNoSegmentFallsBackToTheObject() {
+        XCTAssertEqual(HoverReadout.text(for: hit(mode: 3, segi: "")), "1abc",
+                       "`_mode_expr` selects the whole object for a segi-less atom, "
+                       + "so naming the chain would overstate the pick")
+    }
+
+    func testNoObjectMeansNoReadout() {
+        var id = hit(mode: 1)
+        id.object = ""
+        XCTAssertNil(HoverReadout.text(for: id))
+    }
+
+    // MARK: - Payload decoding
+
+    func testDecodesAFullPayload() {
+        let payload: [String: Any] = [
+            "hit": true, "obj": "1abc", "chain": "J", "resi": "42",
+            "resn": "TYR", "segi": "A1", "name": "CA",
+            "mode": 0, "state": 3, "nstates": 12,
+        ]
+        XCTAssertEqual(HoverReadout.text(payload: payload),
+                       "1abc / state 3 / chain J / TYR 42 / CA")
+    }
+
+    func testMissedPickProducesNoReadout() {
+        XCTAssertNil(HoverReadout.decode(payload: ["hit": false]))
+        XCTAssertNil(HoverReadout.text(payload: ["hit": false]),
+                     "empty space must hide the chip, not leave the last hit on screen")
+    }
+
+    func testUnreadablePayloadProducesNoReadout() {
+        XCTAssertNil(HoverReadout.text(payload: nil))
+        XCTAssertNil(HoverReadout.text(payload: [:]),
+                     "a payload with no `hit` key told us nothing — hide the chip")
+    }
+
+    func testPayloadWithoutModeDefaultsToResidue() {
+        // mouse_selection_mode 1 (residue) is the app default and the fallback
+        // `hover_preview_at` itself uses when the setting can't be read.
+        let payload: [String: Any] = [
+            "hit": true, "obj": "1abc", "chain": "J", "resi": "42", "resn": "TYR",
+        ]
+        XCTAssertEqual(HoverReadout.text(payload: payload), "1abc / chain J / TYR 42")
+    }
+
+    /// The level comes from the PAYLOAD (captured at pick time), not from the
+    /// Swift-side scene mirror, which only refreshes on the ~500 ms poll. Right
+    /// after a Tab (cycle selection level) the mirror is a level behind, and a
+    /// chip formatted from it would name a scope the click no longer commits.
+    func testLevelComesFromThePayload() {
+        let payload: [String: Any] = [
+            "hit": true, "obj": "1abc", "chain": "J", "resi": "42",
+            "resn": "TYR", "segi": "A1", "name": "CA", "mode": 2,
+        ]
+        XCTAssertEqual(HoverReadout.text(payload: payload), "1abc / chain J")
+    }
+}


### PR DESCRIPTION
Closes #359.

Show what the cursor is over in the viewport's top-right corner, at the granularity a click would actually commit — object, chain, segment, residue, atom or molecule, per `mouse_selection_mode`.

Hover picking already resolved all of this to draw the `_preselect` highlight and then threw it away, so nothing named what was under the cursor until you clicked.

## Approach

`hover_preview_at` grows `preview` / `info` flags so the highlight (#165) and the readout ride on **one** pick — the projection over every drawn atom is the expensive part and must not run twice — while each stays independently toggleable.

Python reports identity only (`obj/chain/resi/resn/segi/name`, plus the selection level and displayed state); Swift formats the line. That split is deliberate: the formatting rules end up unit-testable with no core, camera or gesture.

## Decisions worth reviewing

- **The level travels in the payload**, not read from the Swift scene mirror. That mirror only refreshes on the ~500 ms poll, so right after a Tab it is a level behind and the chip would name a scope the click no longer commits.
- **The readout stops where the selection stops.** Object level names only the object; Chain/Segment level with a blank chain/segi falls back to the object, mirroring `_mode_expr`. Naming a residue there would advertise a precision the click does not have.
- **State is named only for multi-state objects**, and it is the *displayed* state — the one `_pick_atom` projects against, not state 1.
- **Nothing goes stale.** Empty space, mouse-exit, drag-start and a failed pick all clear it; an unreadable payload hides the chip rather than leaving a residue on screen the cursor has already left.
- **Molecule level** tags the anchor residue (`mol HEM 501`) so it cannot be misread as a residue-level pick of the same residue.

The toggle lives in Scene ▸ Canvas ("Hover readout"), default on, persisted. I left the Mouse panel alone: its selection row is already ~217 pt of content in a 186 pt card, so a second labelled toggle would have overflowed.

iOS gets the chip from the existing `UIHoverGestureRecognizer` path, so it appears for trackpad / Apple Pencil hover and stays hidden for touch.

## Verification

- **456 unit tests pass, 0 failures**, including 19 new `HoverReadoutTests` covering every selection level, the state rules, blank-field fallbacks and payload decoding.
- **Live core, real structures:** payload correct at all 7 modes on 1ubq; empty space → `{"hit": false}`; `preview=1` still selects all 660 atoms in chain mode; `preview=0` leaves `_preselect` untouched while still writing the readout; `sele` never touched. On 1d3z (10 NMR models) displayed at state 7 it reports `state 7 / nstates 10`.
- **Ran the built app** (`RayMol-359.app`) for a hands-on pass.
- iOS **parses** clean for `arm64-apple-ios17.0`; the iOS slice cannot be fully built from a macOS worktree, so that is not a type-check claim.

## Note on `project.pbxproj`

Two new files, added **by hand** (10 additions, 0 deletions) mirroring the existing `GizmoOverlay.swift` / `CopyRoutingTests.swift` entries. `xcodegen generate` was **not** used: the checked-in project has drifted from what the installed xcodegen emits, and regenerating rewrites the `RayMol.icon` wrapper resource into its individual `*.svg` / `icon.json` members, which breaks the app icon. Verified the built bundle still carries `RayMol.icns`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)