### PR TITLE
fix(seq): sequence viewer only rows objects that are actually displayed (#380)

### DIFF
--- a/modules/pymol/appkit_sequence.py
+++ b/modules/pymol/appkit_sequence.py
@@ -1,8 +1,9 @@
 """Sequence-viewer data query for the native SwiftUI app.
 
-Emits one residue row per enabled molecular object (one guide atom per residue,
-carrying its color index) for the SwiftUI SequencePanel. Mirrors the
-appkit_inspector / appkit_object_panel bundled-module pattern.
+Emits one residue row per *visible* molecular object (one guide atom per
+residue, carrying its color index) for the SwiftUI SequencePanel. Visible means
+enabled and not inside a disabled group — see `_visible_objects` (issue #380).
+Mirrors the appkit_inspector / appkit_object_panel bundled-module pattern.
 
 Alignment behavior (BIMO-style): an alignment object never appears as its own
 row (it has no guide atoms, so it is naturally skipped). When an alignment
@@ -192,6 +193,58 @@ def _apply_alignments(out, posmap):
             done.add(m)
 
 
+def _visible_objects():
+    """Public objects that are actually DRAWN — the sequence panel's row set (#380).
+
+    Two conditions, not one. `enabled_only=1` covers the object's own flag, but
+    disabling a GROUP hides its members while leaving each member's own flag set
+    (`ExecutiveGetNames` tests `rec->visible`, which the group cascade does not
+    clear — verified 2026-09-04), so a member of a switched-off group would still
+    get a row for something nowhere on screen. Walking the group chain and
+    requiring every ancestor closes that.
+
+    Reuses `appkit_inspector.group_parents`, which caches the (expensive)
+    `get_session` parent walk behind a cheap tree-shape fingerprint — the
+    inspector polls at the same cadence, so the map is normally already built.
+    """
+    try:
+        enabled = set(cmd.get_names('public_objects', enabled_only=1) or [])
+    except Exception:
+        return []
+    try:
+        names = list(cmd.get_names('public_objects') or [])
+    except Exception:
+        return sorted(enabled)
+    try:
+        groups = list(cmd.get_names('public_group_objects') or [])
+    except Exception:
+        groups = []
+    parents = {}
+    if groups:
+        try:
+            from pymol import appkit_inspector
+            parents = appkit_inspector.group_parents(names, groups) or {}
+        except Exception:
+            parents = {}
+    gset = set(groups)
+    out = []
+    for o in names:
+        # A group is a container, never a row (it has no atoms of its own), but it
+        # still gates its members below — so it is excluded here, not earlier.
+        if o not in enabled or o in gset:
+            continue
+        p = parents.get(o)
+        seen = set()            # a corrupt parent map must terminate, not spin
+        while p is not None and p not in seen:
+            if p not in enabled:
+                break
+            seen.add(p)
+            p = parents.get(p)
+        else:
+            out.append(o)
+    return out
+
+
 def _build(names, preview):
     out, cols, posmap = _object_rows(names)
     if not preview:
@@ -208,7 +261,12 @@ def poll(preview=False):
     """Write the sequence-panel JSON to a temp file; caller prints the marker.
 
     `preview` True reads only the reserved '__theme_preview' object (theme studio
-    live preview); otherwise all public objects.
+    live preview); otherwise every visible public object.
+
+    Only objects that are actually drawn get a row (issue #380) — a disabled
+    object, or one inside a disabled group, contributes nothing to the viewport,
+    so a sequence row for it is dead weight whose residue cells select atoms you
+    cannot see. See `_visible_objects`.
     """
     import json
     import os
@@ -216,10 +274,7 @@ def poll(preview=False):
     if preview:
         names = ['__theme_preview']
     else:
-        try:
-            names = list(cmd.get_names('public_objects') or [])
-        except Exception:
-            names = []
+        names = _visible_objects()
     data = _build(names, preview)
     p = os.path.join(tempfile.gettempdir(), 'pymol_seq.json')
     with open(p, 'w') as f:

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -4581,6 +4581,10 @@ extension PyMOLEngine {
         #endif
 
         let enabledSet = Set(payload.enabled)
+        // Enabled *objects* only — a selection's pink markers don't put a row in
+        // the sequence strip, so folding them in here would trigger pointless
+        // re-fetches every time a selection is (de)selected. See #380.
+        let enabledObjects = Set(payload.objects.filter { enabledSet.contains($0) })
         let groupSet = Set(payload.groups ?? [])
         let parentMap = payload.parent ?? [:]
         var entries: [ObjectEntry] = []
@@ -4645,6 +4649,16 @@ extension PyMOLEngine {
             // Same guard, and it carries the weight here: with no search running this
             // is empty every tick and must not repaint the panel twice a second.
             if self.msaSearches != searches { self.msaSearches = searches }
+            // The sequence strip rows only enabled objects (#380). This is the
+            // core's own view of what is enabled, so it catches every path that
+            // can change it and cannot race the optimistic checkbox flip. Track
+            // the set even while the panel is hidden — `sequenceVisible`'s
+            // false->true edge does its own fetch, and a stale tracker would
+            // otherwise suppress the next real change.
+            if self.lastSequenceEnabled != enabledObjects {
+                self.lastSequenceEnabled = enabledObjects
+                if self.sequenceVisible { self.fetchSequences() }
+            }
         }
     }
 }

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -158,6 +158,15 @@ final class PyMOLEngine: ObservableObject {
             if sequenceVisible && !oldValue { fetchSequences() }
         }
     }
+    // Names the sequence strip was last built from (issue #380): the panel only
+    // rows ENABLED objects, so any path that changes what is enabled — the object
+    // panel checkbox, "all", a group cascade, `disable` at the prompt, a scene or
+    // session recall — has to republish it. Rather than hooking each of those,
+    // parseObjectPanelFeedback compares the core's authoritative enabled set
+    // against this and re-fetches on a mismatch, which is also immune to the
+    // optimistic-UI flip racing the enable/disable command.
+    var lastSequenceEnabled: Set<String> = []
+
     // True while the Theme studio preview is active: the viewport shows the
     // reserved __theme_preview example, so the sequence panel must read THAT
     // object (it's underscore-prefixed → excluded from public_objects) to stay
@@ -913,6 +922,13 @@ final class PyMOLEngine: ObservableObject {
             DispatchQueue.main.async { self.applyEnabledOptimistically(name, enabled) }
         }
         runCommand(enabled ? "enable \(name)" : "disable \(name)")
+        // The sequence panel only lists ENABLED objects (issue #380), so a toggle
+        // changes its rows. SequencePanel does re-fetch on `objects` change, but
+        // that fires from SwiftUI's next update pass — after the optimistic flip
+        // above and with no guarantee it lands after the enable/disable reaches
+        // the core. Republish here, right after the command, so the strip is
+        // built from the new visibility instead of racing it.
+        if sequenceVisible { fetchSequences() }
     }
 
     /// Flip `name` and, when it is a group, its whole subtree.

--- a/testing/tests/test_appkit_sequence.py
+++ b/testing/tests/test_appkit_sequence.py
@@ -34,10 +34,14 @@ class FakeCmd:
       - `mm[index] = (chain, resi)`                   over `obj`
     """
 
-    def __init__(self, objects, enabled=None, raw=None):
+    def __init__(self, objects, enabled=None, raw=None, parents=None):
         # objects: {name: {"type": str, "atoms": [ {chain,resi,resn,color,index}, ... ]}}
         self._objects = objects
-        self._enabled = set(enabled or objects.keys())
+        # {child: parent_group} — what appkit_inspector.group_parents would report.
+        self.parents = dict(parents or {})
+        # `enabled=None` means "everything"; an explicit empty set means nothing
+        # is enabled and must NOT fall back to all (that masked the #380 case).
+        self._enabled = set(objects.keys()) if enabled is None else set(enabled)
         self._raw = raw or {}
 
     def get_type(self, name):
@@ -45,6 +49,9 @@ class FakeCmd:
 
     def get_names(self, kind="objects", enabled_only=0):
         names = list(self._objects.keys())
+        if kind == "public_group_objects":
+            names = [n for n in names
+                     if self._objects[n]["type"] == "object:group"]
         if enabled_only:
             names = [n for n in names if n in self._enabled]
         return names
@@ -69,6 +76,23 @@ class FakeCmd:
             ns = dict(space)
             ns.update(atom)
             exec(expression, {}, ns)
+
+
+class _FakeInspector:
+    """Stands in for pymol.appkit_inspector's cached group_parents().
+
+    _visible_objects() imports it lazily to walk the group chain; the real one
+    reads `get_session`, which this fake cmd deliberately does not model, so the
+    map is served straight from FakeCmd instead.
+    """
+
+    @staticmethod
+    def group_parents(objs, groups):
+        return dict(getattr(seq.cmd, "parents", {}))
+
+
+sys.modules["pymol.appkit_inspector"] = _FakeInspector
+setattr(sys.modules["pymol"], "appkit_inspector", _FakeInspector)
 
 
 def _mol(name_atoms):
@@ -177,6 +201,122 @@ class ApplyAlignmentsTest(unittest.TestCase):
         seq.cmd = cmd
         data = seq._build(["molA"], preview=False)
         self.assertEqual(data["colors"]["5"], (0.5, 0.2, 0.3))
+
+
+class PollTest(unittest.TestCase):
+    """poll() must publish rows for ENABLED objects only (issue #380)."""
+
+    def _payload(self, cmd, preview=False):
+        import json
+        import tempfile
+        seq.cmd = cmd
+        seq.poll(preview=preview)
+        p = os.path.join(tempfile.gettempdir(), "pymol_seq.json")
+        with open(p) as f:
+            return json.load(f)
+
+    def _two_mols(self, enabled):
+        return FakeCmd({
+            "molA": _mol([_atom("A", "1", "ALA", 5, 101)]),
+            "molB": _mol([_atom("B", "1", "GLY", 6, 201)]),
+        }, enabled=enabled)
+
+    def test_disabled_object_gets_no_row(self):
+        data = self._payload(self._two_mols({"molA"}))
+        self.assertEqual([d["name"] for d in data["objects"]], ["molA"])
+
+    def test_all_enabled_gets_all_rows(self):
+        data = self._payload(self._two_mols({"molA", "molB"}))
+        self.assertEqual([d["name"] for d in data["objects"]], ["molA", "molB"])
+
+    def test_all_disabled_gets_no_rows(self):
+        data = self._payload(self._two_mols(set()))
+        self.assertEqual(data["objects"], [])
+
+    def test_requests_enabled_only_from_the_core(self):
+        # Guard the actual mechanism: get_names must be asked with enabled_only,
+        # not filtered afterwards (a plain 'public_objects' call regressed #380).
+        cmd = self._two_mols({"molA"})
+        calls = []
+        inner = cmd.get_names
+
+        def spy(kind="objects", enabled_only=0):
+            calls.append((kind, enabled_only))
+            return inner(kind, enabled_only)
+
+        cmd.get_names = spy
+        self._payload(cmd)
+        self.assertIn(("public_objects", 1), calls)
+
+    def test_preview_ignores_enabled_state(self):
+        # The theme-studio example is enabled-agnostic: it is the only thing on
+        # screen during a preview, and it is not a public object at all.
+        cmd = FakeCmd({
+            "__theme_preview": _mol([_atom("A", "1", "ALA", 5, 101)]),
+        }, enabled=set())
+        data = self._payload(cmd, preview=True)
+        self.assertEqual([d["name"] for d in data["objects"]], ["example"])
+
+
+class VisibleObjectsTest(unittest.TestCase):
+    """Group ancestry, which `enabled_only` alone does not cover (issue #380).
+
+    Disabling a group hides its members in the viewport but leaves each member's
+    own enabled flag set, so the row set has to require the whole chain.
+    """
+
+    def _grouped(self, enabled):
+        # g_outer > g_inner > molA ; molB at top level.
+        objects = {
+            "molA": _mol([_atom("A", "1", "ALA", 5, 101)]),
+            "molB": _mol([_atom("B", "1", "GLY", 6, 201)]),
+            "g_inner": {"type": "object:group", "atoms": []},
+            "g_outer": {"type": "object:group", "atoms": []},
+        }
+        parents = {"molA": "g_inner", "g_inner": "g_outer"}
+        return FakeCmd(objects, enabled=enabled, parents=parents)
+
+    def test_all_groups_enabled_keeps_the_member(self):
+        cmd = self._grouped({"molA", "molB", "g_inner", "g_outer"})
+        seq.cmd = cmd
+        self.assertEqual(seq._visible_objects(), ["molA", "molB"])
+
+    def test_disabled_parent_group_drops_the_member(self):
+        cmd = self._grouped({"molA", "molB", "g_outer"})   # g_inner off
+        seq.cmd = cmd
+        self.assertEqual(seq._visible_objects(), ["molB"])
+
+    def test_disabled_grandparent_group_drops_the_member(self):
+        cmd = self._grouped({"molA", "molB", "g_inner"})   # g_outer off
+        seq.cmd = cmd
+        self.assertEqual(seq._visible_objects(), ["molB"])
+
+    def test_groups_do_not_hide_top_level_objects(self):
+        cmd = self._grouped({"molB"})                      # everything else off
+        seq.cmd = cmd
+        self.assertEqual(seq._visible_objects(), ["molB"])
+
+    def test_cyclic_parent_map_terminates(self):
+        # A corrupt/stale parent map must not spin. Both are enabled, so the only
+        # thing under test is that the walk ends.
+        objects = {
+            "molA": _mol([_atom("A", "1", "ALA", 5, 101)]),
+            "gx": {"type": "object:group", "atoms": []},
+        }
+        seq.cmd = FakeCmd(objects, enabled={"molA", "gx"},
+                          parents={"molA": "gx", "gx": "molA"})
+        self.assertEqual(seq._visible_objects(), ["molA"])   # 'gx' is a group
+
+    def test_group_member_gets_no_sequence_row(self):
+        # End to end through poll(), the way the panel sees it.
+        cmd = self._grouped({"molA", "molB", "g_outer"})   # g_inner off
+        seq.cmd = cmd
+        seq.poll()
+        import json
+        import tempfile
+        with open(os.path.join(tempfile.gettempdir(), "pymol_seq.json")) as f:
+            data = json.load(f)
+        self.assertEqual([d["name"] for d in data["objects"]], ["molB"])
 
 
 class GapConstantTest(unittest.TestCase):

--- a/testing/tests/test_appkit_sequence.py
+++ b/testing/tests/test_appkit_sequence.py
@@ -91,8 +91,37 @@ class _FakeInspector:
         return dict(getattr(seq.cmd, "parents", {}))
 
 
-sys.modules["pymol.appkit_inspector"] = _FakeInspector
-setattr(sys.modules["pymol"], "appkit_inspector", _FakeInspector)
+_MISSING = object()
+_saved_inspector = (_MISSING, _MISSING)
+
+
+def setUpModule():
+    # Scoped, not global: `from pymol import appkit_inspector` resolves the
+    # attribute on the package first, so leaving either binding in place hands
+    # the fake to every later test module in the same pytest process (that took
+    # out test_appkit_objpanel_poll / _widen_clip / _inspector_transparency).
+    global _saved_inspector
+    _saved_inspector = (
+        sys.modules.get("pymol.appkit_inspector", _MISSING),
+        getattr(sys.modules["pymol"], "appkit_inspector", _MISSING),
+    )
+    sys.modules["pymol.appkit_inspector"] = _FakeInspector
+    setattr(sys.modules["pymol"], "appkit_inspector", _FakeInspector)
+
+
+def tearDownModule():
+    mod, attr = _saved_inspector
+    if mod is _MISSING:
+        sys.modules.pop("pymol.appkit_inspector", None)
+    else:
+        sys.modules["pymol.appkit_inspector"] = mod
+    if attr is _MISSING:
+        try:
+            delattr(sys.modules["pymol"], "appkit_inspector")
+        except AttributeError:
+            pass
+    else:
+        setattr(sys.modules["pymol"], "appkit_inspector", attr)
 
 
 def _mol(name_atoms):


### PR DESCRIPTION
Fixes #380.

## What was wrong

The sequence viewer showed a row for **every** loaded molecular object regardless of visibility. Uncheck an object and it left the viewport but its sequence strip stayed, so the residue cells you can click no longer matched what was on screen.

`appkit_sequence.poll()` collected names with a plain `cmd.get_names('public_objects')`. The module docstring already promised *"one residue row per **enabled** molecular object"* — the implementation had drifted from its own contract — and nothing downstream compensated (`fetchSequences()` just calls `poll()`; `parseSequencePanelFeedback` renders whatever rows arrive).

## Two conditions, not one

`enabled_only=1` was the obvious fix and it is not sufficient. Disabling a **group** hides its members but leaves each member's own `rec->visible` flag set — `ExecutiveGetNames` tests that flag, and the group cascade never clears it. Verified against a running build: with `group g1, 5hbh; disable g1`, `get_names('public_objects', enabled_only=1)` still returned `5hbh` while the viewport drew nothing for it.

So `_visible_objects()` requires the object's own flag **and** every ancestor group's, walking up via `appkit_inspector.group_parents` (already cached behind a cheap tree-shape fingerprint, and the inspector polls at the same cadence, so the map is normally warm). Group containers are dropped — they have no atoms of their own. A cyclic/stale parent map terminates rather than spins.

## Keeping it refreshed

`parseObjectPanelFeedback` compares the core's authoritative enabled-object set against a new `lastSequenceEnabled` and republishes on a mismatch. One hook covers every path that can change visibility — the checkbox, the "all" row, a group cascade, `disable` at the prompt, a scene or session recall — and being driven by core state it cannot be fooled by the optimistic checkbox flip racing the enable/disable command. `setObjectEnabled` also refetches inline so the common path doesn't wait a poll interval.

## Verification

Dev build (`RayMol-380.app`), driven over MCP, screenshotting the window at each step:

| step | viewport | sequence panel |
|---|---|---|
| `fetch 1ubq` + `fetch 5hbh` | both | `1ubq`, `5hbh` |
| `disable 5hbh` | 1ubq only | `1ubq` |
| `enable 5hbh` | both | `1ubq`, `5hbh` |
| `group g1, 5hbh` + `disable g1` | 1ubq only | `1ubq` |
| `enable g1` | both | `1ubq`, `5hbh` |

Tests (`python3 -m unittest testing.tests.test_appkit_sequence`, 19 tests, headless): the `poll()` row set, that `get_names` is asked with `enabled_only` rather than filtered afterwards, group and grandparent gating, groups not hiding top-level objects, a cyclic parent map, and the theme-preview path staying enabled-agnostic. Reverting just the `poll()` line fails 4 of them.

Also fixed `FakeCmd`'s `enabled` handling — an explicit empty set fell back to "everything enabled", which masked exactly this bug.

Theme-studio preview (`preview=True`, reserved `__theme_preview`) and the BIMO alignment gap layout are unchanged; the alignment merge only ever sees the visible members now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)