### PR TITLE
perf(pick): do the hover/click atom pick in C++ (#394)

### DIFF
--- a/.github/workflows/raymol-embedded-tests.yml
+++ b/.github/workflows/raymol-embedded-tests.yml
@@ -74,6 +74,7 @@ jobs:
               testing/tests/raymol/design_enumerate.py \
               testing/tests/raymol/design_region.py \
               testing/tests/raymol/design_saverestore.py \
+              testing/tests/raymol/metal_pick.py \
               testing/tests/raymol/scene_ttt.py \
               testing/tests/raymol/shadow_extent.py \
               testing/tests/predict \

--- a/layer3/MetalPick.cpp
+++ b/layer3/MetalPick.cpp
@@ -1,0 +1,158 @@
+/*
+ * Screen-space atom picking for the Metal backend -- see MetalPick.h.
+ */
+
+#include "MetalPick.h"
+
+#include <algorithm>
+#include <cfloat>
+
+#include "AtomInfo.h"
+#include "CoordSet.h"
+#include "ObjectMolecule.h"
+#include "Rep.h"
+#include "Setting.h"
+#include "Vector.h"
+
+namespace
+{
+
+/// An atom that projected inside the pick radius.
+struct PickCand {
+  float d2;
+  float depth;
+  ObjectMolecule* obj;
+  int atm;
+  float sx, sy;
+};
+
+/**
+ * True if `ai` has geometry a pick can land on.
+ *
+ * Cartoon and ribbon are special: showing them ORs their bit onto EVERY atom of
+ * the object (side chains and solvent included), but the spline only runs
+ * through the guide atoms, so only those are hittable. Mirrors the _DRAWN_REPS
+ * selection in pymol/metal_pick.py.
+ */
+inline bool is_drawn(
+    const AtomInfoType* ai, int rep_mask, int guide_rep_mask)
+{
+  if (ai->visRep & rep_mask)
+    return true;
+  return (ai->visRep & guide_rep_mask) && (ai->flags & cAtomFlag_guide);
+}
+
+} // namespace
+
+MetalPickHit MetalPickAtom(PyMOLGlobals* G,
+    const std::vector<ObjectMolecule*>& objects, int state,
+    const MetalPickCamera& cam, float ndc_x, float ndc_y, float max_ndc2,
+    float cluster_ndc2, int rep_mask, int guide_rep_mask)
+{
+  MetalPickHit hit;
+
+  const float r00 = cam.rot[0], r01 = cam.rot[1], r02 = cam.rot[2];
+  const float r10 = cam.rot[3], r11 = cam.rot[4], r12 = cam.rot[5];
+  const float r20 = cam.rot[6], r21 = cam.rot[7], r22 = cam.rot[8];
+  const float tx = cam.pos[0], ty = cam.pos[1], tz = cam.pos[2];
+  const float ox = cam.origin[0], oy = cam.origin[1], oz = cam.origin[2];
+  // A degenerate slab (front >= back) means the view layout didn't carry usable
+  // clip planes; culling against it would make nothing pickable at all.
+  const bool clipped = cam.clip_back > cam.clip_front;
+
+  if (!(cam.tan_half > 0.f) || !(cam.aspect > 0.f))
+    return hit;
+
+  std::vector<PickCand> cands;
+  float d2min = FLT_MAX;
+
+  for (auto* obj : objects) {
+    if (!obj)
+      continue;
+    const CoordSet* cs = obj->getCoordSet(state);
+    if (!cs)
+      continue;
+
+    // Same transform CoordSetGetAtomTxfVertex applies, hoisted out of the loop:
+    // the pick has to agree with where the renderer put the atom, and for a
+    // moved object (non-identity TTT) that is nowhere near the raw coordinate.
+    const double* mat = nullptr;
+    if (!cs->Matrix.empty() && SettingGet<int>(*cs, cSetting_matrix_mode) > 0)
+      mat = cs->Matrix.data();
+    const bool use_ttt = obj->TTTFlag != 0;
+
+    const AtomInfoType* atom_info = obj->AtomInfo.data();
+    const int n_index = cs->getNIndex();
+
+    for (int idx = 0; idx < n_index; ++idx) {
+      const int atm = cs->IdxToAtm[idx];
+      const AtomInfoType* ai = atom_info + atm;
+      if (!is_drawn(ai, rep_mask, guide_rep_mask))
+        continue;
+
+      float v[3];
+      copy3f(cs->coordPtr(idx), v);
+      if (mat)
+        transform44d3f(mat, v, v);
+      if (use_ttt)
+        transformTTT44f3f(obj->TTT, v, v);
+
+      const float dx = v[0] - ox;
+      const float dy = v[1] - oy;
+      const float dz = v[2] - oz;
+
+      // eye = R*(model-origin) + pos; the camera looks down -Z.
+      const float depth = -(r20 * dx + r21 * dy + r22 * dz + tz);
+      if (depth <= 0.01f)
+        continue;
+      // An atom clipped away isn't visible, so it must not be selectable.
+      if (clipped && (depth < cam.clip_front || depth > cam.clip_back))
+        continue;
+
+      const float half_h = depth * cam.tan_half;
+      const float sx = (r00 * dx + r01 * dy + r02 * dz + tx) /
+                       (half_h * cam.aspect); // NDC x, +1 = right
+      const float sy =
+          (r10 * dx + r11 * dy + r12 * dz + ty) / half_h; // NDC y, +1 = up
+
+      const float ex = sx - ndc_x;
+      const float ey = sy - ndc_y;
+      const float d2 = ex * ex + ey * ey;
+      if (d2 > max_ndc2)
+        continue;
+
+      ++hit.ncand;
+      if (d2 < d2min)
+        d2min = d2;
+      // Anything farther than this can't make the final cluster either, since
+      // d2min only shrinks from here -- so it never needs to be remembered.
+      if (d2 <= d2min + cluster_ndc2)
+        cands.push_back({d2, depth, obj, atm, sx, sy});
+    }
+  }
+
+  if (cands.empty())
+    return hit;
+
+  // Where atoms overlap on screen, select the one actually visible (closest to
+  // the camera) rather than whichever projects marginally nearer the cursor.
+  // Sorting by distance first makes the depth tie-break deterministic.
+  std::stable_sort(cands.begin(), cands.end(),
+      [](const PickCand& a, const PickCand& b) { return a.d2 < b.d2; });
+
+  const float limit = d2min + cluster_ndc2;
+  const PickCand* best = nullptr;
+  for (const auto& c : cands) {
+    if (c.d2 > limit)
+      break; // sorted, so nothing after this qualifies either
+    if (!best || c.depth < best->depth)
+      best = &c;
+  }
+
+  hit.obj = best->obj;
+  hit.atm = best->atm;
+  hit.d2 = best->d2;
+  hit.sx = best->sx;
+  hit.sy = best->sy;
+  return hit;
+}

--- a/layer3/MetalPick.h
+++ b/layer3/MetalPick.h
@@ -1,0 +1,72 @@
+/*
+ * Screen-space atom picking for the Metal backend.
+ *
+ * GL color-picking (SceneDoXYPick) is unavailable on Metal, so the pick is
+ * reproduced by projecting the drawn atoms with the current camera and taking
+ * the front-most one under the cursor. This is the hot inner loop of that:
+ * `pymol.metal_pick` stays the policy layer (camera parsing, grid-cell mapping,
+ * selection-mode expansion, readout payload) and calls in here through
+ * `_cmd.metal_pick` for the per-atom work.
+ *
+ * The projection must agree with what the renderer drew, so it mirrors
+ * CoordSetGetAtomTxfVertex (state matrix + object TTT) rather than reading raw
+ * coordinates.
+ */
+
+#pragma once
+
+#include <vector>
+
+#include "PyMOLGlobals.h"
+
+struct ObjectMolecule;
+
+/**
+ * Camera parameters of the projection, as parsed from cmd.get_view() by
+ * pymol.metal_pick.camera(). See that docstring for the derivation; the
+ * mapping applied here is
+ *
+ *     eye   = rot * (model - origin) + pos
+ *     depth = -eye.z
+ *     ndc   = (eye.x / (depth * tan_half * aspect), eye.y / (depth * tan_half))
+ */
+struct MetalPickCamera {
+  float rot[9] = {};    ///< row-major 3x3 model->camera rotation
+  float pos[3] = {};    ///< camera position (eye-space translation)
+  float origin[3] = {}; ///< rotation origin, in model space
+  float tan_half = 0.f; ///< half-height slope at unit depth
+  float aspect = 1.f;   ///< width / height of the viewport (or grid cell)
+  float clip_front = 0.f;
+  float clip_back = 0.f; ///< clip_back <= clip_front disables slab culling
+};
+
+/**
+ * Outcome of a pick. `obj == nullptr` means the cursor was over empty space.
+ */
+struct MetalPickHit {
+  ObjectMolecule* obj = nullptr;
+  int atm = -1;      ///< atom index within `obj`
+  float d2 = 0.f;    ///< squared NDC distance from the cursor
+  float sx = 0.f;    ///< where the atom projected, in NDC
+  float sy = 0.f;
+  int ncand = 0;     ///< atoms that projected within the pick radius
+};
+
+/**
+ * Front-most drawn atom under (ndc_x, ndc_y).
+ *
+ * @param objects candidate objects, in the order the caller wants ties broken
+ * @param state 0-based state to project, or -2 for each object's current state
+ * @param max_ndc2 squared NDC pick radius; atoms beyond it are not candidates
+ * @param cluster_ndc2 atoms within this squared NDC distance of the closest
+ * candidate count as overlapping under the cursor, and the front-most (least
+ * depth) of them wins
+ * @param rep_mask visRep bits whose geometry is drawn at the atom's own
+ * position, so a pick may land on it
+ * @param guide_rep_mask visRep bits (cartoon/ribbon) that are set on every atom
+ * of an object but only draw through its guide atoms
+ */
+MetalPickHit MetalPickAtom(PyMOLGlobals* G,
+    const std::vector<ObjectMolecule*>& objects, int state,
+    const MetalPickCamera& cam, float ndc_x, float ndc_y, float max_ndc2,
+    float cluster_ndc2, int rep_mask, int guide_rep_mask);

--- a/layer4/Cmd.cpp
+++ b/layer4/Cmd.cpp
@@ -79,6 +79,7 @@ Z* -------------------------------------------------------------------
 #include "CifFile.h"
 
 #include "MoleculeExporter.h"
+#include "MetalPick.h"
 
 #define tmpSele "_tmp"
 #define tmpSele1 "_tmp1"
@@ -2269,6 +2270,68 @@ static PyObject *CmdPushUndo(PyObject * self, PyObject * args)
     APIExit(G);
   }
   return APIResultOk(ok);
+}
+
+/**
+ * Screen-space atom pick for the Metal backend (see layer3/MetalPick.h).
+ *
+ * `cam` is a 19-float list: 3x3 row-major rotation, camera position, rotation
+ * origin, tan_half, aspect, clip_front, clip_back. `objects` is a list naming
+ * the objects to search, in tie-break order; names that aren't molecular
+ * objects are skipped. Returns None for empty space, else the tuple
+ * (d2, object, chain, resi, resn, segi, name, ndc_x, ndc_y).
+ */
+static PyObject *CmdMetalPick(PyObject * self, PyObject * args)
+{
+  PyMOLGlobals *G = nullptr;
+  PyObject *objects_py, *cam_py;
+  int state, rep_mask, guide_rep_mask;
+  float ndc_x, ndc_y, max_ndc2, cluster_ndc2;
+  API_SETUP_ARGS(G, self, args, "OOOiffffii", &self, &objects_py, &cam_py,
+      &state, &ndc_x, &ndc_y, &max_ndc2, &cluster_ndc2, &rep_mask,
+      &guide_rep_mask);
+
+  std::vector<std::string> names;
+  std::vector<float> cam_v;
+  API_ASSERT(PConvFromPyObject(G, objects_py, names));
+  API_ASSERT(PConvFromPyObject(G, cam_py, cam_v));
+  API_ASSERT(cam_v.size() == 19);
+
+  MetalPickCamera cam;
+  std::copy_n(cam_v.begin(), 9, cam.rot);
+  std::copy_n(cam_v.begin() + 9, 3, cam.pos);
+  std::copy_n(cam_v.begin() + 12, 3, cam.origin);
+  cam.tan_half = cam_v[15];
+  cam.aspect = cam_v[16];
+  cam.clip_front = cam_v[17];
+  cam.clip_back = cam_v[18];
+
+  API_ASSERT(APIEnterBlockedNotModal(G));
+
+  std::vector<ObjectMolecule*> objects;
+  objects.reserve(names.size());
+  for (const auto& name : names) {
+    if (auto* obj = ExecutiveFindObjectMoleculeByName(G, name.c_str()))
+      objects.push_back(obj);
+  }
+
+  auto hit = MetalPickAtom(G, objects, state, cam, ndc_x, ndc_y, max_ndc2,
+      cluster_ndc2, rep_mask, guide_rep_mask);
+
+  PyObject *result = nullptr;
+  if (!hit.obj) {
+    result = PConvAutoNone(nullptr);
+  } else {
+    const AtomInfoType* ai = hit.obj->AtomInfo + hit.atm;
+    char resi[8];
+    AtomResiFromResv(resi, sizeof(resi), ai);
+    result = Py_BuildValue("(fssssssff)", hit.d2, hit.obj->Name,
+        LexStr(G, ai->chain), resi, LexStr(G, ai->resn), LexStr(G, ai->segi),
+        LexStr(G, ai->name), hit.sx, hit.sy);
+  }
+
+  APIExitBlocked(G);
+  return result;
 }
 
 static PyObject *CmdGetType(PyObject * self, PyObject * args)
@@ -6588,6 +6651,7 @@ static PyMethodDef Cmd_methods[] = {
   {"mem", CmdMem, METH_VARARGS},
   {"memory_available", CmdMemoryAvailable, METH_VARARGS},
   {"memory_usage", CmdMemoryUsage, METH_VARARGS},
+  {"metal_pick", CmdMetalPick, METH_VARARGS},
   {"mmodify", CmdMModify, METH_VARARGS},
   {"move", CmdMove, METH_VARARGS},
   {"mset", CmdMSet, METH_VARARGS},

--- a/modules/pymol/metal_pick.py
+++ b/modules/pymol/metal_pick.py
@@ -19,6 +19,7 @@ The modelview is MV = T(pos) * R * T(-origin), i.e. eye = R*(model-origin) + pos
 """
 import collections
 import math
+import os
 
 # Screen pick radius (squared, in NDC). Clicks farther than this from any
 # atom's projection are treated as empty space (which clears 'sele').
@@ -321,6 +322,233 @@ def _is_identity(m, eps=1e-6):
     return all(abs(m[i] - ident[i]) < eps for i in range(16))
 
 
+# --- the pick --------------------------------------------------------------
+#
+# Hover preview and hover readout both ride on this, throttled to ~22 picks/s
+# while the pointer moves, so it runs on the main thread between frames. The
+# per-atom work therefore lives in C++ (_cmd.metal_pick, layer3/MetalPick.cpp):
+# rebuilding a chempy model of every drawn atom per pick cost ~1.5 us/atom, so
+# ~75 ms/pick at 50k drawn atoms, more than saturating the main thread (#394).
+# _python_pick is the same math in Python, kept as the reference the native
+# path is tested against, for the PYMOL_PICKDEBUG harness (which reports
+# projection diagnostics the C++ path doesn't collect), and for cores built
+# without the metal_pick entry point.
+
+# Reps drawn AT THE ATOM's own position, as a visRep bitmask for the native
+# pick -- the same filter _DRAWN_REPS spells out as a selection (still used by
+# _python_pick and box_select). The two must name the same reps;
+# testing/tests/raymol/metal_pick.py asserts they agree atom for atom.
+_DRAWN_REP_NAMES = ('spheres', 'sticks', 'lines', 'nb_spheres', 'nonbonded',
+                    'surface', 'dots', 'mesh', 'ellipsoids')
+_GUIDE_REP_NAMES = ('cartoon', 'ribbon')
+
+# State sentinel for _cmd.metal_pick: each object's OWN current state, which is
+# the state the renderer draws it at (pymol::CObject::getObjectState). An object
+# with fewer states than the current frame draws nothing, and correspondingly
+# picks nothing.
+_CURRENT_STATE = -2
+
+_rep_masks_cache = None
+_native_pick_cache = None
+
+
+def _rep_masks():
+    """(drawn_mask, guide_only_mask) for _cmd.metal_pick. Resolved on first use
+    so importing this module still costs nothing without a live core."""
+    global _rep_masks_cache
+    if _rep_masks_cache is None:
+        from pymol.constants import repmasks
+        drawn = guide = 0
+        for rep in _DRAWN_REP_NAMES:
+            drawn |= repmasks[rep]
+        for rep in _GUIDE_REP_NAMES:
+            guide |= repmasks[rep]
+        _rep_masks_cache = (drawn, guide)
+    return _rep_masks_cache
+
+
+def _have_native_pick():
+    """Whether this core carries the C++ pick. Cached — it cannot change within
+    a session, and this sits on the hover path."""
+    global _native_pick_cache
+    if _native_pick_cache is None:
+        try:
+            from pymol.cmd import _cmd
+            _native_pick_cache = hasattr(_cmd, 'metal_pick')
+        except Exception:
+            _native_pick_cache = False
+    return _native_pick_cache
+
+
+def _native_pick(pick_objs, cam, ndc_x, ndc_y, aspect, thresh):
+    """_pick_atom's hit tuple, computed in C++ (see layer3/MetalPick.cpp)."""
+    from pymol import cmd
+    from pymol.cmd import _cmd
+    drawn_mask, guide_mask = _rep_masks()
+    # A None clip layout means the view didn't carry usable planes; a degenerate
+    # slab is how the C++ side spells "don't cull on depth".
+    front = 0.0 if cam.clip_front is None else float(cam.clip_front)
+    back = 0.0 if cam.clip_back is None else float(cam.clip_back)
+    # Both sequences must be lists — that is what PConvFromPyObject accepts.
+    cam_v = list(cam.rot) + list(cam.pos) + list(cam.origin) + \
+        [cam.tan_half, aspect, front, back]
+    with cmd.lockcm:
+        best = _cmd.metal_pick(cmd._COb, list(pick_objs), cam_v, _CURRENT_STATE,
+                               ndc_x, ndc_y, thresh, _CLUSTER_NDC2,
+                               drawn_mask, guide_mask)
+    if best is None:
+        return None
+    d2, obj, chain, resi, resn, segi, name, sx, sy = best
+    # segi falls back to chain, matching the chempy model _python_pick reads.
+    return (d2, obj, chain, resi, resn, segi or chain, name, sx, sy)
+
+
+def _python_pick(pick_objs, cam, ndc_x, ndc_y, aspect, thresh):
+    """Reference implementation of _native_pick: project every drawn atom in
+    pure Python. Same result, ~1.5 us per drawn atom."""
+    from pymol import cmd
+    v = cam.view
+    r00, r01, r02, r10, r11, r12, r20, r21, r22 = cam.rot
+    tx, ty, tz = cam.pos
+    ox, oy, oz = cam.origin
+    fov_deg, tan_half = cam.fov, cam.tan_half
+    clip_front, clip_back = cam.clip_front, cam.clip_back
+
+    best = None  # (screen_d2, obj, chain, resi, resn, segi, name, sx, sy)
+    cands = []   # (d2, depth, obj, chain, resi, resn, segi, name, sx, sy)
+    ncand = 0    # atoms whose projection fell within the pick radius
+    _ext = [1e9, -1e9, 1e9, -1e9]  # projected-NDC extent: sx_min,sx_max,sy_min,sy_max
+
+    # Displayed movie/model state: pick against the coordinates actually
+    # RENDERED. get_model defaults to state 1, so a multi-state (NMR /
+    # trajectory) object shown at a later state would otherwise be picked at
+    # its state-1 positions — residues can be 20+ A (≈0.4 NDC) off, so a click
+    # or hover lands on the wrong residue.
+    try:
+        cur_state = int(cmd.get_state())
+    except Exception:
+        cur_state = 1
+    for obj in pick_objs:
+        # Skip non-molecule objects (distance/angle measurements, maps, CGOs,
+        # groups). Passing their name to the atom-selection parser (below)
+        # raises a C++ "Invalid selection name" Selector-Error that prints to
+        # the feedback log on every click even though Python catches it.
+        try:
+            if cmd.get_type(obj) != 'object:molecule':
+                continue
+        except Exception:
+            continue
+        try:
+            # Only consider atoms that are actually DRAWN, so a click can't
+            # select an invisible atom (e.g. a hidden water under a cartoon).
+            # get_model(obj) alone returns EVERY atom; the `visible` selector
+            # over-reports because cartoon/ribbon set their visRep bit on all
+            # atoms (incl. solvent) though only guide atoms draw — hence the
+            # per-rep _DRAWN_REPS filter (see its definition).
+            sel = '(%s) and (%s)' % (obj, _DRAWN_REPS)
+            model = None
+            # Prefer the displayed state so the pick matches the render.
+            # Only when it isn't state 1 (get_model already defaults to 1),
+            # and fall back to the default if an explicit-state query returns
+            # no atoms — some embedded cores return empty for
+            # get_model(state=N); we must never regress those to a dead pick.
+            if cur_state > 1:
+                try:
+                    m = cmd.get_model(sel, state=cur_state)
+                    if m and m.atom:
+                        model = m
+                except Exception:
+                    model = None
+            if model is None:
+                model = cmd.get_model(sel)
+        except Exception:
+            continue
+        if not model or not model.atom:
+            continue
+        # get_model() already returns coordinates with the object's display
+        # transform (TTT) BAKED IN — verified: get_model() == TTT x raw_coords
+        # for a moved object. So we must NOT re-apply the object matrix here:
+        # doing so DOUBLE-transforms a MOVED object (non-identity TTT) and the
+        # pick lands far from where the atom renders. Non-moved objects only
+        # appeared correct because their TTT is identity (the re-apply was a
+        # no-op) — which is why picking broke only after moving an object.
+        for at in model.atom:
+            cx, cy, cz = at.coord[0], at.coord[1], at.coord[2]
+            dx = cx - ox
+            dy = cy - oy
+            dz = cz - oz
+            # eye = R*(model-origin) + pos
+            ex = r00 * dx + r01 * dy + r02 * dz + tx
+            ey = r10 * dx + r11 * dy + r12 * dz + ty
+            ez = r20 * dx + r21 * dy + r22 * dz + tz
+            depth = -ez                     # camera looks down -Z
+            if depth <= 0.01:
+                continue
+            # Pickability respects the clip slab: an atom clipped away (outside
+            # [front,back]) isn't visible, so it must not be selectable. Guarded
+            # to a sane slab so a bad view layout can never disable picking. (What
+            # IS selected is drawn clip-invariant separately in the renderer.)
+            if clip_front is not None and clip_back > clip_front \
+                    and (depth < clip_front or depth > clip_back):
+                continue
+            half_h = depth * tan_half
+            half_w = half_h * aspect
+            sx = ex / half_w                # NDC x, +1 = right
+            sy = ey / half_h                # NDC y, +1 = up (bottom-left)
+            if sx < _ext[0]: _ext[0] = sx
+            if sx > _ext[1]: _ext[1] = sx
+            if sy < _ext[2]: _ext[2] = sy
+            if sy > _ext[3]: _ext[3] = sy
+            d2 = (sx - ndc_x) ** 2 + (sy - ndc_y) ** 2
+            if d2 > thresh:
+                continue
+            ncand += 1
+            cands.append((d2, depth, obj, at.chain or '', at.resi,
+                          at.resn, at.segi or (at.chain or ''), at.name, sx, sy))
+
+    # Choose the FRONT-MOST atom among those clustered nearest the click, so
+    # that where atoms overlap on screen we select the one actually visible
+    # (closest to the camera), not whichever projects marginally nearer the
+    # cursor. Atoms within _CLUSTER_NDC2 of the closest are treated as
+    # overlapping; the smallest depth (front-most) wins.
+    if cands:
+        cands.sort(key=lambda c: c[0])           # by screen distance²
+        d2min = cands[0][0]
+        cluster = [c for c in cands if c[0] <= d2min + _CLUSTER_NDC2]
+        c = min(cluster, key=lambda c: c[1])     # front-most (min depth)
+        best = (c[0], c[2], c[3], c[4], c[5], c[6], c[7], c[8], c[9])
+
+    _pickdbg(ndc_x, ndc_y, aspect, best, ncand)
+    import os as _os
+    if _os.environ.get('PYMOL_PICKDEBUG'):
+        try:
+            _nv = cmd.count_atoms('visible')
+            _nt = cmd.count_atoms('all')
+            _nhv = cmd.count_atoms('resn HOH and visible')
+            with open(_os.environ['PYMOL_PICKDEBUG'], 'a') as _f:
+                _f.write('  VIS total=%d visible=%d hoh_visible=%d\n' % (_nt, _nv, _nhv))
+                _f.write('  params len(v)=%d fov=%.2f tan_half=%.4f aspect=%.4f '
+                         'pos=(%.2f,%.2f,%.2f) origin=(%.2f,%.2f,%.2f) '
+                         'projext sx=[%.3f,%.3f] sy=[%.3f,%.3f]\n' % (
+                             len(v), fov_deg, tan_half, aspect,
+                             tx, ty, tz, ox, oy, oz,
+                             _ext[0], _ext[1], _ext[2], _ext[3]))
+                _f.write('  rawview=%s\n' % ','.join('%.5f' % x for x in v))
+                if best is not None:
+                    _be = best[1]; _bc = best[2]; _br = best[3]; _bn = best[6]
+                    _xyz = []
+                    cmd.iterate_state(1, '%s and resi %s and name %s%s' % (
+                        _be, _br, _bn,
+                        (' and chain %s' % _bc) if _bc else ''),
+                        '_xyz.extend([x,y,z])', space={'_xyz': _xyz})
+                    if len(_xyz) >= 3:
+                        _f.write('  pickedxyz=(%.3f,%.3f,%.3f)\n' % (_xyz[0], _xyz[1], _xyz[2]))
+        except Exception:
+            pass
+
+    return best
+
+
 def _pick_atom(ndc_x, ndc_y, aspect, max_ndc2=None):
     """Project all DRAWN atoms and return the front-most atom under the click as
     (screen_d2, obj, chain, resi, resn, segi, name, sx, sy), or None for empty
@@ -336,12 +564,6 @@ def _pick_atom(ndc_x, ndc_y, aspect, max_ndc2=None):
         cam = camera()
         if cam is None or aspect <= 0.0:
             return None
-        v = cam.view
-        r00, r01, r02, r10, r11, r12, r20, r21, r22 = cam.rot
-        tx, ty, tz = cam.pos
-        ox, oy, oz = cam.origin
-        fov_deg, tan_half = cam.fov, cam.tan_half
-        clip_front, clip_back = cam.clip_front, cam.clip_back
 
         # Grid mode (by-object): the renderer draws each object in its own
         # viewport cell, so a full-window projection wouldn't line up with what
@@ -356,143 +578,16 @@ def _pick_atom(ndc_x, ndc_y, aspect, max_ndc2=None):
                 return None  # empty cell → treat as empty-space click
             pick_objs = [target_obj]
 
-        best = None  # (screen_d2, obj, chain, resi, resn, segi, name, sx, sy)
-        cands = []   # (d2, depth, obj, chain, resi, resn, segi, name, sx, sy)
-        ncand = 0    # atoms whose projection fell within the pick radius
-        _ext = [1e9, -1e9, 1e9, -1e9]  # projected-NDC extent: sx_min,sx_max,sy_min,sy_max
-
         if pick_objs is None:
-            pick_objs = (cmd.get_names('objects', enabled_only=1) or [])
-        # Displayed movie/model state: pick against the coordinates actually
-        # RENDERED. get_model defaults to state 1, so a multi-state (NMR /
-        # trajectory) object shown at a later state would otherwise be picked at
-        # its state-1 positions — residues can be 20+ A (≈0.4 NDC) off, so a click
-        # or hover lands on the wrong residue.
-        try:
-            cur_state = int(cmd.get_state())
-        except Exception:
-            cur_state = 1
-        for obj in pick_objs:
-            if obj.startswith('_'):
-                continue
-            # Skip non-molecule objects (distance/angle measurements, maps, CGOs,
-            # groups). Passing their name to the atom-selection parser (below)
-            # raises a C++ "Invalid selection name" Selector-Error that prints to
-            # the feedback log on every click even though Python catches it.
-            try:
-                if cmd.get_type(obj) != 'object:molecule':
-                    continue
-            except Exception:
-                continue
-            try:
-                # Only consider atoms that are actually DRAWN, so a click can't
-                # select an invisible atom (e.g. a hidden water under a cartoon).
-                # get_model(obj) alone returns EVERY atom; the `visible` selector
-                # over-reports because cartoon/ribbon set their visRep bit on all
-                # atoms (incl. solvent) though only guide atoms draw — hence the
-                # per-rep _DRAWN_REPS filter (see its definition).
-                sel = '(%s) and (%s)' % (obj, _DRAWN_REPS)
-                model = None
-                # Prefer the displayed state so the pick matches the render.
-                # Only when it isn't state 1 (get_model already defaults to 1),
-                # and fall back to the default if an explicit-state query returns
-                # no atoms — some embedded cores return empty for
-                # get_model(state=N); we must never regress those to a dead pick.
-                if cur_state > 1:
-                    try:
-                        m = cmd.get_model(sel, state=cur_state)
-                        if m and m.atom:
-                            model = m
-                    except Exception:
-                        model = None
-                if model is None:
-                    model = cmd.get_model(sel)
-            except Exception:
-                continue
-            if not model or not model.atom:
-                continue
-            # get_model() already returns coordinates with the object's display
-            # transform (TTT) BAKED IN — verified: get_model() == TTT x raw_coords
-            # for a moved object. So we must NOT re-apply the object matrix here:
-            # doing so DOUBLE-transforms a MOVED object (non-identity TTT) and the
-            # pick lands far from where the atom renders. Non-moved objects only
-            # appeared correct because their TTT is identity (the re-apply was a
-            # no-op) — which is why picking broke only after moving an object.
-            for at in model.atom:
-                cx, cy, cz = at.coord[0], at.coord[1], at.coord[2]
-                dx = cx - ox
-                dy = cy - oy
-                dz = cz - oz
-                # eye = R*(model-origin) + pos
-                ex = r00 * dx + r01 * dy + r02 * dz + tx
-                ey = r10 * dx + r11 * dy + r12 * dz + ty
-                ez = r20 * dx + r21 * dy + r22 * dz + tz
-                depth = -ez                     # camera looks down -Z
-                if depth <= 0.01:
-                    continue
-                # Pickability respects the clip slab: an atom clipped away (outside
-                # [front,back]) isn't visible, so it must not be selectable. Guarded
-                # to a sane slab so a bad view layout can never disable picking. (What
-                # IS selected is drawn clip-invariant separately in the renderer.)
-                if clip_front is not None and clip_back > clip_front \
-                        and (depth < clip_front or depth > clip_back):
-                    continue
-                half_h = depth * tan_half
-                half_w = half_h * aspect
-                sx = ex / half_w                # NDC x, +1 = right
-                sy = ey / half_h                # NDC y, +1 = up (bottom-left)
-                if sx < _ext[0]: _ext[0] = sx
-                if sx > _ext[1]: _ext[1] = sx
-                if sy < _ext[2]: _ext[2] = sy
-                if sy > _ext[3]: _ext[3] = sy
-                d2 = (sx - ndc_x) ** 2 + (sy - ndc_y) ** 2
-                if d2 > thresh:
-                    continue
-                ncand += 1
-                cands.append((d2, depth, obj, at.chain or '', at.resi,
-                              at.resn, at.segi or (at.chain or ''), at.name, sx, sy))
+            pick_objs = [o for o in (cmd.get_names('objects', enabled_only=1) or [])
+                         if not o.startswith('_')]
 
-        # Choose the FRONT-MOST atom among those clustered nearest the click, so
-        # that where atoms overlap on screen we select the one actually visible
-        # (closest to the camera), not whichever projects marginally nearer the
-        # cursor. Atoms within _CLUSTER_NDC2 of the closest are treated as
-        # overlapping; the smallest depth (front-most) wins.
-        if cands:
-            cands.sort(key=lambda c: c[0])           # by screen distance²
-            d2min = cands[0][0]
-            cluster = [c for c in cands if c[0] <= d2min + _CLUSTER_NDC2]
-            c = min(cluster, key=lambda c: c[1])     # front-most (min depth)
-            best = (c[0], c[2], c[3], c[4], c[5], c[6], c[7], c[8], c[9])
-
-        _pickdbg(ndc_x, ndc_y, aspect, best, ncand)
-        import os as _os
-        if _os.environ.get('PYMOL_PICKDEBUG'):
-            try:
-                _nv = cmd.count_atoms('visible')
-                _nt = cmd.count_atoms('all')
-                _nhv = cmd.count_atoms('resn HOH and visible')
-                with open(_os.environ['PYMOL_PICKDEBUG'], 'a') as _f:
-                    _f.write('  VIS total=%d visible=%d hoh_visible=%d\n' % (_nt, _nv, _nhv))
-                    _f.write('  params len(v)=%d fov=%.2f tan_half=%.4f aspect=%.4f '
-                             'pos=(%.2f,%.2f,%.2f) origin=(%.2f,%.2f,%.2f) '
-                             'projext sx=[%.3f,%.3f] sy=[%.3f,%.3f]\n' % (
-                                 len(v), fov_deg, tan_half, aspect,
-                                 tx, ty, tz, ox, oy, oz,
-                                 _ext[0], _ext[1], _ext[2], _ext[3]))
-                    _f.write('  rawview=%s\n' % ','.join('%.5f' % x for x in v))
-                    if best is not None:
-                        _be = best[1]; _bc = best[2]; _br = best[3]; _bn = best[6]
-                        _xyz = []
-                        cmd.iterate_state(1, '%s and resi %s and name %s%s' % (
-                            _be, _br, _bn,
-                            (' and chain %s' % _bc) if _bc else ''),
-                            '_xyz.extend([x,y,z])', space={'_xyz': _xyz})
-                        if len(_xyz) >= 3:
-                            _f.write('  pickedxyz=(%.3f,%.3f,%.3f)\n' % (_xyz[0], _xyz[1], _xyz[2]))
-            except Exception:
-                pass
-
-        return best
+        # The debug harness wants the projection diagnostics only the Python
+        # path collects (candidate count, projected extent), and has no use for
+        # the native path's speed.
+        if _have_native_pick() and not os.environ.get('PYMOL_PICKDEBUG'):
+            return _native_pick(pick_objs, cam, ndc_x, ndc_y, aspect, thresh)
+        return _python_pick(pick_objs, cam, ndc_x, ndc_y, aspect, thresh)
 
     except Exception as e:
         print('metal_pick error: %s' % e)

--- a/testing/tests/raymol/metal_pick.py
+++ b/testing/tests/raymol/metal_pick.py
@@ -1,0 +1,262 @@
+'''
+Screen-space atom picking against a live core -- pymol.metal_pick (#394).
+
+The camera is pinned with set_view so every expected screen position is
+hand-computable rather than whatever zoom() happened to pick:
+
+    rotation = identity, origin = (0,0,0), camera at z = +100 looking down -Z,
+    slab [50, 150], field of view 20 deg.
+
+Under that camera a model point (X, Y, Z) has eye depth 100 - Z, and the
+renderer's half-height at depth D is
+
+    tan_half = tan(2*tan(radians(20)/2) / 2) = tan(tan(radians(10)))
+    half_h   = D * tan_half
+    half_w   = half_h * (W / H)
+
+so ndc = (X / half_w, Y / half_h). Same camera as api/box_select.py.
+
+The pick itself runs in C++ (_cmd.metal_pick); metal_pick._python_pick is the
+reference implementation of the same math, and TestNativeParity holds the two
+to the same answers.
+'''
+
+import math
+
+from pymol import cmd, testing, metal_pick
+
+VIEW = (1.0, 0.0, 0.0,
+        0.0, 1.0, 0.0,
+        0.0, 0.0, 1.0,
+        0.0, 0.0, -100.0,
+        0.0, 0.0, 0.0,
+        50.0, 150.0, -20.0)
+
+CAM_DEPTH = 100.0
+TAN_HALF = math.tan(2.0 * math.tan(math.radians(20.0) / 2.0) / 2.0)
+
+# Reps whose geometry sits at the atom's own position, so a pick may land on
+# it. Spelled out here rather than read off metal_pick, so that dropping one
+# there fails a test instead of quietly deleting it. Cartoon and ribbon are
+# deliberately absent -- they only draw through guide atoms, which
+# testCartoonPicksResolveToGuideAtoms covers.
+DRAWN_REPS = ('spheres', 'sticks', 'lines', 'nb_spheres', 'nonbonded',
+              'surface', 'dots', 'mesh', 'ellipsoids')
+
+
+class PickBase(testing.PyMOLTestCase):
+    '''Pinned camera + geometry helpers shared by the cases below. Carries no
+    test methods of its own.'''
+
+    def setUp(self):
+        super(PickBase, self).setUp()
+        cmd.viewport(400, 300)
+        self.width, self.height = cmd.get_viewport()
+        cmd.set_view(VIEW)
+
+    # -- helpers ----------------------------------------------------------
+
+    def aspect(self):
+        return float(self.width) / float(self.height)
+
+    def ndc(self, model_x, model_y, model_z=0.0):
+        '''Where a model point lands in NDC under the pinned camera.'''
+        half_h = (CAM_DEPTH - model_z) * TAN_HALF
+        return (model_x / (half_h * self.aspect()), model_y / half_h)
+
+    def project(self, xyz):
+        '''The same thing for the CURRENT camera, whatever it is -- the mapping
+        documented at the top of metal_pick.'''
+        cam = metal_pick.camera()
+        d = [xyz[i] - cam.origin[i] for i in range(3)]
+        eye = [sum(cam.rot[3 * k + i] * d[i] for i in range(3)) + cam.pos[k]
+               for k in range(3)]
+        half_h = -eye[2] * cam.tan_half
+        return (eye[0] / (half_h * self.aspect()), eye[1] / half_h)
+
+    def atoms(self, coords, obj='m1', rep='spheres'):
+        '''One pseudoatom per (x, y, z), named a0, a1, ... in order.'''
+        for i, xyz in enumerate(coords):
+            cmd.pseudoatom(obj, name='a%d' % i, pos=list(xyz))
+        cmd.show_as(rep, obj)
+        return obj
+
+    def pick(self, ndc_x, ndc_y, **kwargs):
+        return metal_pick._pick_atom(ndc_x, ndc_y, self.aspect(), **kwargs)
+
+    def picked_name(self, ndc_x, ndc_y, **kwargs):
+        '''Name of the atom under (ndc_x, ndc_y), or None for empty space.'''
+        best = self.pick(ndc_x, ndc_y, **kwargs)
+        return None if best is None else best[6]
+
+    def picked_object(self, ndc_x, ndc_y, **kwargs):
+        best = self.pick(ndc_x, ndc_y, **kwargs)
+        return None if best is None else best[1]
+
+
+class TestPick(PickBase):
+
+    def testTheAtomUnderTheCursorIsPicked(self):
+        self.atoms([(-8, 0, 0), (0, 0, 0), (8, 4, 0)])
+        self.assertEqual(self.picked_name(*self.ndc(-8, 0)), 'a0')
+        self.assertEqual(self.picked_name(*self.ndc(0, 0)), 'a1')
+        self.assertEqual(self.picked_name(*self.ndc(8, 4)), 'a2')
+
+    def testEmptySpaceIsAMiss(self):
+        self.atoms([(0, 0, 0)])
+        self.assertIsNone(self.picked_name(-0.9, -0.9))
+
+    def testTheFrontMostOfTwoOverlappingAtomsWins(self):
+        # Same (x, y), so both project to NDC (0, 0); a1 is 40 A nearer the
+        # camera and is the one the renderer put on top.
+        self.atoms([(0, 0, -20), (0, 0, 20)])
+        self.assertEqual(self.picked_name(0.0, 0.0), 'a1')
+        cmd.hide('everything', 'm1 and name a1')
+        self.assertEqual(self.picked_name(0.0, 0.0), 'a0')
+
+    def testAtomsOutsideTheClipSlabAreNotPickable(self):
+        # depth = 100 - z, and the slab is [50, 150].
+        self.atoms([(0, 0, 60)], obj='near')     # depth 40, in front of the slab
+        self.atoms([(0, 0, -60)], obj='far')     # depth 160, behind it
+        self.assertIsNone(self.picked_name(0.0, 0.0))
+        self.atoms([(0, 0, 0)], obj='mid')       # depth 100, inside
+        self.assertEqual(self.picked_object(0.0, 0.0), 'mid')
+
+    def testAtomsWithNoDrawnRepAreNotPickable(self):
+        self.atoms([(0, 0, 0)])
+        self.assertEqual(self.picked_name(0.0, 0.0), 'a0')
+        cmd.hide('everything', 'm1')
+        self.assertIsNone(self.picked_name(0.0, 0.0))
+
+    def testADisabledObjectIsNotPickable(self):
+        self.atoms([(0, 0, 0)], obj='shown')
+        self.atoms([(0, 0, 20)], obj='hidden')   # nearer, so it would win
+        self.assertEqual(self.picked_object(0.0, 0.0), 'hidden')
+        cmd.disable('hidden')
+        self.assertEqual(self.picked_object(0.0, 0.0), 'shown')
+
+    def testAMovedObjectPicksWhereItRenders(self):
+        # The object matrix (TTT) moves the geometry without touching the
+        # coordinates, so a pick that read raw coordinates would keep hitting
+        # the old screen position.
+        self.atoms([(0, 0, 0)])
+        cmd.translate([6.0, 0.0, 0.0], object='m1', camera=0)
+        self.assertIsNone(self.picked_name(*self.ndc(0, 0)))
+        self.assertEqual(self.picked_name(*self.ndc(6, 0)), 'a0')
+
+    def testTheDisplayedStateIsPicked(self):
+        cmd.pseudoatom('m1', name='a0', pos=[-8.0, 0.0, 0.0])
+        cmd.create('m1', 'm1', 1, 2)          # same atom, a second state
+        cmd.alter_state(2, 'm1', 'x = 8.0')
+        cmd.show_as('spheres', 'm1')
+        self.assertEqual(cmd.count_states('m1'), 2)
+        self.assertEqual(self.picked_name(*self.ndc(-8, 0)), 'a0')
+        self.assertIsNone(self.picked_name(*self.ndc(8, 0)))
+        cmd.frame(2)
+        self.assertIsNone(self.picked_name(*self.ndc(-8, 0)))
+        self.assertEqual(self.picked_name(*self.ndc(8, 0)), 'a0')
+
+    def testTheObjectRadiusIsMoreForgivingThanTheAtomRadius(self):
+        # Object (move-mode) picking passes the wider radius so a tap anywhere
+        # on a molecule identifies it; the default residue radius does not.
+        self.atoms([(0, 0, 0)])
+        off = self.ndc(0, 0)
+        off = (off[0] + 0.2, off[1])
+        self.assertIsNone(self.picked_name(*off))
+        self.assertEqual(
+            self.picked_name(*off, max_ndc2=metal_pick._OBJECT_PICK_NDC2), 'a0')
+
+
+class TestDrawnReps(PickBase):
+    '''What counts as "drawn", i.e. what the visRep bitmask the native pick
+    tests must mean the same thing as the _DRAWN_REPS selection.'''
+
+    @testing.foreach(*DRAWN_REPS)
+    def testEachDrawnRepIsPickable(self, rep):
+        self.atoms([(0, 0, 0)], rep=rep)
+        self.assertEqual(cmd.count_atoms('(m1) and (%s)' % metal_pick._DRAWN_REPS), 1)
+        self.assertEqual(self.picked_name(0.0, 0.0), 'a0')
+
+    def testLabelsAloneAreNotPickable(self):
+        self.atoms([(0, 0, 0)], rep='labels')
+        self.assertEqual(cmd.count_atoms('(m1) and (%s)' % metal_pick._DRAWN_REPS), 0)
+        self.assertIsNone(self.picked_name(0.0, 0.0))
+
+    def testCartoonPicksResolveToGuideAtoms(self):
+        # `show cartoon` sets its visRep bit on EVERY atom of the object, but
+        # the ribbon is a spline through the guide atoms, so those are the only
+        # ones a pick may land on -- otherwise hovering a cartoon snaps to
+        # whichever invisible side-chain atom happens to project nearest.
+        cmd.fab('AWAWA', 'pep')
+        cmd.hide('everything', 'pep')
+        cmd.show('cartoon', 'pep')
+        cmd.orient('pep')
+        hits = 0
+        for xyz, name in self._atom_positions('pep and not name CA'):
+            best = metal_pick._pick_atom(*(self.project(xyz) + (self.aspect(),)))
+            if best is not None:
+                hits += 1
+                self.assertEqual(best[6], 'CA',
+                                 'cursor over %s picked %s' % (name, best[6]))
+        self.assertTrue(hits, 'no cartoon atom was hit at all')
+
+    def _atom_positions(self, selection):
+        rows = []
+        cmd.iterate_state(1, selection, 'rows.append(((x, y, z), name))',
+                          space={'rows': rows}, quiet=1)
+        return rows
+
+
+class TestNativeParity(PickBase):
+    '''The C++ pick and the Python reference must agree everywhere.'''
+
+    def setUp(self):
+        super(TestNativeParity, self).setUp()
+        if not metal_pick._have_native_pick():
+            self.skipTest('core built without _cmd.metal_pick')
+
+    def _scene(self):
+        cmd.fab('AWKGDYF', 'pep')
+        cmd.show_as('sticks', 'pep')
+        cmd.show('spheres', 'pep and name CA')
+        cmd.fab('GGPLA', 'pep2')
+        cmd.show_as('cartoon', 'pep2')
+        cmd.translate([4.0, 3.0, 2.0], object='pep2', camera=0)
+        self.atoms([(0, 0, 5), (2, -2, -5)], obj='dots', rep='dots')
+        cmd.zoom('all', buffer=2)
+        return [o for o in cmd.get_names('objects', enabled_only=1)]
+
+    def _assertSameHit(self, native, python, where):
+        if native is None or python is None:
+            self.assertEqual(native, python, where)
+            return
+        self.assertEqual(native[1:7], python[1:7], where)
+        for i in (0, 7, 8):
+            self.assertAlmostEqual(native[i], python[i], delta=1e-4, msg=where)
+
+    def testTheTwoPathsAgreeAcrossTheViewport(self):
+        objs = self._scene()
+        cam = metal_pick.camera()
+        aspect = self.aspect()
+        thresh = metal_pick._MAX_PICK_NDC2
+        seen = 0
+        for i in range(11):
+            for j in range(11):
+                x, y = -1.0 + 0.2 * i, -1.0 + 0.2 * j
+                native = metal_pick._native_pick(objs, cam, x, y, aspect, thresh)
+                python = metal_pick._python_pick(objs, cam, x, y, aspect, thresh)
+                self._assertSameHit(native, python, 'at ndc (%.1f, %.1f)' % (x, y))
+                seen += native is not None
+        self.assertTrue(seen, 'the sampled grid never hit an atom')
+
+    def testTheTwoPathsAgreeAtTheObjectRadius(self):
+        objs = self._scene()
+        cam = metal_pick.camera()
+        aspect = self.aspect()
+        thresh = metal_pick._OBJECT_PICK_NDC2
+        for i in range(7):
+            x = -0.9 + 0.3 * i
+            self._assertSameHit(
+                metal_pick._native_pick(objs, cam, x, 0.0, aspect, thresh),
+                metal_pick._python_pick(objs, cam, x, 0.0, aspect, thresh),
+                'at ndc (%.1f, 0.0)' % x)

--- a/testing/tests/test_metal_pick.py
+++ b/testing/tests/test_metal_pick.py
@@ -172,7 +172,14 @@ class TestPickAtIntegration(unittest.TestCase):
 
         self.addCleanup(_restore)
 
-    def test_pick_at_creates_selection(self):
+    def _install_mock_cmd(self, native):
+        """A cmd stand-in holding one atom at the rotation origin, so a click at
+        NDC (0,0) lands on it.
+
+        `native` decides which of metal_pick's two paths the module takes: with
+        a metal_pick entry on _cmd it hands the projection to C++, without one
+        it walks a chempy model in Python. Both must end at the same 'sele'.
+        """
         mock_cmd = MagicMock()
         mock_cmd.get_view.return_value = (
             1.0, 0.0, 0.0,
@@ -203,17 +210,31 @@ class TestPickAtIntegration(unittest.TestCase):
         mock_cmd.get_names.side_effect = \
             lambda kind, **kw: ["protein"] if kind == "objects" else []
 
+        if native:
+            # The C++ pick returns the hit tuple ready-made:
+            # (d2, obj, chain, resi, resn, segi, name, sx, sy).
+            mock_cmd._cmd.metal_pick.return_value = (
+                0.0, "protein", "A", "42", "ALA", "A", "CA", 0.0, 0.0)
+        else:
+            # spec=[] gives an object with NO attributes, so metal_pick's
+            # hasattr(_cmd, 'metal_pick') probe fails and it falls back.
+            mock_cmd._cmd = MagicMock(spec=[])
+
         # Patch pymol.cmd inside metal_pick
         _pymol_mod = sys.modules["pymol"]
         _pymol_mod.cmd = mock_cmd
         sys.modules["pymol.cmd"] = mock_cmd
+        return mock_cmd
 
-        # Force re-import of metal_pick
+    def _import_metal_pick(self):
+        """Re-import the module so it re-probes for the native pick (the answer
+        is cached in a module global) against the mock just installed."""
         if "pymol.metal_pick" in sys.modules:
             del sys.modules["pymol.metal_pick"]
-        from pymol.metal_pick import pick_at
-        pick_at(0.0, 0.0, 1.0)
+        import pymol.metal_pick
+        return sys.modules["pymol.metal_pick"]
 
+    def _assertSelectedResidue42(self, mock_cmd):
         # pick_at toggles the clicked residue into the named 'sele' (selection
         # indicators are rendered in C++, NOT via a pseudoatom marker) and enables
         # it. Default mouse_selection_mode is residue, so the expr is resi-scoped.
@@ -223,6 +244,21 @@ class TestPickAtIntegration(unittest.TestCase):
         self.assertIn("resi 42", sel_expr)
         self.assertIn("chain A", sel_expr)
         mock_cmd.enable.assert_called_with("sele")
+
+    def test_pick_at_creates_selection(self):
+        mock_cmd = self._install_mock_cmd(native=False)
+        self._import_metal_pick().pick_at(0.0, 0.0, 1.0)
+        self._assertSelectedResidue42(mock_cmd)
+        # The Python path is the one that reads the chempy model.
+        self.assertTrue(mock_cmd.get_model.called)
+
+    def test_pick_at_uses_the_native_pick_when_the_core_has_one(self):
+        mock_cmd = self._install_mock_cmd(native=True)
+        self._import_metal_pick().pick_at(0.0, 0.0, 1.0)
+        self._assertSelectedResidue42(mock_cmd)
+        # ...and it must not rebuild a chempy model of every drawn atom (#394).
+        self.assertFalse(mock_cmd.get_model.called)
+        mock_cmd._cmd.metal_pick.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #394.

## What was slow

Every pick rebuilt a `chempy` model of **all drawn atoms of every enabled object** (`cmd.get_model`) and projected them in pure Python. Hover preview and hover readout are both on by default and the pick is throttled to ~22/s, so on a large structure the main thread had nothing left for the render loop, the feedback timer or the panel polls.

## What changed

The per-atom work moves to `layer3/MetalPick.cpp`, reached through a new `_cmd.metal_pick`. It:

- walks each `CoordSet`'s coordinate array directly (`IdxToAtm` → coord), so there is no chempy model and no per-atom Python object;
- tests the drawn reps as a `visRep` bitmask instead of running the selection parser once per object — including the cartoon/ribbon special case, which is `(cartoon|ribbon bit) && (flags & cAtomFlag_guide)`;
- applies the same state matrix + object TTT that `CoordSetGetAtomTxfVertex` does, so a moved object still picks where it renders;
- honours the clip slab and the front-most-of-a-cluster rule exactly as before.

`modules/pymol/metal_pick.py` stays the policy layer: camera parsing, grid-cell mapping, `mouse_selection_mode` expansion, `_preselect`, readout payload. The Python projection is kept as `_python_pick` — it is the reference the native path is tested against, it is what the `PYMOL_PICKDEBUG` harness runs (it reports the candidate count and projected extent the C++ path doesn't collect), and it is the fallback for cores built without the new entry point (e.g. the shadow-tree setup over Homebrew pymol).

`pick_at`, `pick_info_at`, `hover_preview_at`, `hover_design_at`, `metal_move` and `appkit_measure` all go through `_pick_atom` and pick this up unchanged. No Swift change.

## Measured

50,400 drawn atoms (84 copies of a 60-mer, sticks + spheres), 800x600 viewport, Release core on Apple silicon:

| | before | after |
|---|---|---|
| `_pick_atom` | 450–920 ms | **0.32 ms** |
| `hover_preview_at(…, 1, 1)` | ~same + ~5 ms | **6.0 ms** |

At 18,000 drawn atoms it is 72 ms → 0.10 ms.

The remaining hover cost is `cmd.select('_preselect', …)` at 5.3 ms (the readout payload is 0.1 ms) — a selector evaluation over the whole atom table, unrelated to this path and left for a follow-up. At 22 picks/s that is ~15% of the main thread rather than the >100% the issue measured.

## Behaviour change worth flagging

An object with **fewer states than the current frame** is no longer pickable. The renderer draws nothing for it (`StateIterator` clamps to `[0, nstate)`), while the old code fell back to `get_model()`'s default state 1 and picked it anyway — i.e. it could select an object that wasn't on screen. The native path asks each object for its own current state (`CObject::getObjectState`), which is also what the renderer asks.

## Tests

New `testing/tests/raymol/metal_pick.py` (22 cases, live core, camera pinned with `set_view` the same way `api/box_select.py` does it):

- every drawn rep is pickable and agrees with the `_DRAWN_REPS` selection; `labels` alone is not — this is the guard against the bitmask and the selection string drifting apart;
- a cartoon-only object resolves every hit to a guide atom, never to an invisible side chain;
- clip slab, front-most-of-two-overlapping, hidden reps, disabled objects, moved (TTT) objects, displayed state, the wider object-pick radius;
- `TestNativeParity` runs the C++ pick and the Python reference over an 11x11 grid of cursor positions on a mixed scene and requires the same hit.

Verified the suite fails without the fix: dropping a rep from the mask fails its `testEachDrawnRepIsPickable` case, and folding cartoon/ribbon into the plain drawn mask fails the guide-atom test and both parity tests.

`testing/tests/test_metal_pick.py` (headless, mocked `cmd`) now covers both branches — the existing case pins the Python path, a new one pins the native path and asserts it never touches `get_model`.

Added to the embedded-tests workflow. Full CI list green locally: 955 unittest + 287 pytest, plus `api/box_select.py`, `api/selecting.py`, `api/querying.py`.

Both build configurations compile clean (no new warnings): the `pip install .` GLUT/OpenGL extension and `swiftui/build_macos.sh`'s Metal-only `libpymol_core.a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)