### PR TITLE
Design tool: target and region as text boxes with dropdowns (#371)

### DIFF
--- a/modules/pymol/raymol_design.py
+++ b/modules/pymol/raymol_design.py
@@ -111,6 +111,51 @@ def _residue_pred(chain, resi):
     return 'resi %s' % resi
 
 
+#: mouse_selection_mode -> the selection keyword that expands one residue to what
+#: a CLICK at that level means. Atom (0), residue (1) and C-alpha (6) have no
+#: entry on purpose: as far as Design is concerned they ARE the residue (a lone
+#: atom or a lone CA contains nothing designable, so a click at those levels would
+#: otherwise select nothing at all).
+_LEVEL_KEYWORD = {2: 'bychain', 3: 'bysegi', 4: 'byobject', 5: 'bymol'}
+
+
+def _level_keyword():
+    """The expansion keyword for the CURRENT selection level, or '' for residue."""
+    try:
+        return _LEVEL_KEYWORD.get(int(cmd.get_setting_int('mouse_selection_mode')), '')
+    except Exception:
+        return ''
+
+
+def _scoped_level_sel(obj, chain, resi, src):
+    """What a Design-mode CLICK on (chain, resi) designates, at the current level.
+
+    'sele' IS the design region, so a click has to put in 'sele' exactly what a
+    click puts there everywhere else in the app: in chain mode the chain, in
+    object mode the object. Design used to force residue scope at every level,
+    which left the region saying "one residue" while the mouse mode said "chains"
+    and the viewport drew the whole chain pink -- the selection and the thing being
+    designed disagreed, and only the click path was to blame.
+
+    Re-derived from (obj, chain, resi) rather than shared with
+    metal_pick._mode_expr because the design pick payload carries no atom name;
+    the by* keywords need none, and expansion from any atom of the residue is the
+    same set as expansion from the clicked atom for every level Design honours.
+
+    The expansion happens INSIDE _scope(obj, src) and is re-intersected with it:
+    the scope is what makes the write resolve where the read resolves (see
+    _scoped_residue_sel), and expanding first would grow the intermediate
+    selection through every object that happens to share a residue number before
+    the scope narrowed it back to the same answer.
+    """
+    scope = _scope(obj, src)
+    inner = '%s and (%s)' % (scope, _residue_pred(chain, resi))
+    kw = _level_keyword()
+    if not kw:
+        return inner
+    return '%s and (%s (%s))' % (scope, kw, inner)
+
+
 def _scoped_residue_sel(obj, chain, resi, src):
     """One residue within the READ scope: the target object plus its edit source.
 
@@ -254,12 +299,14 @@ def sele_design_indices(obj, state, src=''):
 
 
 def toggle_sele_residue(obj, chain, resi, src=''):
-    """Add or remove one residue in the active 'sele' (a Design-mode click).
+    """Add or remove one CLICK's worth of atoms in the active 'sele'.
 
     Deliberately mirrors metal_pick.pick_at's toggle idiom so that a click means
     the same thing in Design mode as in normal mode: already selected -> remove,
-    otherwise add. Always leaves 'sele' enabled so the renderer's pink committed
-    pass draws it.
+    otherwise add, at the level `mouse_selection_mode` names (see
+    _scoped_level_sel -- in chain mode this designates the chain, not the one
+    residue under the pointer). Always leaves 'sele' enabled so the renderer's
+    pink committed pass draws it.
 
     `src` is the edit-session source object, and it is what makes the toggle
     ACTUALLY a toggle: the residue is resolved through _scoped_residue_sel, the
@@ -267,7 +314,7 @@ def toggle_sele_residue(obj, chain, resi, src=''):
     the working copy AND the original together. See _scoped_residue_sel for what
     an object-scoped write broke. Returns 'DESIGN_SELE_TOGGLE:on' or ':off'.
     """
-    expr = '(%s)' % _scoped_residue_sel(obj, chain, resi, src)
+    expr = '(%s)' % _scoped_level_sel(obj, chain, resi, src)
     try:
         already = cmd.count_atoms('(?sele) and %s' % expr) > 0
     except Exception:
@@ -280,7 +327,7 @@ def toggle_sele_residue(obj, chain, resi, src=''):
 
 
 def set_sele_residue(obj, chain, resi, src=''):
-    """Replace the active 'sele' with exactly one residue.
+    """Replace the active 'sele' with exactly one click's worth of atoms.
 
     Used when a Design-mode click lands on a DIFFERENT object than the current
     focus: design retargets to that object and the selection starts fresh there,
@@ -289,7 +336,7 @@ def set_sele_residue(obj, chain, resi, src=''):
     must be visible to a read that resolves by residue identity across an edit
     session's working copy and its original. Returns 'DESIGN_SELE_SET:ok'.
     """
-    cmd.select('sele', _scoped_residue_sel(obj, chain, resi, src), enable=1)
+    cmd.select('sele', _scoped_level_sel(obj, chain, resi, src), enable=1)
     return 'DESIGN_SELE_SET:ok'
 
 

--- a/modules/pymol/raymol_design.py
+++ b/modules/pymol/raymol_design.py
@@ -1,6 +1,7 @@
 """RayMol Design-mode core helpers: residue enumeration, coloring, and
 exact visual-state save/restore. Mirrors the appkit_sequence bundled-module
 pattern (writes JSON to TMPDIR, returns a short marker)."""
+import base64
 import hashlib
 import json
 import os
@@ -328,6 +329,96 @@ def clear_sele():
     """
     cmd.select('sele', 'none', enable=0)
     return 'DESIGN_SELE_CLEAR:ok'
+
+
+def resolve_target(expr_b64):
+    """Resolve a target expression to the ONE object Design will work on (#371).
+
+    Backs the target text box, which accepts an object name OR any selection
+    expression — 'polymer and chain A', a named selection, '1abc and chain B'.
+    Design itself only ever works on one focused structure, so a multi-object
+    expression narrows to the first object rather than failing; `n_objects` reports
+    that it narrowed, so the caller can say so.
+
+    The argument is base64 of UTF-8: it is USER text that the Swift side
+    interpolates into a runPython string, where a quote or a backslash would
+    otherwise end the literal.
+
+    Output: $TMPDIR/raymol_design_target.json =
+        {'object': str, 'n_objects': int, 'error': str}
+      object     - the resolved object name, '' when nothing matched
+      n_objects  - how many objects the expression covered
+      error      - why it resolved to nothing (a rejected selector, or no match)
+    Returns 'DESIGN_TARGET:<object>'.
+    """
+    payload = {'object': '', 'n_objects': 0, 'error': ''}
+    try:
+        expr = base64.b64decode(expr_b64).decode('utf-8')
+    except Exception as e:
+        expr, payload['error'] = '', 'undecodable expression (%s)' % e
+    if expr:
+        try:
+            names = cmd.get_object_list('(%s)' % expr) or []
+        except Exception as e:
+            # A rejected selector, an unknown name, an unbalanced paren: all the
+            # same to the field, which just needs something to show the user.
+            payload['error'] = str(e) or 'invalid selection'
+        else:
+            payload['n_objects'] = len(names)
+            if names:
+                payload['object'] = names[0]
+            else:
+                payload['error'] = 'no structure matches'
+    try:
+        with open(_tmp('raymol_design_target.json'), 'w') as f:
+            json.dump(payload, f)
+    except Exception:
+        pass
+    return 'DESIGN_TARGET:%s' % payload['object']
+
+
+def select_region(expr_b64):
+    """Point the active 'sele' at `expr` (#371).
+
+    Backs the region text box. It WRITES 'sele' rather than keeping a second
+    region of its own, which is the whole point: typing an expression and clicking
+    residues then feed one pipeline, and everything downstream —
+    sele_design_indices, the digest-gated poll, the pink markers — is untouched.
+
+    Base64 for the same reason resolve_target takes it. A rejected selector leaves
+    the live selection exactly as it was.
+
+    enable follows emptiness, as in drop_object_from_sele: an enabled EMPTY 'sele'
+    would suppress every other selection, because cmd.enable is exclusive for
+    selections.
+
+    Output: $TMPDIR/raymol_design_select.json = {'ok': bool, 'count': int, 'error': str}
+      ok     - the selector was accepted (a valid expression matching nothing is
+               ok=True, count=0 — that is an empty region, not a mistake)
+      count  - atoms now in 'sele'
+    Returns 'DESIGN_SELECT:<count>' or 'DESIGN_SELECT:err'.
+    """
+    payload = {'ok': False, 'count': 0, 'error': ''}
+    try:
+        expr = base64.b64decode(expr_b64).decode('utf-8')
+    except Exception as e:
+        expr, payload['error'] = '', 'undecodable expression (%s)' % e
+    if expr:
+        try:
+            n = int(cmd.select('sele', '(%s)' % expr, enable=1) or 0)
+        except Exception as e:
+            payload['error'] = str(e) or 'invalid selection'
+        else:
+            payload['ok'] = True
+            payload['count'] = n
+            if not n:
+                cmd.select('sele', 'none', enable=0)
+    try:
+        with open(_tmp('raymol_design_select.json'), 'w') as f:
+            json.dump(payload, f)
+    except Exception:
+        pass
+    return 'DESIGN_SELECT:%d' % payload['count'] if payload['ok'] else 'DESIGN_SELECT:err'
 
 
 def _record_design_metrics(obj, metric, rows, state=0):

--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		04798DF552010A1889F8FFDD /* RFD3Runtime.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECB1F4D491FA24E65DD3B011 /* RFD3Runtime.swift */; };
 		047FD10B437F95938AB4B3B0 /* WeightsFetchStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C4E3216DAFC42C515FD0C3E /* WeightsFetchStateTests.swift */; };
 		057F3C59DACA26AAC603702E /* AppBuildInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AE160C6EB58F631604002E6 /* AppBuildInfoTests.swift */; };
-		05E260DD0C29E779222642F6 /* BinderDesignController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17A2ACD0B25A85EE1CC5B9E /* BinderDesignController.swift */; };
 		08A70D51DF9F99AD0951EB6D /* RFD3SizeGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D700AB27FB3AB04471A2C4 /* RFD3SizeGuard.swift */; };
 		096FA7333E120551F0CC84A8 /* whatsnew-1100-predict.png in Resources */ = {isa = PBXBuildFile; fileRef = C84C7665566A983E2AAE8FB9 /* whatsnew-1100-predict.png */; };
 		0C0E67D9436CC6DF29DE983C /* DesignEditingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05E6ECE945556A6D1FAE98F9 /* DesignEditingTests.swift */; };
@@ -22,9 +21,11 @@
 		0FFCBEB460CD541E932326AB /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3E805AC2D63B01AB7EE29C /* Theme.swift */; };
 		104B27F848D308735A6D6DD2 /* MetalViewport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E9F8D36908E3216D1C8F893 /* MetalViewport.swift */; };
 		124F6E6764C7D94831B8AC7E /* AppVersionFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3F3410F7C0D3C85783B985F /* AppVersionFooter.swift */; };
+		12A3993A3E181A358E00AF0A /* HoverReadout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80137B4E6E0FA24F011D7E87 /* HoverReadout.swift */; };
 		13B48E7F8C2A51ADAF48F4C3 /* SequencePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474D18A43D0D9A6BDD69EEFD /* SequencePanel.swift */; };
 		13C5A803C8072DE180EB23CC /* ProtenixRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7845A3EB6A6BF8A14F090062 /* ProtenixRuntime.swift */; };
 		13E8687216067D92666E3078 /* openssl-PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = CB0108E0FA1F204BE0E41F0D /* openssl-PrivacyInfo.xcprivacy */; };
+		140DD103665D02064B5C47B1 /* BinderDesignController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F340621635D0C4E9159141A /* BinderDesignController.swift */; };
 		142D8657C5BC7DCD8648D407 /* DesignCompactPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D7FF883D3762DC6E40908F /* DesignCompactPanel.swift */; };
 		154E7F765059977CA80711DA /* RFD3Kit in Frameworks */ = {isa = PBXBuildFile; productRef = C723443B5003DD836EF6A008 /* RFD3Kit */; };
 		1624BC38CDD73398C68FC135 /* MPNNGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56BE219EF1CF1EB2B05E44AD /* MPNNGate.swift */; };
@@ -46,6 +47,7 @@
 		300656C47AD9A9C18C129C42 /* SequencePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474D18A43D0D9A6BDD69EEFD /* SequencePanel.swift */; };
 		303210F410E1AD9DBCCF57F3 /* BoltzJobManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4B5DB2F82A55E25041FE28 /* BoltzJobManager.swift */; };
 		31E2886301F34D938627FF2D /* PanelLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B75287139FE86E2C9524CA8D /* PanelLayoutTests.swift */; };
+		32061FAD7CD7E949C8C6A7BF /* HoverReadout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80137B4E6E0FA24F011D7E87 /* HoverReadout.swift */; };
 		325EE49F9617F5A907D7BDF7 /* whatsnew-1100-msa.png in Resources */ = {isa = PBXBuildFile; fileRef = 727EA43D6A4FCC275ABC49D0 /* whatsnew-1100-msa.png */; };
 		33925DA4B65039A7C4C0DE8F /* BoltzRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2367C4CEE5BD2E682055D3F /* BoltzRuntime.swift */; };
 		33C46A7EB6127A6A99D7048D /* TimelinePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B820FE9080BF73526A54CD66 /* TimelinePanel.swift */; };
@@ -73,7 +75,6 @@
 		48E340346AD8FF81AF09F501 /* MPNNKit in Frameworks */ = {isa = PBXBuildFile; productRef = 7A0C20547CE6C050BA30EDA0 /* MPNNKit */; };
 		4AD1C0E0E53EC4B34CBE7400 /* MetalViewportResponderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C47FBC551127AB2D73BC6CE /* MetalViewportResponderTests.swift */; };
 		4BE37F7CA13DEB10F2AE62D6 /* RayMol.svg in Resources */ = {isa = PBXBuildFile; fileRef = F16058D96E2773BE9A24C323 /* RayMol.svg */; };
-		4D64049F59E457F949961269 /* BinderDesignBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4302CBF253422CDF4ABF2B35 /* BinderDesignBar.swift */; };
 		4E1CFC49EFB50160C3D388B2 /* DesignAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4300265954DF2B8309EDAA6C /* DesignAvailability.swift */; };
 		4FF61FB384E2C1B9388BA273 /* whatsnew-170-homebrew.png in Resources */ = {isa = PBXBuildFile; fileRef = 0C3FB5B53174F8E55104705A /* whatsnew-170-homebrew.png */; };
 		52B5620BEF26DEB8E3A700C1 /* DesignResiduesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48EDC39F7E7F250CFC4F7D0D /* DesignResiduesTests.swift */; };
@@ -100,7 +101,6 @@
 		615CCED824D7A973408A6CBD /* PredictMSAMemorySweepTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48793845CB95A609CD9F37BF /* PredictMSAMemorySweepTests.swift */; };
 		64DDBC57197D8C3A9AB0B68D /* MCPServerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F3D56C490BC7C6166DD79F /* MCPServerManager.swift */; };
 		65873C0416944D5EF92140C6 /* RFD3TrajectoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A75B6DCB76EF7B2E69DA0BFE /* RFD3TrajectoryTests.swift */; };
-		65A0B7E17E245F65ACE4F7E7 /* BinderDesignController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17A2ACD0B25A85EE1CC5B9E /* BinderDesignController.swift */; };
 		65CE08E50C85C8ACDAC92D07 /* DesignSizeGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E69AA2C12DC2D1583FBF8C8 /* DesignSizeGuard.swift */; };
 		667B289D123B261F82B10FFC /* MovieBuilderSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ED5BFF3FEE9D6621BB40AE5 /* MovieBuilderSheet.swift */; };
 		68AB212502F00E7E297F8208 /* ProtenixSizeGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EE8A26A41F551AB296B2F8E /* ProtenixSizeGuard.swift */; };
@@ -108,7 +108,6 @@
 		6A1DB5F97E3738FD1819FF6E /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3E805AC2D63B01AB7EE29C /* Theme.swift */; };
 		6A37175866051AC88BD25C1D /* RFD3RuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB3DD619B055E99FD2F9C1E /* RFD3RuntimeTests.swift */; };
 		6A3892FDD5939A57DC9FFCCE /* CopyRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0B47016374F32C7BB13017 /* CopyRoutingTests.swift */; };
-		FE667ADF3DAD102C12DC4DA2 /* HoverReadoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF1264ED4865B293F313315 /* HoverReadoutTests.swift */; };
 		6C028EE83C8A29A4FDCF2222 /* BoltzJobManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 193D4D739151970412BB6EDF /* BoltzJobManagerTests.swift */; };
 		6C8AA3C224C1B2106FBF4881 /* DesignScoreCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC5AE545F97DF175BFE0462 /* DesignScoreCache.swift */; };
 		6D67CAB3F655837D48E68AF3 /* PredictController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0D207800BE2DDAF04598C1 /* PredictController.swift */; };
@@ -139,15 +138,15 @@
 		8471766417221874246F5252 /* WhatsNewLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3753EB4AA7EC91E685E36B84 /* WhatsNewLogic.swift */; };
 		848682B247E00ECDD720FF73 /* DesignResidues.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFE9998F68625C92B8BCD710 /* DesignResidues.swift */; };
 		86F8E58F4BAA9E8B03380DBB /* TransportBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C562306A5AD1EEDDBA931B98 /* TransportBar.swift */; };
+		876C79ECB2F8DA63EE7BAC84 /* BinderDesignBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4B03344972863CC1362ECB /* BinderDesignBar.swift */; };
 		8852A9FA93BDAAB188D4103C /* PyMOLEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33D6A753E4525628B96C259C /* PyMOLEngine.swift */; };
 		8C04C5D4AB27F2D9BEF79561 /* GizmoOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4C108E3D04FD75288859DA /* GizmoOverlay.swift */; };
-		12A3993A3E181A358E00AF0A /* HoverReadout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80137B4E6E0FA24F011D7E87 /* HoverReadout.swift */; };
 		8CDF44341FE9E9CB053BFC76 /* TransportBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C562306A5AD1EEDDBA931B98 /* TransportBar.swift */; };
 		8DC572A1863238F8B919ED70 /* WhatsNewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5377EE69A856479317FD61 /* WhatsNewModel.swift */; };
 		8E33AC50510ECB1DA4277904 /* RayMol.svg in Resources */ = {isa = PBXBuildFile; fileRef = F16058D96E2773BE9A24C323 /* RayMol.svg */; };
 		8F33D1DB927644308CEF0C5B /* WhatsNew.json in Resources */ = {isa = PBXBuildFile; fileRef = 689CDE512811C244D4BA931B /* WhatsNew.json */; };
 		8F71359FAD68AE5D09416C1B /* GizmoOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4C108E3D04FD75288859DA /* GizmoOverlay.swift */; };
-		32061FAD7CD7E949C8C6A7BF /* HoverReadout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80137B4E6E0FA24F011D7E87 /* HoverReadout.swift */; };
+		900E0E51AA354246F795CA84 /* SelectionInputField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D55EF2F596852510DDACA576 /* SelectionInputField.swift */; };
 		90F5E063444FBF4FF3770118 /* MCPStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1304C662D9011F7C4505FC /* MCPStatusView.swift */; };
 		917ABB57816FDCD8B1D1E9CE /* DesignSizeGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3CAE980896763CAAAF2034 /* DesignSizeGuardTests.swift */; };
 		946A8CF4D62A7AFFFA6E39A9 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 10CCAA289EA2934B267C337A /* PrivacyInfo.xcprivacy */; };
@@ -157,6 +156,7 @@
 		97F0B5805CD3B11723C7B43B /* whatsnew-152-timeline.png in Resources */ = {isa = PBXBuildFile; fileRef = 55094A33AFF9AEF5561CFD96 /* whatsnew-152-timeline.png */; };
 		983BCF8F1E0F251E82C1CF0E /* DesignController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4FB7F151982A2927D612F0 /* DesignController.swift */; };
 		996828523DD2656E579ACE55 /* RFD3JobManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8746A760E75B98C92A547404 /* RFD3JobManager.swift */; };
+		9C6CB8E2C25DB4AE13D42756 /* BinderDesignBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4B03344972863CC1362ECB /* BinderDesignBar.swift */; };
 		9E056CF2985B57F6BF968798 /* ProtenixMLX in Frameworks */ = {isa = PBXBuildFile; productRef = 90EE4E4414E8FBDC2271BEA2 /* ProtenixMLX */; };
 		9FDA615BBA4A6BBDF131EF7F /* ProtenixRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56746569540D202277F2B47F /* ProtenixRuntimeTests.swift */; };
 		9FE703EF6FD7C97884C299DF /* RayMol.icon in Resources */ = {isa = PBXBuildFile; fileRef = BB5ABD1A8C45E5BC97AB0B80 /* RayMol.icon */; };
@@ -198,8 +198,8 @@
 		CCC5944AB82CA9D946A60F10 /* whatsnew-190-redesign.png in Resources */ = {isa = PBXBuildFile; fileRef = 137F4EFE6CA3B90DE4765559 /* whatsnew-190-redesign.png */; };
 		CE1CC588AA02F7FE11A0048B /* MPNNGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56BE219EF1CF1EB2B05E44AD /* MPNNGate.swift */; };
 		CE45D81735E70E8FFFD49875 /* ThemeStudioPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85B66833BF167209A47B9C15 /* ThemeStudioPanel.swift */; };
-		CF401E726434519896E47DE3 /* BinderDesignBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4302CBF253422CDF4ABF2B35 /* BinderDesignBar.swift */; };
 		CFBEE2172EC92121700639E7 /* PendingJobTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DEAB18A89F026148528C71E /* PendingJobTests.swift */; };
+		D0505F6B98C64B96BE87A753 /* DesignTargetSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD9E3092D310E443F7CD546 /* DesignTargetSelectionTests.swift */; };
 		D0BB5840BDEAA557F5B8F387 /* RFD3Runtime.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECB1F4D491FA24E65DD3B011 /* RFD3Runtime.swift */; };
 		D1810E28536159A86EF507F8 /* whatsnew-190-raymolrc.png in Resources */ = {isa = PBXBuildFile; fileRef = 7D10B5CB9ECF81346BD9CAE8 /* whatsnew-190-raymolrc.png */; };
 		D1A6B8D3D1B74B4D1142ADE5 /* PredictSizeGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D177C9A043AE57844A9AEB95 /* PredictSizeGuardTests.swift */; };
@@ -237,10 +237,13 @@
 		F6C4DEEFED66EB440E6359AF /* PyMOLApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D965CB609C447033E5DB0046 /* PyMOLApp.swift */; };
 		F96DF6C063C742C64F3C221C /* PredictScreenAwakeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA9F6B00A6FC98E37CB26EC /* PredictScreenAwakeTests.swift */; };
 		F9F1B10E40B13DDF27C0ACC1 /* PanelLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47211EDB3E34DF3B0CFE8BB /* PanelLayout.swift */; };
+		FA5250EB01CB7F86C4158D2C /* BinderDesignController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F340621635D0C4E9159141A /* BinderDesignController.swift */; };
 		FAB7D942A53C88BEA4D2FFE4 /* whatsnew-1100-predict-progress.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = C5D633C399E993EE52877C82 /* whatsnew-1100-predict-progress.mp4 */; };
 		FC8808FCB845C7543244AC94 /* MovieExportSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FE79EC8844C681A41A1E54A /* MovieExportSheet.swift */; };
 		FCB5A40892C6D7239E49791A /* DesignControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7E41DCBB427678A8F018B0E /* DesignControllerTests.swift */; };
 		FCE3C0AD3EC5319F8F2E144E /* DesignEditInferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6A959CC1590FC60333582B /* DesignEditInferenceTests.swift */; };
+		FE667ADF3DAD102C12DC4DA2 /* HoverReadoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF1264ED4865B293F313315 /* HoverReadoutTests.swift */; };
+		FF325D5404E69D05274EEB81 /* SelectionInputField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D55EF2F596852510DDACA576 /* SelectionInputField.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -269,6 +272,7 @@
 		0C47FBC551127AB2D73BC6CE /* MetalViewportResponderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalViewportResponderTests.swift; sourceTree = "<group>"; };
 		0C4E3216DAFC42C515FD0C3E /* WeightsFetchStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightsFetchStateTests.swift; sourceTree = "<group>"; };
 		0ED5BFF3FEE9D6621BB40AE5 /* MovieBuilderSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieBuilderSheet.swift; sourceTree = "<group>"; };
+		0F340621635D0C4E9159141A /* BinderDesignController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinderDesignController.swift; sourceTree = "<group>"; };
 		104B50C66BDEB03C41A1CE47 /* CameraOverlayUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraOverlayUITests.swift; sourceTree = "<group>"; };
 		10CCAA289EA2934B267C337A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		137F4EFE6CA3B90DE4765559 /* whatsnew-190-redesign.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "whatsnew-190-redesign.png"; sourceTree = "<group>"; };
@@ -291,12 +295,12 @@
 		35DC456EDC3E55F84506C8B7 /* NotesInspectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesInspectorView.swift; sourceTree = "<group>"; };
 		3697F74BD2283492B5A7790C /* KeyRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyRouting.swift; sourceTree = "<group>"; };
 		3753EB4AA7EC91E685E36B84 /* WhatsNewLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewLogic.swift; sourceTree = "<group>"; };
+		3BF1264ED4865B293F313315 /* HoverReadoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverReadoutTests.swift; sourceTree = "<group>"; };
 		3F5377EE69A856479317FD61 /* WhatsNewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewModel.swift; sourceTree = "<group>"; };
 		3FC150B0707033AB3B186189 /* RFD3ResultWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFD3ResultWriter.swift; sourceTree = "<group>"; };
 		3FDAAF431094900F3FC21293 /* whatsnew-1100-metrics.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "whatsnew-1100-metrics.png"; sourceTree = "<group>"; };
 		42F41684D508836307667157 /* RFD3Trajectory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFD3Trajectory.swift; sourceTree = "<group>"; };
 		4300265954DF2B8309EDAA6C /* DesignAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignAvailability.swift; sourceTree = "<group>"; };
-		4302CBF253422CDF4ABF2B35 /* BinderDesignBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinderDesignBar.swift; sourceTree = "<group>"; };
 		474D18A43D0D9A6BDD69EEFD /* SequencePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequencePanel.swift; sourceTree = "<group>"; };
 		48793845CB95A609CD9F37BF /* PredictMSAMemorySweepTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictMSAMemorySweepTests.swift; sourceTree = "<group>"; };
 		48EDC39F7E7F250CFC4F7D0D /* DesignResiduesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignResiduesTests.swift; sourceTree = "<group>"; };
@@ -316,6 +320,7 @@
 		5E9F8D36908E3216D1C8F893 /* MetalViewport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalViewport.swift; sourceTree = "<group>"; };
 		689CDE512811C244D4BA931B /* WhatsNew.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = WhatsNew.json; sourceTree = "<group>"; };
 		6A0950CBB18F3934DDA02CBE /* whatsnew-190-scenes.mp4 */ = {isa = PBXFileReference; path = "whatsnew-190-scenes.mp4"; sourceTree = "<group>"; };
+		6A4B03344972863CC1362ECB /* BinderDesignBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinderDesignBar.swift; sourceTree = "<group>"; };
 		6AE160C6EB58F631604002E6 /* AppBuildInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBuildInfoTests.swift; sourceTree = "<group>"; };
 		6C07F661E0541060409A09F7 /* PredictSizeGuard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictSizeGuard.swift; sourceTree = "<group>"; };
 		6E2FC2AD1A8FEE912986DF9D /* whatsnew-161-hover.mp4 */ = {isa = PBXFileReference; path = "whatsnew-161-hover.mp4"; sourceTree = "<group>"; };
@@ -329,6 +334,7 @@
 		7D10B5CB9ECF81346BD9CAE8 /* whatsnew-190-raymolrc.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "whatsnew-190-raymolrc.png"; sourceTree = "<group>"; };
 		7D3E805AC2D63B01AB7EE29C /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		7DEAB18A89F026148528C71E /* PendingJobTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingJobTests.swift; sourceTree = "<group>"; };
+		80137B4E6E0FA24F011D7E87 /* HoverReadout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverReadout.swift; sourceTree = "<group>"; };
 		82BCB731F0C74F642D78D450 /* PyMOLBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PyMOLBridge.h; sourceTree = "<group>"; };
 		85B66833BF167209A47B9C15 /* ThemeStudioPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStudioPanel.swift; sourceTree = "<group>"; };
 		86E93358875495F499780A00 /* MLXRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLXRuntime.swift; sourceTree = "<group>"; };
@@ -350,7 +356,6 @@
 		A73267D4D7B506E647B7A995 /* ObjectPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectPanel.swift; sourceTree = "<group>"; };
 		A75B6DCB76EF7B2E69DA0BFE /* RFD3TrajectoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFD3TrajectoryTests.swift; sourceTree = "<group>"; };
 		AA4C108E3D04FD75288859DA /* GizmoOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GizmoOverlay.swift; sourceTree = "<group>"; };
-		80137B4E6E0FA24F011D7E87 /* HoverReadout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverReadout.swift; sourceTree = "<group>"; };
 		AD3E224EA1BE94147B322332 /* InferenceRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InferenceRouterTests.swift; sourceTree = "<group>"; };
 		B049A83EEE87CC41BA09889D /* RFD3ResultWriterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFD3ResultWriterTests.swift; sourceTree = "<group>"; };
 		B158150C93613716ED3CE572 /* KeyboardDismissUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardDismissUITests.swift; sourceTree = "<group>"; };
@@ -363,7 +368,6 @@
 		B9EC978B16F58D988575E206 /* MCPDrivingBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPDrivingBanner.swift; sourceTree = "<group>"; };
 		BB5ABD1A8C45E5BC97AB0B80 /* RayMol.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = RayMol.icon; sourceTree = "<group>"; };
 		BF0B47016374F32C7BB13017 /* CopyRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyRoutingTests.swift; sourceTree = "<group>"; };
-		3BF1264ED4865B293F313315 /* HoverReadoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverReadoutTests.swift; sourceTree = "<group>"; };
 		C2C2F36B9B6E660DD0256EC2 /* PredictCompactPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictCompactPanel.swift; sourceTree = "<group>"; };
 		C3F3410F7C0D3C85783B985F /* AppVersionFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionFooter.swift; sourceTree = "<group>"; };
 		C562306A5AD1EEDDBA931B98 /* TransportBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportBar.swift; sourceTree = "<group>"; };
@@ -379,6 +383,7 @@
 		D177C9A043AE57844A9AEB95 /* PredictSizeGuardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictSizeGuardTests.swift; sourceTree = "<group>"; };
 		D1D7FF883D3762DC6E40908F /* DesignCompactPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignCompactPanel.swift; sourceTree = "<group>"; };
 		D4847B7F5C09AD3E9412C3EB /* PredictScreenAwake.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictScreenAwake.swift; sourceTree = "<group>"; };
+		D55EF2F596852510DDACA576 /* SelectionInputField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionInputField.swift; sourceTree = "<group>"; };
 		D60E5CB80464F5616064A91C /* PredictControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictControllerTests.swift; sourceTree = "<group>"; };
 		D965CB609C447033E5DB0046 /* PyMOLApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PyMOLApp.swift; sourceTree = "<group>"; };
 		DA4A62DDBB48F5166D118F32 /* PredictSizeGuardIOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictSizeGuardIOSTests.swift; sourceTree = "<group>"; };
@@ -393,7 +398,6 @@
 		EEC5AE545F97DF175BFE0462 /* DesignScoreCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignScoreCache.swift; sourceTree = "<group>"; };
 		F14E7328C4421ADC9E81417D /* PredictBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictBar.swift; sourceTree = "<group>"; };
 		F16058D96E2773BE9A24C323 /* RayMol.svg */ = {isa = PBXFileReference; path = RayMol.svg; sourceTree = "<group>"; };
-		F17A2ACD0B25A85EE1CC5B9E /* BinderDesignController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinderDesignController.swift; sourceTree = "<group>"; };
 		F2078076B68D28457409F7A5 /* RayMol.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RayMol.entitlements; sourceTree = "<group>"; };
 		F3441C46AD1B569C623A36B7 /* RFD3TrayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFD3TrayTests.swift; sourceTree = "<group>"; };
 		F43E4051E6410834AAAA4047 /* InteractionModeExitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractionModeExitTests.swift; sourceTree = "<group>"; };
@@ -402,7 +406,8 @@
 		F7E41DCBB427678A8F018B0E /* DesignControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignControllerTests.swift; sourceTree = "<group>"; };
 		FB1304C662D9011F7C4505FC /* MCPStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPStatusView.swift; sourceTree = "<group>"; };
 		FF4FB7F151982A2927D612F0 /* DesignController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignController.swift; sourceTree = "<group>"; };
-		"TEMP_F3F316DE-0987-41B7-9ECF-8C063E861C7F" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
+		FFD9E3092D310E443F7CD546 /* DesignTargetSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignTargetSelectionTests.swift; sourceTree = "<group>"; };
+		"TEMP_717F019A-8374-4DC4-958E-D513B981327A" /* PyMOLBridge.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PyMOLBridge.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -532,13 +537,13 @@
 			children = (
 				525F338CAB2EE18987CD1701 /* AppBuildInfo.swift */,
 				C3F3410F7C0D3C85783B985F /* AppVersionFooter.swift */,
+				6A4B03344972863CC1362ECB /* BinderDesignBar.swift */,
+				0F340621635D0C4E9159141A /* BinderDesignController.swift */,
 				5A4B5DB2F82A55E25041FE28 /* BoltzJobManager.swift */,
 				A2367C4CEE5BD2E682055D3F /* BoltzRuntime.swift */,
 				75F059BB95517CE91BD3E26E /* ContentView.swift */,
 				A4CC639810B19E8F5E637E93 /* CopyRouting.swift */,
 				4300265954DF2B8309EDAA6C /* DesignAvailability.swift */,
-				4302CBF253422CDF4ABF2B35 /* BinderDesignBar.swift */,
-				F17A2ACD0B25A85EE1CC5B9E /* BinderDesignController.swift */,
 				C5F2DF248B756BF6CA3CBE92 /* DesignColor.swift */,
 				D1D7FF883D3762DC6E40908F /* DesignCompactPanel.swift */,
 				FF4FB7F151982A2927D612F0 /* DesignController.swift */,
@@ -577,6 +582,7 @@
 				ECB1F4D491FA24E65DD3B011 /* RFD3Runtime.swift */,
 				B6D700AB27FB3AB04471A2C4 /* RFD3SizeGuard.swift */,
 				42F41684D508836307667157 /* RFD3Trajectory.swift */,
+				D55EF2F596852510DDACA576 /* SelectionInputField.swift */,
 				7D3E805AC2D63B01AB7EE29C /* Theme.swift */,
 				EDC5E722722DEF7FBB1D649F /* ThemeManager.swift */,
 				3753EB4AA7EC91E685E36B84 /* WhatsNewLogic.swift */,
@@ -594,7 +600,6 @@
 				1A75842F74BFC453CE7BA777 /* BoltzJobManagerMSATests.swift */,
 				193D4D739151970412BB6EDF /* BoltzJobManagerTests.swift */,
 				BF0B47016374F32C7BB13017 /* CopyRoutingTests.swift */,
-				3BF1264ED4865B293F313315 /* HoverReadoutTests.swift */,
 				2345D7E2703CF29D4A2AA277 /* DesignAvailabilityTests.swift */,
 				1B045EA1D04163863BD9DA94 /* DesignColorTests.swift */,
 				F7E41DCBB427678A8F018B0E /* DesignControllerTests.swift */,
@@ -607,6 +612,8 @@
 				48EDC39F7E7F250CFC4F7D0D /* DesignResiduesTests.swift */,
 				D0BCB2A867C3554FB56A7299 /* DesignScoreCacheTests.swift */,
 				EE3CAE980896763CAAAF2034 /* DesignSizeGuardTests.swift */,
+				FFD9E3092D310E443F7CD546 /* DesignTargetSelectionTests.swift */,
+				3BF1264ED4865B293F313315 /* HoverReadoutTests.swift */,
 				AD3E224EA1BE94147B322332 /* InferenceRouterTests.swift */,
 				F43E4051E6410834AAAA4047 /* InteractionModeExitTests.swift */,
 				1FF072CB363743CAF805155E /* KeyBindingDispatchTests.swift */,
@@ -654,10 +661,10 @@
 			path = Bridge;
 			sourceTree = "<group>";
 		};
-		"TEMP_303BE09A-9D43-493B-AAEE-D3C942A3C3C4" /* swiftui */ = {
+		"TEMP_D648D16E-4E3D-4D0B-958C-7EE103FF4AAC" /* swiftui */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_F3F316DE-0987-41B7-9ECF-8C063E861C7F" /* PyMOLBridge.xcconfig */,
+				"TEMP_717F019A-8374-4DC4-958E-D513B981327A" /* PyMOLBridge.xcconfig */,
 			);
 			path = swiftui;
 			sourceTree = "<group>";
@@ -1330,7 +1337,6 @@
 				238B6F24D467D70AE012E2CB /* BoltzJobManagerMSATests.swift in Sources */,
 				6C028EE83C8A29A4FDCF2222 /* BoltzJobManagerTests.swift in Sources */,
 				6A3892FDD5939A57DC9FFCCE /* CopyRoutingTests.swift in Sources */,
-				FE667ADF3DAD102C12DC4DA2 /* HoverReadoutTests.swift in Sources */,
 				B88942D786AB0D1CDC354C1F /* DesignAvailabilityTests.swift in Sources */,
 				42BC62ABCFB3CDB9C2CE3518 /* DesignColorTests.swift in Sources */,
 				FCB5A40892C6D7239E49791A /* DesignControllerTests.swift in Sources */,
@@ -1343,6 +1349,8 @@
 				52B5620BEF26DEB8E3A700C1 /* DesignResiduesTests.swift in Sources */,
 				6EAC8947F66B8D7AD29BF3B8 /* DesignScoreCacheTests.swift in Sources */,
 				917ABB57816FDCD8B1D1E9CE /* DesignSizeGuardTests.swift in Sources */,
+				D0505F6B98C64B96BE87A753 /* DesignTargetSelectionTests.swift in Sources */,
+				FE667ADF3DAD102C12DC4DA2 /* HoverReadoutTests.swift in Sources */,
 				C98E23FB46AC666B6D1B5A72 /* InferenceRouterTests.swift in Sources */,
 				57E2333020DE9DC8910BDC3E /* InteractionModeExitTests.swift in Sources */,
 				CAC9B9F8A93BC4B71C3DB0D6 /* KeyBindingDispatchTests.swift in Sources */,
@@ -1375,14 +1383,14 @@
 			files = (
 				B532BA92CE9FB3A65DD02D37 /* AppBuildInfo.swift in Sources */,
 				124F6E6764C7D94831B8AC7E /* AppVersionFooter.swift in Sources */,
+				876C79ECB2F8DA63EE7BAC84 /* BinderDesignBar.swift in Sources */,
+				140DD103665D02064B5C47B1 /* BinderDesignController.swift in Sources */,
 				76065C249F1901F993E708A6 /* BoltzJobManager.swift in Sources */,
 				BF09C330B7686E39A51C8626 /* BoltzRuntime.swift in Sources */,
 				DC8A9C1AA5EB1946175041FA /* CommandPanel.swift in Sources */,
 				4128B469229CEE6A6A4E4B68 /* ContentView.swift in Sources */,
 				79604AC1AF5212DADC4C2DE3 /* CopyRouting.swift in Sources */,
 				78893185798035F798A26A9B /* DesignAvailability.swift in Sources */,
-				4D64049F59E457F949961269 /* BinderDesignBar.swift in Sources */,
-				05E260DD0C29E779222642F6 /* BinderDesignController.swift in Sources */,
 				BE397E89274A3180A2E649BF /* DesignColor.swift in Sources */,
 				142D8657C5BC7DCD8648D407 /* DesignCompactPanel.swift in Sources */,
 				E7A7CA409C1DB4D1A78AD5B9 /* DesignController.swift in Sources */,
@@ -1390,7 +1398,7 @@
 				2E559E9581421DDC00C8BBB8 /* DesignScoreCache.swift in Sources */,
 				65CE08E50C85C8ACDAC92D07 /* DesignSizeGuard.swift in Sources */,
 				8C04C5D4AB27F2D9BEF79561 /* GizmoOverlay.swift in Sources */,
-				12A3993A3E181A358E00AF0A /* HoverReadout.swift in Sources */,
+				32061FAD7CD7E949C8C6A7BF /* HoverReadout.swift in Sources */,
 				59414471A1C1412AF869074D /* InferenceJob.swift in Sources */,
 				AC4CB915ECB531A4406CF387 /* InferenceRouter.swift in Sources */,
 				2C2D4B24DF4807FA1407582D /* KeyRouting.swift in Sources */,
@@ -1430,6 +1438,7 @@
 				953186F444ED70F3F5F33746 /* RFD3Trajectory.swift in Sources */,
 				EC4EF850FC58B240AD02346F /* RayMolMain.swift in Sources */,
 				3E6C34959A3934D2DE3E080F /* RayMolUpdater.swift in Sources */,
+				FF325D5404E69D05274EEB81 /* SelectionInputField.swift in Sources */,
 				13B48E7F8C2A51ADAF48F4C3 /* SequencePanel.swift in Sources */,
 				0FFCBEB460CD541E932326AB /* Theme.swift in Sources */,
 				3A8107D094C920B600681B74 /* ThemeManager.swift in Sources */,
@@ -1448,14 +1457,14 @@
 			files = (
 				AA00B9355E30A51B8F4C207B /* AppBuildInfo.swift in Sources */,
 				45817B402639546111EFD5B7 /* AppVersionFooter.swift in Sources */,
+				9C6CB8E2C25DB4AE13D42756 /* BinderDesignBar.swift in Sources */,
+				FA5250EB01CB7F86C4158D2C /* BinderDesignController.swift in Sources */,
 				303210F410E1AD9DBCCF57F3 /* BoltzJobManager.swift in Sources */,
 				33925DA4B65039A7C4C0DE8F /* BoltzRuntime.swift in Sources */,
 				042F08F899EE19B73EFEC143 /* CommandPanel.swift in Sources */,
 				3F96563B0EA8F919B068A421 /* ContentView.swift in Sources */,
 				C2FE6360EC57133D61DC3FAD /* CopyRouting.swift in Sources */,
 				4E1CFC49EFB50160C3D388B2 /* DesignAvailability.swift in Sources */,
-				CF401E726434519896E47DE3 /* BinderDesignBar.swift in Sources */,
-				65A0B7E17E245F65ACE4F7E7 /* BinderDesignController.swift in Sources */,
 				D48D80E395852871CAC65FCA /* DesignColor.swift in Sources */,
 				C2FCBB63D8533AF61056C0C2 /* DesignCompactPanel.swift in Sources */,
 				983BCF8F1E0F251E82C1CF0E /* DesignController.swift in Sources */,
@@ -1463,7 +1472,7 @@
 				6C8AA3C224C1B2106FBF4881 /* DesignScoreCache.swift in Sources */,
 				1A580F6792CD440D91FA9F45 /* DesignSizeGuard.swift in Sources */,
 				8F71359FAD68AE5D09416C1B /* GizmoOverlay.swift in Sources */,
-				32061FAD7CD7E949C8C6A7BF /* HoverReadout.swift in Sources */,
+				12A3993A3E181A358E00AF0A /* HoverReadout.swift in Sources */,
 				82DADD44C2ED6C0A534EBD26 /* InferenceJob.swift in Sources */,
 				966C6886E3CE816365256220 /* InferenceRouter.swift in Sources */,
 				768E23FCAB4D2B27205900B6 /* KeyRouting.swift in Sources */,
@@ -1503,6 +1512,7 @@
 				BF97400ECA54F56EB9D96FC2 /* RFD3Trajectory.swift in Sources */,
 				BA6C9B288CFD5EB53D0E0057 /* RayMolMain.swift in Sources */,
 				F1D17CB3886E8DED5B79A28B /* RayMolUpdater.swift in Sources */,
+				900E0E51AA354246F795CA84 /* SelectionInputField.swift in Sources */,
 				300656C47AD9A9C18C129C42 /* SequencePanel.swift in Sources */,
 				6A1DB5F97E3738FD1819FF6E /* Theme.swift in Sources */,
 				D35B766612AA47956AB18A75 /* ThemeManager.swift in Sources */,
@@ -1695,7 +1705,7 @@
 		};
 		76B7E9DB75E073D1E60928FA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_F3F316DE-0987-41B7-9ECF-8C063E861C7F" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_717F019A-8374-4DC4-958E-D513B981327A" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1802,7 +1812,7 @@
 		};
 		D8F44FDFF036013D2F03BA83 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_F3F316DE-0987-41B7-9ECF-8C063E861C7F" /* PyMOLBridge.xcconfig */;
+			baseConfigurationReference = "TEMP_717F019A-8374-4DC4-958E-D513B981327A" /* PyMOLBridge.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/swiftui/PyMOLViewer/Shared/BinderDesignBar.swift
+++ b/swiftui/PyMOLViewer/Shared/BinderDesignBar.swift
@@ -76,33 +76,33 @@ struct BinderDesignBar: View {
     // Row 2: target + object picker + hotspots + length + count + advanced + Generate.
     private var mainRow: some View {
         HStack(spacing: 8) {
-            // FIXED widths, not `minWidth`. A TextField is greedy: with `minWidth` these
-            // two absorbed every spare point in the bar, so the target box grew to about
-            // half the row and pushed the controls that matter into a huddle on the right.
-            // A definite width plus the Spacer below gives that space back.
-            TextField("target selection", text: $controller.targetText)
-                .textFieldStyle(.roundedBorder).frame(width: 150)
-                .accessibilityIdentifier("binderDesign.target")
-                .onSubmit { controller.inputChanged() }
-                .onChange(of: controller.targetText) { controller.inputChanged() }
+            // Both boxes are SelectionInputField, the form shared with Design (#371),
+            // so the tools that ask "which structure / which residues" ask it once.
+            // The widths stay DEFINITE, never `minWidth` — that lesson is now recorded
+            // on the shared view: a TextField is greedy, and with `minWidth` these two
+            // absorbed every spare point in the bar, growing the target box to about
+            // half the row and pushing the controls that matter into a huddle on the
+            // right. A definite width plus the Spacer below gives that space back.
+            SelectionInputField(
+                placeholder: "target selection",
+                text: $controller.targetText,
+                identifier: "binderDesign.target",
+                objects: engine.objects.filter { !$0.isSelection }.map(\.name),
+                width: 150,
+                applyOnChange: true,          // the estimate re-prices as you type
+                apply: { controller.inputChanged() })
 
-            Menu {
-                ForEach(engine.objects.filter { !$0.isSelection }, id: \.name) { o in
-                    Button(o.name) { controller.targetText = o.name }
-                }
-            } label: { Image(systemName: "cube") }
-            .menuIndicator(.hidden).help("Use a loaded object")
-
-            TextField("hotspots (optional)", text: $controller.hotspotsText)
-                .textFieldStyle(.roundedBorder).frame(width: 110)
-                .accessibilityIdentifier("binderDesign.hotspots")
-                .onSubmit { controller.inputChanged() }
-                .onChange(of: controller.hotspotsText) { controller.inputChanged() }
-
-            // A selection, not a residue list -- so it composes with `sele` and with
-            // anything else that selects atoms.
-            Button { controller.hotspotsText = "sele" } label: { Image(systemName: "scope") }
-                .buttonStyle(.plain).help("Use the current selection as hotspots")
+            // Hotspots are a selection, not a residue list -- so they compose with
+            // `sele` and with anything else that selects atoms.
+            SelectionInputField(
+                placeholder: "hotspots (optional)",
+                text: $controller.hotspotsText,
+                identifier: "binderDesign.hotspots",
+                scope: { controller.hotspotsText = "sele" },
+                width: 110,
+                scopeHelp: "Use the current selection as hotspots",
+                applyOnChange: true,
+                apply: { controller.inputChanged() })
 
             if controller.availableGenerators.count > 1 {
                 Picker("", selection: $controller.generator) {

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -4238,11 +4238,19 @@ private struct DesignRegionStripView: View {
 
     private var controls: some View {
         HStack(spacing: 8) {
-            // No region picker: 'sele' IS the region, so the only way to choose one
-            // is to click residues. The hint keeps the strip from rendering as an
-            // empty band before a region exists.
+            // The region field (#371). 'sele' is STILL the one region — the field
+            // writes it rather than keeping a rival of its own — so clicking residues
+            // and typing an expression are two ways into one pipeline, and the scope
+            // button goes back to reading whatever is selected right now.
+            SelectionInputField(
+                placeholder: "sele",
+                text: $controller.selectionText,
+                identifier: "design.selection",
+                scope: { controller.useCurrentSelection() },
+                minWidth: 100, maxWidth: 150,
+                apply: { controller.applySelection() })
             if !controller.regionModeActive {
-                Text("Select 2 or more residues to redesign a region")
+                Text("or click 2 or more residues")
                     .font(.system(size: 11))
                     .foregroundColor(theme.active.panelText.color.opacity(0.5))
             }
@@ -4668,7 +4676,7 @@ private struct DesignOverlayView: View {
             DesignErrorBanner(controller: controller, theme: theme)
             // ── Main control strip ──────────────────────────────────────
             HStack(spacing: 10) {
-                focusLabel
+                targetField
                 if let s = controller.sequenceScore {
                     Text(String(format: "score %.2f", s))
                         .font(.system(size: 10, design: .monospaced))
@@ -4748,40 +4756,25 @@ private struct DesignOverlayView: View {
         }
     }
 
-    // Focus-object indicator is a dropdown: click a structure in the viewport OR
-    // pick one here. Lists the objects the controller can focus; current is checked.
-    private var focusLabel: some View {
-        Menu {
-            ForEach(controller.allObjects, id: \.self) { obj in
-                Button {
-                    controller.focus(obj)
-                } label: {
-                    if obj == controller.focusObject {
-                        Label(obj, systemImage: "checkmark")
-                    } else {
-                        Text(obj)
-                    }
-                }
-            }
-        } label: {
-            HStack(spacing: 4) {
-                Image(systemName: "atom")
-                    .foregroundColor(theme.active.accent.color)
-                Text(controller.focusObject ?? "Select object to design")
-                    .lineLimit(1)
-                    .font(.system(size: 12, weight: controller.focusObject != nil ? .semibold : .regular))
-                    .foregroundColor(controller.focusObject != nil
-                        ? theme.active.panelText.color
-                        : theme.active.panelText.color.opacity(0.6))
-                Image(systemName: "chevron.down")
-                    .font(.system(size: 8))
-                    .foregroundColor(theme.active.panelText.color.opacity(0.5))
-            }
+    // The target field (#371). Was a dropdown and nothing else, which left Design
+    // the one inference tool with no typed input: a selection expression — a named
+    // selection, 'polymer and chain A', '1abc and chain B' — had no way in at all.
+    // Now it is the same text-box-plus-dropdown Predict and Design Backbone use: type
+    // a target, or let the dropdown fill the box with a loaded object. Clicking a
+    // structure in the viewport still focuses it, and the field follows.
+    private var targetField: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "atom")
+                .foregroundColor(theme.active.accent.color)
+            SelectionInputField(
+                placeholder: "target selection",
+                text: $controller.targetText,
+                identifier: "design.target",
+                objects: controller.allObjects,
+                current: controller.focusObject,
+                minWidth: 110, maxWidth: 170,
+                apply: { controller.applyTarget() })
         }
-        .menuStyle(.borderlessButton)
-        .menuIndicator(.hidden)
-        .fixedSize()
-        .disabled(controller.allObjects.isEmpty)
     }
 
     // Two-button toggle visually equivalent to a segmented control but with per-mode

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -4247,7 +4247,7 @@ private struct DesignRegionStripView: View {
                 text: $controller.selectionText,
                 identifier: "design.selection",
                 scope: { controller.useCurrentSelection() },
-                minWidth: 100, maxWidth: 150,
+                width: 130,
                 apply: { controller.applySelection() })
             if !controller.regionModeActive {
                 Text("or click 2 or more residues")
@@ -4772,7 +4772,7 @@ private struct DesignOverlayView: View {
                 identifier: "design.target",
                 objects: controller.allObjects,
                 current: controller.focusObject,
-                minWidth: 110, maxWidth: 170,
+                width: 150,
                 apply: { controller.applyTarget() })
         }
     }

--- a/swiftui/PyMOLViewer/Shared/DesignCompactPanel.swift
+++ b/swiftui/PyMOLViewer/Shared/DesignCompactPanel.swift
@@ -56,7 +56,7 @@ struct DesignCompactPanel: View {
                 identifier: "design.target",
                 objects: controller.allObjects,
                 current: controller.focusObject,
-                minWidth: 70, maxWidth: 130,
+                width: 110,
                 apply: { controller.applyTarget() })
 
             if let s = controller.sequenceScore {
@@ -102,7 +102,7 @@ struct DesignCompactPanel: View {
                 text: $controller.selectionText,
                 identifier: "design.selection",
                 scope: { controller.useCurrentSelection() },
-                minWidth: 70, maxWidth: 110,
+                width: 100,
                 apply: { controller.applySelection() })
             if !controller.regionModeActive {
                 Text("or tap 2+")

--- a/swiftui/PyMOLViewer/Shared/DesignCompactPanel.swift
+++ b/swiftui/PyMOLViewer/Shared/DesignCompactPanel.swift
@@ -44,29 +44,20 @@ struct DesignCompactPanel: View {
         }
     }
 
-    // Row 1: focus object picker · score readout · settings · exit.
+    // Row 1: target field + object dropdown · score readout · settings · exit.
     private var headerRow: some View {
         HStack(spacing: 8) {
-            Menu {
-                ForEach(controller.allObjects, id: \.self) { name in
-                    Button { controller.focus(name) } label: {
-                        if name == controller.focusObject {
-                            Label(name, systemImage: "checkmark")
-                        } else {
-                            Text(name)
-                        }
-                    }
-                }
-            } label: {
-                HStack(spacing: 3) {
-                    Text(controller.focusObject ?? "Choose object")
-                        .font(.system(size: 12, weight: .medium))
-                        .lineLimit(1)
-                    Image(systemName: "chevron.down").font(.system(size: 8))
-                }
-                .foregroundColor(theme.active.panelText.color)
-            }
-            .menuIndicator(.hidden)
+            // Target field + object dropdown, the same pair as the macOS overlay
+            // (#371): typing a selection expression has to be possible on iPhone
+            // too, and this is where a 40-residue region is least fun to tap out.
+            SelectionInputField(
+                placeholder: "target",
+                text: $controller.targetText,
+                identifier: "design.target",
+                objects: controller.allObjects,
+                current: controller.focusObject,
+                minWidth: 70, maxWidth: 130,
+                apply: { controller.applyTarget() })
 
             if let s = controller.sequenceScore {
                 Text(String(format: "%.2f", s))
@@ -96,7 +87,7 @@ struct DesignCompactPanel: View {
         .padding(.horizontal, 12).padding(.vertical, 8)
     }
 
-    // Row 4: region hint (until a region exists) · redesign (region only) ·
+    // Row 4: region field · hint (until a region exists) · redesign (region only) ·
     // revert (if snapshot) · spacer · repack (editing) · compare (editing) ·
     // Keep / Discard (editing).
     //
@@ -104,10 +95,17 @@ struct DesignCompactPanel: View {
     // type-checker, following the pattern in DesignSequenceStripView.seqCols.
     private var actionRow: some View {
         HStack(spacing: 8) {
-            // No region picker: 'sele' IS the region, so tapping residues is the
-            // only way to build one. The hint keeps the row from reading as empty.
+            // The region field (#371); writes 'sele', so tapping residues still
+            // means exactly what it meant. Scope button = read the live selection.
+            SelectionInputField(
+                placeholder: "sele",
+                text: $controller.selectionText,
+                identifier: "design.selection",
+                scope: { controller.useCurrentSelection() },
+                minWidth: 70, maxWidth: 110,
+                apply: { controller.applySelection() })
             if !controller.regionModeActive {
-                Text("Tap 2+ residues to redesign")
+                Text("or tap 2+")
                     .font(.system(size: 11))
                     .foregroundColor(theme.active.panelText.color.opacity(0.5))
                     .lineLimit(1)

--- a/swiftui/PyMOLViewer/Shared/DesignController.swift
+++ b/swiftui/PyMOLViewer/Shared/DesignController.swift
@@ -42,6 +42,22 @@ final class DesignController: ObservableObject {
     /// Residue index that has been pinned by a click. Persists until the user
     /// clicks the same residue again (toggle) or another residue is pinned.
     @Published var pinnedResidueIndex: Int?
+    /// The Design tool's target field (#371). Holds either an object name or any
+    /// selection expression; `applyTarget()` resolves it to the ONE structure Design
+    /// works on. Peer of Design Backbone's `target` and Predict's `sequence /
+    /// selection` — a text box, with the object dropdown as an optional way to fill it.
+    @Published var targetText: String = ""
+    /// The Design tool's region field (#371). The literal 'sele' is the default and
+    /// means "whatever is selected right now", which is exactly what clicking
+    /// residues builds. Any other expression is WRITTEN to 'sele' by
+    /// `applySelection()`, so there is still one region pipeline and the click path
+    /// is untouched.
+    @Published var selectionText: String = DesignController.liveSelection
+
+    /// PyMOL's live selection. Named rather than spelled out at each use because it
+    /// is a sentinel VALUE in `selectionText`, not just a selection name: it means
+    /// "read, do not write".
+    static let liveSelection = "sele"
 
     // MARK: – Closure type aliases (Task 10 wires in real implementations)
 
@@ -141,6 +157,14 @@ final class DesignController: ObservableObject {
     /// Release the cached MPNN model. Invoked on the inference queue from `exit()`,
     /// never on the main thread — the model is owned by that queue.
     typealias ReleaseModelFn = () -> Void
+    /// Resolve a target expression to the name of ONE object. nil = nothing matched
+    /// (or the selector was rejected); the first object of a multi-object match wins,
+    /// because Design only ever works on the focused structure.
+    typealias ResolveTargetFn = (_ expression: String) -> String?
+    /// Replace the active 'sele' with `expression`. Returns the number of atoms
+    /// selected, or nil when PyMOL rejected the selector — 0 and nil are different
+    /// answers ("matched nothing" vs "not a selection"), and the field reports both.
+    typealias SelectRegionFn = (_ expression: String) -> Int?
 
     // MARK: – Injected dependencies
 
@@ -167,6 +191,12 @@ final class DesignController: ObservableObject {
     private var showAllSidechainsFn: ShowAllSidechainsFn = { _, _ in }
     private var designRegionFn: DesignRegionFn = { r, _, _, _, _ in Array(repeating: 0, count: r.count) }
     private var releaseModelFn: ReleaseModelFn = { }
+    private var resolveTargetFn: ResolveTargetFn?
+    private var selectRegionFn: SelectRegionFn?
+    /// The object `targetText` last resolved to. Lets `focusAwait` tell "the field is
+    /// stale" from "the field is the user's own expression for this very object", so
+    /// a typed expression is never silently rewritten to the object name it matched.
+    private var targetResolvedObject: String?
 
     // MARK: – 'sele' access (single source of truth)
     //
@@ -357,7 +387,9 @@ final class DesignController: ObservableObject {
                      toggleSele: ToggleSeleFn? = nil,
                      setSeleResidue: SetSeleResidueFn? = nil,
                      clearSele: ClearSeleFn? = nil,
-                     dropObjectFromSele: DropObjectFromSeleFn? = nil) {
+                     dropObjectFromSele: DropObjectFromSeleFn? = nil,
+                     resolveTarget: ResolveTargetFn? = nil,
+                     selectRegion: SelectRegionFn? = nil) {
         self.enumerate = enumerate
         self.score = score
         self.applyColoring = applyColoring
@@ -382,6 +414,8 @@ final class DesignController: ObservableObject {
         self.setSeleResidueFn = setSeleResidue
         self.clearSeleFn = clearSele
         self.dropObjectFromSeleFn = dropObjectFromSele
+        self.resolveTargetFn = resolveTarget
+        self.selectRegionFn = selectRegion
     }
 
     // MARK: – Public interface
@@ -557,6 +591,63 @@ final class DesignController: ObservableObject {
         if let o = focusObject { recolor(o) }
     }
 
+    // MARK: – The two typed inputs (#371)
+
+    /// Fire-and-forget target apply (used by the UI on submit and by the object
+    /// dropdown). Wraps `applyTargetAwait` in a Task, mirroring `focus`/`focusAwait`.
+    func applyTarget() { Task { await applyTargetAwait() } }
+
+    /// Resolve `targetText` to one structure and focus it. Awaitable so tests (and
+    /// any caller that needs the focus to have happened) do not have to guess yields.
+    func applyTargetAwait() async {
+        let expr = targetText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !expr.isEmpty else { return }
+        // An exact object name needs no engine round-trip. That is the dropdown's own
+        // path, and the only one that works before the resolve seam is wired.
+        let resolved: String?
+        if allObjects.contains(expr) { resolved = expr } else { resolved = resolveTargetFn?(expr) }
+        guard let object = resolved, !object.isEmpty else {
+            errorText = "No structure matches '\(expr)'"
+            return
+        }
+        errorText = nil
+        targetText = expr               // normalise away the whitespace we trimmed
+        targetResolvedObject = object
+        await focusAwait(object)
+    }
+
+    /// Apply the region field: point 'sele' at `selectionText`, then re-derive the
+    /// region from it — the same single pipeline a click goes through.
+    func applySelection() {
+        let expr = selectionText.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Empty, or the literal 'sele', means "what is selected right now". Rewriting
+        // 'sele' from itself would be a no-op at best and would clobber the user's
+        // clicks at worst, so this path only re-reads it.
+        guard !expr.isEmpty, expr != Self.liveSelection else {
+            if selectionText != Self.liveSelection { selectionText = Self.liveSelection }
+            errorText = nil
+            syncFromSele()
+            return
+        }
+        guard let count = selectRegionFn?(expr) else {
+            errorText = "Invalid selection '\(expr)'"
+            return
+        }
+        selectionText = expr            // normalise away the whitespace we trimmed
+        // A syntactically fine expression that matches nothing is worth saying out
+        // loud: 'sele' is now empty, so the region silently disappeared.
+        errorText = count > 0 ? nil : "No residues match '\(expr)'"
+        syncFromSele()
+    }
+
+    /// The region field's scope button: go back to reading the live 'sele'. Peer of
+    /// Design Backbone's hotspots scope button.
+    func useCurrentSelection() {
+        selectionText = Self.liveSelection
+        errorText = nil
+        syncFromSele()
+    }
+
     /// Fire-and-forget focus (used by the UI). Wraps `focusAwait` in a Task.
     func focus(_ object: String) {
         Task { await focusAwait(object) }
@@ -584,6 +675,13 @@ final class DesignController: ObservableObject {
             clearRegionState()
         }
         focusObject = object
+        // Keep the target field showing what caused this focus: the object name for a
+        // dropdown pick or auto-focus, the user's own expression when that is what
+        // resolved here (#371).
+        if targetResolvedObject != object {
+            targetText = object
+            targetResolvedObject = object
+        }
         for o in allObjects where o != object { dim(o) }
         // Hoist token capture so both the success continuation and the catch can guard against it.
         rescoreToken += 1
@@ -1458,6 +1556,15 @@ final class DesignController: ObservableObject {
         if let setSeleResidue { self.setSeleResidueFn = setSeleResidue }
         if let clearSele { self.clearSeleFn = clearSele }
         if let dropObjectFromSele { self.dropObjectFromSeleFn = dropObjectFromSele }
+    }
+
+    /// Override the target/region field closures for testing (#371). Any argument
+    /// left nil keeps the engine-free behaviour for that operation: an unresolvable
+    /// target reports "no structure matches", and a typed region reports "invalid".
+    func injectFields(resolveTarget: ResolveTargetFn? = nil,
+                      selectRegion: SelectRegionFn? = nil) {
+        if let resolveTarget { self.resolveTargetFn = resolveTarget }
+        if let selectRegion { self.selectRegionFn = selectRegion }
     }
 
     /// Override the model-release closure for testing (Phase 2d).

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -2644,6 +2644,46 @@ final class PyMOLEngine: ObservableObject {
                 from pymol import raymol_design as _rd
                 _rd.drop_object_from_sele('\(obj)')
                 """)
+        },
+        resolveTarget: { [weak self] expression in
+            // #371: the target field takes a selection expression, not just an object
+            // name, so which structure it means is a question only the core can
+            // answer. Base64 because this is USER text going into a Python literal.
+            guard let self else { return nil }
+            let b64 = Data(expression.utf8).base64EncodedString()
+            let path = FileManager.default.temporaryDirectory
+                .appendingPathComponent("raymol_design_target.json")
+            // Drop the previous answer first: runPython is a no-op until the core is
+            // ready, and reading a stale file would answer a question nobody asked.
+            try? FileManager.default.removeItem(at: path)
+            self.runPython("""
+                from pymol import raymol_design as _rd
+                _rd.resolve_target('\(b64)')
+                """)
+            guard let data = FileManager.default.contents(atPath: path.path),
+                  let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let object = root["object"] as? String, !object.isEmpty else { return nil }
+            return object
+        },
+        selectRegion: { [weak self] expression in
+            // #371: writes the typed region THROUGH 'sele', so the click path and the
+            // text box stay one pipeline. nil means the selector was rejected — which
+            // is a different answer from 0 atoms, and the field reports both.
+            guard let self else { return nil }
+            let b64 = Data(expression.utf8).base64EncodedString()
+            let path = FileManager.default.temporaryDirectory
+                .appendingPathComponent("raymol_design_select.json")
+            // Drop the previous answer first: runPython is a no-op until the core is
+            // ready, and reading a stale file would answer a question nobody asked.
+            try? FileManager.default.removeItem(at: path)
+            self.runPython("""
+                from pymol import raymol_design as _rd
+                _rd.select_region('\(b64)')
+                """)
+            guard let data = FileManager.default.contents(atPath: path.path),
+                  let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let ok = root["ok"] as? Bool, ok else { return nil }
+            return root["count"] as? Int ?? 0
         }
         )
         // Propagate isCalculating into @Published isDesignCalculating so

--- a/swiftui/PyMOLViewer/Shared/SelectionInputField.swift
+++ b/swiftui/PyMOLViewer/Shared/SelectionInputField.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+/// A selection text box with optional affordances that FILL it — the one form every
+/// RayMol tool uses to ask "which structure / which residues" (#371).
+///
+/// Predict asks with `sequence / selection` plus an object dropdown; Design Backbone
+/// asks with `target` plus the same dropdown and `hotspots` plus a scope button.
+/// Design asked with a dropdown and nothing else, which is why this exists: the
+/// FIELD is the input of record — it takes any selection expression — and the
+/// dropdown or scope button is a convenience for filling it, never the only way in.
+///
+/// Deliberately non-generic (an `objects` list and an optional `scope` closure rather
+/// than a `@ViewBuilder` accessory): every call site wants one of those two
+/// accessories, and the concrete form keeps the body's type simple enough for the
+/// Swift type-checker in the already-large views that host it.
+struct SelectionInputField: View {
+    let placeholder: String
+    @Binding var text: String
+    /// Accessibility identifier for the text box; the accessories derive theirs from
+    /// it (`<id>.menu`, `<id>.scope`) so a UI test can drive all three.
+    let identifier: String
+    /// Objects the dropdown offers. Empty (the default) = no dropdown.
+    var objects: [String] = []
+    /// The object currently in use, ticked in the dropdown. nil = nothing ticked.
+    var current: String? = nil
+    /// When non-nil, a `scope` button that means "read the live selection" — the
+    /// peer of Design Backbone's hotspots button.
+    var scope: (() -> Void)? = nil
+    var minWidth: CGFloat = 90
+    var maxWidth: CGFloat = 180
+    /// Commit the field: on Return, and whenever an accessory fills it.
+    let apply: () -> Void
+
+    var body: some View {
+        HStack(spacing: 4) {
+            TextField(placeholder, text: $text)
+                .textFieldStyle(.roundedBorder)
+                .font(.system(size: 12))
+                .frame(minWidth: minWidth, maxWidth: maxWidth)
+                .onSubmit(apply)
+                .accessibilityIdentifier(identifier)
+            if !objects.isEmpty { objectMenu }
+            if let scope { scopeButton(scope) }
+        }
+    }
+
+    private var objectMenu: some View {
+        Menu {
+            ForEach(objects, id: \.self) { obj in
+                Button {
+                    text = obj
+                    apply()
+                } label: {
+                    if obj == current {
+                        Label(obj, systemImage: "checkmark")
+                    } else {
+                        Text(obj)
+                    }
+                }
+            }
+        } label: {
+            Image(systemName: "cube")
+        }
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help("Use a loaded object")
+        .accessibilityIdentifier(identifier + ".menu")
+    }
+
+    private func scopeButton(_ action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: "scope")
+        }
+        .buttonStyle(.plain)
+        .help("Use the current selection")
+        .accessibilityIdentifier(identifier + ".scope")
+    }
+}

--- a/swiftui/PyMOLViewer/Shared/SelectionInputField.swift
+++ b/swiftui/PyMOLViewer/Shared/SelectionInputField.swift
@@ -24,10 +24,21 @@ struct SelectionInputField: View {
     /// The object currently in use, ticked in the dropdown. nil = nothing ticked.
     var current: String? = nil
     /// When non-nil, a `scope` button that means "read the live selection" — the
-    /// peer of Design Backbone's hotspots button.
+    /// peer of Binder Design's hotspots button.
     var scope: (() -> Void)? = nil
-    var minWidth: CGFloat = 90
-    var maxWidth: CGFloat = 180
+    /// A DEFINITE width, never `minWidth` (the lesson BinderDesignBar learned the
+    /// hard way): a TextField is greedy, so in a docked bar `minWidth` lets these
+    /// absorb every spare point and push the controls that matter into a huddle on
+    /// the right.
+    var width: CGFloat = 150
+    /// Tooltips, since "a loaded object" and "the current selection" mean slightly
+    /// different things per tool (a target vs hotspots vs a design region).
+    var menuHelp: String = "Use a loaded object"
+    var scopeHelp: String = "Use the current selection"
+    /// Re-apply on every keystroke rather than only on Return. For a tool whose
+    /// `apply` is cheap validation (Binder Design re-prices its estimate); Design's
+    /// apply focuses a structure or rewrites 'sele', so it waits for Return.
+    var applyOnChange: Bool = false
     /// Commit the field: on Return, and whenever an accessory fills it.
     let apply: () -> Void
 
@@ -36,8 +47,9 @@ struct SelectionInputField: View {
             TextField(placeholder, text: $text)
                 .textFieldStyle(.roundedBorder)
                 .font(.system(size: 12))
-                .frame(minWidth: minWidth, maxWidth: maxWidth)
+                .frame(width: width)
                 .onSubmit(apply)
+                .onChange(of: text) { if applyOnChange { apply() } }
                 .accessibilityIdentifier(identifier)
             if !objects.isEmpty { objectMenu }
             if let scope { scopeButton(scope) }
@@ -63,7 +75,7 @@ struct SelectionInputField: View {
         }
         .menuIndicator(.hidden)
         .fixedSize()
-        .help("Use a loaded object")
+        .help(menuHelp)
         .accessibilityIdentifier(identifier + ".menu")
     }
 
@@ -72,7 +84,7 @@ struct SelectionInputField: View {
             Image(systemName: "scope")
         }
         .buttonStyle(.plain)
-        .help("Use the current selection")
+        .help(scopeHelp)
         .accessibilityIdentifier(identifier + ".scope")
     }
 }

--- a/swiftui/PyMOLViewerTests/DesignTargetSelectionTests.swift
+++ b/swiftui/PyMOLViewerTests/DesignTargetSelectionTests.swift
@@ -1,0 +1,190 @@
+#if RAYMOL_MPNN
+import XCTest
+import MPNNKit
+@testable import RayMol
+
+/// The Design tool's two typed inputs (#371): a `target` field that accepts an
+/// object name OR a selection expression, and a `selection` field that writes the
+/// region through PyMOL's 'sele' so the click-to-select path stays the one
+/// pipeline. Both mirror Design Backbone / Predict, which take a text box plus an
+/// optional dropdown that populates it.
+@MainActor
+final class DesignTargetSelectionTests: XCTestCase {
+
+    // Two designable residues, enough for `syncFromSele` to reach region mode.
+    private func residueSet(_ object: String) -> DesignResidueSet {
+        DesignResidueSet(object: object, state: 1, residues: (1...3).map { i in
+            DesignResidue(chain: "A", resi: "\(i)", resn: "ALA", aa: 0,
+                          backbone: .init(n: .zero, ca: .zero, c: .zero, o: .zero,
+                                          chain: 0, resSeq: i),
+                          valid: true)
+        })
+    }
+
+    private func makeController(objects: [String]) -> DesignController {
+        let c = DesignController(
+            enumerate: { [self] obj, _ in residueSet(obj) },
+            score: { r, _ in
+                MPNNModel.ScoreResult(
+                    logProbs: Array(repeating: [Float](repeating: Float(log(1.0 / 21.0)),
+                                                       count: 21),
+                                    count: r.count),
+                    currentAALogProb: [Float](repeating: -1.0, count: r.count))
+            },
+            applyColoring: { _, _, _, _, _, _, _ in },
+            dim: { _ in },
+            snapshot: { _ in },
+            restore: { })
+        c.allObjects = objects
+        return c
+    }
+
+    // MARK: – Target field
+
+    func testTargetFieldFocusesATypedObjectName() async {
+        let c = makeController(objects: ["m1", "m2"])
+        c.enter()
+        c.targetText = "m2"
+        await c.applyTargetAwait()
+        XCTAssertEqual(c.focusObject, "m2")
+        XCTAssertNil(c.errorText)
+    }
+
+    func testTargetFieldResolvesASelectionExpressionToItsObject() async {
+        let c = makeController(objects: ["m1", "m2"])
+        var asked: [String] = []
+        c.injectFields(resolveTarget: { expr in
+            asked.append(expr)
+            return expr.contains("chain A") ? "m1" : nil
+        })
+        c.enter()
+        c.targetText = "polymer and chain A"
+        await c.applyTargetAwait()
+        XCTAssertEqual(asked, ["polymer and chain A"])
+        XCTAssertEqual(c.focusObject, "m1")
+        XCTAssertEqual(c.targetText, "polymer and chain A",
+                       "The typed expression must survive the focus it caused")
+        XCTAssertNil(c.errorText)
+    }
+
+    func testTargetFieldReportsAnExpressionThatMatchesNothing() async {
+        let c = makeController(objects: ["m1", "m2"])
+        c.injectFields(resolveTarget: { _ in nil })
+        c.enter()
+        await c.focusAwait("m1")
+        c.targetText = "chain Z"
+        await c.applyTargetAwait()
+        XCTAssertEqual(c.focusObject, "m1", "A bad target must not drop the focus")
+        XCTAssertEqual(c.errorText, "No structure matches 'chain Z'")
+    }
+
+    func testTargetFieldIgnoresEmptyInput() async {
+        let c = makeController(objects: ["m1", "m2"])
+        var asked = 0
+        c.injectFields(resolveTarget: { _ in asked += 1; return "m1" })
+        c.enter()
+        c.targetText = "   "
+        await c.applyTargetAwait()
+        XCTAssertEqual(asked, 0)
+        XCTAssertNil(c.focusObject)
+        XCTAssertNil(c.errorText)
+    }
+
+    func testFocusingFromTheDropdownFillsTheTargetField() async {
+        let c = makeController(objects: ["m1", "m2"])
+        c.enter()
+        await c.focusAwait("m2")        // what the cube menu's Button does
+        XCTAssertEqual(c.targetText, "m2")
+    }
+
+    // MARK: – Selection field
+
+    func testSelectionFieldRewritesSeleFromAnExpression() async {
+        let c = makeController(objects: ["m1", "m2"])
+        var selected: [String] = []
+        var seleIndices: [Int] = []
+        c.injectFields(selectRegion: { expr in
+            selected.append(expr)
+            seleIndices = [0, 1, 2]
+            return 3
+        })
+        c.injectSele(seleState: { _, _, _ in (seleIndices, "d\(seleIndices.count)", 0) })
+        c.enter()
+        await c.focusAwait("m1")
+        XCTAssertTrue(c.selectedResidueIndices.isEmpty)
+
+        c.selectionText = "  chain A and resi 1-3  "
+        c.applySelection()
+        XCTAssertEqual(selected, ["chain A and resi 1-3"], "Expression is trimmed, then written to 'sele'")
+        XCTAssertEqual(c.selectedResidueIndices, [0, 1, 2], "The region must re-derive from 'sele' at once")
+        XCTAssertNil(c.errorText)
+    }
+
+    func testSelectionFieldLeavesAClickedSelectionAloneForTheLiteralSele() async {
+        let c = makeController(objects: ["m1", "m2"])
+        var selectCalls = 0
+        c.injectFields(selectRegion: { _ in selectCalls += 1; return 0 })
+        c.injectSele(seleState: { _, _, _ in ([0, 1], "clicked", 0) })
+        c.enter()
+        await c.focusAwait("m1")
+
+        c.selectionText = "sele"
+        c.applySelection()
+        XCTAssertEqual(selectCalls, 0, "Rewriting 'sele' from itself would clobber the user's clicks")
+        XCTAssertEqual(c.selectedResidueIndices, [0, 1])
+        XCTAssertNil(c.errorText)
+    }
+
+    func testSelectionFieldNormalisesEmptyInputBackToSele() async {
+        let c = makeController(objects: ["m1", "m2"])
+        var selectCalls = 0
+        c.injectFields(selectRegion: { _ in selectCalls += 1; return 0 })
+        c.enter()
+        await c.focusAwait("m1")
+
+        c.selectionText = ""
+        c.applySelection()
+        XCTAssertEqual(c.selectionText, "sele")
+        XCTAssertEqual(selectCalls, 0)
+    }
+
+    func testSelectionFieldReportsAnExpressionThatMatchesNothing() async {
+        let c = makeController(objects: ["m1", "m2"])
+        c.injectFields(selectRegion: { _ in 0 })
+        c.injectSele(seleState: { _, _, _ in ([], "empty", 0) })
+        c.enter()
+        await c.focusAwait("m1")
+
+        c.selectionText = "resi 999"
+        c.applySelection()
+        XCTAssertEqual(c.errorText, "No residues match 'resi 999'")
+        XCTAssertTrue(c.selectedResidueIndices.isEmpty)
+    }
+
+    func testSelectionFieldReportsAnInvalidExpression() async {
+        let c = makeController(objects: ["m1", "m2"])
+        c.injectFields(selectRegion: { _ in nil })   // nil = PyMOL rejected the selector
+        c.enter()
+        await c.focusAwait("m1")
+
+        c.selectionText = "chain (("
+        c.applySelection()
+        XCTAssertEqual(c.errorText, "Invalid selection 'chain (('")
+    }
+
+    func testScopeButtonRestoresTheLiteralSele() async {
+        let c = makeController(objects: ["m1", "m2"])
+        var selectCalls = 0
+        c.injectFields(selectRegion: { _ in selectCalls += 1; return 0 })
+        c.injectSele(seleState: { _, _, _ in ([0, 1], "clicked", 0) })
+        c.enter()
+        await c.focusAwait("m1")
+
+        c.selectionText = "chain B"
+        c.useCurrentSelection()
+        XCTAssertEqual(c.selectionText, "sele")
+        XCTAssertEqual(selectCalls, 0, "The scope button reads the live selection; it never rewrites it")
+        XCTAssertEqual(c.selectedResidueIndices, [0, 1])
+    }
+}
+#endif

--- a/testing/tests/raymol/design_region.py
+++ b/testing/tests/raymol/design_region.py
@@ -332,3 +332,132 @@ class TestDesignRegion(testing.PyMOLTestCase):
                                 'different objects, whatever they are named')
         finally:
             rd.set_design_active(0)
+
+
+class TestDesignFields(testing.PyMOLTestCase):
+    """The Design tool's two typed inputs (#371).
+
+    `resolve_target` backs the target text box: it answers "which ONE structure
+    does this expression mean", so the field accepts a selection expression and
+    not merely an object name. `select_region` backs the region text box: it
+    points 'sele' at the expression, which is why clicking residues and typing an
+    expression stay one pipeline rather than two.
+
+    Both take base64 so a user's quotes, backslashes and non-ASCII never become
+    Python: the Swift side interpolates the argument into a runPython string.
+    """
+
+    def _b64(self, expr):
+        import base64
+        return base64.b64encode(expr.encode('utf-8')).decode('ascii')
+
+    def _target_payload(self):
+        with open(os.path.join(tempfile.gettempdir(),
+                               'raymol_design_target.json')) as f:
+            return json.load(f)
+
+    def _select_payload(self):
+        with open(os.path.join(tempfile.gettempdir(),
+                               'raymol_design_select.json')) as f:
+            return json.load(f)
+
+    def _two(self):
+        cmd.reinitialize()
+        cmd.fab('AAAAA', 'm1')
+        cmd.fab('GGGGG', 'm2')
+        # cmd.fab leaves the chain EMPTY, so a chain-scoped expression would match
+        # nothing and every assertion about one would pass vacuously.
+        cmd.alter('m1', 'chain = "A"')
+        cmd.alter('m2', 'chain = "B"')
+        cmd.sort()
+
+    # ── resolve_target ─────────────────────────────────────────────────────────
+
+    def testResolveTargetAcceptsAnObjectName(self):
+        self._two()
+        from pymol import raymol_design as rd
+        rd.resolve_target(self._b64('m2'))
+        self.assertEqual(self._target_payload()['object'], 'm2')
+
+    def testResolveTargetResolvesASubSelectionToItsObject(self):
+        self._two()
+        from pymol import raymol_design as rd
+        rd.resolve_target(self._b64('m2 and chain B and resi 2-4'))
+        data = self._target_payload()
+        self.assertEqual(data['object'], 'm2')
+        self.assertEqual(data['error'], '')
+
+    def testResolveTargetTakesTheFirstOfSeveralObjects(self):
+        self._two()
+        from pymol import raymol_design as rd
+        rd.resolve_target(self._b64('polymer'))
+        data = self._target_payload()
+        # Design only ever works on ONE structure, so a multi-object expression
+        # resolves rather than failing — and reports that it narrowed.
+        self.assertEqual(data['object'], 'm1')
+        self.assertEqual(data['n_objects'], 2)
+
+    def testResolveTargetReportsAnExpressionThatMatchesNothing(self):
+        self._two()
+        from pymol import raymol_design as rd
+        rd.resolve_target(self._b64('resi 900-999'))
+        data = self._target_payload()
+        self.assertEqual(data['object'], '')
+
+    def testResolveTargetReportsAnInvalidSelector(self):
+        self._two()
+        from pymol import raymol_design as rd
+        rd.resolve_target(self._b64('chain (('))
+        data = self._target_payload()
+        self.assertEqual(data['object'], '')
+        self.assertTrue(data['error'], 'a rejected selector must say why')
+
+    # ── select_region ──────────────────────────────────────────────────────────
+
+    def testSelectRegionPointsSeleAtTheExpression(self):
+        self._two()
+        from pymol import raymol_design as rd
+        rd.select_region(self._b64('m1 and resi 2+4'))
+        data = self._select_payload()
+        self.assertTrue(data['ok'])
+        self.assertEqual(data['count'], cmd.count_atoms('m1 and resi 2+4'))
+        # 'sele' IS the region: the whole point is that the field feeds the same
+        # selection a click builds.
+        self.assertEqual(cmd.count_atoms('sele'), data['count'])
+
+    def testSelectRegionReplacesAnEarlierSelection(self):
+        self._two()
+        from pymol import raymol_design as rd
+        cmd.select('sele', 'm1 and resi 1')
+        rd.select_region(self._b64('m1 and resi 3+4'))
+        self.assertEqual(cmd.count_atoms('sele and resi 1'), 0)
+        self.assertEqual(cmd.count_atoms('sele'),
+                         cmd.count_atoms('m1 and resi 3+4'))
+
+    def testSelectRegionReportsAnEmptyMatch(self):
+        self._two()
+        from pymol import raymol_design as rd
+        rd.select_region(self._b64('m1 and resi 900'))
+        data = self._select_payload()
+        self.assertTrue(data['ok'], 'valid syntax, no atoms — that is not an error')
+        self.assertEqual(data['count'], 0)
+
+    def testSelectRegionReportsAnInvalidSelector(self):
+        self._two()
+        from pymol import raymol_design as rd
+        cmd.select('sele', 'm1 and resi 1')
+        rd.select_region(self._b64('chain (('))
+        data = self._select_payload()
+        self.assertFalse(data['ok'])
+        self.assertEqual(cmd.count_atoms('sele'), cmd.count_atoms('m1 and resi 1'),
+                         'a rejected selector must leave the live selection alone')
+
+    def testSelectRegionSurvivesQuotesInTheExpression(self):
+        self._two()
+        from pymol import raymol_design as rd
+        # Quotes are legal PyMOL and would end a Python string literal; base64 is
+        # why they reach the selector intact.
+        rd.select_region(self._b64('m1 and chain "A"'))
+        data = self._select_payload()
+        self.assertTrue(data['ok'])
+        self.assertEqual(data['count'], cmd.count_atoms('m1 and chain A'))

--- a/testing/tests/raymol/design_region.py
+++ b/testing/tests/raymol/design_region.py
@@ -114,21 +114,22 @@ class TestDesignRegion(testing.PyMOLTestCase):
         self.assertEqual(self._sele_resis(), ['5'],
                          'set must replace the selection, not extend it')
 
-    def testToggleIsResidueScopedRegardlessOfMouseSelectionMode(self):
-        # D1: Design clicks always expand to RESIDUE scope. With
-        # mouse_selection_mode = 0 (atom) a normal-mode click would commit a single
-        # ATOM, which maps to zero guide residues -- a click that silently selects
-        # nothing. Design must ignore the setting entirely.
+    def testAtomAndCAlphaModesStillMeanTheResidue(self):
+        # What survives of the old "Design ignores mouse_selection_mode" rule
+        # (which #371 replaced -- see TestDesignClickSelectionLevel): a lone ATOM
+        # (mode 0) or a lone CA (mode 6) maps to a scope with nothing designable in
+        # it, so a click at those levels would select nothing at all. Design's unit
+        # is a residue, so both still expand to one.
         obj = self._peptide()
         from pymol import raymol_design as rd
-        for mode in (0, 1, 2, 4):
+        self.addCleanup(cmd.set, 'mouse_selection_mode', 1)
+        for mode in (0, 1, 6):
             cmd.set('mouse_selection_mode', mode)
             rd.clear_sele()
             rd.toggle_sele_residue(obj, '', '2')
             self.assertEqual(self._sele_resis(), ['2'],
-                             'mouse_selection_mode %d must not change the scope '
-                             'of a Design-mode click' % mode)
-        cmd.set('mouse_selection_mode', 1)   # restore the default
+                             'mouse_selection_mode %d must still mean the residue'
+                             % mode)
 
     def testClearSeleEmpties(self):
         obj = self._peptide()
@@ -461,3 +462,127 @@ class TestDesignFields(testing.PyMOLTestCase):
         data = self._select_payload()
         self.assertTrue(data['ok'])
         self.assertEqual(data['count'], cmd.count_atoms('m1 and chain A'))
+
+
+class TestDesignClickSelectionLevel(testing.PyMOLTestCase):
+    """A Design-mode click means what a click means everywhere else.
+
+    'sele' IS the design region, so what a click puts in 'sele' has to obey the
+    same `mouse_selection_mode` the rest of the app obeys: in chain mode a click
+    designates the chain, not the one residue under the pointer. Design used to
+    force residue scope at every level, which left the region saying "one residue"
+    while the mode said "chains" and the viewport drew the whole chain pink.
+
+    The expansion is re-derived from (obj, chain, resi) rather than taken from
+    metal_pick._mode_expr, because the design pick payload carries no atom name --
+    and the by* selection keywords need none.
+    """
+
+    def setUp(self):
+        super(TestDesignClickSelectionLevel, self).setUp()
+        # Never leak a non-default level: every later test in this interpreter
+        # would inherit it, and a click would silently mean something else.
+        self.addCleanup(cmd.set, 'mouse_selection_mode', 1)
+
+    def _two_chains(self):
+        """One object, chain A = resi 1-3, chain B = resi 4-6."""
+        cmd.reinitialize()
+        cmd.fab('AAAAAA', 'm1')
+        cmd.alter('m1 and resi 1-3', 'chain = "A"')
+        cmd.alter('m1 and resi 4-6', 'chain = "B"')
+        cmd.alter('m1 and resi 1-3', 'segi = "S1"')
+        cmd.alter('m1 and resi 4-6', 'segi = "S2"')
+        cmd.sort()
+        return 'm1'
+
+    def _resis(self, sel='(?sele)'):
+        out = set()
+        cmd.iterate('%s and polymer and guide' % sel, 'out.add(resi)', space={'out': out})
+        return sorted(out, key=int)
+
+    def testChainModeClickSelectsTheWholeChain(self):
+        obj = self._two_chains()
+        from pymol import raymol_design as rd
+        cmd.set('mouse_selection_mode', 2)
+        rd.toggle_sele_residue(obj, 'A', '2')
+        self.assertEqual(self._resis(), ['1', '2', '3'])
+
+    def testChainModeClickTogglesTheWholeChainOff(self):
+        obj = self._two_chains()
+        from pymol import raymol_design as rd
+        cmd.set('mouse_selection_mode', 2)
+        rd.toggle_sele_residue(obj, 'A', '2')
+        rd.toggle_sele_residue(obj, 'A', '3')   # same chain, different residue
+        self.assertEqual(self._resis(), [],
+                         'a second click at chain level clears the chain it added')
+
+    def testChainModeLeavesTheOtherChainAlone(self):
+        obj = self._two_chains()
+        from pymol import raymol_design as rd
+        cmd.set('mouse_selection_mode', 2)
+        rd.toggle_sele_residue(obj, 'B', '5')
+        self.assertEqual(self._resis(), ['4', '5', '6'])
+
+    def testSegmentModeClickSelectsTheSegment(self):
+        obj = self._two_chains()
+        from pymol import raymol_design as rd
+        cmd.set('mouse_selection_mode', 3)
+        rd.toggle_sele_residue(obj, 'B', '5')
+        self.assertEqual(self._resis(), ['4', '5', '6'])
+
+    def testObjectModeClickSelectsTheWholeObjectAndNothingElse(self):
+        obj = self._two_chains()
+        cmd.fab('GGG', 'other')
+        from pymol import raymol_design as rd
+        cmd.set('mouse_selection_mode', 4)
+        rd.toggle_sele_residue(obj, 'A', '2')
+        self.assertEqual(self._resis(), ['1', '2', '3', '4', '5', '6'])
+        self.assertEqual(cmd.count_atoms('other and (?sele)'), 0,
+                         'object level means THAT object, not every object')
+
+    def testMoleculeModeClickSelectsTheConnectedMolecule(self):
+        obj = self._two_chains()
+        from pymol import raymol_design as rd
+        cmd.set('mouse_selection_mode', 5)
+        rd.toggle_sele_residue(obj, 'A', '2')
+        # cmd.fab builds one continuous peptide, so the molecule is all six
+        # residues even though they were relabelled into two chains.
+        self.assertEqual(self._resis(), ['1', '2', '3', '4', '5', '6'])
+
+    def testTheRegionArmsWithEveryDesignableResidueOfTheChain(self):
+        # The user-visible outcome: the read the UI performs reports the whole
+        # chain, so Redesign says "3 res" rather than "1 res".
+        obj = self._two_chains()
+        from pymol import raymol_design as rd
+        cmd.set('mouse_selection_mode', 2)
+        rd.toggle_sele_residue(obj, 'A', '2')
+        rd.sele_design_indices(obj, 1)
+        with open(os.path.join(tempfile.gettempdir(),
+                               'raymol_design_sele.json')) as f:
+            data = json.load(f)
+        self.assertEqual(data['indices'], [0, 1, 2])
+        self.assertEqual(data['n_off'], 0)
+
+    def testSetSeleResidueHonoursTheSelectionLevel(self):
+        # The refocus path (a click on a DIFFERENT structure) replaces 'sele'
+        # rather than toggling, and must replace it with the same scope.
+        obj = self._two_chains()
+        from pymol import raymol_design as rd
+        cmd.select('sele', '%s and resi 5' % obj)
+        cmd.set('mouse_selection_mode', 2)
+        rd.set_sele_residue(obj, 'A', '2')
+        self.assertEqual(self._resis(), ['1', '2', '3'],
+                         'the replacement is chain-scoped, and drops the old resi 5')
+
+    def testChainModeClickInAnEditSessionReachesBothCopies(self):
+        # Same invariant the residue-scoped toggle has: the write must resolve in
+        # the scope the read uses, or a region member cannot be removed once an
+        # edit session repoints the focus at the working copy.
+        obj = self._two_chains()
+        cmd.create('m1_design', obj, zoom=0)
+        from pymol import raymol_design as rd
+        cmd.set('mouse_selection_mode', 2)
+        rd.toggle_sele_residue('m1_design', 'A', '2', src=obj)
+        self.assertEqual(self._resis('(m1_design and (?sele))'), ['1', '2', '3'])
+        self.assertEqual(self._resis('(m1 and (?sele))'), ['1', '2', '3'],
+                         'the original carries the same membership, by residue identity')


### PR DESCRIPTION
Closes #371. Rebased onto current master: **three commits**, and it no longer carries the `sele`-unification stack — that work reached master by another route while this was in flight.

## What this changes

The Design tool asked "which structure / which residues" in a form nothing else in the app uses:

* **target** was a dropdown and nothing else, so an object *name* was the only thing you could say — `polymer and chain A`, a named selection, `1abc and chain B` had no way in at all.
* **region** had no field whatsoever: `sele` *is* the region and clicking residues was the only way to build one. A 40-residue interface meant 40 clicks, and pasting an expression was impossible.

Predict (`sequence / selection` + object dropdown) and Binder Design (`target` / `hotspots` + dropdown and scope button) both ask with a text box plus an optional affordance that fills it. Design is now that same pair:

| | before | after |
|---|---|---|
| target | dropdown only (`Select object to design`) | text box `target selection` + cube dropdown |
| region | nothing — clicks only | text box defaulting to `sele` + scope button |

**`sele` stays the one region.** The field *writes* it rather than keeping a rival of its own, so clicking residues and typing an expression are two ways into one pipeline — `sele_design_indices`, the digest-gated poll and the pink markers are untouched. `sele` as a *value* means "read, do not write": rewriting it from itself would clobber the clicks it exists to preserve. The scope button returns the field to `sele`.

A multi-object target expression narrows to its first object, because Design only ever works on one focused structure; the existing "+N off-structure" badge still reports the rest.

This is deliberately **not** a re-added named-selection dropdown: that control's label flipped between a prompt, a name and `sele`, which is exactly what made it read as two selection modes. A box holding `sele` has one meaning.

## New pieces

* **`SelectionInputField`** — field + optional dropdown/scope accessory.
* **`DesignController.applyTarget` / `applySelection` / `useCurrentSelection`** plus two seams: `resolveTarget` (expression → one object) and `selectRegion` (expression → `sele`, returning atoms). `nil` and `0` are different answers — "not a selection" vs "matched nothing" — and the field reports both.
* **`raymol_design.resolve_target` / `select_region`** — both take base64, because the argument is *user* text that Swift interpolates into a `runPython` string, where a quote or a backslash would otherwise end the literal. A rejected selector leaves the live selection alone.

Identifiers are `design.target` / `design.selection` (plus `.menu` / `.scope`), mirroring `binderDesign.*`.

## Second commit: Binder Design adopts the same field

#343 landed the form this issue asked Design to adopt, so the field existed twice. `BinderDesignBar`'s `target` and `hotspots` boxes now use `SelectionInputField` — one control, not two implementations — which is what #371 said to do if the binder bar landed first. Two things came back from it:

* **definite widths, never `minWidth`** — its comment recorded the lesson the hard way (a greedy TextField absorbed every spare point in the bar and huddled the real controls on the right). The shared view takes one `width`, that comment lives on it, and Design's four call sites are definite too.
* **`applyOnChange`** — Binder Design re-prices its estimate per keystroke; Design's apply focuses a structure or rewrites `sele`, so it waits for Return.

`binderDesign.target` / `.hotspots` identifiers are unchanged; the accessories gain `.menu` / `.scope` ones they lacked.

## Verification

**Functionally tested in a disposable macOS VM, not on the host** (`raymol-mac-vm`, Debug build renamed `RayMol-371.app`), driven by real HID input with the engine inspected over MCP:

| behaviour | evidence |
|---|---|
| typed *expression* resolves + focuses | `helixA and chain A` → helixA design-coloured and scored (−3.27), loopB dimmed to `gray70` |
| dropdown fills the field and moves focus | picked `loopB` → field reads `loopB`, loopB coloured, helixA down to one grey |
| typed region writes `sele` | `helixA and resi 3-6` → `count_atoms('?sele') == 61`, resi `[3,4,5,6]`, `Redesign selection · 4 res` armed |
| scope button | field back to `sele`, live selection still 61 atoms (read, not rewritten) |
| bad target | banner `No structure matches 'chain Q'`, focus retained |

iPhone-compact header + dropdown checked in the simulator; the compact **region** row needs a scored focus, which MLX cannot produce in the simulator (documented in `MLXRuntime`), so that row is compile-verified only.

Post-rebase, on this branch:

* macOS unit bundle **657 pass** (11 new).
* Embedded Python **921 pass** (10 new). The 3 `test_raymol_theme_apply` pytest failures in the full-list run reproduce **identically on plain `origin/master`** with the same harness — pre-existing cross-file state leakage, not from this branch (that file passes alone on both).
* Both app targets build (macOS + iOS simulator).

---

## Third commit: a click means what the selection level says

Found while testing the above. With `mouse_selection_mode` set to chains, hovering a residue in Design mode glowed the whole **chain** — `hover_design_at` already expands by `metal_pick._mode_expr` — but clicking committed exactly **one residue**, so the region said "1 res" right after the viewport had shown the chain. Same at segment, object and molecule level.

The click path was the only part of Design that ignored the level: `toggle_sele_residue` / `set_sele_residue` built their expression from `_scoped_residue_sel`, which is residue-scoped by construction. That was a deliberate rule once ("Design ignores `mouse_selection_mode` entirely") and it is wrong for the same reason the region field is: **`sele` IS the region**, so what a click puts in `sele` has to be what a click puts there everywhere else.

`_scoped_level_sel` now expands the picked residue with the `by*` keyword for the current level — `bychain` / `bysegi` / `byobject` / `bymol` — **inside** `_scope(obj, src)` and re-intersected with it, so the write still resolves exactly where the read resolves (the invariant `_scoped_residue_sel` exists for, which an edit session's working copy depends on). Toggle semantics are unchanged and still mirror `pick_at`: already in `sele` → remove that scope, otherwise add it.

What survives of the old rule is its kernel, now its own test: **atom (0) and C-alpha (6) still mean the residue.** A lone atom contains nothing designable, so a click at those levels would otherwise select nothing at all.

Verified in a disposable macOS VM with real HID input, region field at its default `sele`:

| step | result |
|---|---|
| `mouse_selection_mode = 2`, one viewport click | chain A entire — `sele` = resi 1–5 (was resi 3 alone) |
| the region read the UI performs | `sele_design_indices` → indices `[0,1,2,3,4]`, region row armed (palette + temp + Redesign) |
| second click, same chain | chain cleared — `sele` empty |
| back to `mouse_selection_mode = 1`, click | exactly one residue |

9 new Python tests, embedded suite **930 pass**. No Swift change: the Swift side already forwarded the pick and re-derived the region from `sele`.

---

**Confirmed working on the author's own machine** (Design mode, chain-level clicks, both text boxes).

**On the red `macos-embedded` check:** it is `test_raymol_theme_apply.py::TestApplyToUnknownName` (3 tests), and it is **pre-existing on master** — master's own run for `985c4a70d` fails on exactly those three ([run 33564968332](https://github.com/javierbq/RayMol/actions/runs/33564968332)), i.e. since #370 merged. This branch adds no new failures: 930 unittest pass on both, and the same 3 pytest failures appear with or without it (the file passes when run alone, so it is cross-file state leakage). Tracked separately rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
