### PR TITLE
fix(macos): own the viewport render loop so a launch-to-open isn't frozen

### DIFF
--- a/swiftui/PyMOLViewer/Shared/MetalViewport.swift
+++ b/swiftui/PyMOLViewer/Shared/MetalViewport.swift
@@ -116,6 +116,49 @@ class PyMOLMTKView: MTKView {
     override var acceptsFirstResponder: Bool { false }
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 
+    // MARK: - Render loop
+    //
+    // Drive draw(in:) from a display link we own instead of MetalKit's.
+    //
+    // MTKView creates its own CVDisplayLink in viewDidMoveToWindow, but only
+    // starts it for a window that is already visible — and it never retries. A
+    // launch that opens a document (Finder double-click on a .pse, `open file.pse`)
+    // attaches this view to a window that is not visible yet, so the loop never
+    // starts: draw(in:) is then reached ONLY by the handful of manual draw() calls
+    // in PyMOLEngine.initialize()'s blank-on-launch guard and in handleWake. The
+    // window paints those few frames and is stale from then on. Because PyMOL
+    // executes queued mouse input inside a rendered frame (OrthoExecDeferred runs
+    // from SceneRenderMetal), every drag is silently swallowed too — the viewport
+    // looks frozen while menus, panels and the console stay responsive. Launching
+    // the app first and opening the file afterwards hid it, since that view was
+    // attached to a window that did become visible in time.
+    //
+    // Toggling isPaused does NOT fix it: MetalKit will not rebuild a display link
+    // it never created. Owning the link sidesteps the ordering entirely. It ticks
+    // at the screen's refresh rate and follows the view across displays; the
+    // on-demand gate in draw(in:) still skips the GPU work for a static scene, so
+    // a still viewport costs the same idle poll it did before.
+    private var renderLink: CADisplayLink?
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        guard window != nil else {
+            // No window: drop our link and hand the loop back to MetalKit, so a
+            // view that is re-attached later is never left with nothing driving it.
+            renderLink?.invalidate()
+            renderLink = nil
+            isPaused = false
+            return
+        }
+        guard renderLink == nil else { return }
+        let link = displayLink(target: self, selector: #selector(renderTick))
+        link.add(to: .main, forMode: .common)
+        renderLink = link
+        isPaused = true   // ours drives now; don't let both loops draw
+    }
+
+    @objc private func renderTick() { draw() }
+
     // Track pointer motion over the viewport so the hover pre-selection preview
     // (issue #165) can update as the mouse moves WITHOUT any button held. A
     // tracking area is required for mouseMoved/mouseExited to fire; recreate it


### PR DESCRIPTION
## The bug

Double-clicking a `.pse` in Finder (or `open file.pse`) left the viewport showing a **stale frame**. The structure appeared, but dragging did nothing and the app felt "super sluggish" — while menus, panels and the console stayed perfectly responsive. Launching RayMol first and opening the same file afterwards was fine.

## Root cause

`MTKView` creates its `CVDisplayLink` in `viewDidMoveToWindow`, but only starts it for a window that is **already visible**, and it never retries. A launch that opens a document attaches the Metal view to a window that is not visible yet, so the loop never starts. `draw(in:)` is then reached **only** by the handful of manual `draw()` calls in `PyMOLEngine.initialize()`'s blank-on-launch guard and in `handleWake` — six frames, then nothing for the life of the process.

Because PyMOL executes queued mouse input inside a rendered frame (`OrthoExecDeferred` runs from `SceneRenderMetal`), no frames also means every drag is silently swallowed. That is why it read as sluggishness rather than a hang.

## Evidence

Measured with a temporary trace build that counts every entry into `draw(in:)` (kept on `claude/viewport-trace-harness`, not shipped):

| second | launched **with** the .pse | launched **empty** |
|---|---|---|
| 1 | 5 | 2 |
| 2 | 1 | 64 |
| 3 | 0 | 62 |
| 4+ | **0 forever** | ~61/s |

Throughout the dead period the view reported: unpaused, `preferredFramesPerSecond = 120`, delegate intact, in a visible / key / non-occluded window, drawable 2118×918, one view and one coordinator — with the main thread 1–5 % busy and input arriving at **4 ms** latency. The process had no `CVDisplayLink` thread at all. Forcing a single frame rendered in **0.66 ms**, so the renderer was never the problem.

Toggling `isPaused` does **not** help — MetalKit will not rebuild a display link it never created. That was tested and ruled out before landing this.

## The fix

Drive the view from a `CADisplayLink` we own (`NSView.displayLink(target:selector:)`, macOS 14+, which is the deployment target). MetalKit's own loop is paused only once ours is running, and the link is dropped and the loop handed back if the view leaves its window.

43 lines in one file, macOS only. iOS is untouched.

## Verification

On this branch's build, cold-launched with the .pse:

- 60 draws/s from launch
- idle: ~2 rendered fps, 58 skipped by the existing on-demand gate — a static scene costs what it did before
- dragging: 29–39 fps, sub-millisecond frames, viewport rotates (44 % of viewport pixels changed on one drag)
- window moved built-in → DELL P2217H → BenQ: steady 60 draws/s, no dropout

No automated test: this needs a real window on a real screen and would fail on headless CI.

## Not in this PR

Two other things the trace caught, both pre-existing and unrelated: the first frame blocks the main thread for **425 ms** compiling Metal shaders from source (`RendererMetal::buildVBOPipelines` → `newLibraryWithSource`), and the objects-panel poll costs **20–28 ms every 500 ms** on this session (`appkit_inspector.transp_summary` runs `cmd.iterate` over every atom, and each `s.<setting>` read raises and formats a Python `AttributeError` via `PyObject_GenericGetAttrOrItem`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)