### PR TITLE
fix(ios): restore the autosave off SwiftUI's first commit (launch watchdog)

### DIFF
--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -873,10 +873,13 @@ final class PyMOLEngine: ObservableObject {
     }
 
     /// Reload the autosaved session on cold launch. One-shot per process, and
-    /// suppressed when the launch is opening a specific file. Routing through
-    /// runCommand("load …pse") reuses handleSessionViewport, which restores the
-    /// saved camera and letterbox aspect; refreshAfterRestore republishes the
-    /// panels. The .pse carries its own scene settings (bg_color, metal_*), so
+    /// suppressed when the launch is opening a specific file. The load runs
+    /// DEFERRED, behind the busy overlay — see the comment at the call below;
+    /// restoring inline blocks SwiftUI's first commit and gets the app killed by
+    /// the launch watchdog. Routing through `load …pse` reuses
+    /// handleSessionViewport, which restores the saved camera and letterbox
+    /// aspect; refreshAfterRestore republishes the panels. The .pse carries its
+    /// own scene settings (bg_color, metal_*), so
     /// we deliberately do NOT re-assert the active theme here — that would
     /// override the saved scene and the goal is to resume it exactly. Loading
     /// into the empty cold-launch scene reproduces the prior session exactly.
@@ -893,13 +896,36 @@ final class PyMOLEngine: ObservableObject {
            let snap = UIImage(data: data) {
             restoreSnapshot = snap
         }
-        runCommand("load \(url.path)")
-        refreshAfterRestore()
-        // Clear the snapshot once the restored scene has had time to build and
-        // render its first frame; cross-fade so the handoff is seamless.
-        if restoreSnapshot != nil {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.4) { [weak self] in
-                self?.restoreSnapshot = nil   // ContentView fades it via .animation(value:)
+        // DEFERRED, never inline. start() runs from ContentView's .onAppear,
+        // which SwiftUI executes inside the FIRST CATransaction commit — before
+        // any scene exists. A synchronous `load` there holds the main thread for
+        // the whole restore, so iOS's "scene create after launch" watchdog
+        // (19.81s) SIGKILLs the app with 0x8BADF00D before it ever draws a
+        // frame: the user sees a crash on launch, with no way back in, because
+        // the same autosave is retried on every subsequent launch. A 194MB /
+        // 620k-atom session needed ~15s on an M3 Pro and comfortably more than
+        // the budget on an iPhone 15 Pro (measured 2026-09-04).
+        //
+        // runHeavy hops one runloop turn, so the first commit finishes and the
+        // scene is created — the watchdog is satisfied before the load starts —
+        // and it paints the busy overlay for the duration. The restore is still
+        // main-thread: the core's GIL model (PAutoBlock) is not safe off-main.
+        // runCommandCore, not runCommand, because we already are inside
+        // runHeavy; it keeps handleSessionViewport (saved camera + letterbox).
+        let path = url.path
+        runHeavy("Restoring session…") { [weak self] in
+            guard let self else { return }
+            self.runCommandCore("load \(path)")
+            self.refreshAfterRestore()
+            // Clear the snapshot once the restored scene has had time to build
+            // and render its first frame; cross-fade so the handoff is seamless.
+            // Armed HERE rather than at call time: the load above can take tens
+            // of seconds, and a timer started before it would strip the snapshot
+            // mid-restore and expose the empty scene it exists to hide.
+            if self.restoreSnapshot != nil {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.4) { [weak self] in
+                    self?.restoreSnapshot = nil   // ContentView fades it via .animation(value:)
+                }
             }
         }
     }


### PR DESCRIPTION
## The bug

RayMol became **unlaunchable on iPhone**. TestFlight 1.10.1 (84) died on every cold launch with:

```
WatchdogEvent: scene-create
"exhausted real (wall clock) time allowance of 19.81 seconds"
EXC_CRASH (SIGKILL) 0x8BADF00D
```

This is **not a crash**. `PyMOLEngine.start()` runs from ContentView's `.onAppear`, which SwiftUI executes **inside the first `CATransaction` commit** — before any scene exists — and `restoreAutosaveIfAvailable()` called `runCommand("load <autosave.pse>")` **synchronously on the main thread** there. On a large session the commit never returns, no scene is ever created, and iOS's "scene create after launch" watchdog kills the process. The same autosave is retried next launch, so **the app is permanently unlaunchable with no way back in.**

The crash report pins it exactly:

```
_AppearanceActionModifier.MergedBox.update()      <- .onAppear
  <- Update.dispatchActions / _UIHostingView.layoutSubviews
  <- CA::Transaction::commit
  <- __34-[UIApplication _firstCommitBlock]_block_invoke_2
```

with the main thread down in the PyMOL core.

**Not a deadlock, not memory.** Two reports 90 minutes apart show *different* innermost frames (it is grinding, making progress), `watchdogd` logs `"Not impacted directly by deadlock"`, and no `JetsamEvent` names RayMol.

**A cliff, not a regression.** The call site is unchanged since #23. Measured on the session that triggered it: **194.5 MB, 44 objects, 620,906 atoms, 14.5 s to load headless on an M3 Pro** — past budget on an iPhone 15 Pro. It worked until the autosave grew enough to cross the line, so no recent commit is worth reverting.

## The fix

Route the restore through the existing `runHeavy`, which hops one runloop turn. The first commit completes and the scene is created — **satisfying the watchdog** — before the load begins, and the busy overlay is painted for its duration.

- The load stays **main-thread**: the core's GIL model (`PAutoBlock`) is not safe off-main.
- `runCommandCore` rather than `runCommand`, since we are already inside `runHeavy`; it still runs `handleSessionViewport`, so the saved camera and letterbox aspect restore as before.
- The 1.4 s `restoreSnapshot`-clear timer moves **inside** the closure. Armed at call time it would fire mid-restore and expose the empty scene it exists to hide.

## Verification

Built `PyMOLViewer_iOS` (Release) and launched on an iPhone 17 Pro simulator with the **real 194.5 MB session** staged in the app container:

| t | state |
|---|---|
| 2 s | full UI drawn — **scene exists** |
| 5 s | UI + "Restoring session…" overlay |
| 20-30 s | restore completes |
| 40 s | session fully restored: **44 objects, 4 selections**, sequence viewer live |

Before this change the main thread was still inside the first commit at 2 s with nothing on screen. Confirmed on the final uninstrumented binary (`strings | grep -c RESTOREDBG` = 0).

## Not covered by a test, deliberately

`restoreAutosaveIfAvailable` is `#if os(iOS)` and `PyMOLViewerTests` is `platform: macOS`, so the code **is not compiled into the test target**. Covering it needs a platform-neutral helper extracted first — worth doing, but a refactor beyond this fix.

## Known limitation

This makes the app **survive**, not fast: a 194 MB restore still blocks the UI for ~20-30 s behind the overlay. A size guard or incremental restore is the durable answer and should be filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)