### PR TITLE
fix(open): load .pse sessions bare and warn before replacing a session

### DIFF
--- a/.github/workflows/raymol-embedded-tests.yml
+++ b/.github/workflows/raymol-embedded-tests.yml
@@ -62,6 +62,7 @@ jobs:
               testing/tests/test_appkit_widen_clip.py \
               testing/tests/test_inspector_transparency.py \
               testing/tests/test_raymolrc.py \
+              testing/tests/test_raymol_theme_apply.py \
               testing/tests/test_mcp_events.py \
               testing/tests/test_mcp_server.py \
               testing/tests/test_mcp_tools.py \

--- a/modules/pymol/raymol_theme.py
+++ b/modules/pymol/raymol_theme.py
@@ -135,8 +135,17 @@ def apply_default_style(obj):
 
 
 def apply_to(obj):
-    """Theme a NEWLY loaded object: default style + themed chain/element colors."""
+    """Theme a NEWLY loaded object: default style + themed chain/element colors.
+
+    No-op when no object by that name exists — e.g. a caller guessed a name from
+    a filename that the load didn't create (a .pse restores its own object names,
+    issue #272). Skipping BEFORE touching the selector matters: the C++ selector
+    writes `Invalid selection name` straight to the console feedback stream, so
+    the try/except below can't suppress it (same mechanism as issue #219).
+    """
     try:
+        if obj not in cmd.get_names("objects"):
+            return
         apply_default_style(obj)
         cbc("(%s)" % obj)
         cnc("(%s)" % obj)

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -1202,6 +1202,9 @@ struct ContentView: View {
         panel.allowedContentTypes = macImportTypes
         panel.title = "Open Structure"
         guard panel.runModal() == .OK, let url = panel.url else { return }
+        // A chosen .pse replaces the whole session (no multi-window yet, #29) —
+        // same warn/save/cancel stopgap as the Finder open path (issue #349).
+        guard confirmReplaceSessionIfNeeded(opening: url, engine: engine) else { return }
         let raw = url.deletingPathExtension().lastPathComponent
         var name = String(raw.map { $0.isLetter || $0.isNumber ? $0 : "_" })
         if name.isEmpty { name = "mol" }

--- a/swiftui/PyMOLViewer/Shared/PyMOLApp.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLApp.swift
@@ -3,6 +3,7 @@
 import SwiftUI
 #if os(macOS)
 import AppKit
+import UniformTypeIdentifiers
 #endif
 #if os(iOS)
 import UIKit
@@ -522,6 +523,9 @@ func loadOpenedFile(_ url: URL, into engine: PyMOLEngine, attempt: Int = 0) {
         }
         return
     }
+    #if os(macOS)
+    guard confirmReplaceSessionIfNeeded(opening: url, engine: engine) else { return }
+    #endif
     let scoped = url.startAccessingSecurityScopedResource()
     defer { if scoped { url.stopAccessingSecurityScopedResource() } }
     let ext = url.pathExtension.isEmpty ? "pdb" : url.pathExtension
@@ -542,6 +546,71 @@ func loadOpenedFile(_ url: URL, into engine: PyMOLEngine, attempt: Int = 0) {
     // so observers read the newly restored embedded Analysis Notes payload.
     engine.currentSessionURL = (ext.lowercased() == "pse") ? url : nil
 }
+
+// Opening a session file REPLACES the whole current session — PyMOL sessions are
+// app-global and there is no multi-window support yet (#29), so a Finder
+// double-click on a .pse silently wiped whatever was on screen (issue #349).
+// True when that destructive replace is about to happen: a session file is being
+// opened while objects are loaded. Pure and engine-free so it's unit-testable
+// (same pattern as handleOpenedURLs below).
+func openWouldReplaceSession(_ url: URL, hasObjects: Bool) -> Bool {
+    hasObjects && PyMOLEngine.isSessionFile(url.path)
+}
+
+#if os(macOS)
+// Stopgap for issue #349 until sessions can open in their own window/tab: before
+// a .pse/.psw replaces a non-empty session, offer to save the current one first,
+// replace it outright, or cancel the open. Returns false when the open must not
+// proceed (Cancel, or a failed/cancelled save).
+@MainActor
+func confirmReplaceSessionIfNeeded(opening url: URL, engine: PyMOLEngine) -> Bool {
+    guard openWouldReplaceSession(url, hasObjects: !engine.objects.isEmpty)
+    else { return true }
+    let alert = NSAlert()
+    alert.messageText = "Replace the current session?"
+    alert.informativeText = """
+        Opening “\(url.lastPathComponent)” will replace everything in the current \
+        session. RayMol can’t open sessions in separate windows yet.
+        """
+    alert.alertStyle = .warning
+    alert.addButton(withTitle: "Save and Replace…")
+    alert.addButton(withTitle: "Replace")
+    alert.addButton(withTitle: "Cancel")
+    switch alert.runModal() {
+    case .alertFirstButtonReturn:
+        return saveCurrentSessionForReplace(engine: engine)
+    case .alertSecondButtonReturn:
+        return true
+    default:
+        return false
+    }
+}
+
+// Save the outgoing session before it's replaced, mirroring ⌘S semantics: an open
+// document is overwritten silently; an untitled session shows the Save panel.
+// Ordering is safe without waiting — cmd.save and the subsequent `load` both run
+// synchronously through the bridge on the main actor, in issue order. Returns
+// false when the user cancels the panel, which aborts the replace.
+@MainActor
+private func saveCurrentSessionForReplace(engine: PyMOLEngine) -> Bool {
+    let notes = AnalysisNotesStore.shared
+    let dest: URL
+    if let current = engine.currentSessionURL {
+        dest = current
+    } else {
+        let panel = NSSavePanel()
+        if let pse = UTType(filenameExtension: "pse") { panel.allowedContentTypes = [pse] }
+        panel.nameFieldStringValue = "session.pse"
+        panel.canCreateDirectories = true
+        panel.title = "Save Session"
+        guard panel.runModal() == .OK, let url = panel.url else { return false }
+        dest = url
+    }
+    notes.sessionDidSave(to: dest)
+    engine.saveSession(to: dest)
+    return true
+}
+#endif
 
 // Load EVERY URL the OS handed us in one open (multi-file Terminal `open`, Finder
 // "Open With" multi-select, Dock-icon drop). Factored out of RayMolAppDelegate so

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -1379,12 +1379,34 @@ final class PyMOLEngine: ObservableObject {
         runPython(py)
     }
 
+    /// True when `path` is a session file (.pse/.psw). A session restores its own
+    /// object names, colors, representations and settings, so the coordinate-file
+    /// load contract (object name + theming) does not apply to it.
+    static func isSessionFile(_ path: String) -> Bool {
+        let ext = (path as NSString).pathExtension.lowercased()
+        return ext == "pse" || ext == "psw"
+    }
+
+    /// The exact command pair `loadStructure` runs — factored pure for tests.
+    /// Sessions load bare: passing an object name to `load foo.pse` is meaningless
+    /// (nothing by that name is created, and the selector logs `Invalid selection
+    /// name` straight to the console — issue #272), and theming would clobber the
+    /// very colors/representations the .pse was saved to keep.
+    static func loadInvocation(path: String, name: String)
+        -> (command: String, theme: String?) {
+        if isSessionFile(path) { return ("load \(path)", nil) }
+        return ("load \(path), \(name)",
+                "from pymol import raymol_theme as _rt; _rt.apply_to('\(name)')")
+    }
+
     /// Load a structure then theme it (default style + chain/element colors) for
-    /// the NEW object only. Routes all UI/agent/open-with load paths.
+    /// the NEW object only — or restore a session untouched. Routes all UI/agent/
+    /// open-with load paths.
     func loadStructure(path: String, name: String) {
         guard isReady else { return }
-        runCommand("load \(path), \(name)")
-        runPython("from pymol import raymol_theme as _rt; _rt.apply_to('\(name)')")
+        let (command, theme) = Self.loadInvocation(path: path, name: name)
+        runCommand(command)
+        if let theme { runPython(theme) }
     }
 
     /// Fetch a PDB id then theme the NEW object.

--- a/swiftui/PyMOLViewerTests/OpenFilesTests.swift
+++ b/swiftui/PyMOLViewerTests/OpenFilesTests.swift
@@ -36,4 +36,52 @@ final class OpenFilesTests: XCTestCase {
         handleOpenedURLs([], into: PyMOLEngine.shared) { _, _ in called = true }
         XCTAssertFalse(called)
     }
+
+    // MARK: - Issue #272: sessions load bare — no object name, no theming
+
+    func testSessionLoadHasNoObjectNameAndNoTheme() {
+        // `load foo.pse, name` creates nothing named `name` (the session restores
+        // its own objects), so the old theming call spammed `Invalid selection
+        // name` on every session open — and would have clobbered the session's
+        // saved colors/reps had the name resolved.
+        let (command, theme) = PyMOLEngine.loadInvocation(
+            path: "/tmp/open_E277B7EE.pse", name: "top6_candidates")
+        XCTAssertEqual(command, "load /tmp/open_E277B7EE.pse")
+        XCTAssertNil(theme)
+    }
+
+    func testSessionExtensionMatchIsCaseInsensitiveAndCoversPsw() {
+        for path in ["/tmp/a.PSE", "/tmp/b.psw", "/tmp/c.Psw"] {
+            let (command, theme) = PyMOLEngine.loadInvocation(path: path, name: "x")
+            XCTAssertEqual(command, "load \(path)", path)
+            XCTAssertNil(theme, path)
+        }
+    }
+
+    func testCoordinateLoadKeepsObjectNameAndTheme() {
+        let (command, theme) = PyMOLEngine.loadInvocation(
+            path: "/tmp/5hbh.pdb", name: "5hbh")
+        XCTAssertEqual(command, "load /tmp/5hbh.pdb, 5hbh")
+        XCTAssertEqual(theme,
+            "from pymol import raymol_theme as _rt; _rt.apply_to('5hbh')")
+    }
+
+    // MARK: - Issue #349: a .pse open must not silently wipe a non-empty session
+
+    func testSessionOpenOverNonEmptySessionNeedsConfirmation() {
+        let pse = URL(fileURLWithPath: "/tmp/other.pse")
+        XCTAssertTrue(openWouldReplaceSession(pse, hasObjects: true))
+    }
+
+    func testSessionOpenIntoEmptySessionNeedsNoConfirmation() {
+        // Cold launch from a Finder double-click: nothing to lose, no prompt.
+        let pse = URL(fileURLWithPath: "/tmp/other.pse")
+        XCTAssertFalse(openWouldReplaceSession(pse, hasObjects: false))
+    }
+
+    func testCoordinateOpenNeverPrompts() {
+        // A .pdb/.cif ADDS an object — it doesn't replace the session.
+        let pdb = URL(fileURLWithPath: "/tmp/5hbh.pdb")
+        XCTAssertFalse(openWouldReplaceSession(pdb, hasObjects: true))
+    }
 }

--- a/testing/tests/test_raymol_theme_apply.py
+++ b/testing/tests/test_raymol_theme_apply.py
@@ -1,0 +1,124 @@
+"""Regression tests for pymol.raymol_theme.apply_to (issue #272).
+
+Opening a .pse used to log on every session open:
+
+    raymol_theme.apply_to('top6_candidates') failed:  Error: Invalid selection
+    name "top6_candidates".
+
+because the app themed a filename-derived object name that a session restore
+never creates (a .pse restores its OWN object names). apply_to must no-op for a
+name that doesn't resolve — and it must decide that BEFORE touching the
+selector, because the C++ selector writes `Invalid selection name` straight to
+the console feedback stream (fd 1), out of reach of apply_to's try/except (same
+mechanism as issue #219).
+
+Runs under the embedded harness: pymol -ckqy testing/testing.py --run <this>.
+"""
+
+import contextlib
+import os
+import sys
+import tempfile
+
+from pymol import cmd, testing
+from pymol import raymol_theme
+
+
+@contextlib.contextmanager
+def capture_console():
+    """Capture the REAL console stream (fd 1), not just sys.stdout.
+
+    The selector error is written by C++ through PyMOL's feedback system
+    directly to fd 1; contextlib.redirect_stdout never sees it, so a test built
+    on it would pass against the unfixed code. Same helper as
+    test_appkit_objpanel_poll.py (issue #219).
+    """
+    sys.stdout.flush()
+    saved = os.dup(1)
+    tmp = tempfile.TemporaryFile(mode='w+b')
+    try:
+        os.dup2(tmp.fileno(), 1)
+        yield tmp
+        sys.stdout.flush()
+    finally:
+        os.dup2(saved, 1)
+        os.close(saved)
+        tmp.seek(0)
+
+
+@contextlib.contextmanager
+def capture_all_output():
+    """Capture fd 1 AND the current sys.stdout object, yield a getter for both.
+
+    Both layers matter: the fork's embedded build emits the selector error
+    through C++ straight to fd 1, while apply_to's own `failed:` fallback is a
+    Python print — and under pytest, sys.stdout is pytest's capture object,
+    which does NOT write through fd 1. Capturing only the fd let the unfixed
+    code pass this test.
+    """
+    import io
+    pyout = io.StringIO()
+    result = {}
+    with capture_console() as fdout, contextlib.redirect_stdout(pyout):
+        yield lambda: result['console']
+    # capture_console's finally has restored fd 1 and rewound the temp file;
+    # only now is its content readable.
+    result['console'] = (fdout.read().decode(errors='replace')
+                         + pyout.getvalue())
+
+
+SELECTOR_ERROR = 'Invalid selection name'
+
+
+class TestApplyToUnknownName(testing.PyMOLTestCase):
+
+    def testUnknownNameIsSilent(self):
+        # Non-empty session, then theme a name nothing created — the exact call
+        # the app used to make after `load session.pse, <filename-stem>`.
+        cmd.pseudoatom('s26_r3d56_il2')
+
+        with capture_all_output() as get_console:
+            raymol_theme.apply_to('top6_candidates')
+        console = get_console()
+
+        self.assertNotIn(SELECTOR_ERROR, console,
+                         'apply_to on a missing name must not reach the '
+                         'selector (issue #272); console was: %r' % console)
+        self.assertNotIn('failed', console,
+                         'apply_to on a missing name must no-op silently, not '
+                         'print its failure fallback; console was: %r' % console)
+
+    def testSessionRestoreSequenceIsSilent(self):
+        # Full issue-#272 sequence: save a session, restore it, then theme the
+        # filename-derived name the restore never creates.
+        cmd.pseudoatom('s26_r3d56_il2')
+        with testing.mktemp('.pse') as session:
+            cmd.save(session)
+            cmd.reinitialize()
+
+            with capture_all_output() as get_console:
+                cmd.load(session)
+                raymol_theme.apply_to('top6_candidates')
+            console = get_console()
+
+        # The restore itself must have worked...
+        self.assertIn('s26_r3d56_il2', cmd.get_names('objects'))
+        # ...and the bogus theming call must leave no trace on the console.
+        self.assertNotIn(SELECTOR_ERROR, console,
+                         'session open must not log a selector error '
+                         '(issue #272); console was: %r' % console)
+
+    def testExistingObjectIsStillThemed(self):
+        # The guard must only skip MISSING names — a real freshly loaded object
+        # still gets the default style (spheres here: visible on any atoms).
+        cmd.pseudoatom('m1')
+        saved_style = raymol_theme._default_style
+        raymol_theme._default_style = 'spheres'
+        try:
+            raymol_theme.apply_to('m1')
+        finally:
+            raymol_theme._default_style = saved_style
+
+        self.assertEqual(cmd.count_atoms('m1 and rep spheres'),
+                         cmd.count_atoms('m1'),
+                         'apply_to must still theme an object that exists')


### PR DESCRIPTION
Fixes #272. Stopgap for #349 (proper fix is multi-window support, #29).

## #272 — every .pse open logged `Invalid selection name`

`loadStructure(path:name:)` routed all opens through `load <path>, <name>` + `raymol_theme.apply_to('<name>')`. Both are wrong for a session file: the object-name argument is meaningless (a session restores its own object names, so nothing by the filename-derived name is ever created), and theming a restored session would clobber exactly the colors/representations the .pse was saved to keep.

- `PyMOLEngine.loadStructure` now branches on `.pse`/`.psw`: sessions load bare — no object name, no `apply_to`. The command construction is factored into a pure `loadInvocation(path:name:)` so the contract is unit-testable without booting the engine.
- Defense-in-depth: `raymol_theme.apply_to` no-ops when no object by that name exists, checked **before** touching the selector — the selector writes `Invalid selection name` straight to the console feedback stream, out of reach of the Python `try/except` (same mechanism as #219).

## #349 — Finder-opening a .pse silently wiped the current session

Stopgap as discussed on the issue: when a `.pse`/`.psw` would replace a **non-empty** session — Finder double-click / Open With, drag-drop, or the Open panel — an alert now offers **Save and Replace… / Replace / Cancel**. Save mirrors ⌘S semantics: the tracked document is overwritten silently, an untitled session gets the Save panel; cancelling the panel aborts the open. Cold launches from a Finder double-click (empty session) never prompt. Ordering is safe without waiting: `cmd.save` and the subsequent `load` both run synchronously through the bridge on the main actor.

## Tests

- `testing/tests/test_raymol_theme_apply.py` (added to CI): the exact #272 sequence (save session → restore → theme the filename-derived name) must leave no trace on the console. Verified to **fail against the unfixed code**. Note: it captures fd 1 *and* the live `sys.stdout`, because under pytest the Python-side failure print goes to pytest's capture object, never fd 1 — an fd-only capture passes against the unfixed code.
- Six new `OpenFilesTests` cases: session loads carry no object name/theme (incl. `.psw` + case-insensitivity), coordinate loads keep both, and the replace-prompt predicate fires only for session files over a non-empty session.
- Local runs: embedded suite (new file + theme/objpanel/object-panel tests) all pass under the brew-pymol shadow harness; `UnitTests_macOS` scheme: 646 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)