### PR TITLE
feat(macos): drag the inspector seam to resize the sidebar (#350)

### DIFF
--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -2403,6 +2403,11 @@ private struct ObjectRowContent: View {
             .truncationMode(.tail)
             .contentShape(Rectangle())
             .onTapGesture { toggleEnabled() }   // tap name = toggle enable
+            // #350: a row's fixed chrome (gutter + five action buttons) leaves the
+            // name column narrow, so names that differ only in a long suffix
+            // ("…_relaxed_model_2") truncate to the same thing. Widening the panel
+            // is the fix; this tooltip reads the full name without resizing at all.
+            .help(entry.displayName)
 
         // Model / state count, right of the name (the structure's "frame count").
         if entry.stateCount > 1 {

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -174,6 +174,12 @@ struct ContentView: View {
     // The console height the current macOS drag started from, in points. nil when
     // no drag is in flight; the committed size lives in `consoleFrac`.
     @State private var macConsoleDragAnchor: CGFloat? = nil
+    // The macOS inspector width the USER chose, as a fraction of the window width
+    // (#350: object names were unreadable at the fixed column width). 0 means
+    // "never resized", which selects the absolute 340pt default instead.
+    @AppStorage(PanelLayout.inspectorFracKey) private var inspectorFrac = 0.0
+    // The inspector width the current macOS seam drag started from, in points.
+    @State private var macInspectorDragAnchor: CGFloat? = nil
 
     // ~/.raymolrc first-run migration prompt (RayMol#225): shown once, before
     // raymolrc.load() ever runs, when an existing ~/.pymolrc(.py) could be
@@ -396,7 +402,7 @@ struct ContentView: View {
         }
     }
 
-    // MARK: - macOS: HSplitView with sidebar
+    // MARK: - macOS: viewport column + resizable inspector column
 
     #if os(macOS)
     // Minimizable mouse-mode legend: full card with a minimize button, or a
@@ -512,6 +518,76 @@ struct ContentView: View {
             )
     }
 
+    // The right (inspector / Theme Studio) column's current width: the share the
+    // user dragged the seam to, or the absolute 340pt default until they have
+    // (#350) — clamped every layout pass so a window shrink can't squeeze the
+    // viewport below its minimum width.
+    private func macInspectorWidth(windowWidth: CGFloat) -> CGFloat {
+        PanelLayout.inspectorWidth(frac: CGFloat(inspectorFrac),
+                                   windowWidth: windowWidth,
+                                   maxWidth: PanelLayout.maxInspectorWidth(windowWidth: windowWidth))
+    }
+
+    // macOS: the seam between the viewport column and the right column, doubling
+    // as the drag handle that resizes it (#350 — object names truncate at a fixed
+    // width). Same recipe as macConsoleDivider: a 1pt themed hairline with a wider
+    // invisible hit strip, a resize cursor, and the committed size persisted as a
+    // fraction of the window width. Deliberately NOT an HSplitView divider — its
+    // mouse-tracking band swallowed clicks on the inspector tongue that straddles
+    // this seam (#325); the tongue's pill draws later than this strip, so it keeps
+    // winning hit-testing where the two overlap.
+    @ViewBuilder
+    private func macInspectorDivider(windowWidth: CGFloat) -> some View {
+        let maxW = PanelLayout.maxInspectorWidth(windowWidth: windowWidth)
+        Rectangle()
+            .fill(hairlineColor)
+            .frame(width: 1)
+            // A 9pt grab band (about what an AppKit splitter tracks) grown entirely
+            // on the VIEWPORT side, so the visible hairline still sits immediately
+            // against the panel's leading edge — which is where panelTongue's
+            // seam:true offset expects it, and how the seam looked before it became
+            // draggable. Padding is layout width in the HStack, not an overlay, so
+            // it cannot steal clicks from the panel's own controls; a 1pt-wide
+            // target, meanwhile, was measurably hard to hit in VM testing.
+            .padding(.leading, 8)
+            .contentShape(Rectangle())
+            .onHover { inside in
+                if inside { NSCursor.resizeLeftRight.push() } else { NSCursor.pop() }
+            }
+            .gesture(
+                DragGesture(minimumDistance: 1)
+                    .onChanged { v in
+                        let start = macInspectorDragAnchor ?? macInspectorWidth(windowWidth: windowWidth)
+                        macInspectorDragAnchor = start
+                        // Freeze the Metal drawable while the seam moves so the
+                        // renderer doesn't reallocate its offscreen targets every
+                        // frame (same guard as the iOS resizeDivider); the frames
+                        // still track the drag, and one reshape snaps the viewport
+                        // crisp on release.
+                        engine.suppressDrawableResize = true
+                        // The column sits on the RIGHT: dragging left grows it.
+                        let w = min(max(start - v.translation.width,
+                                        PanelLayout.macMinInspectorWidth), maxW)
+                        if let f = PanelLayout.inspectorFrac(width: w, windowWidth: windowWidth) {
+                            inspectorFrac = Double(f)
+                        }
+                    }
+                    .onEnded { _ in
+                        macInspectorDragAnchor = nil
+                        engine.suppressDrawableResize = false
+                    }
+            )
+            // A drag that never ends normally — the column is toggled away by the
+            // tongue or a menu while the button is still down — would otherwise
+            // leave the drawable frozen at its mid-drag size for good (a blurry,
+            // wrongly-scaled viewport with no way back but a relaunch). onEnded
+            // doesn't fire for a cancelled gesture, so release the freeze here too.
+            .onDisappear {
+                macInspectorDragAnchor = nil
+                engine.suppressDrawableResize = false
+            }
+    }
+
     private var macOSLayoutBase: some View {
         // Sequence height cap: 1–5 sequence rows (~26pt each + 8pt padding) so the
         // strip can't grow into the viewport. minHeight is set a few pt below the
@@ -535,14 +611,14 @@ struct ContentView: View {
             #if !RAYMOL_MAS_RESTRICTED
             MCPDrivingBanner()
             #endif
-            // Left | right as a plain HStack, NOT an HSplitView. The right column is
-            // a FIXED 340pt (see below), so that split view's divider could never be
-            // dragged — all it contributed was a system divider whose mouse-tracking
-            // band SWALLOWED clicks on the inspector tongue sitting on the seam (#325;
-            // bisected in the VM: x=679 dead, x=690 live). A 1pt themed hairline draws
-            // the same seam, lets the tongue straddle it, and is exactly what the iPad
-            // landscape layout does. The VSplitView inside — which IS draggable and
-            // carries the console/sequence sizing — stays.
+            // Left | right as a plain HStack, NOT an HSplitView: that split view's
+            // system divider had a mouse-tracking band that SWALLOWED clicks on the
+            // inspector tongue sitting on the seam (#325; bisected in the VM: x=679
+            // dead, x=690 live). Our own seam (macInspectorDivider) draws the same
+            // 1pt hairline, lets the tongue straddle it, and — since #350 — is also
+            // the drag handle that resizes the right column, with the share
+            // persisted the way the console's is. The VSplitView inside — which IS
+            // draggable and carries the console/sequence sizing — stays.
             HStack(spacing: 0) {
             // Left column: the pane rail pinned on TOP, then terminal, sequence and
             // the 3D viewport stacked in a VSplitView so each stays drag-resizable.
@@ -615,23 +691,26 @@ struct ContentView: View {
             }
 
             // Right column: objects + (chat). Only exists (and only occupies its
-            // 300pt width) when at least one of its panels is shown — when both are
-            // off the HSplitView collapses to just the left column. The mouse
+            // width) when at least one of its panels is shown — when both are off
+            // the layout collapses to just the left column. Width is 340pt until
+            // the user drags the seam (#350); Theme Studio shares the SAME width so
+            // toggling between the two never makes the right edge jump. The mouse
             // legend moved to the floating viewport overlay (above) so it stays
             // reachable regardless.
             if showThemeStudio {
                 // Theme studio takes over the right column; viewport stays live.
-                Rectangle().fill(hairlineColor).frame(width: 1)
+                macInspectorDivider(windowWidth: winGeo.size.width)
                 ThemeStudioPanel(onClose: { withAnimation(.easeInOut(duration: 0.2)) { showThemeStudio = false } })
                     .environmentObject(engine)
                     .environmentObject(themeManager)
-                    .frame(width: 340)
+                    .frame(width: macInspectorWidth(windowWidth: winGeo.size.width))
             } else if showObjectPanel {
-                // The seam the tongue centres on. Drawn by us now that the HSplitView
-                // divider is gone — same hairline the iPad layout uses.
-                Rectangle().fill(hairlineColor).frame(width: 1)
+                // The seam the tongue centres on, and (#350) the drag handle that
+                // resizes the column. The Movie-tab transport is shrunk (TransportBar
+                // kT* consts) to fit the 340pt default rather than requiring more.
+                macInspectorDivider(windowWidth: winGeo.size.width)
                 inspectorSwitcher()
-                    .frame(width: 340)   // compact; the Movie-tab transport is shrunk (TransportBar kT* consts) to fit rather than widening the column
+                    .frame(width: macInspectorWidth(windowWidth: winGeo.size.width))
                     .overlay(alignment: .leading) {
                         // seam:true shifts the pill left by half its width so it is
                         // centred ON the hairline rather than sitting beside it.

--- a/swiftui/PyMOLViewer/Shared/PanelLayout.swift
+++ b/swiftui/PyMOLViewer/Shared/PanelLayout.swift
@@ -36,6 +36,10 @@ enum PanelLayout {
     /// The user's console height, as a fraction of the window height. Absent
     /// until they resize it, which is what selects the absolute default (#331).
     static let consoleFracKey = ns + "consoleFrac"
+    /// The user's macOS inspector (right column) width, as a fraction of the
+    /// window width. Absent until they drag the seam (#350), which is what
+    /// selects the absolute default width.
+    static let inspectorFracKey = ns + "inspectorFrac"
     /// iPad bottom-panel share of the screen.
     static let panelFracKey = ns + "panelFrac"
     /// Sequence strip visible. Written by PyMOLEngine, which owns the flag.
@@ -46,7 +50,7 @@ enum PanelLayout {
     static let allKeys: [String] = [
         consoleVisibleKey, objectsVisibleKey,
         landscapeConsoleVisibleKey, landscapeObjectsVisibleKey,
-        consoleFracKey, panelFracKey, sequenceVisibleKey,
+        consoleFracKey, inspectorFracKey, panelFracKey, sequenceVisibleKey,
     ]
 
     // MARK: - Bounds
@@ -79,6 +83,55 @@ enum PanelLayout {
     static let defaultPanelFrac: CGFloat = 0.53
     static let minPanelFrac: CGFloat = 0.2
     static let maxPanelFrac: CGFloat = 0.8
+
+    /// #350: the macOS inspector column's width on a launch with nothing stored.
+    /// ABSOLUTE points for the same reason as the console default — an untouched
+    /// inspector looks the same on a laptop and on a 6K display. 340 is the width
+    /// the narrow-inspector redesign settled on (fits the Movie transport, matches
+    /// the Theme Studio column).
+    static let macDefaultInspectorWidth: CGFloat = 340
+    /// Below this an Objects row is nothing but its fixed chrome — gutter (26) +
+    /// five 38pt A/S/H/L/C buttons + chevron/indent — with no room left for even
+    /// a short name, so shrinking further only breaks the panel.
+    static let macMinInspectorWidth: CGFloat = 280
+    /// The macOS viewport's own minimum WIDTH; the inspector may grow until the
+    /// viewport is down to this. The horizontal sibling of `macViewportMinHeight`.
+    static let macViewportMinWidth: CGFloat = 480
+
+    // MARK: - macOS inspector sizing (#350)
+
+    /// How wide the inspector is allowed to get in a window of `windowWidth`,
+    /// given a viewport beside it that needs `viewportMin`. Same bracket shape as
+    /// `maxConsoleHeight`: never more than half the window (the viewport must
+    /// remain the main event), never less than `minCeilingFrac`.
+    static func maxInspectorWidth(windowWidth: CGFloat,
+                                  viewportMin: CGFloat = macViewportMinWidth) -> CGFloat {
+        guard windowWidth.isFinite, windowWidth > 0 else { return 0 }
+        return min(max(windowWidth - viewportMin, windowWidth * minCeilingFrac),
+                   windowWidth * 0.5)
+    }
+
+    /// The inspector's width in a window of `windowWidth`.
+    ///
+    /// `frac` is the persisted share and applies only once the user has dragged
+    /// the seam themselves; a missing, zero, negative or non-finite value (an
+    /// unset UserDefaults Double reads as 0) means "untouched" and yields the
+    /// absolute default. The CEILING WINS when it crosses the usable minimum —
+    /// in a very narrow window, better a cramped inspector than no viewport.
+    static func inspectorWidth(frac: CGFloat, windowWidth: CGFloat,
+                               maxWidth: CGFloat) -> CGFloat {
+        guard windowWidth.isFinite, windowWidth > 0 else { return macMinInspectorWidth }
+        let w = (frac.isFinite && frac > 0) ? frac * windowWidth : macDefaultInspectorWidth
+        return min(max(w, macMinInspectorWidth), maxWidth)
+    }
+
+    /// The fraction to persist for an inspector measured at `width`, clamped into
+    /// the storable band so nothing unrestorable can ever be written. nil for a
+    /// degenerate window — there is nothing meaningful to store, so don't write.
+    static func inspectorFrac(width: CGFloat, windowWidth: CGFloat) -> CGFloat? {
+        guard windowWidth.isFinite, windowWidth > 0, width.isFinite else { return nil }
+        return min(max(width / windowWidth, minStorableFrac), maxStorableFrac)
+    }
 
     // MARK: - Console sizing
 

--- a/swiftui/PyMOLViewerTests/PanelLayoutTests.swift
+++ b/swiftui/PyMOLViewerTests/PanelLayoutTests.swift
@@ -193,6 +193,96 @@ final class PanelLayoutTests: XCTestCase {
                        PanelLayout.defaultPanelFrac, accuracy: 1e-9)
     }
 
+    // MARK: - macOS inspector width (#350)
+
+    /// Same contract as the console: untouched means the ABSOLUTE default, on
+    /// any display.
+    func testUnsetInspectorFracYieldsTheAbsoluteDefault() {
+        for window in [CGFloat(1000), 1512, 2400] {
+            XCTAssertEqual(
+                PanelLayout.inspectorWidth(
+                    frac: 0, windowWidth: window,
+                    maxWidth: PanelLayout.maxInspectorWidth(windowWidth: window)),
+                PanelLayout.macDefaultInspectorWidth, accuracy: 1e-9,
+                "an untouched inspector must not scale with a \(window)pt window")
+        }
+    }
+
+    func testStoredInspectorFractionIsHonouredInsideTheBand() {
+        XCTAssertEqual(
+            PanelLayout.inspectorWidth(
+                frac: 0.3, windowWidth: 1600,
+                maxWidth: PanelLayout.maxInspectorWidth(windowWidth: 1600)),
+            480, accuracy: 1e-9)
+    }
+
+    func testInspectorNeverShrinksBelowItsRowChromeMinimum() {
+        XCTAssertEqual(
+            PanelLayout.inspectorWidth(
+                frac: 0.05, windowWidth: 1600,
+                maxWidth: PanelLayout.maxInspectorWidth(windowWidth: 1600)),
+            PanelLayout.macMinInspectorWidth, accuracy: 1e-9)
+    }
+
+    func testInspectorFractionAboveTheCeilingIsCapped() {
+        // 1000pt window: ceiling = min(max(1000-480, 200), 500) = 500.
+        XCTAssertEqual(
+            PanelLayout.inspectorWidth(
+                frac: 0.9, windowWidth: 1000,
+                maxWidth: PanelLayout.maxInspectorWidth(windowWidth: 1000)),
+            500, accuracy: 1e-9)
+    }
+
+    func testInspectorCeilingLeavesTheViewportItsMinimum() {
+        // 800pt window, 480pt viewport minimum -> the inspector may reach 320pt.
+        XCTAssertEqual(PanelLayout.maxInspectorWidth(windowWidth: 800),
+                       320, accuracy: 1e-9)
+    }
+
+    func testInspectorCeilingNeverExceedsHalfTheWindow() {
+        // A wide window would otherwise let the sidebar take all but 480pt.
+        XCTAssertEqual(PanelLayout.maxInspectorWidth(windowWidth: 2000),
+                       1000, accuracy: 1e-9)
+    }
+
+    func testInspectorCeilingNeverFallsBelowMinCeilingFrac() {
+        XCTAssertEqual(PanelLayout.maxInspectorWidth(windowWidth: 500),
+                       100, accuracy: 1e-9)
+        XCTAssertEqual(PanelLayout.maxInspectorWidth(windowWidth: 0), 0, accuracy: 1e-9)
+    }
+
+    func testInspectorFractionRoundTripsThroughAWidth() throws {
+        let w = PanelLayout.inspectorWidth(
+            frac: 0.31, windowWidth: 1600,
+            maxWidth: PanelLayout.maxInspectorWidth(windowWidth: 1600))
+        XCTAssertEqual(try XCTUnwrap(PanelLayout.inspectorFrac(width: w, windowWidth: 1600)),
+                       0.31, accuracy: 1e-9)
+    }
+
+    func testMeasuredInspectorFractionIsClampedIntoTheStorableBand() throws {
+        XCTAssertEqual(try XCTUnwrap(PanelLayout.inspectorFrac(width: 2, windowWidth: 1000)),
+                       PanelLayout.minStorableFrac, accuracy: 1e-9)
+        XCTAssertEqual(try XCTUnwrap(PanelLayout.inspectorFrac(width: 990, windowWidth: 1000)),
+                       PanelLayout.maxStorableFrac, accuracy: 1e-9)
+    }
+
+    func testNoInspectorFractionIsStorableForADegenerateWindow() {
+        XCTAssertNil(PanelLayout.inspectorFrac(width: 340, windowWidth: 0))
+        XCTAssertNil(PanelLayout.inspectorFrac(width: .nan, windowWidth: 1000))
+    }
+
+    /// The point of storing a fraction: a sidebar dragged to 30% of a wide window
+    /// comes back proportional in a narrower one — still clamped by ITS ceiling.
+    func testInspectorFractionRestoresProportionallyIntoASmallerWindow() throws {
+        let stored = try XCTUnwrap(PanelLayout.inspectorFrac(width: 600, windowWidth: 2000))
+        XCTAssertEqual(stored, 0.3, accuracy: 1e-9)
+        XCTAssertEqual(
+            PanelLayout.inspectorWidth(
+                frac: stored, windowWidth: 1200,
+                maxWidth: PanelLayout.maxInspectorWidth(windowWidth: 1200)),
+            360, accuracy: 1e-9)
+    }
+
     // MARK: - key namespace
 
     func testEveryKeyIsNamespaced() {


### PR DESCRIPTION
Closes #350.

## The problem

The macOS right column was a fixed 340pt, so object names that differ only in a long suffix all truncated to the same string. With three prediction models loaded, every row read `ubiquitin_desi…` — exactly the complaint in the issue ("suffixes that differentiate models are impossible to read"). The [narrow-inspector design](docs/superpowers/specs/2026-07-06-narrow-macos-inspector-design.md) considered a resizable divider and deliberately deferred it; this is that follow-up.

## What changed

**The seam is now the drag handle.** It follows `macConsoleDivider`'s recipe (a themed hairline with a grab band, a resize cursor, and a persisted size) rather than reinstating an `HSplitView` — that split view's mouse-tracking band is what swallowed clicks on the inspector tongue in #325, and the tongue still straddles this seam. The 9pt grab band grows entirely on the viewport side so the visible hairline stays exactly where `panelTongue(seam: true)` centres its pill.

**Sizing lives in `PanelLayout`** as pure functions, mirroring the console's contract:
- An untouched column is an absolute **340pt** on any display, so it looks the same on a laptop and a 6K monitor.
- A width the user drags to is stored as a **fraction of the window width**, so it restores proportionally instead of squeezing a smaller window's viewport away.
- Floors at **280pt** (below that a row is nothing but its gutter and five action buttons) and grows until the viewport is down to **480pt**, never past half the window. The ceiling outranks the floor, so a narrow window always keeps a viewport.

Theme Studio reads the same width, so the right edge stays in sync when the two columns swap.

**Two extras that came out of testing:**
- A full-name tooltip on object rows — makes a truncated name readable without resizing at all.
- The drag's Metal drawable freeze is released on `onDisappear` too. `onEnded` doesn't fire for a cancelled gesture, so toggling the column away mid-drag would otherwise leave the viewport stuck at its mid-drag drawable size until relaunch.

## Verification

`PanelLayoutTests`: **34 passing** (11 new, covering the default, the stored fraction, both clamps, the round trip, and proportional restore).

Functionally verified in a disposable macOS VM, measuring the panel's real frame through the accessibility tree:

| check | result |
|---|---|
| default width, no stored pref | 340pt |
| drag resizes live, both directions | 340 → 405 → 463 → 512; 512 → 426 → 365 → 304 |
| max clamp in a 1024pt window | stops at exactly 512pt (`maxInspectorWidth`), viewport keeps 512 |
| persistence | `raymol.panels.inspectorFrac = 0.296875` (= 304/1024) |
| proportional restore into a 1200pt window | 356pt (0.296875 × 1200 = 356.25) |
| tongue still collapses / reopens (#325) | collapses; reopens at the dragged 392pt |
| widened grab band | catches a drag 7pt into the viewport side; ignores points inside the panel |

At 500pt the same three objects read `ubiquitin_design_APB0142_relaxed_model_…` — the differentiating suffix is visible, which is what the issue asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)