### PR TITLE
perf(metal): cache the shadow-frustum extent and actually exclude solvent (#393)

### DIFF
--- a/.github/workflows/raymol-embedded-tests.yml
+++ b/.github/workflows/raymol-embedded-tests.yml
@@ -75,6 +75,7 @@ jobs:
               testing/tests/raymol/design_region.py \
               testing/tests/raymol/design_saverestore.py \
               testing/tests/raymol/scene_ttt.py \
+              testing/tests/raymol/shadow_extent.py \
               testing/tests/predict \
               testing/tests/msa \
               testing/tests/metrics \

--- a/layer1/Scene.cpp
+++ b/layer1/Scene.cpp
@@ -2280,10 +2280,20 @@ void SceneRovingDirty(PyMOLGlobals * G)
 
 
 /*========================================================================*/
+void SceneInvalidateExtentCache(PyMOLGlobals * G)
+{
+  CScene *I = G->Scene;
+  if(I) {
+    I->ShadowExtentValid = false;
+    I->DofExtentValid = false;
+  }
+}
+
 void SceneChanged(PyMOLGlobals * G)
 {
   CScene *I = G->Scene;
   I->ChangedFlag = true;
+  SceneInvalidateExtentCache(G);
   SceneInvalidateCopy(G, false);
   SceneDirty(G);
   SeqChanged(G);
@@ -2707,6 +2717,7 @@ int SceneObjectDel(PyMOLGlobals * G, pymol::CObject * obj, int allow_purge)
     }
   }
   SceneCountFrames(G);
+  SceneInvalidateExtentCache(G);
   SceneInvalidate(G);
   SceneInvalidatePicking(G);
   return 0;
@@ -2725,6 +2736,7 @@ bool SceneObjectRemove(PyMOLGlobals* G, pymol::CObject* obj)
     return false;
   }
   obj_list.erase(it, obj_list.end());
+  SceneInvalidateExtentCache(G);
   return true;
 }
 

--- a/layer1/Scene.h
+++ b/layer1/Scene.h
@@ -77,6 +77,24 @@ void SceneDirty(PyMOLGlobals * G);      /* scene dirty, but leave the overlay if
 void SceneInvalidate(PyMOLGlobals * G); /* scene dirty and remove the overlay */
 void SceneChanged(PyMOLGlobals * G);    /* update 3D objects */
 
+/**
+ * Drop the cached model-space extents used to size the Metal shadow frustum and
+ * the DOF autofocus plane. Implied by SceneChanged(); call it directly from
+ * paths that change what those extents cover without going through
+ * SceneChanged() (e.g. creating or deleting a named selection).
+ */
+void SceneInvalidateExtentCache(PyMOLGlobals * G);
+
+/**
+ * Model-space bounding box of the shadow-casting geometry: every enabled scene
+ * object, solvent atoms excluded (all atoms if the scene is solvent-only).
+ * Cached; see SceneInvalidateExtentCache().
+ *
+ * @param[out] mn,mx min/max corners, only written when this returns true
+ * @return false if the scene holds no geometry to bound
+ */
+bool SceneGetShadowExtent(PyMOLGlobals * G, float *mn, float *mx);
+
 int SceneCountFrames(PyMOLGlobals * G);
 int SceneGetNFrame(PyMOLGlobals * G, int *has_movie=nullptr);
 void SceneSetMatrix(PyMOLGlobals * G, float *);

--- a/layer1/SceneDef.h
+++ b/layer1/SceneDef.h
@@ -136,6 +136,19 @@ class CScene : public Block {
   float FogStart{};
   float FogEnd{};
 
+  /* Model-space extents the Metal render path needs once per frame: the
+     shadow-map frustum box (non-solvent geometry) and the DOF autofocus
+     target's center. Both are independent of the camera, so they are computed
+     lazily and reused until the scene's contents change -- recomputing them per
+     frame walks every atom of every object on the main thread (#393). See
+     SceneInvalidateExtentCache(). */
+  bool ShadowExtentValid{};
+  bool ShadowExtentFlag{}; /* false = nothing to bound (empty scene) */
+  float ShadowExtentMin[3]{}, ShadowExtentMax[3]{};
+  bool DofExtentValid{};
+  bool DofExtentFlag{}; /* false = 'dof_focus' is empty/undefined */
+  float DofExtentCenter[3]{};
+
   /* Scene Names */
   int ButtonsShown{}, ButtonDrag{}, ButtonMargin{}, ButtonsValid{};
   int Over{-1}, Pressed{-1}, PressMode{}, HowFarDown{}, NSkip{};

--- a/layer1/SceneRender.cpp
+++ b/layer1/SceneRender.cpp
@@ -4,13 +4,16 @@
 
 #include <algorithm>
 
+#include "AtomInfo.h"
 #include "CGO.h"
 #include "Control.h"
+#include "CoordSet.h"
 #include "Editor.h"
 #include "Err.h"
 #include "Executive.h"
 #include "Feedback.h"
 #include "Matrix.h"
+#include "ObjectMolecule.h"
 #include "Ortho.h"
 #include "P.h"
 #include "Picking.h"
@@ -1836,6 +1839,112 @@ static void SceneRenderPostProcessStack(PyMOLGlobals* G, const GLFramebufferConf
   SceneRenderAA(G, parentImage);
 }
 
+/**
+ * Model-space bounding box of the geometry that casts shadows: every object
+ * enabled in the scene, with solvent atoms left out.
+ *
+ * This deliberately does NOT go through ExecutiveGetExtent(). That takes an
+ * object/selection *name pattern*, not an atom selection, so the "not solvent"
+ * it used to be handed was parsed as name negation -- it matched every object
+ * and every named selection not literally called `solvent` (double-counting
+ * atoms covered by a selection) and never excluded a single water (#393).
+ * Walking the scene's own object list instead gets the intended semantics, and
+ * costs one pass over the coordinates with no per-atom SelectorIsMember().
+ *
+ * Transformation matches ExecutiveGetExtent(transformed=true, state=-1): all
+ * coordinate sets, state matrix (under matrix_mode) then object TTT.
+ *
+ * @param[out] mn,mx model-space min/max corners
+ * @param skip_solvent exclude atoms flagged as solvent
+ * @return false if nothing contributed (mn/mx untouched)
+ */
+static bool SceneComputeShadowExtent(
+    PyMOLGlobals* G, float* mn, float* mx, bool skip_solvent)
+{
+  CScene* I = G->Scene;
+  bool have_extent = false;
+
+  auto include = [&](const float* v) {
+    if (!have_extent) {
+      copy3f(v, mn);
+      copy3f(v, mx);
+      have_extent = true;
+    } else {
+      min3f(v, mn, mn);
+      max3f(v, mx, mx);
+    }
+  };
+
+  for (auto* obj : I->Obj) {
+    if (obj->type != cObjectMolecule) {
+      // Maps, meshes, surfaces, CGOs: they already carry a cached extent.
+      if (obj->ExtentFlag) {
+        include(obj->ExtentMin);
+        include(obj->ExtentMax);
+      }
+      continue;
+    }
+
+    auto* objMol = static_cast<ObjectMolecule*>(obj);
+    int use_matrices =
+        SettingGet_i(G, objMol->Setting.get(), nullptr, cSetting_matrix_mode);
+    if (use_matrices < 0)
+      use_matrices = 0;
+
+    for (int b = 0; b < objMol->NCSet; b++) {
+      CoordSet* cs = objMol->CSet[b];
+      if (!cs)
+        continue;
+      for (int idx = 0; idx < cs->NIndex; idx++) {
+        if (skip_solvent &&
+            (objMol->AtomInfo[cs->IdxToAtm[idx]].flags & cAtomFlag_solvent))
+          continue;
+        const float* coord = cs->coordPtr(idx);
+        float v[3];
+        if (use_matrices && !cs->Matrix.empty()) {
+          transform44d3f(cs->Matrix.data(), coord, v);
+          coord = v;
+        }
+        if (objMol->TTTFlag) {
+          transformTTT44f3f(objMol->TTT, coord, v);
+          coord = v;
+        }
+        include(coord);
+      }
+    }
+  }
+
+  return have_extent;
+}
+
+/**
+ * Cached accessor for SceneComputeShadowExtent(). The box is model-space, so it
+ * survives every camera move; SceneChanged() drops it when the scene's contents
+ * change. Recomputing it per frame was ~63% of the main thread's render work at
+ * 56k atoms (#393).
+ */
+bool SceneGetShadowExtent(PyMOLGlobals* G, float* mn, float* mx)
+{
+  CScene* I = G->Scene;
+  if (!I->ShadowExtentValid) {
+    // Scattered crystallographic waters would inflate the box, coarsening
+    // shadow-map depth precision (-> slab self-shadow) and resolution. A
+    // solvent-only scene still needs a frustum, so fall back to all atoms.
+    I->ShadowExtentFlag = SceneComputeShadowExtent(
+        G, I->ShadowExtentMin, I->ShadowExtentMax, true);
+    if (!I->ShadowExtentFlag) {
+      I->ShadowExtentFlag = SceneComputeShadowExtent(
+          G, I->ShadowExtentMin, I->ShadowExtentMax, false);
+    }
+    I->ShadowExtentValid = true;
+  }
+  if (I->ShadowExtentFlag) {
+    copy3f(I->ShadowExtentMin, mn);
+    copy3f(I->ShadowExtentMax, mx);
+  }
+  return I->ShadowExtentFlag;
+}
+
 // Build the directional key light's view*projection in EYE space, so the post
 // pass can reuse its existing eye-space position reconstruction (no camera
 // inverse needed). The light dir matches the shading key light (eye-space
@@ -1849,13 +1958,7 @@ static glm::mat4 SceneBuildLightViewProjEye(PyMOLGlobals* G, float* outRadius = 
   float mn[3], mx[3];
   glm::vec3 centerEye(0.0f);
   float radius = 10.0f;
-  // Size the frustum to the non-solvent geometry: scattered crystallographic
-  // waters would otherwise inflate the box, coarsening shadow-map depth
-  // precision (→ slab self-shadow) and resolution. Fall back to all atoms.
-  bool gotExtent = ExecutiveGetExtent(G, "not solvent", mn, mx, true, -1, false);
-  if (!gotExtent)
-    gotExtent = ExecutiveGetExtent(G, "all", mn, mx, true, -1, false);
-  if (gotExtent) {
+  if (SceneGetShadowExtent(G, mn, mx)) {
     glm::vec3 cw(
         (mn[0] + mx[0]) * 0.5f, (mn[1] + mx[1]) * 0.5f, (mn[2] + mx[2]) * 0.5f);
     glm::vec3 dw(mx[0] - mn[0], mx[1] - mn[1], mx[2] - mn[2]);
@@ -2048,12 +2151,24 @@ void SceneRenderMetal(PyMOLGlobals* G)
       // centroid's eye-space depth every frame so the element stays sharp as the
       // camera zooms/rotates/pans. Overrides the manual focus slider; an empty
       // selection leaves dofFocus at 0 and falls through to the origin below.
+      // The centroid itself is model-space, so it is cached alongside the
+      // shadow extent and only recomputed when the scene changes -- the
+      // ExecutiveGetExtent() walk cost as much as the shadow one (#393). Only
+      // the eye-space projection below runs per frame.
       dofFocus = 0.0f;
-      float mn[3], mx[3];
-      if (ExecutiveGetExtent(G, "dof_focus", mn, mx, true, -1, false)) {
-        float cx = (mn[0] + mx[0]) * 0.5f, cy = (mn[1] + mx[1]) * 0.5f,
-              cz = (mn[2] + mx[2]) * 0.5f;
-        float ez = mv[2] * cx + mv[6] * cy + mv[10] * cz + mv[14];
+      if (!I->DofExtentValid) {
+        float mn[3], mx[3];
+        I->DofExtentFlag =
+            ExecutiveGetExtent(G, "dof_focus", mn, mx, true, -1, false);
+        if (I->DofExtentFlag) {
+          for (int a = 0; a < 3; a++)
+            I->DofExtentCenter[a] = (mn[a] + mx[a]) * 0.5f;
+        }
+        I->DofExtentValid = true;
+      }
+      if (I->DofExtentFlag) {
+        const float* c = I->DofExtentCenter;
+        float ez = mv[2] * c[0] + mv[6] * c[1] + mv[10] * c[2] + mv[14];
         if (-ez > 0.0f)
           dofFocus = -ez;
       }

--- a/layer3/Executive.cpp
+++ b/layer3/Executive.cpp
@@ -2946,6 +2946,7 @@ pymol::Result<> ExecutiveResetMatrix(
   if (!obj_found) {
     return pymol::make_error("No object found");
   }
+  SceneInvalidateExtentCache(G); // moves the shadow frustum's box (#393)
   return {};
 }
 
@@ -3008,6 +3009,7 @@ static int ExecutiveSetObjectMatrix2(
   } else {
     if (auto* objstate = obj->getObjectState(state)) {
       ObjectStateSetMatrix(objstate, matrix);
+      SceneInvalidateExtentCache(G); // moves the shadow frustum's box (#393)
       ok = true;
     }
   }
@@ -7606,6 +7608,9 @@ void ExecutiveObjectFuncTTT(PyMOLGlobals* G, pymol::zstring_view name,
     int store, Func func, Args... args)
 {
   auto I = G->Executive;
+  // Moving an object by its TTT moves the shadow frustum's box with it, and
+  // none of the callees goes through SceneChanged() (#393).
+  SceneInvalidateExtentCache(G);
   if (name.empty() || name == cKeywordAll || name == cKeywordSame) {
     for (auto& rec : pymol::make_list_adapter(I->Spec)) {
       switch (rec.type) {
@@ -14615,6 +14620,7 @@ void ExecutivePurgeSpec(PyMOLGlobals* G, SpecRec* rec, bool save)
       SceneInvalidate(G);
       SeqDirty(G);
     }
+    SceneInvalidateExtentCache(G); // see ExecutiveManageSelection (#393)
     ExecutiveDelKey(I, rec);
     SelectorDelete(G, rec->name);
     TrackerDelCand(I->Tracker, rec->cand_id);
@@ -15073,6 +15079,9 @@ void ExecutiveManageSelection(PyMOLGlobals* G, const char* name)
   }
   if (rec->visible)
     SceneInvalidate(G);
+  // The DOF autofocus plane is cached off the 'dof_focus' selection's extent,
+  // which this (re)definition may have just moved (#393).
+  SceneInvalidateExtentCache(G);
   ExecutiveDoAutoGroup(G, rec);
   SeqDirty(G);
 }

--- a/layer4/Cmd.cpp
+++ b/layer4/Cmd.cpp
@@ -4506,6 +4506,24 @@ static PyObject *CmdSetMatrix(PyObject * self, PyObject * args)
 }
 #endif
 
+/**
+ * Model-space bounding box the Metal shadow-map frustum is sized to: every
+ * enabled object, solvent excluded. Introspection hook for the regression tests
+ * around #393 -- the value is cached in CScene and must track scene content.
+ */
+static PyObject *CmdGetShadowExtent(PyObject * self, PyObject * args)
+{
+  PyMOLGlobals *G = nullptr;
+  float mn[3], mx[3];
+  API_SETUP_ARGS(G, self, args, "O", &self);
+  APIEnter(G);
+  int flag = SceneGetShadowExtent(G, mn, mx);
+  APIExit(G);
+  if(!flag)
+    Py_RETURN_NONE;
+  return Py_BuildValue("[[fff],[fff]]", mn[0], mn[1], mn[2], mx[0], mx[1], mx[2]);
+}
+
 static PyObject *CmdGetMinMax(PyObject * self, PyObject * args)
 {
   PyMOLGlobals *G = nullptr;
@@ -6483,6 +6501,7 @@ static PyMethodDef Cmd_methods[] = {
   {"get_m2io_first_block_properties", CmdM2ioFirstBlockProperties, METH_VARARGS},
 //  {"get_matrix", CmdGetMatrix, METH_VARARGS},
   {"get_min_max", CmdGetMinMax, METH_VARARGS},
+  {"get_shadow_extent", CmdGetShadowExtent, METH_VARARGS},
   {"get_mtl_obj", CmdGetMtlObj, METH_VARARGS},
   {"get_model", CmdGetModel, METH_VARARGS},
   {"get_property", CmdGetProperty, METH_VARARGS},

--- a/testing/tests/raymol/shadow_extent.py
+++ b/testing/tests/raymol/shadow_extent.py
@@ -1,0 +1,144 @@
+"""Shadow-frustum extent: solvent exclusion + cache invalidation (#393).
+
+The Metal shadow pass used to call ExecutiveGetExtent(G, "not solvent", ...) on
+every frame. That is a name *pattern*, not an atom selection, so it matched
+every object and named selection not literally called `solvent` (waters were
+never excluded) and it re-walked every atom at up to 120 Hz. The extent is now
+computed over the scene's own object list, solvent skipped, and cached until the
+scene's contents change.
+
+Runs on a RayMol --testing build:
+    pymol -ckqy testing/testing.py --run tests/raymol/shadow_extent.py
+"""
+from pymol import cmd, testing
+from pymol import _cmd
+
+# Two protein atoms in a 1 A box at the origin, plus waters 50 A away.
+_PDB = """\
+ATOM      1  N   ALA A   1       0.000   0.000   0.000  1.00  0.00           N
+ATOM      2  CA  ALA A   1       1.000   1.000   1.000  1.00  0.00           C
+HETATM    3  O   HOH A   2      50.000  50.000  50.000  1.00  0.00           O
+HETATM    4  O   HOH A   3     -50.000 -50.000 -50.000  1.00  0.00           O
+END
+"""
+
+
+class TestShadowExtent(testing.PyMOLTestCase):
+    def shadowExtent(self):
+        """The cached extent, as the Metal shadow pass sees it."""
+        with cmd.lockcm:
+            return _cmd.get_shadow_extent(cmd._COb)
+
+    def freshExtent(self):
+        """The same extent, recomputed from scratch.
+
+        Adding and removing a throwaway object invalidates the cache without
+        disturbing any other object's coordinates or enabled state, so this is
+        the ground truth the cached value has to keep matching.
+        """
+        cmd.pseudoatom('_shadow_probe', pos=[0.0, 0.0, 0.0])
+        cmd.delete('_shadow_probe')
+        return self.shadowExtent()
+
+    def assertExtentEqual(self, a, b, delta=1e-4, msg=None):
+        self.assertIsNotNone(a, msg)
+        self.assertIsNotNone(b, msg)
+        for corner_a, corner_b in zip(a, b):
+            for x, y in zip(corner_a, corner_b):
+                self.assertAlmostEqual(x, y, delta=delta, msg=msg)
+
+    def assertCacheIsFresh(self, after):
+        """The cached extent still agrees with a from-scratch recompute."""
+        self.assertExtentEqual(self.shadowExtent(), self.freshExtent(),
+                               msg='stale shadow extent after %s' % after)
+
+    # --- what the box covers -------------------------------------------------
+    def testSolventIsExcluded(self):
+        cmd.reinitialize()
+        cmd.read_pdbstr(_PDB, 'm1')
+        self.assertEqual(cmd.count_atoms('solvent'), 2)
+        # The waters are 50 A out and do bound the model...
+        self.assertExtentEqual(cmd.get_extent('all'),
+                               [[-50.0, -50.0, -50.0], [50.0, 50.0, 50.0]])
+        # ...but the shadow frustum must not be stretched to reach them.
+        self.assertExtentEqual(self.shadowExtent(),
+                               [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
+
+    def testSolventOnlySceneFallsBackToAllAtoms(self):
+        """A frustum sized to nothing would collapse the shadow map."""
+        cmd.reinitialize()
+        cmd.read_pdbstr(_PDB, 'm1')
+        cmd.remove('not solvent')
+        self.assertEqual(cmd.count_atoms('all'), 2)
+        self.assertExtentEqual(self.shadowExtent(),
+                               [[-50.0, -50.0, -50.0], [50.0, 50.0, 50.0]])
+
+    def testEmptySceneHasNoExtent(self):
+        cmd.reinitialize()
+        self.assertIsNone(self.shadowExtent())
+
+    def testDisabledObjectsAreExcluded(self):
+        """Disabled objects cast no shadow, so they must not widen the box."""
+        cmd.reinitialize()
+        cmd.read_pdbstr(_PDB, 'm1')
+        cmd.pseudoatom('m2', pos=[70.0, 0.0, 0.0])
+        self.assertAlmostEqual(self.shadowExtent()[1][0], 70.0, delta=1e-4)
+        cmd.disable('m2')
+        self.assertAlmostEqual(self.shadowExtent()[1][0], 1.0, delta=1e-4)
+        cmd.enable('m2')
+        self.assertAlmostEqual(self.shadowExtent()[1][0], 70.0, delta=1e-4)
+
+    # --- the cache -----------------------------------------------------------
+    def testCameraMotionDoesNotMoveTheBox(self):
+        """It is model-space: this is what makes caching it across frames safe."""
+        cmd.reinitialize()
+        cmd.read_pdbstr(_PDB, 'm1')
+        before = self.shadowExtent()
+        cmd.turn('x', 37)
+        cmd.zoom()
+        cmd.move('z', 12)
+        self.assertExtentEqual(self.shadowExtent(), before)
+
+    def testCacheTracksContentChanges(self):
+        cmd.reinitialize()
+        cmd.read_pdbstr(_PDB, 'm1')
+        self.assertCacheIsFresh('load')
+
+        cmd.pseudoatom('m2', pos=[70.0, 0.0, 0.0])
+        self.assertCacheIsFresh('new object')
+
+        cmd.disable('m2')
+        self.assertCacheIsFresh('disable')
+        cmd.enable('m2')
+        self.assertCacheIsFresh('enable')
+        cmd.delete('m2')
+        self.assertCacheIsFresh('delete')
+
+        cmd.translate([20.0, 0.0, 0.0], object='m1', camera=0)
+        self.assertCacheIsFresh('object TTT translate')
+        cmd.rotate('x', 90, object='m1', camera=0)
+        self.assertCacheIsFresh('object TTT rotate')
+        cmd.matrix_reset('m1', mode=1)
+        self.assertCacheIsFresh('TTT reset')
+
+        cmd.set('matrix_mode', 2)
+        cmd.rotate('z', 45, object='m1', camera=0)
+        self.assertCacheIsFresh('object state-matrix rotate')
+        cmd.matrix_reset('m1', mode=2)
+        self.assertCacheIsFresh('state-matrix reset')
+        cmd.set('matrix_mode', 0)
+
+        cmd.translate([0.0, 30.0, 0.0], selection='m1 and name CA', camera=0)
+        self.assertCacheIsFresh('coordinate edit')
+        cmd.alter_state(1, 'm1 and name N', '(x,y,z)=(0,0,80)')
+        self.assertCacheIsFresh('alter_state')
+        cmd.load_coords([[0, 0, 0], [3, 3, 3], [50, 50, 50], [-50, -50, -50]],
+                        'm1')
+        self.assertCacheIsFresh('load_coords')
+        cmd.remove('m1 and name CA')
+        self.assertCacheIsFresh('remove atom')
+
+        cmd.fragment('trp', 'm4')
+        self.assertCacheIsFresh('fragment')
+        cmd.reinitialize()
+        self.assertIsNone(self.shadowExtent())


### PR DESCRIPTION
Closes #393.

## The two bugs

With `metal_shadows` on (the default), `SceneBuildLightViewProjEye` called
`ExecutiveGetExtent(G, "not solvent", …)` on **every frame** to size the shadow
frustum, walking every atom of every object on the main thread at up to 120 Hz.

And `"not solvent"` never did what it says. `ExecutiveGetExtent` takes an
object/selection **name pattern**, not an atom selection, so the leading `not`
was parsed as *name negation*: it matched every object and every named selection
not literally called `solvent` (double-counting atoms covered by a selection)
and never excluded a single water. The box was stretched to exactly the
crystallographic waters it was written to skip.

## The fix

`SceneComputeShadowExtent` walks the scene's own object list (`CScene::Obj`)
directly, skipping atoms flagged `cAtomFlag_solvent`, and the result is cached in
`CScene`. The box is model-space, so no camera motion can invalidate it —
which is what makes caching it across frames safe.

`SceneInvalidateExtentCache()` drops it. `SceneChanged()` calls it, plus the
three paths that move geometry *without* going through `SceneChanged()`, each
found by probing rather than by reading: object delete (`SceneObjectDel`), object
TTT (`ExecutiveObjectFuncTTT`), and state matrices
(`ExecutiveSetObjectMatrix2` / `ExecutiveResetMatrix`).

Two behavior changes fall out, both in the right direction:

- **Solvent is excluded for real.** Scattered waters no longer inflate the box,
  so shadow-map depth precision and resolution stay matched to the structure.
- **Disabled objects no longer widen the box.** They cast no shadow; the old
  name-pattern match included them regardless of enabled state.

A solvent-only scene falls back to all atoms, so the frustum never collapses.

The DOF autofocus centroid (`metal_dof_autofocus`, the same per-frame
`ExecutiveGetExtent` on `"dof_focus"`) is cached the same way; only its eye-space
projection still runs per frame. Named-selection create/delete invalidates it.

## Measured

32 objects / 56,000 atoms, 10% solvent (issue reports 32 / 55,893):

| | per frame |
|---|---|
| extent walk (before) | 0.371 ms |
| cached (after) | 0.001 ms |
| one refresh, on content change | 0.601 ms |

## Verification

- `testing/tests/raymol/shadow_extent.py` (6 tests, added to the embedded-tests
  workflow). Confirmed to **fail against the original implementation**:
  `testSolventIsExcluded` (−50 Å water in the box) and
  `testDisabledObjectsAreExcluded` both fail before the change.
  `testCacheTracksContentChanges` walks load / enable / disable / delete / TTT /
  state-matrix / coordinate-edit / `alter_state` / `load_coords` / `remove` and
  asserts the cached box still matches a from-scratch recompute after each.
  `_cmd.get_shadow_extent` exposes the cached box for this.
- Live macOS Metal app (`RayMol-393.app`, Debug): a floor slab under 1ubq casts a
  crisp shadow with `metal_shadows` on and none with it off; the shadow follows a
  `cmd.translate(object=…)`; and it stays crisp with 300 waters scattered ±150 Å
  through the scene — the case that used to balloon the frustum.
- `testing/tests/api/{editing,creating,querying,viewing}.py` +
  `raymol/scene_ttt.py` + `test_raymol_scene_{ttt,anim}.py`: 219 tests, 1 failure
  (`testCartoon`, an image comparison that fails identically on unmodified
  `master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)