### PR TITLE
fix(sticks): close proline's ring in sidechain sticks (#405)

### DIFF
--- a/modules/pymol/appkit_theme_preview.py
+++ b/modules/pymol/appkit_theme_preview.py
@@ -58,9 +58,11 @@ def style():
     already reflect the live edit. Re-run on every theme edit while open."""
     try:
         from pymol import raymol_theme as _rt
+        from pymol import raymol_design as _rd
         cmd.hide("everything", OBJ)
         cmd.show("cartoon", OBJ)
-        cmd.show("sticks", "(%s and (sidechain or name CA) and not hydro)" % OBJ)
+        cmd.show("sticks", "(%s and %s and not hydro)"
+                 % (OBJ, _rd.SIDECHAIN_STICKS_PRED))
         # CA shared cleanly between cartoon trace and sidechain stick.
         cmd.set("cartoon_side_chain_helper", 1, OBJ)
         cmd.set("cartoon_flat_sheets", 1 if _rt._flat_sheets else 0, OBJ)

--- a/modules/pymol/raymol_design.py
+++ b/modules/pymol/raymol_design.py
@@ -718,6 +718,26 @@ def restore_visual_state():
 # stick-repped themselves are detected and left completely untouched.
 _STICK_COLORS = {}
 
+# Atoms that make up a "sidechain sticks" preview.
+#
+# PyMOL's `sidechain` excludes CA, so CA is added back — otherwise the sticks
+# float detached from the backbone with no CA–CB bond.
+#
+# It also excludes N, which breaks proline: PRO's ring closes CD back onto the
+# backbone N, so without N the ring is drawn as an open, dangling zig-zag
+# (#405).  The `neighbor` clause adds that N back, and only there — in every
+# other residue N's heavy neighbours are CA and the preceding C, neither of
+# which is a sidechain atom.  Stating it as a bond query rather than `resn PRO`
+# also covers HYP and other N-alkylated residues for free.
+#
+# `and not hydro` inside the neighbour test is load-bearing, not decoration:
+# on a hydrogenated N-terminus `h_add` produces an extra amide H (named H01)
+# that PyMOL classifies as *sidechain*, so a bare `neighbor sidechain` drags
+# residue 1's backbone N into every hydrogenated structure.  Restricting the
+# test to heavy neighbours leaves proline as the only match.
+SIDECHAIN_STICKS_PRED = (
+    '(sidechain or name CA or (name N and neighbor (sidechain and not hydro)))')
+
 # Module-level store for the full visual state (per-atom colors + transparency
 # settings) saved when compare first turns on. Keyed by src object name; popped
 # on compare-off or reset_compare.
@@ -750,10 +770,10 @@ def set_residue_sticks(obj, chain, resi, on):
     try:
         on = bool(on) if isinstance(on, bool) else bool(int(on))
         res_sel = _residue_sel(obj, chain, resi)
-        # Include CA so the CA–CB bond is drawn — otherwise the sidechain sticks
-        # float detached from the backbone (PyMOL's `sidechain` excludes CA).
+        # SIDECHAIN_STICKS_PRED adds back the backbone atoms PyMOL's `sidechain`
+        # drops but the sticks need (CA everywhere, N in proline).
         # Exclude hydrogens (`not hydro`) — H sticks just clutter the preview.
-        side_sel = '(%s) and (sidechain or name CA) and not hydro' % res_sel
+        side_sel = '(%s) and %s and not hydro' % (res_sel, SIDECHAIN_STICKS_PRED)
         key = '%s\x01%s\x01%s' % (obj, chain, resi)
         if on:
             # Only add if the sidechain has atoms and none are already sticks
@@ -1074,9 +1094,9 @@ def set_pinned_indicator(obj, chain, resi):
 def show_all_sidechains(obj, on):
     """Show or hide all sidechain sticks on obj.
 
-    on truthy: show sticks for '(obj) and (sidechain or name CA) and not hydro'
-      (CA included so the CA–CB bond draws from the backbone; hydrogens excluded),
-      then apply cnc coloring so
+    on truthy: show sticks for '(obj) and SIDECHAIN_STICKS_PRED and not hydro'
+      (CA included so the CA–CB bond draws from the backbone, proline's N so its
+      ring closes; hydrogens excluded), then apply cnc coloring so
       heteroatoms are colored by element while carbons inherit the residue's
       current confidence color.
     on falsy: hide sticks for the same selection.
@@ -1085,7 +1105,7 @@ def show_all_sidechains(obj, on):
     """
     _on = bool(on) if isinstance(on, bool) else bool(int(on))
     # Exclude hydrogens (`not hydro`) — H sticks just clutter the display.
-    sel = '(%s) and (sidechain or name CA) and not hydro' % obj
+    sel = '(%s) and %s and not hydro' % (obj, SIDECHAIN_STICKS_PRED)
     if _on:
         cmd.show('sticks', sel)
         try:

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -37,6 +37,29 @@ private let kGutterW: CGFloat = 26
 private let kIndentW: CGFloat = 13
 private let kMaxIndentDepth: Int = 3
 
+/// Atom predicate behind the S ▸ / H ▸ "side chains" menu items.
+///
+/// PyMOL's `sidechain` selection drops two backbone atoms the sticks need:
+///
+/// - **CA**, always — without it the CA–CB bond is missing and every side chain
+///   floats detached from the backbone.
+/// - **N**, in proline — PRO's ring closes CD back onto the backbone N, so
+///   without N the ring renders as an open, dangling zig-zag (#405). The
+///   `neighbor` clause restores it there and nowhere else: in every other
+///   residue N's heavy neighbours are CA and the preceding C, neither of which
+///   is a sidechain atom. Written as a bond query rather than `resn PRO` so HYP
+///   and other N-alkylated residues are covered too.
+///
+/// `and not hydro` inside the neighbour test is load-bearing: on a hydrogenated
+/// N-terminus `h_add` produces an extra amide H that PyMOL classifies as
+/// *sidechain*, so a bare `neighbor sidechain` would drag residue 1's backbone N
+/// into every hydrogenated structure.
+///
+/// Keep in sync with `raymol_design.SIDECHAIN_STICKS_PRED`. Show and hide must
+/// use the identical predicate, or hiding leaves proline's N stick behind.
+private let kSidechainPred =
+    "(sidechain or name CA or (name N and neighbor (sidechain and not hydro)))"
+
 // MARK: - Representation inspector: polled state models
 // (Inlined here rather than a separate file so they're in both app targets
 // without editing the Xcode project's explicit file references.)
@@ -2009,15 +2032,13 @@ private struct ShowButton: View {
             // with the cartoon side-chain helper so it composes cleanly with a
             // cartoon. A common daily-use shortcut absent from the plain rep list.
             Menu("side chains") {
-                // Include `name CA` so the CA–CB bond is drawn (PyMOL's `sidechain`
-                // selection excludes the alpha-carbon, leaving sidechains floating
-                // off the backbone); cartoon_side_chain_helper yields the CA from
-                // the cartoon so the stick connects cleanly. Hydrogens excluded.
+                // cartoon_side_chain_helper yields the CA from the cartoon so the
+                // stick connects cleanly. Hydrogens excluded.
                 Button("as sticks") {
-                    engine.runCommand("show sticks, (\(name)) and (sidechain or name CA) and not hydro; set cartoon_side_chain_helper, 1, \(name)")
+                    engine.runCommand("show sticks, (\(name)) and \(kSidechainPred) and not hydro; set cartoon_side_chain_helper, 1, \(name)")
                 }
                 Button("as lines") {
-                    engine.runCommand("show lines, (\(name)) and (sidechain or name CA) and not hydro; set cartoon_side_chain_helper, 1, \(name)")
+                    engine.runCommand("show lines, (\(name)) and \(kSidechainPred) and not hydro; set cartoon_side_chain_helper, 1, \(name)")
                 }
                 Button("as spheres") {
                     engine.runCommand("show spheres, (\(name)) and sidechain")
@@ -2061,7 +2082,9 @@ private struct HideButton: View {
     var body: some View {
         Menu {
             Button("side chains") {
-                engine.runCommand("hide sticks, (\(name)) and (sidechain or name CA); hide lines, (\(name)) and (sidechain or name CA)")
+                // Same predicate as S ▸ side chains, so hiding takes back exactly
+                // what showing put up — including proline's N (#405).
+                engine.runCommand("hide sticks, (\(name)) and \(kSidechainPred); hide lines, (\(name)) and \(kSidechainPred)")
             }
             // Hydrogens are a selection, not a rep, so they sit beside "side
             // chains" rather than in the shared rep list (#353). Mirrors

--- a/testing/tests/raymol/design_editing.py
+++ b/testing/tests/raymol/design_editing.py
@@ -239,3 +239,71 @@ class TestDesignEditing(testing.PyMOLTestCase):
         self.assertEqual(obj_count, trp_count,
                          "atom count after replace (%d) != TRP source (%d)" %
                          (obj_count, trp_count))
+
+    def testProlineRingClosesInSidechainSticks(self):
+        """Proline's ring must not be drawn open (#405).
+
+        PRO closes its ring CD->N onto the *backbone* nitrogen, which PyMOL's
+        `sidechain` selection excludes. Showing sidechain sticks without that N
+        leaves the CD->N bond with only one drawn endpoint, so the ring renders
+        as an open, dangling zig-zag. Every other residue is unaffected: their
+        N's heavy neighbours are CA and the preceding C, neither a sidechain
+        atom.
+        """
+        from pymol import raymol_design as rd
+        cmd.reinitialize()
+        cmd.fragment('pro', 'm')
+        # Fragments arrive with representations already on, which would make the
+        # assertions below pass without show_all_sidechains doing anything.
+        cmd.hide('everything', 'm')
+
+        rd.show_all_sidechains('m', True)
+
+        shown = set()
+        cmd.iterate('m and rep sticks', 'shown.add(name)', space={'shown': shown})
+        # All five ring atoms, so all five ring bonds have both endpoints drawn.
+        for atom in ('N', 'CA', 'CB', 'CG', 'CD'):
+            self.assertIn(atom, shown,
+                          "PRO ring atom %s missing from sidechain sticks: "
+                          "the ring renders open (#405)" % atom)
+
+        # ...and hiding takes the N back off, or it is orphaned on the backbone.
+        rd.show_all_sidechains('m', False)
+        self.assertEqual(cmd.count_atoms('m and name N and rep sticks'), 0,
+                         "PRO backbone N left behind as a stick after hide")
+
+    def testSidechainSticksAddNoBackboneNOutsideProline(self):
+        """The proline fix must not drag backbone N into other residues (#405)."""
+        from pymol import raymol_design as rd
+        cmd.reinitialize()
+        for frag in ('arg', 'gly', 'ala', 'trp'):
+            cmd.delete('m')
+            cmd.fragment(frag, 'm')
+            cmd.hide('everything', 'm')
+            rd.show_all_sidechains('m', True)
+            self.assertEqual(
+                cmd.count_atoms('m and name N and rep sticks'), 0,
+                "%s: backbone N should not be in sidechain sticks" % frag.upper())
+
+    def testSidechainSticksSkipHydrogenatedNTerminus(self):
+        """Only PRO's N joins the sticks, even with hydrogens present (#405).
+
+        `h_add` puts an extra amide H on the N-terminal nitrogen, and PyMOL
+        classifies that H as *sidechain*. A neighbour test that does not exclude
+        hydrogens therefore pulls residue 1's backbone N into the sticks of
+        every hydrogenated structure.
+        """
+        from pymol import raymol_design as rd
+        cmd.reinitialize()
+        cmd.fab('AGPRA', 'pep')      # N-terminus, plus PRO at residue 3
+        cmd.h_add('pep')
+        cmd.hide('everything', 'pep')
+
+        rd.show_all_sidechains('pep', True)
+
+        got = set()
+        cmd.iterate('pep and name N and rep sticks', 'got.add(resi)',
+                    space={'got': got})
+        self.assertEqual(got, {'3'},
+                         "backbone N drawn outside PRO 3 (got residues %s): the "
+                         "neighbour test is matching an amide hydrogen" % sorted(got))


### PR DESCRIPTION
Fixes #405.

## The bug

Gabriel reported that "stick representation is broken on prolines — for some reason line is good, not stick."

Every "side chains" entry point selected `sidechain or name CA`:

- `ObjectPanel.swift` — S ▸ side chains ▸ as sticks / as lines, and H ▸ side chains
- `raymol_design.set_residue_sticks` — Design mode's per-residue hover/pin preview
- `raymol_design.show_all_sidechains` — Design mode's show-all toggle
- `appkit_theme_preview.style` — the theme preview molecule

PyMOL's `sidechain` keyword excludes the backbone N, and proline is the one standard residue whose side chain bonds to it — PRO closes its ring CD→N. With N absent from the selection the ring bond has only one drawn endpoint, so it isn't drawn at all: the ring renders as an open, dangling zig-zag with CD hanging in space.

The lines-vs-sticks asymmetry is a matter of visual weight, not two different code paths — a plain `show lines` includes N and looks right, and even from the same selection a hairline open ring reads as just another side chain where a fat open stick ring is glaring.

Reproduced on 1ubq PRO 19 via the exact command the S menu emits:

```
show sticks, (1ubq) and (sidechain or name CA) and not hydro
set cartoon_side_chain_helper, 1, 1ubq
```

Before, PRO 19's ring is an open four-atom zig-zag (CA-CB-CG-CD) with CD ending in
mid-air; after, the five-membered ring closes through N. Ray-traced before/after
renders are attached in a comment below.

## The fix

Add the N back with a bond query rather than a `resn PRO` special case:

```
name N and neighbor (sidechain and not hydro)
```

In every other residue N's heavy neighbours are CA and the preceding C, neither a sidechain atom — so proline is the only match, and HYP and other N-alkylated residues are covered for free.

**`not hydro` inside the neighbour test is load-bearing.** On a hydrogenated N-terminus `h_add` produces an extra amide H (`H01`) that PyMOL classifies as *sidechain*, so a bare `neighbor sidechain` drags residue 1's backbone N into the sticks of every hydrogenated structure. A regression test pins this — it was caught by testing the fix, not by reading it.

The predicate now lives in one constant per language (`raymol_design.SIDECHAIN_STICKS_PRED`, `ObjectPanel.kSidechainPred`) rather than being spelled out at five call sites.

**H ▸ side chains is switched over too.** It hid the narrower selection, so after this change it would have left proline's N stick orphaned on the backbone after a show/hide round trip. Show and hide now use the identical predicate.

`S ▸ side chains ▸ as spheres` is deliberately left on plain `sidechain`: spheres are per-atom, so ring closure doesn't apply, and adding CA/N there would change what the menu item draws.

## Testing

Three cases added to `testing/tests/raymol/design_editing.py`:

- `testProlineRingClosesInSidechainSticks` — all five ring atoms are drawn, and hiding takes the N back off
- `testSidechainSticksAddNoBackboneNOutsideProline` — ARG/GLY/ALA/TRP gain no backbone N
- `testSidechainSticksSkipHydrogenatedNTerminus` — on `fab AGPRA` + `h_add`, only PRO 3's N is drawn

The first and third fail against the old predicate (verified by reverting the constant).

Full embedded suite: **933 tests, same 3 pre-existing `generate/` errors as master** (`get_coordset` SystemError under the local shadow-tree harness — baselined by stashing this patch and re-running).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
