### PR TITLE
fix(console): select and copy across log lines (#406)

### DIFF
--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		6A1DB5F97E3738FD1819FF6E /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3E805AC2D63B01AB7EE29C /* Theme.swift */; };
 		6A37175866051AC88BD25C1D /* RFD3RuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB3DD619B055E99FD2F9C1E /* RFD3RuntimeTests.swift */; };
 		6A3892FDD5939A57DC9FFCCE /* CopyRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0B47016374F32C7BB13017 /* CopyRoutingTests.swift */; };
+		4C0E5A17B93D4F2A81C6D0E2 /* ConsoleLogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0E5A17B93D4F2A81C6D0E1 /* ConsoleLogTests.swift */; };
 		6C028EE83C8A29A4FDCF2222 /* BoltzJobManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 193D4D739151970412BB6EDF /* BoltzJobManagerTests.swift */; };
 		6C8AA3C224C1B2106FBF4881 /* DesignScoreCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC5AE545F97DF175BFE0462 /* DesignScoreCache.swift */; };
 		6D67CAB3F655837D48E68AF3 /* PredictController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0D207800BE2DDAF04598C1 /* PredictController.swift */; };
@@ -371,6 +372,7 @@
 		B820FE9080BF73526A54CD66 /* TimelinePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelinePanel.swift; sourceTree = "<group>"; };
 		B9EC978B16F58D988575E206 /* MCPDrivingBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPDrivingBanner.swift; sourceTree = "<group>"; };
 		BB5ABD1A8C45E5BC97AB0B80 /* RayMol.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = RayMol.icon; sourceTree = "<group>"; };
+		4C0E5A17B93D4F2A81C6D0E1 /* ConsoleLogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleLogTests.swift; sourceTree = "<group>"; };
 		BF0B47016374F32C7BB13017 /* CopyRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyRoutingTests.swift; sourceTree = "<group>"; };
 		C2C2F36B9B6E660DD0256EC2 /* PredictCompactPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictCompactPanel.swift; sourceTree = "<group>"; };
 		C3F3410F7C0D3C85783B985F /* AppVersionFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionFooter.swift; sourceTree = "<group>"; };
@@ -604,6 +606,7 @@
 				6AE160C6EB58F631604002E6 /* AppBuildInfoTests.swift */,
 				1A75842F74BFC453CE7BA777 /* BoltzJobManagerMSATests.swift */,
 				193D4D739151970412BB6EDF /* BoltzJobManagerTests.swift */,
+				4C0E5A17B93D4F2A81C6D0E1 /* ConsoleLogTests.swift */,
 				BF0B47016374F32C7BB13017 /* CopyRoutingTests.swift */,
 				2345D7E2703CF29D4A2AA277 /* DesignAvailabilityTests.swift */,
 				7C0379A1B2C3D4E5F6072379 /* ColorMenuTests.swift */,
@@ -1343,6 +1346,7 @@
 				057F3C59DACA26AAC603702E /* AppBuildInfoTests.swift in Sources */,
 				238B6F24D467D70AE012E2CB /* BoltzJobManagerMSATests.swift in Sources */,
 				6C028EE83C8A29A4FDCF2222 /* BoltzJobManagerTests.swift in Sources */,
+				4C0E5A17B93D4F2A81C6D0E2 /* ConsoleLogTests.swift in Sources */,
 				6A3892FDD5939A57DC9FFCCE /* CopyRoutingTests.swift in Sources */,
 				B88942D786AB0D1CDC354C1F /* DesignAvailabilityTests.swift in Sources */,
 				7C0379A1B2C3D4E5F6071379 /* ColorMenuTests.swift in Sources */,

--- a/swiftui/PyMOLViewer/Panels/CommandPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/CommandPanel.swift
@@ -29,8 +29,11 @@ struct CommandPanel: View {
     var body: some View {
         VStack(spacing: 0) {
             // Scrolling log area
-            LogView(entries: engine.feedbackLog, textColor: logTextColor,
-                    font: termFont, bg: bgColor)
+            // Theme values, not resolved Colors/Fonts: the macOS log is an
+            // AppKit text view and needs NSColor/NSFont (and Equatable specs to
+            // tell a theme change from a new log line). See LogView.
+            LogView(entries: engine.feedbackLog, textColor: theme.terminalText,
+                    font: theme.terminalFont, bg: theme.panelBackground)
 
             if showInput {
                 Divider()
@@ -98,11 +101,18 @@ struct CommandPanel: View {
 
 private struct LogView: View {
     let entries: [String]
-    let textColor: Color
-    let font: Font
-    let bg: Color
+    let textColor: RGBA
+    let font: FontSpec
+    let bg: RGBA
 
-    private var bgColor: Color { bg }
+#if os(macOS)
+
+    // One selectable text view for the whole log — see ConsoleTextView (#406).
+    var body: some View {
+        ConsoleTextView(entries: entries, textColor: textColor, font: font, bg: bg)
+    }
+
+#else
 
     var body: some View {
         ScrollViewReader { proxy in
@@ -110,8 +120,8 @@ private struct LogView: View {
                 LazyVStack(alignment: .leading, spacing: 0) {
                     ForEach(Array(entries.enumerated()), id: \.offset) { index, line in
                         Text(line)
-                            .font(font)
-                            .foregroundColor(textColor)
+                            .font(font.font)
+                            .foregroundColor(textColor.color)
                             .textSelection(.enabled)
                             .id(index)
                     }
@@ -123,7 +133,7 @@ private struct LogView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(4)
             }
-            .background(bgColor)
+            .background(bg.color)
             // Swipe the log down to dismiss the keyboard (and peek at output
             // while typing) — complements the command field's Done button.
             .scrollDismissesKeyboard(.interactively)
@@ -147,7 +157,231 @@ private struct LogView: View {
             }
         }
     }
+
+#endif
 }
+
+#if os(macOS)
+
+// MARK: - Console log text view (macOS)
+
+/// The console log rendered as ONE selectable `NSTextView` instead of a SwiftUI
+/// `Text` per line (#406).
+///
+/// `.textSelection(.enabled)` scopes a selection to a single text view, so with
+/// a `Text` per line a drag could never reach past the line it started on and
+/// ⌘C could only ever copy that one line; the `LazyVStack` compounded it by
+/// never materialising the scrolled-away rows. A single text view gets
+/// multi-line drag selection, ⇧-click, ⌘A and ⌘C for free, and its `copy:` is
+/// exactly the responder `CopyRouting` offers ⌘C to before falling back to the
+/// viewport image (#287).
+///
+/// Deliberately non-editable and not a field editor: `ContentView`'s
+/// `textFocusFlags()` counts only editable text views as "the user is typing",
+/// so a focused log must NOT look like a text field — otherwise arrows, home,
+/// end and the ctrl-letter chords would stop reaching PyMOL's key bindings for
+/// as long as the console had focus.
+///
+/// iOS keeps the per-row rendering above: the report is macOS-only (there is no
+/// ⌘C without a hardware keyboard), and the SwiftUI ScrollView there also owns
+/// the interactive keyboard dismissal the command field depends on.
+private struct ConsoleTextView: NSViewRepresentable {
+    let entries: [String]
+    let textColor: RGBA
+    let font: FontSpec
+    let bg: RGBA
+
+    func makeNSView(context: Context) -> NSScrollView {
+        // Structure only; the theme lands in updateNSView, which runs once with
+        // a nil `styling` right after this.
+        ConsoleLogText.makeScrollView()
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        guard let textView = scrollView.documentView as? NSTextView else { return }
+        let coordinator = context.coordinator
+
+        // Re-style only when the theme actually changed: restyling touches every
+        // character and forces a full re-layout, which would undo the point of
+        // appending incrementally below.
+        let styling = Styling(textColor: textColor, font: font, bg: bg)
+        if coordinator.styling != styling {
+            coordinator.styling = styling
+            scrollView.backgroundColor = bg.nsColor
+            textView.backgroundColor = bg.nsColor
+            textView.typingAttributes = styling.attributes
+            if let storage = textView.textStorage, storage.length > 0 {
+                storage.setAttributes(styling.attributes,
+                                      range: NSRange(location: 0, length: storage.length))
+            }
+        }
+
+        let update = ConsoleLogText.plan(previous: coordinator.rendered, current: entries)
+        guard update != .none else { return }
+        // Follow new output only when the user is already parked at the bottom.
+        // Scrolling unconditionally (what the SwiftUI log did) would yank the
+        // view away from anyone reading — or mid-drag selecting — older output
+        // every time a command printed a line.
+        let follow = coordinator.rendered.isEmpty || Self.isScrolledToBottom(scrollView)
+
+        ConsoleLogText.apply(update, to: textView, attributes: styling.attributes)
+        coordinator.rendered = entries
+
+        if follow {
+            // Deferred a runloop so the appended text is laid out first —
+            // scrolling immediately stops short of the true bottom.
+            DispatchQueue.main.async { textView.scrollToEndOfDocument(nil) }
+        }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    /// Holds what the text view currently shows, so each update is a diff
+    /// rather than a rebuild. SwiftUI hands `updateNSView` only the new value.
+    final class Coordinator {
+        var rendered: [String] = []
+        var styling: Styling?
+    }
+
+    /// The theme-derived look of the log, as value types so "did the theme
+    /// change?" is a cheap `==` rather than an NSColor/NSFont comparison.
+    struct Styling: Equatable {
+        let textColor: RGBA
+        let font: FontSpec
+        let bg: RGBA
+
+        var attributes: [NSAttributedString.Key: Any] {
+            [.font: font.nsFont, .foregroundColor: textColor.nsColor]
+        }
+    }
+
+    /// Within a point of the end. Slack because the clip view's bounds and the
+    /// document height rarely land on exactly the same fractional value.
+    private static func isScrolledToBottom(_ scrollView: NSScrollView) -> Bool {
+        guard let documentHeight = scrollView.documentView?.frame.height else { return true }
+        return scrollView.contentView.bounds.maxY >= documentHeight - 1
+    }
+}
+
+// MARK: - Console log text model (macOS)
+
+/// The edit that turns what the console log currently displays into what a new
+/// `feedbackLog` value says it should display.
+enum ConsoleLogUpdate: Equatable {
+    /// Nothing changed.
+    case none
+    /// Rewrite the whole document — first fill, or a log that was cleared or
+    /// rewritten rather than extended.
+    case replace(String)
+    /// Append at the end. The common case, and the only one that leaves the
+    /// user's selection and scroll position completely untouched.
+    case append(String)
+    /// The log ALSO lost leading lines — `PyMOLEngine` trims the front once the
+    /// feedback log passes its 400-line cap. Delete that many UTF-16 units from
+    /// the start, then append (which may be empty).
+    case trimThenAppend(dropCharacters: Int, append: String)
+}
+
+/// Turns `feedbackLog` (an array of lines) into edits for a single text view,
+/// and owns the text view those edits land in.
+///
+/// Split out of `ConsoleTextView` so it can be tested: a test cannot drag-select
+/// in a live app, but it CAN plan an edit, apply it to a real text view, select
+/// all and copy — which is exactly what #406 is about. The interesting case is
+/// the one that is invisible until it bites: a log trimmed at the front must not
+/// be mistaken for a log that only grew at the back.
+enum ConsoleLogText {
+
+    /// One line per line: the separator IS what makes ⌘C paste as multiple
+    /// lines rather than one run-on string.
+    static let lineSeparator = "\n"
+
+    static func text(for entries: some Sequence<String>) -> String {
+        entries.joined(separator: lineSeparator)
+    }
+
+    /// The log's scroll view + text view, configured but unstyled. A factory
+    /// rather than inline setup in `makeNSView` so a test can hold the real
+    /// thing: an `NSViewRepresentable`'s `Context` cannot be built outside
+    /// SwiftUI, which would otherwise put every AppKit-side guarantee here —
+    /// selectable, NOT editable, `copy:` reachable — out of reach of a test.
+    static func makeScrollView() -> NSScrollView {
+        let scrollView = NSTextView.scrollableTextView()
+        scrollView.hasVerticalScroller = true
+        scrollView.drawsBackground = true
+
+        guard let textView = scrollView.documentView as? NSTextView else { return scrollView }
+        textView.isEditable = false          // see ConsoleTextView: keeps textFocusFlags() honest
+        textView.isSelectable = true
+        textView.isRichText = false
+        textView.allowsUndo = false
+        textView.drawsBackground = true
+        // Matches the .padding(4) the SwiftUI log had.
+        textView.textContainerInset = NSSize(width: 4, height: 4)
+        // Wrap long lines instead of scrolling sideways, as the Text rows did.
+        textView.textContainer?.widthTracksTextView = true
+        textView.isHorizontallyResizable = false
+        return scrollView
+    }
+
+    /// Performs a planned edit on the log's text view.
+    static func apply(_ update: ConsoleLogUpdate, to textView: NSTextView,
+                      attributes: [NSAttributedString.Key: Any]) {
+        guard let storage = textView.textStorage else { return }
+        switch update {
+        case .none:
+            break
+        case .replace(let text):
+            storage.setAttributedString(NSAttributedString(string: text, attributes: attributes))
+        case .append(let text):
+            storage.append(NSAttributedString(string: text, attributes: attributes))
+        case .trimThenAppend(let dropCharacters, let text):
+            let selection = textView.selectedRange()
+            storage.beginEditing()
+            storage.deleteCharacters(in: NSRange(location: 0, length: dropCharacters))
+            if !text.isEmpty {
+                storage.append(NSAttributedString(string: text, attributes: attributes))
+            }
+            storage.endEditing()
+            textView.setSelectedRange(shiftSelection(selection, by: dropCharacters))
+        }
+    }
+
+    /// The smallest edit that takes the view from `previous` to `current`.
+    static func plan(previous: [String], current: [String]) -> ConsoleLogUpdate {
+        if previous == current { return .none }
+        if previous.isEmpty || current.isEmpty { return .replace(text(for: current)) }
+
+        // Longest suffix of `previous` that is still a prefix of `current`: what
+        // survived on screen. Anything before it was trimmed off the front,
+        // anything after it is new output. Quadratic in the worst case but
+        // linear in practice — a wrong overlap dies on its first comparison.
+        for overlap in stride(from: min(previous.count, current.count), through: 1, by: -1) {
+            guard previous.suffix(overlap).elementsEqual(current.prefix(overlap)) else { continue }
+            let added = current.dropFirst(overlap)
+            let appended = added.isEmpty ? "" : lineSeparator + text(for: added)
+            let dropped = previous.count - overlap
+            if dropped == 0 { return .append(appended) }
+            // The trimmed lines plus the newline that separated them from the
+            // first surviving one.
+            let head = text(for: previous.prefix(dropped)) + lineSeparator
+            return .trimThenAppend(dropCharacters: (head as NSString).length, append: appended)
+        }
+        // No overlap at all — the log was replaced wholesale.
+        return .replace(text(for: current))
+    }
+
+    /// Slides a selection back over a front-trim, giving up whatever part of it
+    /// the trim consumed. Without this, hitting the 400-line cap mid-selection
+    /// would silently leave the highlight sitting on different text.
+    static func shiftSelection(_ range: NSRange, by dropCharacters: Int) -> NSRange {
+        let lost = max(0, min(range.length, dropCharacters - range.location))
+        return NSRange(location: max(0, range.location - dropCharacters),
+                       length: range.length - lost)
+    }
+}
+
+#endif
 
 // MARK: - Command Text Field (handles up/down arrow keys)
 

--- a/swiftui/PyMOLViewer/Shared/ContentView.swift
+++ b/swiftui/PyMOLViewer/Shared/ContentView.swift
@@ -928,9 +928,10 @@ struct ContentView: View {
     //   editing — focused AND non-empty (drives Tier B, the arrows/home/end/
     //     ctrl-letter yield while the user is composing).
     // We require the text view to be editable or a field editor: the feedback
-    // log uses .textSelection(.enabled), and if SwiftUI's selectable-but-not-
-    // editable NSTextView ever becomes first responder its `string` is the
-    // entire log, which would silently disable arrows/home/end until focus moved.
+    // log is a selectable-but-not-editable NSTextView (ConsoleTextView, #406),
+    // and it DOES take first responder when clicked — its `string` is the entire
+    // log, so counting it as a focused field would silently disable arrows/
+    // home/end for as long as the console held focus.
     private func textFocusFlags() -> (focused: Bool, editing: Bool) {
         let responder = NSApp.keyWindow?.firstResponder
         if let tv = responder as? NSTextView, tv.isEditable || tv.isFieldEditor {

--- a/swiftui/PyMOLViewer/Shared/Theme.swift
+++ b/swiftui/PyMOLViewer/Shared/Theme.swift
@@ -2,6 +2,9 @@
 // A Theme is fully Codable so custom themes persist as JSON in UserDefaults.
 
 import SwiftUI
+#if canImport(AppKit)
+import AppKit
+#endif
 
 /// sRGB color, Codable (SwiftUI.Color is not Codable).
 struct RGBA: Codable, Equatable {
@@ -10,6 +13,13 @@ struct RGBA: Codable, Equatable {
         self.r = r; self.g = g; self.b = b; self.a = a
     }
     var color: Color { Color(.sRGB, red: r, green: g, blue: b, opacity: a) }
+#if canImport(AppKit)
+    /// AppKit twin of `color`, for the parts of the UI that are AppKit views
+    /// rather than SwiftUI ones (the console log, #406). Built straight from the
+    /// components rather than via `NSColor(color)` so it is a plain sRGB color
+    /// that compares equal to another one made from the same theme values.
+    var nsColor: NSColor { NSColor(srgbRed: r, green: g, blue: b, alpha: a) }
+#endif
     /// "r, g, b" in 0..1 for PyMOL set_color.
     var pymolTriplet: String { String(format: "%.4f, %.4f, %.4f", r, g, b) }
     /// Linear blend toward `other` by `t` (0…1). Keeps alpha solid for both
@@ -33,6 +43,26 @@ struct FontSpec: Codable, Equatable {
         }
     }
     var font: Font { .system(size: size, design: design) }
+#if canImport(AppKit)
+    /// AppKit twin of `font` (#406). `withDesign` is how a system font picks up
+    /// the monospaced/serif/rounded variant, matching what `Font.system(size:
+    /// design:)` resolves to on the SwiftUI side.
+    var nsFont: NSFont {
+        let base = NSFont.systemFont(ofSize: size)
+        guard let descriptor = base.fontDescriptor.withDesign(nsDesign),
+              let styled = NSFont(descriptor: descriptor, size: size) else { return base }
+        return styled
+    }
+
+    private var nsDesign: NSFontDescriptor.SystemDesign {
+        switch family {
+        case .monospaced: return .monospaced
+        case .serif:      return .serif
+        case .rounded:    return .rounded
+        case .system:     return .default
+        }
+    }
+#endif
 }
 
 enum Appearance: String, Codable, CaseIterable, Identifiable {

--- a/swiftui/PyMOLViewerTests/ConsoleLogTests.swift
+++ b/swiftui/PyMOLViewerTests/ConsoleLogTests.swift
@@ -1,0 +1,174 @@
+import XCTest
+import AppKit
+@testable import RayMol
+
+/// Coverage for the console log's text model — the half of #406 that can be
+/// tested without a mouse.
+///
+/// The bug: the log rendered one SwiftUI `Text` per line, and
+/// `.textSelection(.enabled)` scopes a selection to a single text view, so a
+/// drag could never reach past the line it started on and ⌘C could only ever
+/// copy that one line. The fix backs the log with one `NSTextView`, which turns
+/// "append a line" into an edit against existing text instead of a rebuild —
+/// and an edit can get the selection wrong in ways a rebuild cannot.
+final class ConsoleLogTests: XCTestCase {
+
+    private let attributes: [NSAttributedString.Key: Any] =
+        [.font: NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)]
+
+    // MARK: - Planning edits
+
+    /// First fill: nothing on screen yet, so everything is new.
+    func testFirstFillReplacesTheWholeDocument() {
+        XCTAssertEqual(ConsoleLogText.plan(previous: [], current: ["one", "two"]),
+                       .replace("one\ntwo"))
+    }
+
+    /// The common case, and the one worth protecting: a new output line must be
+    /// an APPEND, because appending is what leaves an in-progress selection and
+    /// the scroll position alone.
+    func testNewLineAppendsRatherThanRebuilding() {
+        XCTAssertEqual(ConsoleLogText.plan(previous: ["one", "two"],
+                                           current: ["one", "two", "three"]),
+                       .append("\nthree"))
+    }
+
+    func testUnchangedLogIsNoEdit() {
+        XCTAssertEqual(ConsoleLogText.plan(previous: ["one"], current: ["one"]), .none)
+    }
+
+    /// PyMOLEngine caps `feedbackLog` at 400 lines by dropping from the FRONT,
+    /// so past the cap every new line both trims and appends. Treating that as a
+    /// plain append would duplicate the surviving text; treating it as a full
+    /// rebuild would drop the user's selection on every single line of output.
+    func testCapTrimsTheFrontAndAppendsTheTail() {
+        let update = ConsoleLogText.plan(previous: ["one", "two", "three"],
+                                         current: ["two", "three", "four"])
+        // "one\n" — the dropped line plus its separator.
+        XCTAssertEqual(update, .trimThenAppend(dropCharacters: 4, append: "\nfour"))
+    }
+
+    /// Repeated lines are ordinary in a console ("PyMOL>fetch 1ubq" twice), and
+    /// they are exactly what a naive scan for the overlap gets wrong.
+    func testRepeatedLinesPickTheLongestRealOverlap() {
+        let update = ConsoleLogText.plan(previous: ["a", "b", "b"],
+                                         current: ["b", "b", "c"])
+        XCTAssertEqual(update, .trimThenAppend(dropCharacters: 2, append: "\nc"))
+    }
+
+    /// Clear Session empties the log.
+    func testClearedLogIsReplacedWithNothing() {
+        XCTAssertEqual(ConsoleLogText.plan(previous: ["one", "two"], current: []),
+                       .replace(""))
+    }
+
+    /// Nothing in common — a rebuild is the only correct edit.
+    func testUnrelatedLogIsRebuilt() {
+        XCTAssertEqual(ConsoleLogText.plan(previous: ["one"], current: ["two", "three"]),
+                       .replace("two\nthree"))
+    }
+
+    // MARK: - Applying edits
+
+    /// End to end, against a real text view: the log accumulates the same text a
+    /// rebuild would produce, one edit at a time.
+    func testAppliedEditsMatchARebuild() {
+        let textView = makeTextView()
+        var rendered: [String] = []
+        for entries in [["one"], ["one", "two"], ["one", "two", "three"],
+                        ["two", "three", "four"], []] {
+            ConsoleLogText.apply(ConsoleLogText.plan(previous: rendered, current: entries),
+                                 to: textView, attributes: attributes)
+            rendered = entries
+            XCTAssertEqual(textView.string, ConsoleLogText.text(for: entries),
+                           "incremental edits drifted from the log contents")
+        }
+    }
+
+    /// THE issue, as close as a test can get to it: with the whole log selected,
+    /// the copy that ⌘C routes through (CopyRouting sends this exact selector)
+    /// must put every line on the pasteboard, line breaks intact — not just the
+    /// one line the old per-`Text` rendering could select.
+    @MainActor
+    func testSelectAllThenCopyYieldsEveryLine() {
+        let saved = NSPasteboard.general.string(forType: .string)
+        defer {
+            NSPasteboard.general.clearContents()
+            if let saved { NSPasteboard.general.setString(saved, forType: .string) }
+        }
+
+        let textView = makeTextView()
+        ConsoleLogText.apply(
+            ConsoleLogText.plan(previous: [], current: ["PyMOL>fetch 1ubq",
+                                                        " Executive: object \"1ubq\" created.",
+                                                        "PyMOL>color cyan"]),
+            to: textView, attributes: attributes)
+
+        textView.selectAll(nil)
+        NSPasteboard.general.clearContents()
+        XCTAssertTrue(NSApp.sendAction(#selector(NSText.copy(_:)), to: textView, from: nil))
+
+        XCTAssertEqual(NSPasteboard.general.string(forType: .string),
+                       "PyMOL>fetch 1ubq\n Executive: object \"1ubq\" created.\nPyMOL>color cyan",
+                       "⌘C must copy the whole selection across lines, line breaks preserved")
+    }
+
+    /// A selection that spans lines has to survive the log filling up, or the
+    /// highlight silently slides onto different text mid-drag once the 400-line
+    /// cap starts trimming.
+    func testSelectionSurvivesACapTrim() {
+        let textView = makeTextView()
+        ConsoleLogText.apply(.replace("one\ntwo\nthree"), to: textView, attributes: attributes)
+        // "two\nthree" — a two-line selection, the thing #406 makes possible.
+        textView.setSelectedRange(NSRange(location: 4, length: 9))
+
+        ConsoleLogText.apply(ConsoleLogText.plan(previous: ["one", "two", "three"],
+                                                 current: ["two", "three", "four"]),
+                             to: textView, attributes: attributes)
+
+        XCTAssertEqual((textView.string as NSString).substring(with: textView.selectedRange()),
+                       "two\nthree", "the selection must still cover the same text")
+    }
+
+    /// The trim can also eat into the selection. What is gone is gone; what
+    /// remains must stay selected rather than the range going stale (or out of
+    /// bounds, which throws).
+    func testSelectionClippedByATrimKeepsWhatSurvived() {
+        XCTAssertEqual(ConsoleLogText.shiftSelection(NSRange(location: 1, length: 5), by: 3),
+                       NSRange(location: 0, length: 3))
+        XCTAssertEqual(ConsoleLogText.shiftSelection(NSRange(location: 10, length: 5), by: 4),
+                       NSRange(location: 6, length: 5))
+        XCTAssertEqual(ConsoleLogText.shiftSelection(NSRange(location: 0, length: 2), by: 9),
+                       NSRange(location: 0, length: 0))
+        // An empty selection (just a caret) must not gain a length.
+        XCTAssertEqual(ConsoleLogText.shiftSelection(NSRange(location: 3, length: 0), by: 9),
+                       NSRange(location: 0, length: 0))
+    }
+
+    // MARK: - Text view configuration
+
+    /// Two properties the rest of the app depends on, neither of them visible:
+    /// selectable is what makes ⌘C have anything to copy, and NOT editable is
+    /// what keeps ContentView's `textFocusFlags()` from reading a focused
+    /// console as "the user is typing" — which would strip arrows, home, end and
+    /// the ctrl-letter chords from PyMOL's key bindings while the log had focus.
+    func testLogTextViewIsSelectableButNotEditable() {
+        let textView = makeTextView()
+        XCTAssertTrue(textView.isSelectable)
+        XCTAssertFalse(textView.isEditable)
+        XCTAssertFalse(textView.isFieldEditor)
+        XCTAssertTrue(textView.responds(to: #selector(NSText.copy(_:))),
+                      "the log must handle the selector CopyRouting offers ⌘C to")
+    }
+
+    // MARK: - Helpers
+
+    private func makeTextView() -> NSTextView {
+        let scrollView = ConsoleLogText.makeScrollView()
+        guard let textView = scrollView.documentView as? NSTextView else {
+            XCTFail("the console scroll view must be backed by an NSTextView")
+            return NSTextView()
+        }
+        return textView
+    }
+}


### PR DESCRIPTION
Fixes #406.

## The problem

The console log rendered one SwiftUI `Text` per line, each with its own `.textSelection(.enabled)`. That modifier scopes a selection to a single text view, so a drag could never reach past the line it started on — #287 fixed ⌘C's *routing*, but there was never more than one line for it to act on. The `LazyVStack` compounded it: scrolled-away rows are never materialised, so even a hypothetical cross-view selection could not have reached them.

## The fix

macOS backs the log with one selectable, non-editable `NSTextView` in an `NSScrollView` (`ConsoleTextView`). That brings multi-line drag selection, ⇧-click, ⌘A and ⌘C with line breaks intact, and its `copy:` is exactly the responder `CopyRouting` already offers ⌘C to — so the viewport-image fallback is untouched.

The text view is deliberately **non-editable and not a field editor**, because `ContentView.textFocusFlags()` counts only editable text views as "the user is typing". A focused log that looked like a text field would strip arrows, home, end and the ctrl-letter chords from PyMOL's key bindings for as long as the console had focus.

iOS keeps the per-row rendering: the report is macOS-only (no ⌘C without a hardware keyboard), and the SwiftUI `ScrollView` there owns the interactive keyboard dismissal the command field depends on.

Two consequences of turning the log into one document, both handled:

- **Appending is now an edit, not a rebuild**, and edits can be got wrong in ways rebuilds cannot. The diffing is a pure `ConsoleLogText.plan` with tests. The case that matters is `PyMOLEngine`'s 400-line cap: past it, every new line BOTH trims the front and appends. A plain append would duplicate the surviving text; a full rebuild would drop the user's selection on every single line of output.
- **The log only follows new output when it is already at the bottom** (the old `LogView` scrolled unconditionally). Streaming output no longer yanks the view away from someone reading — or mid-drag selecting — older lines.

Scrollback needed no new cap: `PyMOLEngine` already trims `feedbackLog` to 400 lines.

## Tests

`ConsoleLogTests` (12 tests, macOS unit target) covers the planning cases — first fill, append, no-op, cap trim, repeated lines, clear, wholesale replacement — plus, against a real `NSTextView`: incremental edits matching a rebuild, selection surviving a cap trim, and select-all + the selector ⌘C routes through putting **every** line on the pasteboard with line breaks preserved. Reverting the trim handling fails 3 of them.

`xcodebuild -scheme UnitTests_macOS … test`: 687 tests, 0 failures.

## Manual verification

In a disposable macOS VM (`raymol-mac-vm`), against `RayMol-406.app`:

- Drag across three log lines → ⌘C pastes `HA_ONE\nBRAVO_TWO\nCHARLIE_`.
- ⌘A → ⌘C pastes all 36 lines, **including the startup banner scrolled far above the viewport** — content the old `LazyVStack` never materialised.
- With nothing selected (command line focused), ⌘C still puts the rendered viewport image on the pasteboard — #287's arbitration intact.
- New output still auto-scrolls to the bottom; the command line still takes input after the log has held focus.

Note: the pbxproj entry for the new test file was hand-added rather than regenerated, since `xcodegen generate` rewrites `RayMol.icon` and breaks the app icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)