### PR TITLE
fix(ios): Design action row scrolls instead of displacing the iPhone layout (#386)

### DIFF
--- a/swiftui/PyMOLViewer/Shared/DesignCompactPanel.swift
+++ b/swiftui/PyMOLViewer/Shared/DesignCompactPanel.swift
@@ -94,35 +94,44 @@ struct DesignCompactPanel: View {
     // Decomposed into leaf properties to keep each expression short for the Swift
     // type-checker, following the pattern in DesignSequenceStripView.seqCols.
     private var actionRow: some View {
-        HStack(spacing: 8) {
-            // The region field (#371); writes 'sele', so tapping residues still
-            // means exactly what it meant. Scope button = read the live selection.
-            SelectionInputField(
-                placeholder: "sele",
-                text: $controller.selectionText,
-                identifier: "design.selection",
-                scope: { controller.useCurrentSelection() },
-                width: 100,
-                apply: { controller.applySelection() })
-            if !controller.regionModeActive {
-                Text("or tap 2+")
-                    .font(.system(size: 11))
-                    .foregroundColor(theme.active.panelText.color.opacity(0.5))
-                    .lineLimit(1)
+        // Horizontally scrollable (#386). A plain HStack here reports a MINIMUM
+        // width — the region field is a fixed 100pt and Cmp/Keep/Discard are
+        // .fixedSize() — that exceeds an iPhone's ~390pt once an edit session is
+        // live. An over-wide row does not merely clip itself: a VStack adopts the
+        // width of its widest child, so the whole iPhone stack (title row, rail,
+        // viewport, inspector) was displaced sideways and lost its trailing edge
+        // off-screen. A ScrollView never reports an oversized ideal width, so the
+        // row scrolls and its siblings keep the screen's geometry.
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                // The region field (#371); writes 'sele', so tapping residues still
+                // means exactly what it meant. Scope button = read the live selection.
+                SelectionInputField(
+                    placeholder: "sele",
+                    text: $controller.selectionText,
+                    identifier: "design.selection",
+                    scope: { controller.useCurrentSelection() },
+                    width: 100,
+                    apply: { controller.applySelection() })
+                if !controller.regionModeActive {
+                    Text("or tap 2+")
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.active.panelText.color.opacity(0.5))
+                        .lineLimit(1)
+                }
+                if controller.seleResiduesOffFocus > 0 {
+                    Label("\(controller.seleResiduesOffFocus)", systemImage: "eye.slash")
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(theme.active.panelText.color.opacity(0.5))
+                        .accessibilityLabel(
+                            "\(controller.seleResiduesOffFocus) selected residues on other structures, ignored")
+                }
+                if controller.regionModeActive { redesignButton }
+                if controller.redesignSnapshot != nil { revertButton }
+                if controller.editing { editControls }
             }
-            if controller.seleResiduesOffFocus > 0 {
-                Label("\(controller.seleResiduesOffFocus)", systemImage: "eye.slash")
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundColor(theme.active.panelText.color.opacity(0.5))
-                    .accessibilityLabel(
-                        "\(controller.seleResiduesOffFocus) selected residues on other structures, ignored")
-            }
-            if controller.regionModeActive { redesignButton }
-            if controller.redesignSnapshot != nil { revertButton }
-            Spacer(minLength: 0)
-            if controller.editing { editControls }
+            .padding(.horizontal, 12).padding(.vertical, 6)
         }
-        .padding(.horizontal, 12).padding(.vertical, 6)
     }
 
     private var redesignButton: some View {
@@ -189,8 +198,8 @@ struct DesignCompactPanel: View {
         .fixedSize()
         .accessibilityLabel("Compare with original")
 
-        // Keep/Discard: .fixedSize() so nothing to their left can push them
-        // off-screen.
+        // Keep/Discard: .fixedSize() so the scroll content sizes them to their
+        // labels rather than squeezing the text.
         Button { Task { await controller.keepEditsAwait() } } label: {
             Text("Keep").font(.system(size: 12, weight: .semibold))
         }


### PR DESCRIPTION
Fixes #386.

## The bug

On iPhone portrait in Design mode, the **entire app** was shifted ~34pt to the right and clipped at the trailing edge — the Export button sliced in half, the Objects rows missing their `C` column, the 5th inspector tab cut, the panel subtitle truncated to "Ch…". The Design bar's own background still bled to x=0 while the title row and inspector started at x≈34pt, which is what made it read as two different leading edges.

## Root cause

One over-wide child, not a global container problem.

`DesignCompactPanel.actionRow` is a plain `HStack` whose parts cannot compress: the region field is a fixed 100pt and `Cmp` / `Keep` / `Discard` are all `.fixedSize()`. Once an edit session is live its **minimum** width runs past an iPhone's ~390pt — the panel's own doc comment already states the budget ("an iPhone has ~390").

A `VStack` adopts the width of its widest child. So that single row widened the whole iPhone stack, and the title row, rail, viewport and inspector were laid out in the widened space and pushed sideways off-screen. The row did not merely clip itself — it moved everything else. The ironic part is the `.fixedSize()` on Keep/Discard, whose comment says it is there "so nothing to their left can push them off-screen": it is exactly what made the row incompressible, and Discard was off-screen anyway.

## The fix

Wrap the row in a horizontal `ScrollView`. A ScrollView reports the proposed width as its ideal and never an oversized one, so the stack keeps the screen's geometry and the row scrolls to reach its trailing controls.

**One deliberate behaviour change:** `Spacer(minLength: 0)` is dropped, because it is inert inside a horizontal ScrollView (which sizes content to its ideal width). Keep/Discard therefore pack after the left-hand controls instead of docking to the trailing edge on roomy widths — visible in iPhone **landscape**, where there is plenty of room. Everything stays reachable. Say the word if you'd rather keep right-docking; `ViewThatFits` would restore it (docked candidate first, scrolling fallback), at the cost of a selection layer I could not verify here — see below.

## Verification

Design mode **cannot run on the iOS simulator at all** — MLX aborts with `MTLStorageModePrivate is required for heaps` the moment it allocates. Filed separately as #401. So the real panel could not be exercised locally.

Instead I reproduced the mechanism by standing an over-wide row in the same slot in `iPhoneLayout`, on an iPhone 16 simulator (1179×2556 — the same 393pt width the bug was reported at), and measured the chrome's leading edge from the framebuffer:

| | title row | Objects panel |
|---|---|---|
| over-wide row, before | x=248px, trailing edge cut | x=248px, trailing edge cut |
| same row inside a ScrollView | **x=0** | **x=0** |

With the ScrollView, all five `A S H L C` columns, the 5th tab, the full "Residues" label and the whole Export capsule are visible again. The probe was removed before this commit; it is not part of the diff.

Also checked: a horizontal ScrollView in a VStack does not grab vertical space — the row keeps its compact height and the viewport is unaffected.

`UnitTests_macOS`: **674 tests, 0 failures**, 4 skipped.

## Not verified

The fix is verified against a stand-in row with the identical layout characteristic, not against the real Design panel, because of #401. **Worth a look on-device before merging** — load a structure, enter Design mode, start an edit session, and confirm the chrome is flush at x=0 and Keep/Discard are reachable by scrolling the action row.

## Follow-up worth considering

The container is still fragile: any future docked row with an oversized minimum will displace the whole iPhone stack the same way. I tried the obvious guard — `.frame(width: geo.size.width, alignment: .leading).clipped()` on the stack — and it does **not** work; SwiftUI centers an oversized child in a fixed frame regardless of the alignment, so the displacement was unchanged. A general containment fix needs a different approach and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)