### PR TITLE
Shortcut cheat-sheet tool picker + keyboard toggles for Console / Seq / side panel (#360, #361)

### DIFF
--- a/modules/pymol/raymol_keys.py
+++ b/modules/pymol/raymol_keys.py
@@ -8,13 +8,21 @@
 #
 # This module names that collision out loud, once, right after ~/.raymolrc runs.
 #
-# Only these two keys can collide: every other RayMol menu shortcut carries ⌘,
-# and the Swift classifier passes ⌘ events straight through to the menus.
+# Only the CTRL-letter keys can collide: every other RayMol menu shortcut
+# carries ⌘, and the Swift classifier passes ⌘ events straight through to the
+# menus.
 
 # Canonical key token -> the menu command it would shadow.
+#
+# Mirrors the ⌃-letter entries of AppShortcuts in
+# swiftui/PyMOLViewer/Shared/PyMOLApp.swift — a new ⌃ shortcut there must be
+# added here too (AppShortcutsTests pins the set on the Swift side).
 APP_SHORTCUTS = {
     'CTRL-M': 'Move Objects (Mouse menu)',
+    'CTRL-E': 'Measure Distances (Mouse menu)',
+    'CTRL-B': 'Box Select (Mouse menu)',
     'CTRL-D': 'Enter/Exit Design Mode (Design menu)',
+    'CTRL-P': 'Enter/Exit Predict Mode (Predict menu)',
 }
 
 # CTRL-D only exists in RAYMOL_MPNN builds, so the caller says whether the

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -2434,6 +2434,12 @@ struct ContentView: View {
                 .contentShape(Capsule())
         }
         .buttonStyle(.plain)
+        // Every call site toggles the side panel (objectsBinding), so the
+        // shortcut lives here rather than as a parameter (#361). Live binding on
+        // iPadOS; on macOS the View-menu command carries the same constant.
+        .keyboardShortcut(AppShortcuts.sidePanel)
+        .help("\(isShown ? "Hide" : "Show") the side panel"
+              + " (\(AppShortcuts.hint(AppShortcuts.sidePanel)))")
         .accessibilityLabel(isShown ? "Hide panel" : "Show panel")
         // Center the little tab within a thin full-width / full-height strip. Only
         // the chevron pill is hit-testable; the rest of the strip passes touches
@@ -2506,10 +2512,12 @@ struct ContentView: View {
     @ViewBuilder
     private func topPaneRail(floating: Bool = true, centered: Bool = true) -> some View {
         let pillRow = HStack(spacing: 8) {
-            railTongue(icon: "terminal", label: "Console", shown: consoleBinding)
+            railTongue(icon: "terminal", label: "Console", shown: consoleBinding,
+                       shortcut: AppShortcuts.consolePane)
             // No icon — the word "Seq" IS the label. The old `textformat.abc` glyph
             // rendered as a literal "Abc", so the pill read "Abc Seq".
-            railTongue(icon: nil, label: "Seq", shown: $engine.sequenceVisible)
+            railTongue(icon: nil, label: "Seq", shown: $engine.sequenceVisible,
+                       shortcut: AppShortcuts.sequencePane)
             // Move / Measure / Design are mutually-exclusive interaction modes, so
             // they share ONE Tools pill that opens a menu (#304) instead of three
             // toggles — the same consolidation as the Mac toolbar's macToolsMenu,
@@ -2552,7 +2560,12 @@ struct ContentView: View {
 
     // `icon` is optional: a tongue whose label already names the pane (Seq) shows the
     // word alone rather than pairing it with a redundant glyph.
-    private func railTongue(icon: String?, label: String, shown: Binding<Bool>) -> some View {
+    // `shortcut` (#361) both registers the key on the pill — the live binding on
+    // iPadOS hardware keyboards; on macOS the View-menu command with the same
+    // AppShortcuts constant is what fires — and names it in the hover tooltip,
+    // the pill's only surface that can show a hint.
+    private func railTongue(icon: String?, label: String, shown: Binding<Bool>,
+                            shortcut: KeyboardShortcut? = nil) -> some View {
         let on = shown.wrappedValue
         return Button {
             withAnimation(.easeInOut(duration: 0.25)) { shown.wrappedValue.toggle() }
@@ -2585,6 +2598,9 @@ struct ContentView: View {
             .contentShape(Capsule())
         }
         .buttonStyle(.plain)
+        .keyboardShortcut(shortcut)
+        .help("\(on ? "Hide" : "Show") the \(label) pane"
+              + (shortcut.map { " (\(AppShortcuts.hint($0)))" } ?? ""))
         .accessibilityIdentifier("rail-\(label.lowercased())")
         .accessibilityLabel("\(label) pane, \(on ? "shown" : "hidden")")
     }
@@ -3382,6 +3398,11 @@ struct ContentView: View {
     /// opens mid-inference and shows which mode is active.
     @ViewBuilder
     private var interactionToolItems: some View {
+        // Every row carries its AppShortcuts binding (#360), which is what makes
+        // the shortcut render right-aligned in the row — the menu doubles as the
+        // shortcut cheat sheet. On macOS the real menu-bar command with the SAME
+        // constant is what fires reliably (see PyMOLApp.macCommands); on iPadOS
+        // the row registration is the live one and surfaces in the ⌘-hold HUD.
         Button {
             engine.setInteractionMode(engine.interactionMode == .move ? .viewing : .move)
         } label: {
@@ -3392,6 +3413,7 @@ struct ContentView: View {
             }
         }
         .disabled(isDesignLocked)
+        .keyboardShortcut(AppShortcuts.moveTool)
 
         // (Box Select is deliberately absent: its control is the lasso toggle in
         // the Selections panel header, which both enters the mode and shows that
@@ -3406,6 +3428,7 @@ struct ContentView: View {
             }
         }
         .disabled(isDesignLocked)
+        .keyboardShortcut(AppShortcuts.measureTool)
 
         #if RAYMOL_MPNN
         // Also gated on DesignAvailability: Design needs a minimum iOS version, and
@@ -3422,6 +3445,7 @@ struct ContentView: View {
                 }
             }
             .disabled(isDesignLocked)
+            .keyboardShortcut(AppShortcuts.designTool)
         }
         #endif
         // Gated on PredictAvailability for the same reason Design is gated on
@@ -3439,7 +3463,7 @@ struct ContentView: View {
                 }
             }
             .disabled(isDesignLocked)
-            .keyboardShortcut("p", modifiers: .control)
+            .keyboardShortcut(AppShortcuts.predictTool)
         }
     }
 
@@ -3449,11 +3473,18 @@ struct ContentView: View {
     /// appending rather than as fixed strings so the two conditions compose; the
     /// hardcoded variants this replaced could not express "MPNN but no Predict".
     private var toolsMenuHelp: String {
-        var parts = ["Move objects", "Measure distances"]
+        // Shortcut hints come from the same AppShortcuts constants the rows
+        // register (#360), so the tooltip cannot drift from the menu.
+        var parts = ["Move objects (\(AppShortcuts.hint(AppShortcuts.moveTool)))",
+                     "Measure distances (\(AppShortcuts.hint(AppShortcuts.measureTool)))"]
         #if RAYMOL_MPNN
-        if DesignAvailability.isSupported { parts.append("Design with MPNN") }
+        if DesignAvailability.isSupported {
+            parts.append("Design with MPNN (\(AppShortcuts.hint(AppShortcuts.designTool)))")
+        }
         #endif
-        if PredictAvailability.isSupported { parts.append("Predict structures") }
+        if PredictAvailability.isSupported {
+            parts.append("Predict structures (\(AppShortcuts.hint(AppShortcuts.predictTool)))")
+        }
         let tools = parts.joined(separator: " · ")
         guard let active = activeInteractionTool else { return "Tools: \(tools)" }
         return "\(active.name) mode is active — Tools: \(tools)"

--- a/swiftui/PyMOLViewer/Shared/PyMOLApp.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLApp.swift
@@ -49,6 +49,57 @@ final class RayMolAppDelegate: NSObject, NSApplicationDelegate {
 }
 #endif
 
+// MARK: - Keyboard shortcut table (#360, #361)
+
+/// The one table behind every discoverable app shortcut: the binding that is
+/// REGISTERED and the hint the user SEES both come from these constants, so
+/// they cannot drift (#360). macOS registers each tool shortcut on a real
+/// menu-bar command (a menu key equivalent is what fires reliably — see the ⌘C
+/// note in macCommands); the shared tool-picker rows and pane toggles attach
+/// the same constant, which is what renders the hint in their menus and makes
+/// the shortcut reach iPadOS hardware keyboards.
+///
+/// Every ⌃-letter entry must be mirrored in modules/pymol/raymol_keys.py
+/// (APP_SHORTCUTS), the launch-time audit that warns when ~/.raymolrc binds
+/// over a menu shortcut. ⌘ entries need no mirror: KeyRouting passes ⌘ events
+/// straight through to the menus, so a user binding can never shadow them.
+enum AppShortcuts {
+    // Tool picker (#360): the exclusive viewport modes, one ⌃-mnemonic each —
+    // Move / mEasure / Design / Predict — plus Box Select on the same scheme.
+    // ⌃E is the first letter of "measure" not already spoken for (⌃M is Move).
+    static let moveTool = KeyboardShortcut("m", modifiers: .control)
+    static let measureTool = KeyboardShortcut("e", modifiers: .control)
+    static let designTool = KeyboardShortcut("d", modifiers: .control)
+    static let predictTool = KeyboardShortcut("p", modifiers: .control)
+    static let boxSelect = KeyboardShortcut("b", modifiers: .control)
+
+    // Pane toggles (#361): open-if-closed / close-if-open, one plain-⌘ family.
+    // ⌘' not ⌘` because ⌘` is the system's cycle-windows shortcut.
+    static let consolePane = KeyboardShortcut("'", modifiers: .command)
+    static let sequencePane = KeyboardShortcut("l", modifiers: .command)
+    static let sidePanel = KeyboardShortcut("0", modifiers: .command)
+
+    /// Every entry above. The collision test runs off this list, so a new
+    /// shortcut must be added here too (same contract as PanelLayout.allKeys).
+    static let all: [KeyboardShortcut] = [
+        moveTool, measureTool, designTool, predictTool, boxSelect,
+        consolePane, sequencePane, sidePanel,
+    ]
+
+    /// The macOS-style symbol hint ("⌃M", "⌘0") for the surfaces that don't
+    /// render one from the registration itself — rail-pill tooltips and
+    /// toolsMenuHelp. Menus draw their own glyphs from the attached shortcut.
+    static func hint(_ shortcut: KeyboardShortcut) -> String {
+        var out = ""
+        if shortcut.modifiers.contains(.control) { out += "⌃" }
+        if shortcut.modifiers.contains(.option) { out += "⌥" }
+        if shortcut.modifiers.contains(.shift) { out += "⇧" }
+        if shortcut.modifiers.contains(.command) { out += "⌘" }
+        out += String(shortcut.key.character).uppercased()
+        return out
+    }
+}
+
 struct PyMOLApp: App {
     @StateObject private var engine = PyMOLEngine.shared
     @StateObject private var notes = AnalysisNotesStore.shared
@@ -172,6 +223,13 @@ struct PyMOLApp: App {
             #endif
         }
     #if os(macOS)
+    // The pane-visibility flags behind the View-menu toggles (#361): the same
+    // UserDefaults keys ContentView reads through @AppStorage (defaults must
+    // match its declarations), so the menu command, the rail pill, and the
+    // tongue all flip one persisted flag and can never disagree.
+    @AppStorage(PanelLayout.consoleVisibleKey) private var showCommandPanel = true
+    @AppStorage(PanelLayout.objectsVisibleKey) private var showObjectPanel = true
+
     /// True while any MLX Design inference is in flight. Mirrors ContentView.isDesignLocked
     /// so the macOS menu commands (⌃M, ⌃D) respect the same lock as toolbar and rail buttons.
     private var isDesignLocked: Bool {
@@ -248,25 +306,55 @@ struct PyMOLApp: App {
                     NotificationCenter.default.post(name: .raymolClearSession, object: nil)
                 }
             }
-            // Mouse menu: toggle Move mode (rigid-body object gizmo). ⌃M.
+            // Mouse menu: the exclusive viewport tools that reinterpret a
+            // click/drag. Shortcuts come from AppShortcuts (#360) so these menu
+            // commands and the tool-picker rows can never disagree.
             CommandMenu("Mouse") {
                 Button(engine.interactionMode == .move ? "Stop Moving Objects" : "Move Objects") {
                     engine.setInteractionMode(engine.interactionMode == .move ? .viewing : .move)
                 }
                 .disabled(isDesignLocked)
-                .keyboardShortcut("m", modifiers: .control)
+                .keyboardShortcut(AppShortcuts.moveTool)
+                // Measure (#360): previously mouse-only; the menu command is what
+                // makes ⌃E fire reliably on macOS (see the ⌘C note above) — the
+                // tool-picker row carries the same constant for the hint.
+                Button(engine.measureMode != nil ? "Stop Measuring" : "Measure Distances") {
+                    engine.setMeasureMode(engine.measureMode == nil ? .distance : nil)
+                }
+                .disabled(isDesignLocked)
+                .keyboardShortcut(AppShortcuts.measureTool)
                 // Box Select (#358): the other exclusive viewport tool that
                 // reinterprets a drag, so it belongs on the same menu. ⌃B.
                 Button(engine.interactionMode == .boxSelect ? "Stop Box Select" : "Box Select") {
                     engine.setInteractionMode(engine.interactionMode == .boxSelect ? .viewing : .boxSelect)
                 }
                 .disabled(isDesignLocked)
-                .keyboardShortcut("b", modifiers: .control)
+                .keyboardShortcut(AppShortcuts.boxSelect)
             }
-            // Grouped so the two menus together count as ONE entry against the
+            // Grouped so these entries together count as ONE against the
             // @CommandsBuilder's 10-child ceiling (Group<Commands> exists for
-            // exactly this reason).
+            // exactly this reason) — the builder is already at capacity.
             Group {
+                // View menu: the pane toggles (#361) — open if closed, close if
+                // open. One plain-⌘ family, which KeyRouting passes straight
+                // through to the menus, so a ~/.raymolrc binding can never
+                // shadow them. The rail pills / tongue flip the same persisted
+                // flags (PanelLayout keys / engine.sequenceVisible), so menu and
+                // pointer stay in agreement.
+                CommandGroup(after: .sidebar) {
+                    Button(showCommandPanel ? "Hide Console" : "Show Console") {
+                        showCommandPanel.toggle()
+                    }
+                    .keyboardShortcut(AppShortcuts.consolePane)
+                    Button(engine.sequenceVisible ? "Hide Sequence" : "Show Sequence") {
+                        engine.sequenceVisible.toggle()
+                    }
+                    .keyboardShortcut(AppShortcuts.sequencePane)
+                    Button(showObjectPanel ? "Hide Side Panel" : "Show Side Panel") {
+                        showObjectPanel.toggle()
+                    }
+                    .keyboardShortcut(AppShortcuts.sidePanel)
+                }
                 #if RAYMOL_MPNN
                 // Design menu: toggle Design mode (MPNN score/color overlay). ⌃D.
                 CommandMenu("Design") {
@@ -274,7 +362,7 @@ struct PyMOLApp: App {
                         engine.setDesignMode(!engine.designMode)
                     }
                     .disabled(isDesignLocked)
-                    .keyboardShortcut("d", modifiers: .control)
+                    .keyboardShortcut(AppShortcuts.designTool)
                 }
                 #endif
                 // Predict menu: toggle Predict mode (structure prediction panel). ⌃P.
@@ -285,7 +373,7 @@ struct PyMOLApp: App {
                         engine.setPredictMode(!engine.predictMode)
                     }
                     .disabled(isDesignLocked)
-                    .keyboardShortcut("p", modifiers: .control)
+                    .keyboardShortcut(AppShortcuts.predictTool)
                 }
             }
             // Movie: enter/exit the Timeline (movie studio) mode. Carries the

--- a/swiftui/PyMOLViewer/Shared/PyMOLApp.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLApp.swift
@@ -73,11 +73,12 @@ enum AppShortcuts {
     static let predictTool = KeyboardShortcut("p", modifiers: .control)
     static let boxSelect = KeyboardShortcut("b", modifiers: .control)
 
-    // Pane toggles (#361): open-if-closed / close-if-open, one plain-⌘ family.
-    // ⌘' not ⌘` because ⌘` is the system's cycle-windows shortcut.
-    static let consolePane = KeyboardShortcut("'", modifiers: .command)
-    static let sequencePane = KeyboardShortcut("l", modifiers: .command)
-    static let sidePanel = KeyboardShortcut("0", modifiers: .command)
+    // Pane toggles (#361): open-if-closed / close-if-open, one numbered ⌘
+    // family in the order the panes appear — the rail pills left to right
+    // (Console, Seq), then the side panel.
+    static let consolePane = KeyboardShortcut("1", modifiers: .command)
+    static let sequencePane = KeyboardShortcut("2", modifiers: .command)
+    static let sidePanel = KeyboardShortcut("3", modifiers: .command)
 
     /// Every entry above. The collision test runs off this list, so a new
     /// shortcut must be added here too (same contract as PanelLayout.allKeys).
@@ -86,7 +87,7 @@ enum AppShortcuts {
         consolePane, sequencePane, sidePanel,
     ]
 
-    /// The macOS-style symbol hint ("⌃M", "⌘0") for the surfaces that don't
+    /// The macOS-style symbol hint ("⌃M", "⌘1") for the surfaces that don't
     /// render one from the registration itself — rail-pill tooltips and
     /// toolsMenuHelp. Menus draw their own glyphs from the attached shortcut.
     static func hint(_ shortcut: KeyboardShortcut) -> String {

--- a/swiftui/PyMOLViewerTests/KeyRoutingTests.swift
+++ b/swiftui/PyMOLViewerTests/KeyRoutingTests.swift
@@ -341,9 +341,9 @@ final class AppShortcutsTests: XCTestCase {
         XCTAssertEqual(AppShortcuts.hint(AppShortcuts.measureTool), "⌃E")
         XCTAssertEqual(AppShortcuts.hint(AppShortcuts.designTool), "⌃D")
         XCTAssertEqual(AppShortcuts.hint(AppShortcuts.predictTool), "⌃P")
-        XCTAssertEqual(AppShortcuts.hint(AppShortcuts.consolePane), "⌘'")
-        XCTAssertEqual(AppShortcuts.hint(AppShortcuts.sequencePane), "⌘L")
-        XCTAssertEqual(AppShortcuts.hint(AppShortcuts.sidePanel), "⌘0")
+        XCTAssertEqual(AppShortcuts.hint(AppShortcuts.consolePane), "⌘1")
+        XCTAssertEqual(AppShortcuts.hint(AppShortcuts.sequencePane), "⌘2")
+        XCTAssertEqual(AppShortcuts.hint(AppShortcuts.sidePanel), "⌘3")
         XCTAssertEqual(
             AppShortcuts.hint(KeyboardShortcut("k", modifiers: [.command, .shift, .option, .control])),
             "⌃⌥⇧⌘K")

--- a/swiftui/PyMOLViewerTests/KeyRoutingTests.swift
+++ b/swiftui/PyMOLViewerTests/KeyRoutingTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import AppKit
+import SwiftUI
 @testable import RayMol
 
 /// Coverage for KeyRouting.token — the pure NSEvent-facts → PyMOL key-token
@@ -318,5 +319,52 @@ final class KeyRoutingTests: XCTestCase {
                        [6, 0, 1, 2, 3, 4, 5])
         XCTAssertTrue((0..<n).contains(SelectionModeMenu.nextMode(from: 42, forward: true)))
         XCTAssertTrue((0..<n).contains(SelectionModeMenu.nextMode(from: -3, forward: false)))
+    }
+}
+
+/// AppShortcuts (#360, #361) — the one table behind every registered shortcut
+/// and every hint the user sees. In the same file as KeyRoutingTests because the
+/// two contracts interlock: KeyRouting's pass-through rules are what make the
+/// table's ⌘/⌃ split safe.
+final class AppShortcutsTests: XCTestCase {
+
+    /// Two commands sharing a key equivalent would fight silently; the table
+    /// exists to make that impossible to miss.
+    func testNoDuplicateBindings() {
+        XCTAssertEqual(Set(AppShortcuts.all).count, AppShortcuts.all.count,
+                       "AppShortcuts.all contains a duplicate key equivalent")
+    }
+
+    /// The symbol hints tooltips show, in macOS glyph order (⌃⌥⇧⌘).
+    func testHintSymbols() {
+        XCTAssertEqual(AppShortcuts.hint(AppShortcuts.moveTool), "⌃M")
+        XCTAssertEqual(AppShortcuts.hint(AppShortcuts.measureTool), "⌃E")
+        XCTAssertEqual(AppShortcuts.hint(AppShortcuts.designTool), "⌃D")
+        XCTAssertEqual(AppShortcuts.hint(AppShortcuts.predictTool), "⌃P")
+        XCTAssertEqual(AppShortcuts.hint(AppShortcuts.consolePane), "⌘'")
+        XCTAssertEqual(AppShortcuts.hint(AppShortcuts.sequencePane), "⌘L")
+        XCTAssertEqual(AppShortcuts.hint(AppShortcuts.sidePanel), "⌘0")
+        XCTAssertEqual(
+            AppShortcuts.hint(KeyboardShortcut("k", modifiers: [.command, .shift, .option, .control])),
+            "⌃⌥⇧⌘K")
+    }
+
+    /// Every ⌃-letter shortcut must be mirrored in the Python launch audit
+    /// (modules/pymol/raymol_keys.py APP_SHORTCUTS), which warns when a
+    /// ~/.raymolrc binding shadows a menu command. Pin the set here so a new ⌃
+    /// entry fails this test until the audit table learns it. ⌘ entries need no
+    /// mirror — KeyRouting passes ⌘ straight through to the menus.
+    func testControlShortcutsMatchPythonAuditTable() {
+        let ctrl = AppShortcuts.all.filter { $0.modifiers.contains(.control) }
+        XCTAssertEqual(Set(ctrl.map { String($0.key.character) }),
+                       ["m", "e", "d", "p", "b"])
+    }
+
+    /// The pane toggles are one plain-⌘ family (#361): immune to raymolrc
+    /// shadowing, and consistent with each other as the issue asks.
+    func testPaneTogglesAreCommandFamily() {
+        for s in [AppShortcuts.consolePane, AppShortcuts.sequencePane, AppShortcuts.sidePanel] {
+            XCTAssertEqual(s.modifiers, .command)
+        }
     }
 }

--- a/testing/tests/test_raymol_keys.py
+++ b/testing/tests/test_raymol_keys.py
@@ -4,8 +4,9 @@ Covers the shadow-warning audit (RayMol#258): when a user's ~/.raymolrc binds a
 key that RayMol also uses as a menu shortcut, the user is told once rather than
 left wondering why the menu item stopped responding to its key.
 
-Only ⌃M and ⌃D can collide: every other RayMol menu shortcut carries ⌘, and the
-classifier passes ⌘ events straight through to the menus.
+Only the ⌃-letter shortcuts (⌃M/⌃E/⌃B/⌃D/⌃P) can collide: every other RayMol
+menu shortcut carries ⌘, and the classifier passes ⌘ events straight through to
+the menus.
 """
 
 import contextlib
@@ -76,6 +77,20 @@ class AuditShadowedTests(unittest.TestCase):
         fake = FakeCmd({"CTRL-M": "zoom", "CTRL-D": "turn x, 5"})
         lines = raymol_keys.audit_shadowed(has_design=True, _self=fake)
         self.assertEqual(len(lines), 2)
+
+    def test_warns_for_measure_boxselect_predict(self):
+        # The #360 additions: ⌃E (Measure) is new, ⌃B (Box Select) and ⌃P
+        # (Predict) were menu shortcuts the table had fallen behind on. None
+        # is design-gated, so has_design stays at its default here.
+        fake = FakeCmd({"CTRL-E": "ray", "CTRL-B": "zoom", "CTRL-P": "orient"})
+        lines = raymol_keys.audit_shadowed(_self=fake)
+        self.assertEqual(len(lines), 3)
+        joined = "\n".join(lines)
+        for token, label in (("CTRL-E", "Measure Distances"),
+                             ("CTRL-B", "Box Select"),
+                             ("CTRL-P", "Predict Mode")):
+            self.assertIn(token, joined)
+            self.assertIn(label, joined)
 
     def test_empty_binding_is_not_a_shadow(self):
         # cmd.set_key(key, '') is how a binding is CLEARED; it shadows nothing.


### PR DESCRIPTION
Closes #360. Closes #361.

One PR for both issues because they share the same backbone: a single source-of-truth shortcut table, `AppShortcuts` (PyMOLApp.swift), from which every registration and every visible hint is drawn.

## #360 — the tool picker doubles as the shortcut cheat sheet

- Every row in the Tools menu now renders its shortcut right-aligned (the standard `⌃P`-style glyphs), not just Predict: **Move ⌃M · Measure ⌃E · Design ⌃D · Predict ⌃P**.
- **Measure had no shortcut; it gets ⌃E** (mEasure — ⌃M was already Move's) and a real "Measure Distances" command in the Mouse menu, which is what makes the key fire reliably on macOS (same rationale as the existing ⌘C / ⌃P comments).
- The menu-bar commands, the picker rows, and the Tools pill's hover tooltip all read the same `AppShortcuts` constants, so the registered key and the shown hint cannot drift.
- iPad: the picker rows are shared code, so the shortcuts register for hardware keyboards and appear in the ⌘-hold discoverability HUD — exactly how Predict's ⌃P already behaved.

## #361 — keyboard toggles for the three pointer-only panes

One plain-⌘ family (all toggles: open if closed, close if open), in a new View-menu section on macOS:

| Pane | Shortcut |
|---|---|
| Console | `⌘1` |
| Sequence | `⌘2` |
| Side panel | `⌘3` |

A numbered family in pane order rather than the issue's mnemonic examples — self-explaining, consistent, and free of collisions (⌘1–⌘9 were unused). The menu commands flip the same persisted flags (`PanelLayout` keys / `engine.sequenceVisible`) the rail pills and the chevron tongue use, so menu and pointer can never disagree. The pills and tongue register the same constants (live bindings on iPad hardware keyboards) and now name the key in their hover tooltips.

Plain-⌘ was chosen deliberately: `KeyRouting` passes ⌘ events straight through to the menus, so a `~/.raymolrc` binding can never shadow these.

## Keeping the tables honest

- The launch-time shadow audit `raymol_keys.APP_SHORTCUTS` had fallen behind reality (missing ⌃P and ⌃B); it now lists all five ⌃-letter shortcuts.
- New `AppShortcutsTests` pin: no duplicate bindings in the table, the hint glyph format, the pane toggles staying in the ⌘ family, and the exact ⌃-letter set — so adding a ⌃ shortcut in Swift fails a test until the Python audit table learns it too.

## Verification

- Full `UnitTests_macOS` suite: **TEST SUCCEEDED** (Debug, arm64), including the new `AppShortcutsTests` (4/4) and the untouched `KeyRoutingTests`.
- `testing/tests/test_raymol_keys.py`: 10/10, including a new test for the ⌃E/⌃B/⌃P audit entries.
- Not run: the iOS slice (pre-existing: it does not build on this machine) and in-VM functional testing. All changed Swift is in the shared macOS+iOS files and compiles in the macOS slice; the iPad-facing behavior uses the identical `.keyboardShortcut` mechanism the Predict row already shipped with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

