### PR TITLE
fix(ui): real build banner in console; Background opacity drives transparent export (#377, #378)

### DIFF
--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -262,7 +262,7 @@ enum SceneCatalog {
     static let params: [SceneParam] = [
         // --- Canvas: background + multi-object/state layout ---
         SceneParam(setting: "bg_rgb",     label: "Background", kind: .toggle, group: "Canvas", isColor: true,
-                   help: "Viewport background color."),
+                   help: "Viewport background color. Opacity below 50% exports images with a transparent background (the same switch as Share ▸ Transparent background); the live view stays opaque."),
         // grid_mode is an int (0=off, 1=by object, 2=by state); the toggle maps
         // off→0 / on→1 and reads on for any non-zero mode.
         SceneParam(setting: "grid_mode",  label: "Grid", kind: .toggle, group: "Canvas",
@@ -2047,6 +2047,10 @@ private func colorFromHex(_ hex: String) -> Color? {
 struct DebouncedColorPicker: View {
     let get: () -> Color
     let apply: (Color) -> Void
+    // Off by default: PyMOL colors (set_color, bg_rgb) have no alpha channel, so
+    // the system picker's opacity slider would be a dead control (issue #378).
+    // Only the Background swatch opts in, where alpha drives ray_opaque_background.
+    var supportsOpacity: Bool = false
     @State private var pending: Color? = nil
     @State private var work: DispatchWorkItem? = nil
 
@@ -2059,23 +2063,52 @@ struct DebouncedColorPicker: View {
                 let w = DispatchWorkItem { apply(c) }   // debounced: hit the core
                 work = w
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.15, execute: w)
-            }))
+            }), supportsOpacity: supportsOpacity)
             .labelsHidden()
     }
 }
 
-/// SwiftUI Color → PyMOL set_color list "[r,g,b]" in 0…1.
-private func rgb01List(_ color: Color) -> String {
+/// SwiftUI Color → sRGB components in 0…1, alpha included.
+private func rgba01(_ color: Color) -> (r: Double, g: Double, b: Double, a: Double) {
 #if canImport(AppKit)
     let ns = NSColor(color).usingColorSpace(.sRGB) ?? NSColor.white
-    return String(format: "[%.3f,%.3f,%.3f]", ns.redComponent, ns.greenComponent, ns.blueComponent)
+    return (ns.redComponent, ns.greenComponent, ns.blueComponent, ns.alphaComponent)
 #elseif canImport(UIKit)
     var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
     UIColor(color).getRed(&r, green: &g, blue: &b, alpha: &a)
-    return String(format: "[%.3f,%.3f,%.3f]", r, g, b)
+    return (r, g, b, a)
 #else
-    return "[1,1,1]"
+    return (1, 1, 1, 1)
 #endif
+}
+
+/// SwiftUI Color → PyMOL set_color list "[r,g,b]" in 0…1. Alpha is dropped:
+/// PyMOL colors have none (see `BackgroundOpacity` for the one place it matters).
+private func rgb01List(_ color: Color) -> String {
+    let c = rgba01(color)
+    return String(format: "[%.3f,%.3f,%.3f]", c.r, c.g, c.b)
+}
+
+/// How the Background swatch's opacity maps onto PyMOL. `bg_rgb` has no alpha;
+/// transparency is the separate, binary `ray_opaque_background` setting, and it
+/// only affects rendered/exported images (the live viewport stays opaque). The
+/// swatch shares the `exportTransparent` default with the Share menu's
+/// "Transparent background" toggle, so the two affordances are one state
+/// rather than a real switch next to a dead one (issue #378).
+enum BackgroundOpacity {
+    /// The `@AppStorage` key ContentView's export menu already persists.
+    static let defaultsKey = "exportTransparent"
+
+    /// Alpha below one half reads as "transparent"; the setting is binary.
+    static func isTransparent(alpha: Double) -> Bool { alpha < 0.5 }
+
+    /// The alpha the swatch shows for the persisted state.
+    static func alpha(transparent: Bool) -> Double { transparent ? 0 : 1 }
+
+    /// The PyMOL command that makes `ray`/`png`/exports honor the choice.
+    static func command(transparent: Bool) -> String {
+        "set ray_opaque_background, \(transparent ? 0 : 1)"
+    }
 }
 
 private func sanitizeName(_ s: String) -> String {
@@ -3086,6 +3119,9 @@ struct SceneCard: View {
 struct SceneParamRow: View {
     let param: SceneParam
     @ObservedObject var engine: PyMOLEngine
+    // Shared with ContentView's Share ▸ "Transparent background" toggle; the
+    // Background swatch's opacity is a second handle on the same state.
+    @AppStorage(BackgroundOpacity.defaultsKey) private var exportTransparent = false
     // Compact layout for the camera dock: natural-width label and no trailing
     // Spacer, so the slider fills the row instead of splitting the space with a
     // Spacer (the dock card bounds the overall width). Inspector uses the default.
@@ -3108,15 +3144,19 @@ struct SceneParamRow: View {
     @ViewBuilder
     private func sceneControl(_ p: SceneParam) -> some View {
         if p.isColor {
+            let isBackground = p.setting == "bg_rgb"
             DebouncedColorPicker(
                 get: {
-                    let c = (p.setting == "bg_rgb") ? engine.sceneState.bg : engine.sceneState.outlineColor
+                    let c = isBackground ? engine.sceneState.bg : engine.sceneState.outlineColor
+                    let alpha = isBackground ? BackgroundOpacity.alpha(transparent: exportTransparent) : 1
                     return Color(.sRGB, red: c.count > 0 ? c[0] : 0,
-                                 green: c.count > 1 ? c[1] : 0, blue: c.count > 2 ? c[2] : 0)
+                                 green: c.count > 1 ? c[1] : 0, blue: c.count > 2 ? c[2] : 0,
+                                 opacity: alpha)
                 },
                 apply: { c in
-                    if p.setting == "bg_rgb" { setBackground(c) } else { setOutlineColor(c) }
-                })
+                    if isBackground { setBackground(c) } else { setOutlineColor(c) }
+                },
+                supportsOpacity: isBackground)
                 .frame(width: 28)
         } else {
             let v = engine.sceneState.values[p.setting] ?? 0
@@ -3223,7 +3263,11 @@ struct SceneParamRow: View {
     }
 
     private func setBackground(_ color: Color) {
-        engine.runCommand("set_color _bgcol, \(rgb01List(color))\nbg_color _bgcol")
+        let transparent = BackgroundOpacity.isTransparent(alpha: rgba01(color).a)
+        // Persisting through the shared default also flips the Share menu toggle.
+        exportTransparent = transparent
+        engine.runCommand("set_color _bgcol, \(rgb01List(color))\nbg_color _bgcol\n"
+                          + BackgroundOpacity.command(transparent: transparent))
     }
 
     private func setOutlineColor(_ color: Color) {

--- a/swiftui/PyMOLViewer/Shared/AppBuildInfo.swift
+++ b/swiftui/PyMOLViewer/Shared/AppBuildInfo.swift
@@ -35,6 +35,12 @@ enum AppBuildInfo {
     /// True when this build came off the beta pipeline.
     static var isBeta: Bool { betaLabel != nil }
 
+    /// The line the in-app console prints first at launch, e.g.
+    /// " [build] RayMol 1.10.0 (27)". Derived from the bundle so it can never go
+    /// stale: it replaced a hand-bumped "v35" marker that sat two months behind
+    /// the real version (GitHub issue #377).
+    static var consoleBanner: String { consoleBanner(displayVersion: displayVersion) }
+
     // MARK: - Pure logic (unit-tested; no Bundle access)
 
     /// Treat a missing key and a present-but-blank one identically. The
@@ -59,6 +65,13 @@ enum AppBuildInfo {
         case (true, false):  return "(\(build))"
         case (true, true):   return ""
         }
+    }
+
+    /// Leading space matches the console's other status lines. An Info.plist
+    /// with neither key still prints an honest line rather than "RayMol ".
+    static func consoleBanner(displayVersion: String) -> String {
+        displayVersion.isEmpty ? " [build] RayMol (unknown version)"
+                               : " [build] RayMol \(displayVersion)"
     }
 
     // MARK: - Bundle access

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -232,7 +232,16 @@ struct ContentView: View {
         Toggle(isOn: $exportRayTraced) {
             Label("Ray-traced (AO + shadows)", systemImage: "sparkles")
         }
-        Toggle(isOn: $exportTransparent) {
+        // Applies ray_opaque_background to the core on the spot (not only at
+        // export time) so a typed `ray`/`png` honors it too. The Canvas Background
+        // swatch's opacity writes the same default and does the same (#378); an
+        // .onChange on the @AppStorage did not fire for toolbar-menu toggles.
+        Toggle(isOn: Binding(
+            get: { exportTransparent },
+            set: { on in
+                exportTransparent = on
+                engine.runCommand(BackgroundOpacity.command(transparent: on))
+            })) {
             Label("Transparent background", systemImage: "square.dashed")
         }
     }
@@ -3104,7 +3113,7 @@ struct ContentView: View {
             // chain — including depth-of-field. The old transparent branch used the
             // CPU ray-tracer, which is slow and drops every Metal post-effect (DOF,
             // outline, tone-map). rtFlag still selects hardware-RT AO/shadows.
-            engine.runCommand("set ray_opaque_background, \(exportTransparent ? 0 : 1)")
+            engine.runCommand(BackgroundOpacity.command(transparent: exportTransparent))
             engine.renderHiResPNG(url.path, width: width, height: height,
                                   rayTraced: exportRayTraced ? 1 : 0)
             done(FileManager.default.fileExists(atPath: url.path) ? url : nil)
@@ -3684,7 +3693,7 @@ struct ContentView: View {
     private func renderExportPNG(_ path: String, _ w: Int, _ h: Int,
                                  done: @escaping () -> Void = {}) {
         engine.runHeavy("Rendering image…") {
-            engine.runCommand("set ray_opaque_background, \(exportTransparent ? 0 : 1)")
+            engine.runCommand(BackgroundOpacity.command(transparent: exportTransparent))
             engine.renderHiResPNG(path, width: w, height: h, rayTraced: rtFlag)
             done()
         }

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -470,11 +470,11 @@ final class PyMOLEngine: ObservableObject {
 
         isReady = true
 
-        // Build marker — lets us confirm the device is running THIS binary (not a
-        // cached/stale install) when verifying gesture-direction fixes. Bump the
-        // tag whenever gesture behavior changes; it shows at the top of the log.
+        // Build banner — lets anyone confirm which binary a device is running (not
+        // a cached/stale install). Generated from the bundle's version + build
+        // number, never hand-maintained (issue #377). Shows at the top of the log.
         DispatchQueue.main.async { [weak self] in
-            self?.feedbackLog.append(" [build] v35  (Long-press context menu + iOS reset menu)")
+            self?.feedbackLog.append(AppBuildInfo.consoleBanner)
         }
 
         // `fetch` downloads into fetch_path. Use the temp directory: it's always

--- a/swiftui/PyMOLViewerTests/AppBuildInfoTests.swift
+++ b/swiftui/PyMOLViewerTests/AppBuildInfoTests.swift
@@ -103,4 +103,29 @@ final class AppBuildInfoTests: XCTestCase {
     func testBundleDisplayVersionIsNonEmpty() {
         XCTAssertFalse(AppBuildInfo.displayVersion.isEmpty)
     }
+
+    // MARK: - consoleBanner (#377)
+
+    // The console's first line must come from the bundle, not a hand-bumped
+    // string: the old marker read "v35" for two months of unrelated releases.
+    func testConsoleBannerCarriesTheDisplayVersion() {
+        XCTAssertEqual(AppBuildInfo.consoleBanner(displayVersion: "1.10.0 (27)"),
+                       " [build] RayMol 1.10.0 (27)")
+        XCTAssertEqual(AppBuildInfo.consoleBanner(displayVersion: "1.9.1-beta27"),
+                       " [build] RayMol 1.9.1-beta27")
+    }
+
+    // A plist missing both keys must still print something a tester can quote,
+    // not a trailing-space "RayMol " that looks like a rendering glitch.
+    func testConsoleBannerWithoutVersionSaysSo() {
+        XCTAssertEqual(AppBuildInfo.consoleBanner(displayVersion: ""),
+                       " [build] RayMol (unknown version)")
+    }
+
+    // The live property must go through the same formatter as the tested one.
+    func testLiveConsoleBannerMatchesDisplayVersion() {
+        XCTAssertEqual(AppBuildInfo.consoleBanner,
+                       AppBuildInfo.consoleBanner(displayVersion: AppBuildInfo.displayVersion))
+        XCTAssertTrue(AppBuildInfo.consoleBanner.hasPrefix(" [build] RayMol "))
+    }
 }

--- a/swiftui/PyMOLViewerTests/SmokeTests.swift
+++ b/swiftui/PyMOLViewerTests/SmokeTests.swift
@@ -4,3 +4,37 @@ import XCTest
 final class SmokeTests: XCTestCase {
     func testHarnessRuns() { XCTAssertEqual(1 + 1, 2) }
 }
+
+/// The Background swatch's opacity → `ray_opaque_background` mapping (#378).
+/// PyMOL's `bg_rgb` has no alpha, so the picker's opacity slider used to be a
+/// dead control; it now drives the same binary export switch as the Share menu.
+final class BackgroundOpacityTests: XCTestCase {
+    func testFullyOpaqueAndTransparentEndpoints() {
+        XCTAssertFalse(BackgroundOpacity.isTransparent(alpha: 1))
+        XCTAssertTrue(BackgroundOpacity.isTransparent(alpha: 0))
+    }
+
+    // The underlying setting is binary, so the threshold sits at the midpoint:
+    // a nudge off 100% stays opaque, anything under half becomes transparent.
+    func testThresholdIsHalf() {
+        XCTAssertFalse(BackgroundOpacity.isTransparent(alpha: 0.5))
+        XCTAssertFalse(BackgroundOpacity.isTransparent(alpha: 0.95))
+        XCTAssertTrue(BackgroundOpacity.isTransparent(alpha: 0.49))
+    }
+
+    // What the swatch shows must round-trip through the policy.
+    func testSwatchAlphaRoundTrips() {
+        XCTAssertTrue(BackgroundOpacity.isTransparent(alpha: BackgroundOpacity.alpha(transparent: true)))
+        XCTAssertFalse(BackgroundOpacity.isTransparent(alpha: BackgroundOpacity.alpha(transparent: false)))
+    }
+
+    func testCommandTogglesRayOpaqueBackground() {
+        XCTAssertEqual(BackgroundOpacity.command(transparent: true), "set ray_opaque_background, 0")
+        XCTAssertEqual(BackgroundOpacity.command(transparent: false), "set ray_opaque_background, 1")
+    }
+
+    // Both affordances must persist under the one key ContentView already uses.
+    func testSharesTheExportMenuDefaultsKey() {
+        XCTAssertEqual(BackgroundOpacity.defaultsKey, "exportTransparent")
+    }
+}


### PR DESCRIPTION
Closes #377. Closes #378.

## What
- **#377** The console's first line is now generated from the bundle (`AppBuildInfo.consoleBanner`, e.g. ` [build] RayMol 1.10.0 (27)`) instead of the hand-bumped ` [build] v35 (…)` string that had been stale since June.
- **#378** The Canvas ▸ Background swatch's opacity now means something: alpha below 50% flips the same `exportTransparent` default the Share menu's "Transparent background" toggle uses, and applies `ray_opaque_background` to the core immediately (so a typed `ray`/`png` honors it, not only the export paths). The toggle updates the swatch in turn — one state, two handles. All other `DebouncedColorPicker` uses pass `supportsOpacity: false`, since `set_color` has no alpha either.
- The Share toggle applies the setting through its binding's setter; an `.onChange(of:)` on the `@AppStorage` did not fire for toolbar-menu toggles (observed in the VM), so it is not relied on.

## Tests
- New unit tests: `AppBuildInfoTests` (banner) and `BackgroundOpacityTests` (threshold, round trip, command, shared key).
- `UnitTests_macOS`: 665 tests, 0 failures.

## Verified in a disposable macOS VM (Tahoe golden)
- Console top line reads ` [build] RayMol 1.10.0 (27)`.
- Background swatch → opacity 0%: `ray_opaque_background` 0, `exportTransparent` = 1; back to 100%: 1 / 0.
- Share ▸ Transparent background off/on: 1 / 0 then 0 / 1; the swatch shows the transparent (diagonal) state, and after a relaunch with the default persisted the swatch comes up transparent.
- Outline color swatch's Colors panel has no opacity slider; Background's does.

## iOS
Debug build for the iPhone 17 Pro simulator builds and launches (smoke only; the UI path is shared Swift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
