### PR TITLE
fix(metal): iOS launch crash under Metal validation (MSAA depth-stencil resolve)

### DIFF
--- a/layerGraphics/metal/RendererMetal.mm
+++ b/layerGraphics/metal/RendererMetal.mm
@@ -296,6 +296,33 @@ fragment float4 batch_fragment(BatchVertexOut in [[stage_in]])
 void RendererMetal::setSampleCount(NSUInteger n)
 {
   if (n < 1) n = 1;
+  // The MSAA scene pass resolves the Depth32Float_Stencil8 depth attachment
+  // (StoreAndMultisampleResolve, see ensurePostTargets). A depth-stencil
+  // format is only a legal MSAA resolve target on Apple GPU family 5+ (A12 and
+  // later) and on Mac GPUs; the iOS *simulator* and older iPhones reject it —
+  // under Metal API validation (any run from Xcode) that is a hard assert in
+  // beginFrame on the very first frame, i.e. a crash on launch. Fall back to
+  // single-sample rendering there rather than resolving an unsupported format.
+  if (n > 1 && _device) {
+    bool depthStencilResolveOK = false;
+#if TARGET_OS_SIMULATOR
+    depthStencilResolveOK = false;
+#else
+    if (@available(macOS 10.15, iOS 13.0, *)) {
+      depthStencilResolveOK = [_device supportsFamily:MTLGPUFamilyApple5]
+                           || [_device supportsFamily:MTLGPUFamilyMac2];
+    }
+#endif
+    if (!depthStencilResolveOK) {
+      static bool warned = false;
+      if (!warned) {
+        NSLog(@"RendererMetal: MSAA depth-stencil resolve unsupported on this GPU; "
+              @"rendering single-sample (metal_msaa ignored)");
+        warned = true;
+      }
+      n = 1;
+    }
+  }
   if (n == _sampleCount) return;
   _sampleCount = n;
   // Rebuild every sample-count-dependent (opaque-pass) pipeline. OIT and
@@ -1088,6 +1115,7 @@ struct PostU {
   float shadowRadius;    // world half-extent of the shadow ortho box (Angstroms)
   float shadowBias;      // metal_shadow_bias: user multiplier on the self-shadow bias
   float projOrtho;       // >0.5: orthographic projection (linear eye-z / no foreshortening)
+  float pad0;            // 16-byte multiple: the C++ mirror must be >= this size
 };
 
 // Linear eye distance (positive, toward the scene) from window depth [0,1].
@@ -2461,7 +2489,9 @@ void RendererMetal::runPostChain()
       float shadowRadius;      // matches MSL PostU: shadow ortho half-extent
       float shadowBias;        // matches MSL PostU: metal_shadow_bias multiplier
       float projOrtho;         // matches MSL PostU: 1 = orthographic (#139)
+      float pad0;              // matches MSL PostU padding (16-byte multiple)
     } u;
+    u.pad0 = 0.0f;
     u.projA = _projA; u.projB = _projB;
     u.fogStart = _fogStart; u.fogEnd = _fogEnd;
     u.bgR = _bgR; u.bgG = _bgG; u.bgB = _bgB;


### PR DESCRIPTION
## Summary

The iOS app aborts on its first frame when run from Xcode (Metal API validation on):

```
_MTLDebugValidateRenderPassDescriptorAndTrackAttachments:487: failed assertion
`RenderPass Descriptor Validation
 MTLRenderPassAttachmentDescriptor MTLStoreActionStoreAndMultisampleResolve store action
 for the depth attachment is not supported by device
 PixelFormat MTLPixelFormatDepth32Float_Stencil8 cannot be a MSAA resolve target'
```

The MSAA scene pass (`metal_msaa`, default on) resolves its `Depth32Float_Stencil8` depth attachment. A depth-stencil format is only a legal MSAA resolve target on Apple GPU family 5+ (A12 and later) and on Mac GPUs; the iOS **simulator** and older devices reject it. Without validation the driver tolerates it, which is why plain launches (and TestFlight/App Store builds) did not show the crash — any debug run from Xcode does.

## Fix

- `RendererMetal::setSampleCount` falls back to single-sample rendering (one `NSLog`) on the simulator and on GPUs that lack depth-stencil resolve, instead of building the unsupported pass. A12+ iPhones/iPads and Macs keep 4x MSAA unchanged.
- The `PostU` uniform struct gets one trailing pad float so the C++ mirror passed with `setFragmentBytes` matches the 16-byte-multiple MSL struct size (validation checks buffer length ≥ argument size). Behaviour-neutral.

Independent of #374; the same change is also included there (plus the equivalent padding for the RT uniforms) so that branch is validation-clean too.

## Verification

Reproduced and fixed on the iPhone 17 Pro simulator with
`MTL_DEBUG_LAYER=1 METAL_DEVICE_WRAPPER_TYPE=1 MTL_DEBUG_LAYER_ERROR_MODE=assert`:

- before: assert in `beginFrame` → SIGABRT on the first rendered frame
- after: app launches, logs the single fallback line, renders; also launched with `metal_raytrace` + `metal_rt_shadows` on, stays up
- plain launches on iPhone 17 Pro and iPad Pro (M4) simulators unaffected
- macOS core compiles clean (`swiftui/build_macos.sh`); macOS keeps MSAA (`MTLGPUFamilyMac2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
