### PR TITLE
feat(panels): add hydrogens entries to object row S/H menus

### DIFF
--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -1850,6 +1850,12 @@ private struct ShowButton: View {
                     engine.runCommand("show spheres, (\(name)) and sidechain")
                 }
             }
+            // Hydrogens are a selection, not a rep, so they sit beside "side
+            // chains" rather than in the shared rep list (#353). Same command
+            // as A → Hydrogens → show.
+            Button("hydrogens") {
+                engine.runCommand("show sticks, (\(name)) and hydro")
+            }
             Divider()
             ForEach(Array(showHideOptions.enumerated()), id: \.offset) { _, opt in
                 if opt.label == "---" {
@@ -1883,6 +1889,17 @@ private struct HideButton: View {
         Menu {
             Button("side chains") {
                 engine.runCommand("hide sticks, (\(name)) and (sidechain or name CA); hide lines, (\(name)) and (sidechain or name CA)")
+            }
+            // Hydrogens are a selection, not a rep, so they sit beside "side
+            // chains" rather than in the shared rep list (#353). Mirrors
+            // upstream mol_hide's hydrogens submenu (menu.py hide_hydro).
+            Menu("hydrogens") {
+                Button("all") {
+                    engine.runCommand("hide (\(name) and hydro)")
+                }
+                Button("nonpolar") {
+                    engine.runCommand("hide (\(name) and hydro and (elem C extend 1))")
+                }
             }
             Divider()
             ForEach(Array(showHideOptions.enumerated()), id: \.offset) { _, opt in


### PR DESCRIPTION
Closes #353.

Hiding hydrogens was only reachable via the object row's **A** → *Hydrogens* → *hide*; the **H** button — where users instinctively look for "hide \<thing>" — didn't list hydrogens at all (reported by Gabriel Rocklin).

## Changes

- **H menu**: new `hydrogens` submenu matching upstream `mol_hide`'s `hide_hydro` (`modules/pymol/menu.py`):
  - `all` → `hide (<name> and hydro)`
  - `nonpolar` → `hide (<name> and hydro and (elem C extend 1))`
- **S menu**: new `hydrogens` entry mirroring **A** → *Hydrogens* → *show*: `show sticks, (<name>) and hydro`

Both entries sit beside "side chains" rather than in the shared `showHideOptions` rep list, since hydrogens are a selection, not a representation. The existing **A** → *Hydrogens* submenu is untouched — this adds a second, discoverable path. The buttons are shared by object rows, selection rows, and the pinned "all" row, so the entries appear in all three.

## Testing

- `xcodebuild -scheme PyMOLViewer_macOS -configuration Debug` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)