### PR TITLE
feat(object-panel): bring back PyMOL's tiered color menu (#379)

### DIFF
--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		3F96563B0EA8F919B068A421 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75F059BB95517CE91BD3E26E /* ContentView.swift */; };
 		40DAE7C10C0EEEC2C1EB09F2 /* whatsnew-1100-interface.png in Resources */ = {isa = PBXBuildFile; fileRef = 283BC19B58F7146F72950E97 /* whatsnew-1100-interface.png */; };
 		4128B469229CEE6A6A4E4B68 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75F059BB95517CE91BD3E26E /* ContentView.swift */; };
+		7C0379A1B2C3D4E5F6071379 /* ColorMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0379A1B2C3D4E5F6072379 /* ColorMenuTests.swift */; };
 		42BC62ABCFB3CDB9C2CE3518 /* DesignColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B045EA1D04163863BD9DA94 /* DesignColorTests.swift */; };
 		42D3395698D37E4BF7055EEA /* MCPBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A18D8A6B0FB56FCD3C31211 /* MCPBridge.swift */; };
 		42F2467DC338FA8435632918 /* WhatsNew.json in Resources */ = {isa = PBXBuildFile; fileRef = 689CDE512811C244D4BA931B /* WhatsNew.json */; };
@@ -111,6 +112,7 @@
 		6C028EE83C8A29A4FDCF2222 /* BoltzJobManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 193D4D739151970412BB6EDF /* BoltzJobManagerTests.swift */; };
 		6C8AA3C224C1B2106FBF4881 /* DesignScoreCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC5AE545F97DF175BFE0462 /* DesignScoreCache.swift */; };
 		6D67CAB3F655837D48E68AF3 /* PredictController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0D207800BE2DDAF04598C1 /* PredictController.swift */; };
+		7C0379A1B2C3D4E5F6073379 /* ColorMenuUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0379A1B2C3D4E5F6074379 /* ColorMenuUITests.swift */; };
 		6E6BAB43588CEBE88230F5C5 /* WhatsNewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BAC08EBD7DD4DCB8C18EDC /* WhatsNewUITests.swift */; };
 		6E8C51546C660EE26D379D14 /* whatsnew-1100-metrics.png in Resources */ = {isa = PBXBuildFile; fileRef = 3FDAAF431094900F3FC21293 /* whatsnew-1100-metrics.png */; };
 		6E945630A8B9A6195B98A958 /* MLX in Frameworks */ = {isa = PBXBuildFile; productRef = FBA4CCD670BAF318F243E692 /* MLX */; };
@@ -282,6 +284,7 @@
 		1A55383922D69D691CA1BAB1 /* 1ubq.cif */ = {isa = PBXFileReference; path = 1ubq.cif; sourceTree = "<group>"; };
 		1A75842F74BFC453CE7BA777 /* BoltzJobManagerMSATests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoltzJobManagerMSATests.swift; sourceTree = "<group>"; };
 		1AA9F6B00A6FC98E37CB26EC /* PredictScreenAwakeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictScreenAwakeTests.swift; sourceTree = "<group>"; };
+		7C0379A1B2C3D4E5F6072379 /* ColorMenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorMenuTests.swift; sourceTree = "<group>"; };
 		1B045EA1D04163863BD9DA94 /* DesignColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignColorTests.swift; sourceTree = "<group>"; };
 		1FF072CB363743CAF805155E /* KeyBindingDispatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyBindingDispatchTests.swift; sourceTree = "<group>"; };
 		221117550FAD97CF81924E05 /* MousePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MousePanel.swift; sourceTree = "<group>"; };
@@ -315,6 +318,7 @@
 		56BE219EF1CF1EB2B05E44AD /* MPNNGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPNNGate.swift; sourceTree = "<group>"; };
 		57E9E81F5C4757D03AAF7ABD /* dylib-Info-template.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "dylib-Info-template.plist"; sourceTree = "<group>"; };
 		589928DEEE69075B965DB9F2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		7C0379A1B2C3D4E5F6074379 /* ColorMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorMenuUITests.swift; sourceTree = "<group>"; };
 		58BAC08EBD7DD4DCB8C18EDC /* WhatsNewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewUITests.swift; sourceTree = "<group>"; };
 		5A4B5DB2F82A55E25041FE28 /* BoltzJobManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoltzJobManager.swift; sourceTree = "<group>"; };
 		5E9F8D36908E3216D1C8F893 /* MetalViewport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalViewport.swift; sourceTree = "<group>"; };
@@ -502,6 +506,7 @@
 				104B50C66BDEB03C41A1CE47 /* CameraOverlayUITests.swift */,
 				B158150C93613716ED3CE572 /* KeyboardDismissUITests.swift */,
 				E8EE6573045A81CF52A9CDF5 /* PyMOLGestureUITests.swift */,
+				7C0379A1B2C3D4E5F6074379 /* ColorMenuUITests.swift */,
 				58BAC08EBD7DD4DCB8C18EDC /* WhatsNewUITests.swift */,
 			);
 			path = PyMOLViewerUITests;
@@ -601,6 +606,7 @@
 				193D4D739151970412BB6EDF /* BoltzJobManagerTests.swift */,
 				BF0B47016374F32C7BB13017 /* CopyRoutingTests.swift */,
 				2345D7E2703CF29D4A2AA277 /* DesignAvailabilityTests.swift */,
+				7C0379A1B2C3D4E5F6072379 /* ColorMenuTests.swift */,
 				1B045EA1D04163863BD9DA94 /* DesignColorTests.swift */,
 				F7E41DCBB427678A8F018B0E /* DesignControllerTests.swift */,
 				4D6A959CC1590FC60333582B /* DesignEditInferenceTests.swift */,
@@ -1324,6 +1330,7 @@
 				72C53CF3B3DE0AC1001A6981 /* CameraOverlayUITests.swift in Sources */,
 				5E0DDAA214299444AB084E74 /* KeyboardDismissUITests.swift in Sources */,
 				CCA9FAAAD0E59CE43443B7DA /* PyMOLGestureUITests.swift in Sources */,
+				7C0379A1B2C3D4E5F6073379 /* ColorMenuUITests.swift in Sources */,
 				6E6BAB43588CEBE88230F5C5 /* WhatsNewUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1338,6 +1345,7 @@
 				6C028EE83C8A29A4FDCF2222 /* BoltzJobManagerTests.swift in Sources */,
 				6A3892FDD5939A57DC9FFCCE /* CopyRoutingTests.swift in Sources */,
 				B88942D786AB0D1CDC354C1F /* DesignAvailabilityTests.swift in Sources */,
+				7C0379A1B2C3D4E5F6071379 /* ColorMenuTests.swift in Sources */,
 				42BC62ABCFB3CDB9C2CE3518 /* DesignColorTests.swift in Sources */,
 				FCB5A40892C6D7239E49791A /* DesignControllerTests.swift in Sources */,
 				FCE3C0AD3EC5319F8F2E144E /* DesignEditInferenceTests.swift in Sources */,

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -613,30 +613,200 @@ private let labelOptions: [(label: String, expr: String?)] = [
     ("Elements",  "elem"),
 ]
 
+/// One named PyMOL color and its sRGB value, mirrored from the core color
+/// table (layer1/Color.cpp) so the menu swatch matches what `color <name>`
+/// actually paints.
+struct PyMOLNamedColor: Equatable {
+    let name: String
+    let red: Double
+    let green: Double
+    let blue: Double
+    var swatch: Color { Color(.sRGB, red: red, green: green, blue: blue) }
+}
+
+/// One hue family of desktop PyMOL's two-level color menu (#379).
+struct PyMOLColorFamily {
+    let label: String
+    let shades: [PyMOLNamedColor]
+    /// The family entry is tinted with its first (canonical) shade, exactly
+    /// like upstream menu.py, which colors the family label with `c_list[0]`.
+    var swatch: Color { shades[0].swatch }
+}
+
+/// Desktop PyMOL's tiered color menu — `all_colors_list` in
+/// modules/pymol/menu.py — surfaced in the SwiftUI "C" menu as one submenu per
+/// hue family (#379). Family order and membership mirror upstream (a few
+/// shades, e.g. limon and wheat, deliberately appear in two families there);
+/// the RGB values are the core's, so no colors are invented here.
+enum PyMOLColorMenu {
+    static let families: [PyMOLColorFamily] = [
+        PyMOLColorFamily(label: "reds", shades: [
+            PyMOLNamedColor(name: "red",           red: 1.0, green: 0.0, blue: 0.0),
+            PyMOLNamedColor(name: "tv_red",        red: 1.0, green: 0.2, blue: 0.2),
+            PyMOLNamedColor(name: "raspberry",     red: 0.7, green: 0.3, blue: 0.4),
+            PyMOLNamedColor(name: "darksalmon",    red: 0.73, green: 0.55, blue: 0.52),
+            PyMOLNamedColor(name: "salmon",        red: 1.0, green: 0.6, blue: 0.6),
+            PyMOLNamedColor(name: "deepsalmon",    red: 1.0, green: 0.5, blue: 0.5),
+            PyMOLNamedColor(name: "warmpink",      red: 0.85, green: 0.2, blue: 0.5),
+            PyMOLNamedColor(name: "firebrick",     red: 0.698, green: 0.13, blue: 0.13),
+            PyMOLNamedColor(name: "ruby",          red: 0.6, green: 0.2, blue: 0.2),
+            PyMOLNamedColor(name: "chocolate",     red: 0.555, green: 0.222, blue: 0.111),
+            PyMOLNamedColor(name: "brown",         red: 0.65, green: 0.32, blue: 0.17),
+        ]),
+        PyMOLColorFamily(label: "greens", shades: [
+            PyMOLNamedColor(name: "green",         red: 0.0, green: 1.0, blue: 0.0),
+            PyMOLNamedColor(name: "tv_green",      red: 0.2, green: 1.0, blue: 0.2),
+            PyMOLNamedColor(name: "chartreuse",    red: 0.5, green: 1.0, blue: 0.0),
+            PyMOLNamedColor(name: "splitpea",      red: 0.52, green: 0.75, blue: 0.0),
+            PyMOLNamedColor(name: "smudge",        red: 0.55, green: 0.7, blue: 0.4),
+            PyMOLNamedColor(name: "palegreen",     red: 0.65, green: 0.9, blue: 0.65),
+            PyMOLNamedColor(name: "limegreen",     red: 0.0, green: 1.0, blue: 0.5),
+            PyMOLNamedColor(name: "lime",          red: 0.5, green: 1.0, blue: 0.5),
+            PyMOLNamedColor(name: "limon",         red: 0.75, green: 1.0, blue: 0.25),
+            PyMOLNamedColor(name: "forest",        red: 0.2, green: 0.6, blue: 0.2),
+        ]),
+        PyMOLColorFamily(label: "blues", shades: [
+            PyMOLNamedColor(name: "blue",          red: 0.0, green: 0.0, blue: 1.0),
+            PyMOLNamedColor(name: "tv_blue",       red: 0.3, green: 0.3, blue: 1.0),
+            PyMOLNamedColor(name: "marine",        red: 0.0, green: 0.5, blue: 1.0),
+            PyMOLNamedColor(name: "slate",         red: 0.5, green: 0.5, blue: 1.0),
+            PyMOLNamedColor(name: "lightblue",     red: 0.75, green: 0.75, blue: 1.0),
+            PyMOLNamedColor(name: "skyblue",       red: 0.2, green: 0.5, blue: 0.8),
+            PyMOLNamedColor(name: "purpleblue",    red: 0.5, green: 0.0, blue: 1.0),
+            PyMOLNamedColor(name: "deepblue",      red: 0.25, green: 0.25, blue: 0.65),
+            PyMOLNamedColor(name: "density",       red: 0.1, green: 0.1, blue: 0.6),
+        ]),
+        PyMOLColorFamily(label: "yellows", shades: [
+            PyMOLNamedColor(name: "yellow",        red: 1.0, green: 1.0, blue: 0.0),
+            PyMOLNamedColor(name: "tv_yellow",     red: 1.0, green: 1.0, blue: 0.2),
+            PyMOLNamedColor(name: "paleyellow",    red: 1.0, green: 1.0, blue: 0.5),
+            PyMOLNamedColor(name: "yelloworange",  red: 1.0, green: 0.87, blue: 0.37),
+            PyMOLNamedColor(name: "limon",         red: 0.75, green: 1.0, blue: 0.25),
+            PyMOLNamedColor(name: "wheat",         red: 0.99, green: 0.82, blue: 0.65),
+            PyMOLNamedColor(name: "sand",          red: 0.72, green: 0.55, blue: 0.3),
+        ]),
+        PyMOLColorFamily(label: "magentas", shades: [
+            PyMOLNamedColor(name: "magenta",       red: 1.0, green: 0.0, blue: 1.0),
+            PyMOLNamedColor(name: "lightmagenta",  red: 1.0, green: 0.2, blue: 0.8),
+            PyMOLNamedColor(name: "hotpink",       red: 1.0, green: 0.0, blue: 0.5),
+            PyMOLNamedColor(name: "pink",          red: 1.0, green: 0.65, blue: 0.85),
+            PyMOLNamedColor(name: "lightpink",     red: 1.0, green: 0.75, blue: 0.87),
+            PyMOLNamedColor(name: "dirtyviolet",   red: 0.7, green: 0.5, blue: 0.5),
+            PyMOLNamedColor(name: "violet",        red: 1.0, green: 0.5, blue: 1.0),
+            PyMOLNamedColor(name: "violetpurple",  red: 0.55, green: 0.25, blue: 0.6),
+            PyMOLNamedColor(name: "purple",        red: 0.75, green: 0.0, blue: 0.75),
+            PyMOLNamedColor(name: "deeppurple",    red: 0.6, green: 0.1, blue: 0.6),
+        ]),
+        PyMOLColorFamily(label: "cyans", shades: [
+            PyMOLNamedColor(name: "cyan",          red: 0.0, green: 1.0, blue: 1.0),
+            PyMOLNamedColor(name: "palecyan",      red: 0.8, green: 1.0, blue: 1.0),
+            PyMOLNamedColor(name: "aquamarine",    red: 0.5, green: 1.0, blue: 1.0),
+            PyMOLNamedColor(name: "greencyan",     red: 0.25, green: 1.0, blue: 0.75),
+            PyMOLNamedColor(name: "teal",          red: 0.0, green: 0.75, blue: 0.75),
+            PyMOLNamedColor(name: "deepteal",      red: 0.1, green: 0.6, blue: 0.6),
+            PyMOLNamedColor(name: "lightteal",     red: 0.4, green: 0.7, blue: 0.7),
+        ]),
+        PyMOLColorFamily(label: "oranges", shades: [
+            PyMOLNamedColor(name: "orange",        red: 1.0, green: 0.5, blue: 0.0),
+            PyMOLNamedColor(name: "tv_orange",     red: 1.0, green: 0.55, blue: 0.15),
+            PyMOLNamedColor(name: "brightorange",  red: 1.0, green: 0.7, blue: 0.2),
+            PyMOLNamedColor(name: "lightorange",   red: 1.0, green: 0.8, blue: 0.5),
+            PyMOLNamedColor(name: "yelloworange",  red: 1.0, green: 0.87, blue: 0.37),
+            PyMOLNamedColor(name: "olive",         red: 0.77, green: 0.7, blue: 0.0),
+            PyMOLNamedColor(name: "deepolive",     red: 0.6, green: 0.6, blue: 0.1),
+        ]),
+        PyMOLColorFamily(label: "tints", shades: [
+            PyMOLNamedColor(name: "wheat",         red: 0.99, green: 0.82, blue: 0.65),
+            PyMOLNamedColor(name: "palegreen",     red: 0.65, green: 0.9, blue: 0.65),
+            PyMOLNamedColor(name: "lightblue",     red: 0.75, green: 0.75, blue: 1.0),
+            PyMOLNamedColor(name: "paleyellow",    red: 1.0, green: 1.0, blue: 0.5),
+            PyMOLNamedColor(name: "lightpink",     red: 1.0, green: 0.75, blue: 0.87),
+            PyMOLNamedColor(name: "palecyan",      red: 0.8, green: 1.0, blue: 1.0),
+            PyMOLNamedColor(name: "lightorange",   red: 1.0, green: 0.8, blue: 0.5),
+            PyMOLNamedColor(name: "bluewhite",     red: 0.85, green: 0.85, blue: 1.0),
+        ]),
+        PyMOLColorFamily(label: "grays", shades: [
+            PyMOLNamedColor(name: "white",         red: 1.0, green: 1.0, blue: 1.0),
+            PyMOLNamedColor(name: "gray90",        red: 0.909, green: 0.909, blue: 0.909),
+            PyMOLNamedColor(name: "gray80",        red: 0.808, green: 0.808, blue: 0.808),
+            PyMOLNamedColor(name: "gray70",        red: 0.707, green: 0.707, blue: 0.707),
+            PyMOLNamedColor(name: "gray60",        red: 0.606, green: 0.606, blue: 0.606),
+            PyMOLNamedColor(name: "gray50",        red: 0.505, green: 0.505, blue: 0.505),
+            PyMOLNamedColor(name: "gray40",        red: 0.404, green: 0.404, blue: 0.404),
+            PyMOLNamedColor(name: "gray30",        red: 0.303, green: 0.303, blue: 0.303),
+            PyMOLNamedColor(name: "gray20",        red: 0.202, green: 0.202, blue: 0.202),
+            PyMOLNamedColor(name: "gray10",        red: 0.101, green: 0.101, blue: 0.101),
+            PyMOLNamedColor(name: "black",         red: 0.0, green: 0.0, blue: 0.0),
+        ]),
+    ]
+
+    /// Every distinct named color in the table, in menu order.
+    static var allColorNames: [String] {
+        var seen = Set<String>()
+        return families.flatMap(\.shades).map(\.name).filter { seen.insert($0).inserted }
+    }
+
+    /// Look up a named color anywhere in the tiered table.
+    static func color(named name: String) -> PyMOLNamedColor? {
+        for family in families {
+            if let c = family.shades.first(where: { $0.name == name }) { return c }
+        }
+        return nil
+    }
+
+    /// Classic `gray` (0.5) is not in upstream's family table (which lists the
+    /// gray10…gray90 ramp), but it is the color people reach for, so it heads
+    /// the grays row.
+    static let gray = PyMOLNamedColor(name: "gray", red: 0.5, green: 0.5, blue: 0.5)
+
+    /// The rows of the "C" menu's color section (#379). Like desktop PyMOL's
+    /// object-panel popup, each row IS a color — clicking "red" paints red —
+    /// and the same row expands (arrow) into that hue's named variants. Rows
+    /// without a natural base color (tints) are plain submenus.
+    static let rows: [PyMOLColorMenuRow] = {
+        let base: [String: PyMOLNamedColor?] = [
+            "reds": color(named: "red"),
+            "greens": color(named: "green"),
+            "blues": color(named: "blue"),
+            "yellows": color(named: "yellow"),
+            "magentas": color(named: "magenta"),
+            "cyans": color(named: "cyan"),
+            "oranges": color(named: "orange"),
+            "tints": nil,
+            "grays": gray,
+        ]
+        return families.map { PyMOLColorMenuRow(family: $0, primary: base[$0.label] ?? nil) }
+    }()
+}
+
+/// One row of the color section: a hue family plus the color a click on the
+/// row itself applies (nil = the row only expands).
+struct PyMOLColorMenuRow {
+    let family: PyMOLColorFamily
+    let primary: PyMOLNamedColor?
+    /// What the row reads: the base color's name when clickable, else the
+    /// family's name.
+    var title: String { primary?.name ?? family.label }
+    var swatch: Color { primary?.swatch ?? family.swatch }
+}
+
 /// Color options with optional swatch color
-private struct ColorOption {
+struct ColorOption {
     let label: String
     let command: String?
     let swatch: Color?
+
 }
 
-private let colorOptions: [ColorOption] = [
+/// The coloring modes at the top of the "C" menu. The colors themselves follow
+/// as PyMOLColorMenu.rows (click = base color, expand = its variants), so the
+/// old flat red…white list is gone — it duplicated the rows (#379).
+let colorOptions: [ColorOption] = [
     ColorOption(label: "by element",  command: "util.cnc",   swatch: nil),
     ColorOption(label: "by chain",    command: "util.cbc",   swatch: nil),
     ColorOption(label: "by ss",       command: "util.cbss",  swatch: nil),
     ColorOption(label: "spectrum",    command: "spectrum",    swatch: nil),
     ColorOption(label: "by b-factor", command: "spectrum_b",  swatch: nil),
-    ColorOption(label: "---",         command: nil,           swatch: nil),
-    ColorOption(label: "red",         command: "red",         swatch: Color(.sRGB, red: 1.0, green: 0.0, blue: 0.0)),
-    ColorOption(label: "green",       command: "green",       swatch: Color(.sRGB, red: 0.0, green: 1.0, blue: 0.0)),
-    ColorOption(label: "blue",        command: "blue",        swatch: Color(.sRGB, red: 0.0, green: 0.3, blue: 1.0)),
-    ColorOption(label: "yellow",      command: "yellow",      swatch: Color(.sRGB, red: 1.0, green: 1.0, blue: 0.0)),
-    ColorOption(label: "magenta",     command: "magenta",     swatch: Color(.sRGB, red: 1.0, green: 0.0, blue: 1.0)),
-    ColorOption(label: "cyan",        command: "cyan",        swatch: Color(.sRGB, red: 0.0, green: 1.0, blue: 1.0)),
-    ColorOption(label: "orange",      command: "orange",      swatch: Color(.sRGB, red: 1.0, green: 0.5, blue: 0.0)),
-    ColorOption(label: "lightteal",   command: "lightteal",   swatch: Color(.sRGB, red: 0.7, green: 0.9, blue: 0.9)),
-    ColorOption(label: "gray",        command: "gray",        swatch: Color(.sRGB, red: 0.5, green: 0.5, blue: 0.5)),
-    ColorOption(label: "white",       command: "white",       swatch: Color.white),
 ]
 
 // MARK: - Action Menu Structure
@@ -1974,14 +2144,31 @@ private struct ColorMenuButton: View {
                     Button {
                         applyColor(command: command)
                     } label: {
-                        HStack(spacing: 6) {
-                            if let swatch = opt.swatch {
-                                Circle()
-                                    .fill(swatch)
-                                    .frame(width: 10, height: 10)
-                            }
-                            Text(opt.label)
-                        }
+                        swatchLabel(opt.label, swatch: opt.swatch)
+                    }
+                }
+            }
+            Divider()
+            // Desktop PyMOL's tiered colors (#379): each row is a base color —
+            // click it to apply — and the same row expands into that hue's
+            // named variants from the core table. On macOS the row's click
+            // fires primaryAction and the arrow opens the variants; UIKit
+            // menus can't do both, so on iOS tapping the row drills into the
+            // variants, where the base color is the first entry.
+            ForEach(PyMOLColorMenu.rows, id: \.family.label) { row in
+                if let primary = row.primary {
+                    Menu {
+                        familyShades(row.family)
+                    } label: {
+                        swatchLabel(row.title, swatch: row.swatch)
+                    } primaryAction: {
+                        applyColor(command: primary.name)
+                    }
+                } else {
+                    Menu {
+                        familyShades(row.family)
+                    } label: {
+                        swatchLabel(row.title, swatch: row.swatch)
                     }
                 }
             }
@@ -1997,6 +2184,9 @@ private struct ColorMenuButton: View {
                 .contentShape(Rectangle())
         }
         .repMenuChrome()
+        // Stable AX hook so UI tests can open a specific row's color menu
+        // (the visible label "C" is shared by every row).
+        .accessibilityIdentifier("colorMenu.\(name)")
         .popover(isPresented: $showCustom, arrowEdge: .bottom) {
             VStack(spacing: 8) {
                 Text("Custom color").font(.system(size: 11, weight: .semibold))
@@ -2004,6 +2194,30 @@ private struct ColorMenuButton: View {
                                      apply: { customColor = $0; applyCustomColor($0) })
             }
             .padding(12)
+        }
+    }
+
+    @ViewBuilder
+    private func familyShades(_ family: PyMOLColorFamily) -> some View {
+        ForEach(family.shades, id: \.name) { shade in
+            Button {
+                applyColor(command: shade.name)
+            } label: {
+                swatchLabel(shade.name, swatch: shade.swatch)
+            }
+        }
+    }
+
+    /// Menu rows are native menu items on both platforms (NSMenuItem / UIMenu
+    /// element), which render only a label's text and image — a `Circle()`
+    /// swatch is silently dropped (the flat list's swatches were never visible
+    /// on macOS). So the swatch is rasterised into a small image.
+    @ViewBuilder
+    private func swatchLabel(_ text: String, swatch: Color?) -> some View {
+        if let swatch {
+            Label { Text(text) } icon: { ColorSwatchImage.image(for: swatch) }
+        } else {
+            Text(text)
         }
     }
 
@@ -2028,6 +2242,46 @@ private struct ColorMenuButton: View {
 }
 
 // MARK: - Inspector: color helpers
+
+/// Tiny filled-circle swatch images for menu items (see swatchLabel). Menu
+/// items only display images, not arbitrary views, and a template image would
+/// be recoloured to the menu's text colour, so these are explicitly
+/// non-template originals. Cached per colour: the C menu lists ~90 swatches
+/// and is rebuilt on every open.
+@MainActor
+enum ColorSwatchImage {
+    private static var cache: [Color: Image] = [:]
+    static let pointSize: CGFloat = 12
+
+    static func image(for color: Color) -> Image {
+        if let cached = cache[color] { return cached }
+        let made = render(color)
+        cache[color] = made
+        return made
+    }
+
+    private static func render(_ color: Color) -> Image {
+        let size = CGSize(width: pointSize, height: pointSize)
+        let oval = CGRect(origin: .zero, size: size).insetBy(dx: 1, dy: 1)
+#if canImport(AppKit)
+        let ns = NSImage(size: size, flipped: false) { _ in
+            NSColor(color).setFill()
+            NSBezierPath(ovalIn: oval).fill()
+            return true
+        }
+        ns.isTemplate = false
+        return Image(nsImage: ns)
+#elseif canImport(UIKit)
+        let ui = UIGraphicsImageRenderer(size: size).image { _ in
+            UIColor(color).setFill()
+            UIBezierPath(ovalIn: oval).fill()
+        }
+        return Image(uiImage: ui.withRenderingMode(.alwaysOriginal))
+#else
+        return Image(systemName: "circle.fill")
+#endif
+    }
+}
 
 private func colorFromHex(_ hex: String) -> Color? {
     var s = hex

--- a/swiftui/PyMOLViewerTests/ColorMenuTests.swift
+++ b/swiftui/PyMOLViewerTests/ColorMenuTests.swift
@@ -1,0 +1,129 @@
+import XCTest
+import SwiftUI
+@testable import RayMol
+
+/// The tiered "C" color menu (#379) mirrors desktop PyMOL's `all_colors_list`
+/// (modules/pymol/menu.py); these pin the table's shape so a stray edit cannot
+/// silently drop a family, duplicate a shade, or ship an out-of-range swatch.
+final class ColorMenuTests: XCTestCase {
+
+    /// Upstream's family order, so the SwiftUI menu reads like the desktop one.
+    func testFamiliesMirrorUpstreamMenuOrder() {
+        XCTAssertEqual(PyMOLColorMenu.families.map(\.label),
+                       ["reds", "greens", "blues", "yellows", "magentas",
+                        "cyans", "oranges", "tints", "grays"])
+    }
+
+    /// Each family opens on its canonical base color, like upstream, whose
+    /// family label is tinted with the first entry of the list.
+    func testEachFamilyLeadsWithItsBaseColor() {
+        let leads = Dictionary(uniqueKeysWithValues:
+            PyMOLColorMenu.families.map { ($0.label, $0.shades.first?.name) })
+        XCTAssertEqual(leads["reds"], "red")
+        XCTAssertEqual(leads["greens"], "green")
+        XCTAssertEqual(leads["blues"], "blue")
+        XCTAssertEqual(leads["yellows"], "yellow")
+        XCTAssertEqual(leads["magentas"], "magenta")
+        XCTAssertEqual(leads["cyans"], "cyan")
+        XCTAssertEqual(leads["oranges"], "orange")
+        XCTAssertEqual(leads["grays"], "white")
+    }
+
+    func testShadesAreDistinctWithinAFamilyAndInRange() {
+        for family in PyMOLColorMenu.families {
+            XCTAssertFalse(family.shades.isEmpty, "\(family.label) has no shades")
+            let names = family.shades.map(\.name)
+            XCTAssertEqual(names.count, Set(names).count,
+                           "\(family.label) lists a shade twice: \(names)")
+            for shade in family.shades {
+                for (channel, v) in [("red", shade.red), ("green", shade.green), ("blue", shade.blue)] {
+                    XCTAssertTrue((0.0...1.0).contains(v),
+                                  "\(shade.name).\(channel) = \(v) is outside 0…1")
+                }
+                // Names are sent verbatim as `color <name>, <object>`: no
+                // spaces or punctuation the command parser would choke on.
+                XCTAssertNil(shade.name.rangeOfCharacter(from: CharacterSet.alphanumerics.union(["_"]).inverted),
+                             "\(shade.name) is not a bare PyMOL color name")
+            }
+        }
+    }
+
+    /// Upstream lists some shades under two families (limon is a green and a
+    /// yellow; wheat is a yellow and a tint). The table must agree with
+    /// itself about their RGB, otherwise the swatch depends on the path taken.
+    func testShadesSharedAcrossFamiliesHaveOneColor() {
+        var seen: [String: PyMOLNamedColor] = [:]
+        for shade in PyMOLColorMenu.families.flatMap(\.shades) {
+            if let prior = seen[shade.name] {
+                XCTAssertEqual(prior, shade, "\(shade.name) has two different RGB values")
+            } else {
+                seen[shade.name] = shade
+            }
+        }
+        XCTAssertNotNil(seen["limon"])
+        XCTAssertEqual(PyMOLColorMenu.allColorNames.count, seen.count)
+    }
+
+    /// The gray ramp in the core is `grayNN = NN / 99`, not NN / 100.
+    func testGrayRampMatchesTheCoreFormula() {
+        for nn in stride(from: 10, through: 90, by: 10) {
+            let shade = PyMOLColorMenu.color(named: "gray\(nn)")
+            XCTAssertNotNil(shade, "gray\(nn) missing from the grays family")
+            XCTAssertEqual(shade?.red ?? -1, Double(nn) / 99.0, accuracy: 0.0006)
+            XCTAssertEqual(shade?.red, shade?.green)
+            XCTAssertEqual(shade?.red, shade?.blue)
+        }
+    }
+
+    /// A few core values spot-checked against layer1/Color.cpp.
+    func testSwatchesMatchTheCoreColorTable() {
+        XCTAssertEqual(PyMOLColorMenu.color(named: "firebrick"),
+                       PyMOLNamedColor(name: "firebrick", red: 0.698, green: 0.13, blue: 0.13))
+        XCTAssertEqual(PyMOLColorMenu.color(named: "density"),
+                       PyMOLNamedColor(name: "density", red: 0.1, green: 0.1, blue: 0.6))
+        XCTAssertEqual(PyMOLColorMenu.color(named: "lightteal"),
+                       PyMOLNamedColor(name: "lightteal", red: 0.4, green: 0.7, blue: 0.7))
+        XCTAssertNil(PyMOLColorMenu.color(named: "not_a_color"))
+    }
+
+    /// The menu's color section is one row per family; a row reads as (and
+    /// applies) its base color, and tints — which have no base — only expand.
+    func testRowsAreTheFamiliesWithTheirBaseColors() {
+        let rows = PyMOLColorMenu.rows
+        XCTAssertEqual(rows.map(\.family.label), PyMOLColorMenu.families.map(\.label))
+        XCTAssertEqual(rows.map(\.title),
+                       ["red", "green", "blue", "yellow", "magenta", "cyan", "orange", "tints", "gray"])
+        for row in rows {
+            guard let primary = row.primary else {
+                XCTAssertEqual(row.family.label, "tints", "only tints should be a bare submenu")
+                continue
+            }
+            XCTAssertEqual(row.title, primary.name)
+            // A clickable row must be a real core color name (see the gray note
+            // below) — it is sent verbatim as `color <name>`.
+            if primary.name != "gray" {
+                XCTAssertEqual(PyMOLColorMenu.color(named: primary.name), primary,
+                               "\(primary.name) is not in the tiered table")
+                XCTAssertEqual(row.family.shades.first, primary,
+                               "\(row.family.label) should lead with its base color")
+            }
+        }
+    }
+
+    /// `gray` (0.5) heads the grays row even though upstream's list only has
+    /// the gray10…gray90 ramp; it is the classic name people type.
+    func testGrayRowUsesClassicGray() {
+        XCTAssertEqual(PyMOLColorMenu.gray, PyMOLNamedColor(name: "gray", red: 0.5, green: 0.5, blue: 0.5))
+        XCTAssertEqual(PyMOLColorMenu.rows.last?.primary, PyMOLColorMenu.gray)
+    }
+
+    /// The modes above the color rows are actions, never bare color names.
+    func testTopLevelOptionsAreColoringModes() {
+        XCTAssertEqual(colorOptions.map(\.label),
+                       ["by element", "by chain", "by ss", "spectrum", "by b-factor"])
+        for opt in colorOptions {
+            XCTAssertNil(opt.swatch, "\(opt.label) is a mode, not a color")
+            XCTAssertNotNil(opt.command)
+        }
+    }
+}

--- a/swiftui/PyMOLViewerUITests/ColorMenuUITests.swift
+++ b/swiftui/PyMOLViewerUITests/ColorMenuUITests.swift
@@ -1,0 +1,168 @@
+// ColorMenuUITests.swift — the tiered per-object color menu (#379) on iOS.
+//
+// Desktop PyMOL's "C" menu lists colors as rows that both apply (click "red")
+// and expand into that hue's named variants (firebrick, salmon, …). This
+// drives the real SwiftUI Menu through UIKit and confirms the viewport
+// actually recoloured (pixel-diff, as in PyMOLGestureUITests).
+//
+// Run: xcodebuild test -scheme PyMOLViewer_iOS -sdk iphonesimulator \
+//        -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+//        -only-testing:PyMOLViewerUITests/ColorMenuUITests
+
+import XCTest
+
+final class ColorMenuUITests: XCTestCase {
+
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchEnvironment["PYMOL_AUTOLOAD"] = "1ubq.cif"
+        app.launchEnvironment["PYMOL_AUTOCMD"] = "hide everything; show cartoon; orient"
+        app.launchEnvironment["PYMOL_AUTOPANEL"] = "open"       // expand bottom panel
+        app.launchEnvironment["PYMOL_AUTOTAB"] = "objects"      // …on the Objects tab
+        app.launchEnvironment["PYMOL_SKIP_GESTURE_HELP"] = "1"
+        app.launchEnvironment["PYMOL_SKIP_FIRSTBOOT_THEME"] = "1"
+        app.launchEnvironment["PYMOL_SKIP_WHATS_NEW"] = "1"
+        app.launchArguments += ["-ipadGestureCoachSeen", "YES"]
+    }
+
+    /// PYMOL_AUTOLOAD names the object "mol".
+    private var cButton: XCUIElement { app.descendants(matching: .any)["colorMenu.mol"] }
+
+    private func openMenu() {
+        guard cButton.waitForExistence(timeout: 20) else {
+            print("=== AX DUMP ===\n\(app.debugDescription)\n=== END DUMP ===")
+            return XCTFail("the mol row's C menu button never appeared")
+        }
+        cButton.tap()
+        XCTAssertTrue(item("by element").waitForExistence(timeout: 5), "menu did not open")
+    }
+
+    /// Wait for the menu (and any submenu) to be fully gone so a viewport
+    /// pixel-diff measures the molecule, not the menu overlay.
+    private func waitForMenuToClose() {
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline, item("by element").exists || item("firebrick").exists {
+            Thread.sleep(forTimeInterval: 0.25)
+        }
+        XCTAssertFalse(item("by element").exists || item("firebrick").exists,
+                       "the color menu did not close after picking a color")
+        settle(1.5)
+    }
+
+    /// The chevron end of a row: on iOS a row that both acts and expands is a
+    /// UIKit menu with a submenu, and which half of the row does what has
+    /// changed between OS versions, so the tests target it explicitly.
+    private func chevron(of row: XCUIElement) -> XCUICoordinate {
+        row.coordinate(withNormalizedOffset: CGVector(dx: 0.92, dy: 0.5))
+    }
+
+    /// Tapping the "red" row applies red — either directly (primaryAction) or
+    /// by drilling into the variants, where red is the first entry. Both paths
+    /// must end with the menu closed and the molecule recoloured.
+    func testRedRowAppliesRed() {
+        app.launch()
+        XCTAssertTrue(waitForRender(timeout: 30),
+                      "molecule never rendered (embedded Python boot + load)")
+        let before = viewportSignature()   // green cartoon, menu closed
+        openMenu()
+        for row in ["red", "green", "blue", "yellow", "magenta", "cyan", "orange"] {
+            XCTAssertTrue(item(row).exists, "'\(row)' row missing")
+        }
+        attach("color-menu-top")
+        settle(0.5)
+
+        item("red").tap()
+        if item("firebrick").waitForExistence(timeout: 3) {
+            // Drilled into the variants: the base color leads the list. "red"
+            // now appears twice (submenu header + shade); the shade is last.
+            attach("color-menu-red-variants")
+            let reds = app.descendants(matching: .any).matching(NSPredicate(format: "label == 'red'"))
+            reds.element(boundBy: reds.count - 1).tap()
+        }
+        waitForMenuToClose()
+        attach("after-red")
+        XCTAssertTrue(changed(before, viewportSignature()),
+                      "the 'red' row did not recolour the viewport")
+        XCTAssertEqual(app.state, .runningForeground, "app crashed after applying a color")
+    }
+
+    /// The row's chevron opens that hue's named variants, and picking one
+    /// recolours the object.
+    func testVariantAppliesToTheObject() {
+        app.launch()
+        XCTAssertTrue(waitForRender(timeout: 30),
+                      "molecule never rendered (embedded Python boot + load)")
+        let before = viewportSignature()
+        openMenu()
+        settle(0.5)
+        chevron(of: item("red")).tap()
+        if !item("firebrick").waitForExistence(timeout: 3) {
+            item("red").tap()   // older layouts expand from anywhere on the row
+        }
+        XCTAssertTrue(item("firebrick").waitForExistence(timeout: 5), "'firebrick' variant never appeared")
+        XCTAssertTrue(item("salmon").exists, "'salmon' variant missing")
+        attach("color-menu-red-variants")
+
+        item("firebrick").tap()
+        waitForMenuToClose()
+        attach("after-firebrick")
+        XCTAssertTrue(changed(before, viewportSignature()),
+                      "choosing 'firebrick' did not recolour the viewport")
+        XCTAssertEqual(app.state, .runningForeground, "app crashed after applying a shade")
+    }
+
+    // MARK: - helpers
+
+    /// A menu row by its visible title; UIKit exposes UIMenu rows with varying
+    /// element types across OS versions, so match on label rather than type.
+    private func item(_ title: String) -> XCUIElement {
+        app.descendants(matching: .any)
+            .matching(NSPredicate(format: "label == %@", title))
+            .firstMatch
+    }
+
+    private func settle(_ s: TimeInterval = 1.0) { Thread.sleep(forTimeInterval: s) }
+
+    private func attach(_ name: String) {
+        let att = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
+        att.name = name
+        att.lifetime = .keepAlways
+        add(att)
+    }
+
+    /// 48×48 grey thumbnail of the viewport band (rows 12 %…67 % of the screen).
+    private func viewportSignature() -> [UInt8] {
+        guard let cg = XCUIScreen.main.screenshot().image.cgImage else { return [] }
+        let w = cg.width, h = cg.height
+        let crop = CGRect(x: 0, y: Int(Double(h) * 0.12),
+                          width: w, height: Int(Double(h) * 0.55))
+        guard let region = cg.cropping(to: crop) else { return [] }
+        let sw = 48, sh = 48
+        var buf = [UInt8](repeating: 0, count: sw * sh)
+        guard let ctx = CGContext(data: &buf, width: sw, height: sh,
+                                  bitsPerComponent: 8, bytesPerRow: sw,
+                                  space: CGColorSpaceCreateDeviceGray(),
+                                  bitmapInfo: CGImageAlphaInfo.none.rawValue) else { return [] }
+        ctx.draw(region, in: CGRect(x: 0, y: 0, width: sw, height: sh))
+        return buf
+    }
+
+    private func changed(_ a: [UInt8], _ b: [UInt8], threshold: Double = 0.06) -> Bool {
+        guard !a.isEmpty, a.count == b.count else { return false }
+        var diff = 0
+        for i in 0..<a.count where abs(Int(a[i]) - Int(b[i])) > 12 { diff += 1 }
+        return Double(diff) / Double(a.count) > threshold
+    }
+
+    private func waitForRender(timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if viewportSignature().contains(where: { $0 > 40 }) { return true }
+            Thread.sleep(forTimeInterval: 0.5)
+        }
+        return false
+    }
+}


### PR DESCRIPTION
Closes #379.

## What
The per-object **C** menu now matches desktop PyMOL's object-panel popup: after the coloring modes (by element / chain / ss / spectrum / b-factor) it lists one row per hue — **red, green, blue, yellow, magenta, cyan, orange, tints, gray** — each with a swatch and a chevron.

- **macOS:** clicking the row paints the base color (`color red, <obj>`); the chevron/hover opens that hue's named variants (red, tv_red, raspberry, darksalmon, salmon, deepsalmon, warmpink, firebrick, ruby, chocolate, brown, …).
- **iOS:** UIKit menus can't both act and expand, so tapping the row drills into the variants, where the base color is the first entry.
- The table (`PyMOLColorMenu`) mirrors `menu.py`'s `all_colors_list` (9 families, 71 names) with RGB from `layer1/Color.cpp`; all 80 swatches were checked against the running core's `get_color_tuple`.
- Swatches are rasterised images: native menu items only show text + image, so the previous `Circle()` swatches never rendered on macOS.
- The old flat red…white list is gone (it duplicated the rows and overflowed a 768 pt display).

## Tests
- `ColorMenuTests` (macOS unit): family order matches upstream, rows lead with their base color, gray ramp is `NN/99`, shades shared across families agree, names are bare identifiers. Full `UnitTests_macOS` suite: 666 tests, 0 failures.
- `ColorMenuUITests` (iOS XCUITest, iPhone 17 Pro sim): row → `color red, mol`; chevron → firebrick → `color firebrick, mol`; both assert the viewport recolours after the menu has closed.
- Manual in the macOS VM (`RayMol-379.app` over MCP): `color red, 1ubq` and `color firebrick, 1ubq` issued from the menu; all atoms carry the expected color index.

Note for running the iOS UI tests: `-scheme PyMOLViewer_iOS` fails planning because the macOS-only `PyMOLViewerTests` is a testable in it; a local copy of the scheme without that testable (in `xcuserdata/`) works with `-only-testing:PyMOLViewerUITests/ColorMenuUITests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
