### PR TITLE
perf(metal): acquire the drawable after the scene is encoded (#396)

### DIFF
--- a/layer1/SceneRender.cpp
+++ b/layer1/SceneRender.cpp
@@ -2233,7 +2233,7 @@ void SceneRenderMetal(PyMOLGlobals* G)
         specPower,
         SettingGetGlobal_f(G, cSetting_metal_sss_wrap));
     // MSAA: 4x when metal_msaa is on, otherwise single-sample. The renderer
-    // stashes this and applies it at the next setDrawable (no encoder open),
+    // stashes this and applies it at the next beginLiveFrame (no encoder open),
     // so toggling at runtime never mismatches an in-flight encoder.
     G->Renderer->setDesiredSampleCount(
         SettingGetGlobal_b(G, cSetting_metal_msaa) ? 4 : 1);

--- a/layer5/main_appkit.mm
+++ b/layer5/main_appkit.mm
@@ -856,13 +856,14 @@ static void handleKeyDown(NSView *view, NSEvent *event) {
     auto* renderer = static_cast<pymol::RendererMetal*>(G->Renderer);
     if (!renderer) return;
 
-    // Get drawable and pass descriptor for this frame
-    id<CAMetalDrawable> drawable = self.currentDrawable;
-    MTLRenderPassDescriptor *passDesc = self.currentRenderPassDescriptor;
-    if (!drawable || !passDesc) return;
-
-    // Hand the drawable to the renderer and begin the frame
-    renderer->setDrawable(drawable, passDesc);
+    // Size the offscreen scene/post targets for this frame. The drawable itself
+    // is acquired after the scene is encoded, at the bottom of this method —
+    // only the final post pass writes to it, and waiting on `currentDrawable`
+    // here blocked the main thread (and input) whenever the GPU was behind
+    // (#396).
+    CGSize drawableSize = self.drawableSize;
+    if (drawableSize.width < 1 || drawableSize.height < 1) return;
+    renderer->beginLiveFrame((int)drawableSize.width, (int)drawableSize.height);
 
     // Process idle work (needs GIL for Python callbacks).
     // PyMOL_Idle uses PYMOL_API_TRYLOCK which calls PTryLockAPIAndUnblock:
@@ -911,6 +912,15 @@ static void handleKeyDown(NSView *view, NSEvent *event) {
     PyMOL_PopValidContext(pymolInstance);
 
     ImmBatch_SetActiveRenderer(nullptr);
+
+    // Late drawable acquisition (see beginLiveFrame above): the display server's
+    // wait now overlaps this frame's CPU encoding instead of preceding it. A nil
+    // drawable presents nothing; the next tick renders again.
+    id<CAMetalDrawable> drawable = self.currentDrawable;
+    MTLRenderPassDescriptor *passDesc =
+        drawable ? self.currentRenderPassDescriptor : nil;
+    if (drawable && passDesc)
+        renderer->setPresentTarget(drawable, passDesc);
 
     renderer->endFrame();
 }

--- a/layerGraphics/metal/RendererMetal.h
+++ b/layerGraphics/metal/RendererMetal.h
@@ -5,7 +5,9 @@
 #import <MetalKit/MetalKit.h>
 
 #include <array>
+#include <atomic>
 #include <cstring>
+#include <memory>
 #include <stack>
 #include <string>
 #include <unordered_map>
@@ -18,16 +20,34 @@ public:
   RendererMetal(id<MTLDevice> device, id<MTLCommandQueue> queue);
   ~RendererMetal() override;
 
-  // Call before each frame to provide the view's drawable and pass descriptor
-  void setDrawable(
+  // Live frame setup, deliberately split in two (#396). Only the FINAL post
+  // pass writes to the drawable, so the drawable is acquired as late as
+  // possible: everything that just needs the target SIZE (MSAA rebuild,
+  // offscreen post targets) happens in beginLiveFrame from the drawable's
+  // dimensions, and setPresentTarget hands over the actual CAMetalDrawable
+  // right before endFrame. Waiting on `currentDrawable` before encoding the
+  // scene blocked the main thread (and therefore input) for roughly half of
+  // every GPU-bound frame.
+  //
+  // beginLiveFrame clears any previous drawable, so a frame whose drawable
+  // never arrives presents nothing rather than re-presenting a stale one.
+  void beginLiveFrame(int drawableW, int drawableH);
+  void setPresentTarget(
       id<CAMetalDrawable> drawable, MTLRenderPassDescriptor* passDesc);
+
+  // Live command buffers that have been committed but whose GPU work has not
+  // completed yet. The render loop uses this to skip a tick instead of piling
+  // frames onto the queue, which is what keeps the (now late) currentDrawable
+  // wait short — see RenderGate in MetalViewport.swift. Offscreen/export
+  // frames block until completion and are never counted.
+  int framesInFlight() const { return _inFlight ? _inFlight->load() : 0; }
 
   // Frame lifecycle
   void beginFrame() override;
   void endFrame() override;
 
   // MSAA: stash the desired sample count (from metal_msaa). Applied at the top
-  // of the next setDrawable, before any encoder is open, so a toggle never
+  // of the next beginLiveFrame, before any encoder is open, so a toggle never
   // mismatches an in-flight encoder. n < 1 is clamped to 1.
   void setDesiredSampleCount(int n) override
   {
@@ -192,7 +212,7 @@ public:
   // the PNG capture; the caller then runs the normal beginFrame / scene-draw /
   // endOffscreen sequence. endOffscreen runs the full post chain (skipping the
   // drawable blit), commits, and blocks until the GPU has written the PNG.
-  // Targets self-heal to the window size on the next live setDrawable.
+  // Targets self-heal to the window size on the next live beginLiveFrame.
   void beginOffscreen(int w, int h, const std::string& path);
   void endOffscreen();
   void beginTransparentOIT() override;
@@ -269,6 +289,10 @@ private:
   id<MTLRenderCommandEncoder> _encoder;
   MTLRenderPassDescriptor* _passDesc;
   id<CAMetalDrawable> _drawable;
+  // In-flight live frame count. Held behind a shared_ptr because the command
+  // buffer's completion handler (a background thread) decrements it and may
+  // outlive this renderer.
+  std::shared_ptr<std::atomic<int>> _inFlight;
 
   // Buffer pool
   uint32_t _nextBufferId = 1;
@@ -331,13 +355,13 @@ private:
   id<MTLTexture> _sceneColorMS = nil;
   id<MTLTexture> _sceneDepthMS = nil;
   NSUInteger _sampleCount = 4;        // 4x MSAA by default (metal_msaa)
-  NSUInteger _desiredSampleCount = 4; // applied at next setDrawable (no encoder)
+  NSUInteger _desiredSampleCount = 4; // applied at next beginLiveFrame (no encoder)
   void setSampleCount(NSUInteger n);  // rebuilds targets+pipelines on change
   void buildBatchPipeline();
   MTLRenderPassDescriptor* _scenePassDesc = nil;
   MTLRenderPassDescriptor* _screenPassDesc = nil;
   NSUInteger _rtW = 0, _rtH = 0;
-  // Live render-target height, captured in setDrawable. Pixel-radius post passes
+  // Live render-target height, captured in beginLiveFrame. Pixel-radius post passes
   // (DoF aperture, outline thickness) are authored against the live resolution;
   // offscreen exports run at a higher _rtH, so scaling those radii by
   // _rtH/_liveRefH keeps the effect resolution-relative (WYSIWYG). 0 until the

--- a/layerGraphics/metal/RendererMetal.mm
+++ b/layerGraphics/metal/RendererMetal.mm
@@ -167,6 +167,7 @@ RendererMetal::RendererMetal(id<MTLDevice> device, id<MTLCommandQueue> queue)
     , _sphereImpostorPipeline(nil)
     , _cylinderImpostorPipeline(nil)
     , _depthStencilState(nil)
+    , _inFlight(std::make_shared<std::atomic<int>>(0))
 {
   _modelviewMatrix = identityMatrix();
   _modelviewInv = identityMatrix();
@@ -463,11 +464,13 @@ RendererMetal::~RendererMetal()
 #pragma mark - Drawable setup
 // ---------------------------------------------------------------------------
 
-void RendererMetal::setDrawable(
-    id<CAMetalDrawable> drawable, MTLRenderPassDescriptor* passDesc)
+void RendererMetal::beginLiveFrame(int drawableW, int drawableH)
 {
-  _drawable = drawable;
-  _screenPassDesc = passDesc;       // the drawable target (final composite pass)
+  // No drawable yet — it is acquired after the scene is encoded (#396). Clear
+  // the previous frame's target so a frame that never gets one cannot present
+  // stale contents; setPresentTarget fills these in before endFrame.
+  _drawable = nil;
+  _screenPassDesc = nil;
   // Apply any pending MSAA sample-count change here, before any encoder is open
   // (endFrame ended the previous one and beginFrame hasn't run yet). This
   // rebuilds the opaque pipelines + forces target recreation below, so the new
@@ -475,14 +478,17 @@ void RendererMetal::setDrawable(
   setSampleCount(_desiredSampleCount);
   // Render the scene into offscreen targets sized to the drawable; the existing
   // scene-draw code keys off _passDesc, so point it at the offscreen descriptor.
-  id<MTLTexture> tex = drawable.texture;
+  // The size comes from the caller (MTKView.drawableSize) rather than
+  // drawable.texture, precisely so no drawable has to exist yet.
+  if (drawableW < 1) drawableW = 1;
+  if (drawableH < 1) drawableH = 1;
   // Reduced-resolution rendering (metal_upscale): size the scene + post-chain
   // targets at _renderScale of the drawable; the final blit upscales to the
   // native drawable. _renderScale==1 (upscale off, the default) is byte-identical.
   // Forced to native when a frame PNG capture is pending so exports stay full-res.
   _renderScale = (_upscaleEnabled && _capturePath.empty()) ? 0.667f : 1.0f;
-  NSUInteger rw = (NSUInteger)lround(tex.width * _renderScale);
-  NSUInteger rh = (NSUInteger)lround(tex.height * _renderScale);
+  NSUInteger rw = (NSUInteger)lround(drawableW * _renderScale);
+  NSUInteger rh = (NSUInteger)lround(drawableH * _renderScale);
   if (rw < 1) rw = 1;
   if (rh < 1) rh = 1;
   ensurePostTargets(rw, rh);
@@ -492,6 +498,13 @@ void RendererMetal::setDrawable(
   // pixelRadiusScale()==1, so the on-screen appearance is unchanged.
   _liveRefH = rh;
   _passDesc = _scenePassDesc;
+}
+
+void RendererMetal::setPresentTarget(
+    id<CAMetalDrawable> drawable, MTLRenderPassDescriptor* passDesc)
+{
+  _drawable = drawable;
+  _screenPassDesc = passDesc;       // the drawable target (final composite pass)
 }
 
 void RendererMetal::ensureUpscaler(NSUInteger inW, NSUInteger inH,
@@ -770,6 +783,11 @@ void RendererMetal::endFrame()
 
   // The scene was rendered to _sceneColor/_sceneDepth; run the post-process
   // chain, whose final pass writes to the drawable.
+  //
+  // No drawable is a legitimate outcome now that it is acquired after the scene
+  // is encoded (#396): `currentDrawable` can time out. Nothing is presented and
+  // any pending PNG capture stays pending (runPostChain owns _capturePath), so
+  // the caller re-renders — see the forced redraw in MetalViewport's RenderGate.
   if (_drawable && _cmdBuffer && _screenPassDesc && _sceneColor) {
     runPostChain();
     [_cmdBuffer presentDrawable:_drawable];
@@ -803,6 +821,15 @@ void RendererMetal::endFrame()
         }
       }];
     }
+    // Count this frame as in flight until the GPU reports it done, so the
+    // render loop can throttle itself instead of queueing frames faster than
+    // they retire (#396). The handler runs on a background thread and can fire
+    // after this renderer is gone, hence the shared atomic.
+    auto inFlight = _inFlight;
+    inFlight->fetch_add(1, std::memory_order_relaxed);
+    [_cmdBuffer addCompletedHandler:^(id<MTLCommandBuffer>) {
+      inFlight->fetch_sub(1, std::memory_order_relaxed);
+    }];
     [_cmdBuffer commit];
     _cmdBuffer = nil;
   }
@@ -840,7 +867,7 @@ void RendererMetal::beginOffscreen(int w, int h, const std::string& path)
 // End the offscreen render: close the scene encoder, run the full post chain
 // (which writes the PNG via the capture block), commit, and block until the
 // GPU finishes so the file exists on return. Leaves _offscreen=false; the next
-// live setDrawable recreates the targets at the window size.
+// live beginLiveFrame recreates the targets at the window size.
 void RendererMetal::endOffscreen()
 {
   if (_encoder) {

--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -246,6 +246,7 @@
 		FCB5A40892C6D7239E49791A /* DesignControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7E41DCBB427678A8F018B0E /* DesignControllerTests.swift */; };
 		FCE3C0AD3EC5319F8F2E144E /* DesignEditInferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6A959CC1590FC60333582B /* DesignEditInferenceTests.swift */; };
 		FE667ADF3DAD102C12DC4DA2 /* HoverReadoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF1264ED4865B293F313315 /* HoverReadoutTests.swift */; };
+		A3960001396A396A396A0001 /* RenderGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3960002396A396A396A0002 /* RenderGateTests.swift */; };
 		FF325D5404E69D05274EEB81 /* SelectionInputField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D55EF2F596852510DDACA576 /* SelectionInputField.swift */; };
 /* End PBXBuildFile section */
 
@@ -300,6 +301,7 @@
 		3697F74BD2283492B5A7790C /* KeyRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyRouting.swift; sourceTree = "<group>"; };
 		3753EB4AA7EC91E685E36B84 /* WhatsNewLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewLogic.swift; sourceTree = "<group>"; };
 		3BF1264ED4865B293F313315 /* HoverReadoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverReadoutTests.swift; sourceTree = "<group>"; };
+		A3960002396A396A396A0002 /* RenderGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderGateTests.swift; sourceTree = "<group>"; };
 		3F5377EE69A856479317FD61 /* WhatsNewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewModel.swift; sourceTree = "<group>"; };
 		3FC150B0707033AB3B186189 /* RFD3ResultWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFD3ResultWriter.swift; sourceTree = "<group>"; };
 		3FDAAF431094900F3FC21293 /* whatsnew-1100-metrics.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "whatsnew-1100-metrics.png"; sourceTree = "<group>"; };
@@ -623,6 +625,7 @@
 				EE3CAE980896763CAAAF2034 /* DesignSizeGuardTests.swift */,
 				FFD9E3092D310E443F7CD546 /* DesignTargetSelectionTests.swift */,
 				3BF1264ED4865B293F313315 /* HoverReadoutTests.swift */,
+				A3960002396A396A396A0002 /* RenderGateTests.swift */,
 				AD3E224EA1BE94147B322332 /* InferenceRouterTests.swift */,
 				F43E4051E6410834AAAA4047 /* InteractionModeExitTests.swift */,
 				1FF072CB363743CAF805155E /* KeyBindingDispatchTests.swift */,
@@ -1363,6 +1366,7 @@
 				917ABB57816FDCD8B1D1E9CE /* DesignSizeGuardTests.swift in Sources */,
 				D0505F6B98C64B96BE87A753 /* DesignTargetSelectionTests.swift in Sources */,
 				FE667ADF3DAD102C12DC4DA2 /* HoverReadoutTests.swift in Sources */,
+				A3960001396A396A396A0001 /* RenderGateTests.swift in Sources */,
 				C98E23FB46AC666B6D1B5A72 /* InferenceRouterTests.swift in Sources */,
 				57E2333020DE9DC8910BDC3E /* InteractionModeExitTests.swift in Sources */,
 				CAC9B9F8A93BC4B71C3DB0D6 /* KeyBindingDispatchTests.swift in Sources */,

--- a/swiftui/PyMOLViewer/Bridge/PyMOLBridge.h
+++ b/swiftui/PyMOLViewer/Bridge/PyMOLBridge.h
@@ -87,7 +87,27 @@ void PyMOLBridge_RenderMetal(PyMOLHandle instance);
 // per-frame drawable + render-pass descriptor (mtkView/drawable/passDescriptor
 // passed as opaque void* so this C header needs no Metal import).
 void PyMOLBridge_SetupMetalRenderer(PyMOLHandle instance, void *mtkView);
-void PyMOLBridge_RenderMetalFrame(PyMOLHandle instance, void *drawable, void *passDescriptor, int width, int height);
+
+// Render one live frame at width x height (backing pixels).
+//
+// The CAMetalDrawable is acquired HERE, from the view, only once the scene has
+// been encoded — not by the caller beforehand (#396). Only the final post pass
+// writes to the drawable, so asking for it earlier just parked the main thread
+// in `currentDrawable` (and stalled input) for as long as the GPU was behind.
+//
+// Returns 1 if a frame was presented, 0 if the drawable never arrived (the
+// offscreen work is still committed; the caller should render again) or if
+// there is no renderer yet.
+int PyMOLBridge_RenderMetalFrame(PyMOLHandle instance, void *mtkView, int width, int height);
+
+// Live Metal frames committed but not yet completed on the GPU. The render loop
+// skips a tick above a small cap so the late currentDrawable wait stays short.
+// 0 when there is no renderer.
+int PyMOLBridge_MetalFramesInFlight(PyMOLHandle instance);
+
+// Current value of cSetting_metal_raytrace (1/0). Ray tracing is the GPU-bound
+// case, where the render loop drops its display link to 60 Hz.
+int PyMOLBridge_GetMetalRaytrace(PyMOLHandle instance);
 
 // Debug: execute raw Python (PyRun_SimpleString) under the GIL.
 void PyMOLBridge_RunPython(const char *code);

--- a/swiftui/PyMOLViewer/Bridge/PyMOLBridge.mm
+++ b/swiftui/PyMOLViewer/Bridge/PyMOLBridge.mm
@@ -555,17 +555,16 @@ void PyMOLBridge_SetupMetalRenderer(PyMOLHandle h, void *mtkViewPtr)
     G->Renderer = new pymol::RendererMetal(g_metalDevice, g_metalQueue);
 }
 
-void PyMOLBridge_RenderMetalFrame(PyMOLHandle h, void *drawablePtr,
-                                  void *passDescPtr, int width, int height)
+int PyMOLBridge_RenderMetalFrame(PyMOLHandle h, void *mtkViewPtr,
+                                 int width, int height)
 {
-    if (!h) return;
+    if (!h || !mtkViewPtr) return 0;
     PyMOLGlobals *G = PyMOL_GetGlobals(INST(h));
-    if (!G) return;
+    if (!G) return 0;
     auto *renderer = static_cast<pymol::RendererMetal *>(G->Renderer);
-    if (!renderer) return;
-    id<CAMetalDrawable> drawable = (__bridge id<CAMetalDrawable>)drawablePtr;
-    MTLRenderPassDescriptor *passDesc = (__bridge MTLRenderPassDescriptor *)passDescPtr;
-    if (!drawable || !passDesc) return;
+    if (!renderer) return 0;
+    MTKView *view = (__bridge MTKView *)mtkViewPtr;
+    if (width < 1 || height < 1) return 0;
 
     // Keep PyMOL's window/scene-block size in sync with the actual drawable
     // (backing pixels). Without this the scene block stays at the default
@@ -597,7 +596,8 @@ void PyMOLBridge_RenderMetalFrame(PyMOLHandle h, void *drawablePtr,
     }
 
     // Mirror main_appkit.mm drawInMTKView (805-869); ordering is load-bearing.
-    renderer->setDrawable(drawable, passDesc);
+    // beginLiveFrame takes only the SIZE — the drawable is fetched below (#396).
+    renderer->beginLiveFrame(width, height);
     renderer->setLetterboxOrigin(ox, oy);
     renderer->viewport(ox, oy, vpW, vpH);
     renderer->beginFrame();
@@ -606,7 +606,38 @@ void PyMOLBridge_RenderMetalFrame(PyMOLHandle h, void *drawablePtr,
     SceneRenderMetal(G);
     PyMOL_PopValidContext(INST(h));
     ImmBatch_SetActiveRenderer(nullptr);
+
+    // Now — with the whole scene already encoded into the offscreen targets —
+    // ask for the drawable that only the final post pass needs. Any wait the
+    // display server imposes has been overlapped with this frame's CPU encoding
+    // instead of preceding it. Both properties must come from the same access
+    // window; `currentRenderPassDescriptor` is derived from `currentDrawable`,
+    // so a nil drawable means we simply present nothing this frame and endFrame
+    // commits the offscreen work as-is.
+    id<CAMetalDrawable> drawable = view.currentDrawable;
+    MTLRenderPassDescriptor *passDesc =
+        drawable ? view.currentRenderPassDescriptor : nil;
+    if (drawable && passDesc)
+        renderer->setPresentTarget(drawable, passDesc);
     renderer->endFrame();
+    return (drawable && passDesc) ? 1 : 0;
+}
+
+int PyMOLBridge_MetalFramesInFlight(PyMOLHandle h)
+{
+    if (!h) return 0;
+    PyMOLGlobals *G = PyMOL_GetGlobals(INST(h));
+    if (!G) return 0;
+    auto *renderer = static_cast<pymol::RendererMetal *>(G->Renderer);
+    return renderer ? renderer->framesInFlight() : 0;
+}
+
+int PyMOLBridge_GetMetalRaytrace(PyMOLHandle h)
+{
+    if (!h) return 0;
+    PyMOLGlobals *G = PyMOL_GetGlobals(INST(h));
+    if (!G) return 0;
+    return SettingGetGlobal_b(G, cSetting_metal_raytrace) ? 1 : 0;
 }
 
 // Render one offscreen frame at the current (already-reshaped) size. path may be

--- a/swiftui/PyMOLViewer/Shared/MetalViewport.swift
+++ b/swiftui/PyMOLViewer/Shared/MetalViewport.swift
@@ -7,6 +7,68 @@ import MetalKit
 import UIKit
 #endif
 
+// MARK: - Render-loop gate (#396)
+
+/// The decision the render loop makes on every display-link tick, factored out
+/// as a pure type so it can be tested (a test cannot drive a CADisplayLink).
+///
+/// Two things had to change here. The old gate consumed PyMOL's redisplay flag
+/// with `GetRedisplay(inst, reset: 1)` *before* the drawable was acquired, so a
+/// frame that then failed to get a drawable dropped both the frame and the
+/// request for it — the same shape as the earlier "mouse rotate silently
+/// dropped" bug. And with ray tracing on, the GPU is the bottleneck: the loop
+/// would keep handing frames to a queue that could not retire them, so the main
+/// thread sat in `currentDrawable` (blocking input, the feedback timer and
+/// SwiftUI commits) for about half of every rotation.
+///
+/// So: the gate PEEKS the flag (`reset: 0`), a separate in-flight cap makes the
+/// loop skip a tick rather than pile on, and the flag is consumed only once the
+/// frame is actually about to be encoded.
+enum RenderGate {
+
+    /// Committed-but-not-completed frames allowed before a tick is skipped.
+    ///
+    /// `CAMetalLayer.maximumDrawableCount` is 3, so staying below it leaves a
+    /// drawable free and keeps the (now late) `currentDrawable` wait short.
+    /// Two is still enough in-flight work to keep the GPU fed.
+    static let maxFramesInFlight = 2
+
+    enum Decision: Equatable {
+        /// Encode a frame. The caller consumes the redisplay flag first.
+        case render
+        /// Nothing has changed; leave the last presented frame on screen.
+        case skip
+        /// There IS work to do, but too many frames are already in flight.
+        /// The redisplay flag is left set, so a later tick picks this up.
+        case throttle
+    }
+
+    static func decide(forceRedraw: Bool,
+                       hasRenderedOnce: Bool,
+                       redisplayPending: Bool,
+                       framesInFlight: Int) -> Decision {
+        // The very first frame always renders (defensive against a blank start
+        // before anything has flagged a redisplay), and so does a forced one
+        // after a wake/activate — the display can discard the drawable's
+        // contents while asleep, and an unchanged scene flags no redisplay.
+        let wants = forceRedraw || !hasRenderedOnce || redisplayPending
+        guard wants else { return .skip }
+        return framesInFlight >= maxFramesInFlight ? .throttle : .render
+    }
+
+    /// Whether the next tick must render unconditionally, given whether the
+    /// frame just encoded reached the screen. A frame with no drawable rendered
+    /// into the offscreen targets but presented nothing, and its redisplay flag
+    /// is already consumed — without this the viewport would hold a stale image
+    /// until the next interaction.
+    static func forceRedrawAfterRender(presented: Bool) -> Bool { !presented }
+
+    /// Display-link ceiling. Ray tracing makes frames GPU-bound well below
+    /// 120 Hz, where the extra ticks buy nothing and each one still costs a
+    /// `PyMOL_Idle` poll on the main thread.
+    static func preferredFPS(rayTracing: Bool) -> Float { rayTracing ? 60 : 120 }
+}
+
 #if os(macOS)
 struct MetalViewport: NSViewRepresentable {
     @EnvironmentObject var engine: PyMOLEngine
@@ -20,7 +82,9 @@ struct MetalViewport: NSViewRepresentable {
         // Allow ProMotion (120Hz) on capable displays; the system clamps this to
         // the panel's actual max (e.g. 60 on non-ProMotion). The on-demand gate in
         // draw(in:) keeps the GPU idle on a static scene, so the higher tick only
-        // costs a cheap idle poll when nothing is moving.
+        // costs a cheap idle poll when nothing is moving. The rate actually in
+        // force comes from the view's own display link (setPreferredFPS), which
+        // draw(in:) halves while ray tracing is on (#396).
         view.preferredFramesPerSecond = 120
         view.enableSetNeedsDisplay = false
         view.isPaused = false
@@ -154,10 +218,31 @@ class PyMOLMTKView: MTKView {
         let link = displayLink(target: self, selector: #selector(renderTick))
         link.add(to: .main, forMode: .common)
         renderLink = link
+        applyFPSToLink()  // re-assert a rate requested before the link existed
         isPaused = true   // ours drives now; don't let both loops draw
     }
 
     @objc private func renderTick() { draw() }
+
+    // Ceiling for our display link, in Hz. Called every tick by the render loop
+    // (which lowers it while ray tracing is on, #396) and applied only on a
+    // change, so a steady rate costs one comparison. The link is created in
+    // viewDidMoveToWindow, which may not have run yet — the value is remembered
+    // and re-applied there.
+    private var appliedFPS: Float = 0
+    func setPreferredFPS(_ fps: Float) {
+        guard fps > 0 else { return }
+        appliedFPS = fps
+        applyFPSToLink()
+    }
+    private func applyFPSToLink() {
+        guard let link = renderLink, appliedFPS > 0 else { return }
+        // A range, not a fixed rate: the system is free to tick slower when the
+        // display or thermal state calls for it. The 30 Hz floor keeps a scene
+        // that IS animating from being throttled to a crawl.
+        link.preferredFrameRateRange = CAFrameRateRange(
+            minimum: min(30, appliedFPS), maximum: appliedFPS, preferred: appliedFPS)
+    }
 
     // Track pointer motion over the viewport so the hover pre-selection preview
     // (issue #165) can update as the mouse moves WITHOUT any button held. A
@@ -230,7 +315,8 @@ struct MetalViewport: UIViewRepresentable {
         // Allow ProMotion (120Hz) on capable displays; the system clamps this to
         // the panel's actual max (e.g. 60 on non-ProMotion). The on-demand gate in
         // draw(in:) keeps the GPU idle on a static scene, so the higher tick only
-        // costs a cheap idle poll when nothing is moving.
+        // costs a cheap idle poll when nothing is moving. draw(in:) lowers this
+        // to 60 while ray tracing is on, where frames are GPU-bound anyway (#396).
         view.preferredFramesPerSecond = 120
         view.enableSetNeedsDisplay = false
         view.isPaused = false
@@ -445,6 +531,22 @@ extension MetalViewport {
         private var hasRenderedOnce = false
         private var moveSyncCounter = 0
 
+        // Keep the tick rate matched to how expensive frames currently are
+        // (#396). On macOS the view owns the display link we drive; on iOS
+        // MetalKit's own loop is still in charge, so this goes through the
+        // view's preferredFramesPerSecond.
+        private func applyPreferredFPS(to view: MTKView, engine: PyMOLEngine) {
+            let fps = RenderGate.preferredFPS(rayTracing: engine.metalRayTracing)
+            #if os(macOS)
+            (view as? PyMOLMTKView)?.setPreferredFPS(fps)
+            #else
+            let target = Int(fps)
+            if view.preferredFramesPerSecond != target {
+                view.preferredFramesPerSecond = target
+            }
+            #endif
+        }
+
         func draw(in view: MTKView) {
             guard let engine = engine, engine.isReady else { return }
             // A movie export renders frames off the main thread and owns the core
@@ -494,32 +596,51 @@ extension MetalViewport {
                 }
             }
             // Build RendererMetal on the first frame (bridge no-ops thereafter),
-            // then hand off this frame's drawable + pass descriptor and render.
+            // then run PyMOL's idle work (advances movies/animations and sets the
+            // redisplay flag).
             engine.setupMetalRenderer(view: view)
+            // Ray tracing makes frames GPU-bound far below 120 Hz; drop the tick
+            // rate so the surplus ticks stop costing a PyMOL_Idle each (#396).
+            // Cheap and idempotent, so it can ride along on every tick.
+            applyPreferredFPS(to: view, engine: engine)
             engine.idle()
-            // On-demand rendering: after idle() (which advances movies/animations
-            // and sets PyMOL's redisplay flag), skip the GPU-expensive frame when
-            // nothing needs redrawing — a static structure then costs only a cheap
-            // idle poll instead of a full render every tick, the bulk of the
+
+            // On-demand rendering: skip the GPU-expensive frame when nothing
+            // needs redrawing — a static structure then costs only a cheap idle
+            // poll instead of a full render every tick, the bulk of the
             // battery/thermal win. The last presented frame stays on screen.
-            // Mirrors the legacy AppKit loop (main_appkit.mm). The first frame
-            // always renders (defensive against a blank start before any redisplay).
-            // forceRedraw bypasses the gate after a wake/activate: the display can
-            // discard the drawable's contents during sleep, and since the scene is
-            // unchanged the redisplay flag alone wouldn't repaint it (-> a black
-            // viewport until the next interaction). It's cleared only once a frame
-            // actually renders below, so a not-yet-ready drawable doesn't drop it.
-            if !forceRedraw, hasRenderedOnce, let inst = engine.instance,
-               PyMOLBridge_GetRedisplay(inst, 1) == 0 {
+            // Mirrors the legacy AppKit loop (main_appkit.mm).
+            //
+            // The flag is PEEKED here (reset: 0) and consumed below only once
+            // this tick has committed to encoding a frame, so a throttled tick
+            // leaves the request standing instead of swallowing it (#396).
+            let pending = engine.instance.map { PyMOLBridge_GetRedisplay($0, 0) != 0 } ?? false
+            switch RenderGate.decide(forceRedraw: forceRedraw,
+                                     hasRenderedOnce: hasRenderedOnce,
+                                     redisplayPending: pending,
+                                     framesInFlight: engine.metalFramesInFlight) {
+            case .skip, .throttle:
                 return
+            case .render:
+                break
             }
-            guard let drawable = view.currentDrawable,
-                  let passDesc = view.currentRenderPassDescriptor else { return }
+
+            // Consume the flag NOW, before the scene traversal: PyMOL sets it
+            // again from inside SceneRenderMetal when queued input (a drag, a
+            // click) needs another frame, so clearing it afterwards would eat
+            // the next frame of every drag.
+            if let inst = engine.instance { _ = PyMOLBridge_GetRedisplay(inst, 1) }
+
+            // The bridge acquires the drawable itself, after the scene is
+            // encoded — see PyMOLBridge_RenderMetalFrame. `presented` is false
+            // when no drawable arrived: the frame rendered offscreen but nothing
+            // reached the screen, so force the next tick to render again.
             let size = view.drawableSize
-            engine.renderMetalFrame(drawable: drawable, passDescriptor: passDesc,
-                                    width: Int(size.width), height: Int(size.height))
-            hasRenderedOnce = true
-            forceRedraw = false
+            let presented = engine.renderMetalFrame(view: view,
+                                                    width: Int(size.width),
+                                                    height: Int(size.height))
+            hasRenderedOnce = hasRenderedOnce || presented
+            forceRedraw = RenderGate.forceRedrawAfterRender(presented: presented)
             // This frame built any deferred rep geometry (e.g. a surface mesh);
             // let the engine clear the "Calculating…" overlay once the build
             // frame(s) have completed.

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -3514,12 +3514,32 @@ final class PyMOLEngine: ObservableObject {
         PyMOLBridge_SetupMetalRenderer(inst, Unmanaged.passUnretained(view).toOpaque())
     }
 
-    // Hand the current frame's drawable + render-pass descriptor to RendererMetal.
-    func renderMetalFrame(drawable: CAMetalDrawable, passDescriptor: MTLRenderPassDescriptor, width: Int, height: Int) {
-        guard let inst = instance else { return }
-        let dPtr = Unmanaged.passUnretained(drawable as AnyObject).toOpaque()
-        let pPtr = Unmanaged.passUnretained(passDescriptor).toOpaque()
-        PyMOLBridge_RenderMetalFrame(inst, dPtr, pPtr, Int32(width), Int32(height))
+    // Render one live frame at width x height (backing pixels).
+    //
+    // The view — not a drawable — is what gets handed over: the bridge acquires
+    // the CAMetalDrawable itself, after the scene has been encoded, since only
+    // the final post pass writes to it (#396). Returns false when no drawable
+    // arrived, i.e. nothing was presented and the caller should render again.
+    @discardableResult
+    func renderMetalFrame(view: MTKView, width: Int, height: Int) -> Bool {
+        guard let inst = instance else { return false }
+        let vPtr = Unmanaged.passUnretained(view).toOpaque()
+        return PyMOLBridge_RenderMetalFrame(inst, vPtr, Int32(width), Int32(height)) != 0
+    }
+
+    /// Live Metal frames committed but not yet completed on the GPU. The render
+    /// loop caps this (RenderGate.maxFramesInFlight) so it skips a tick instead
+    /// of queueing frames the GPU cannot retire.
+    var metalFramesInFlight: Int {
+        guard let inst = instance else { return 0 }
+        return Int(PyMOLBridge_MetalFramesInFlight(inst))
+    }
+
+    /// Current `metal_raytrace` setting — the GPU-bound case, which the render
+    /// loop runs at a lower tick rate.
+    var metalRayTracing: Bool {
+        guard let inst = instance else { return false }
+        return PyMOLBridge_GetMetalRaytrace(inst) != 0
     }
 
     // MARK: - Polling

--- a/swiftui/PyMOLViewerTests/RenderGateTests.swift
+++ b/swiftui/PyMOLViewerTests/RenderGateTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+@testable import RayMol
+
+/// Coverage for `RenderGate` — the per-tick decision the Metal render loop
+/// makes (issue #396).
+///
+/// The loop itself cannot be unit-tested (a test cannot drive a CADisplayLink or
+/// a GPU), so the whole decision lives in this pure type and is pinned down
+/// here. Two regressions are the point of these tests:
+///
+///  1. The gate must not *consume* PyMOL's redisplay flag for a tick it then
+///     declines to render. The old code cleared the flag and only afterwards
+///     asked for a drawable, so a frame that failed to get one dropped the
+///     frame AND the request for it — the viewport froze until the next
+///     interaction. `.throttle` is a distinct outcome from `.render` precisely
+///     so the caller knows not to consume the flag.
+///  2. A frame that renders but presents nothing must force the next tick.
+final class RenderGateTests: XCTestCase {
+
+    // MARK: - What makes a tick render
+
+    func testStaticSceneSkips() {
+        XCTAssertEqual(
+            RenderGate.decide(forceRedraw: false, hasRenderedOnce: true,
+                              redisplayPending: false, framesInFlight: 0),
+            .skip,
+            "a static scene must cost only the idle poll — this is the "
+            + "battery/thermal win of on-demand rendering")
+    }
+
+    func testFirstFrameAlwaysRenders() {
+        XCTAssertEqual(
+            RenderGate.decide(forceRedraw: false, hasRenderedOnce: false,
+                              redisplayPending: false, framesInFlight: 0),
+            .render,
+            "the first frame must render even with no redisplay flagged, or the "
+            + "window starts blank")
+    }
+
+    func testForceRedrawBypassesTheFlag() {
+        // Wake/activate: the display can discard the drawable's contents while
+        // asleep, and an unchanged scene flags no redisplay — so the flag alone
+        // would leave a black viewport.
+        XCTAssertEqual(
+            RenderGate.decide(forceRedraw: true, hasRenderedOnce: true,
+                              redisplayPending: false, framesInFlight: 0),
+            .render)
+    }
+
+    func testPendingRedisplayRenders() {
+        XCTAssertEqual(
+            RenderGate.decide(forceRedraw: false, hasRenderedOnce: true,
+                              redisplayPending: true, framesInFlight: 0),
+            .render)
+    }
+
+    // MARK: - The in-flight cap
+
+    func testThrottlesAtTheCapRatherThanQueueingFrames() {
+        XCTAssertEqual(
+            RenderGate.decide(forceRedraw: false, hasRenderedOnce: true,
+                              redisplayPending: true,
+                              framesInFlight: RenderGate.maxFramesInFlight),
+            .throttle,
+            "at the cap the loop must skip the tick; handing another frame to a "
+            + "queue that cannot retire it is what parked the main thread in "
+            + "currentDrawable for ~half of every rotation (#396)")
+    }
+
+    func testRendersJustBelowTheCap() {
+        XCTAssertEqual(
+            RenderGate.decide(forceRedraw: false, hasRenderedOnce: true,
+                              redisplayPending: true,
+                              framesInFlight: RenderGate.maxFramesInFlight - 1),
+            .render,
+            "the cap must not starve the GPU — one frame short of it still renders")
+    }
+
+    func testThrottleIsDistinctFromSkip() {
+        // The caller consumes the redisplay flag only on `.render`. If throttling
+        // collapsed into `.skip` that would be fine, but if it collapsed into
+        // `.render` the flag would be consumed for a frame never encoded.
+        let throttled = RenderGate.decide(
+            forceRedraw: false, hasRenderedOnce: true, redisplayPending: true,
+            framesInFlight: RenderGate.maxFramesInFlight)
+        XCTAssertNotEqual(throttled, .render,
+                          "a throttled tick must never be reported as rendering")
+    }
+
+    func testAForcedRedrawStillRespectsTheCap() {
+        // forceRedraw overrides the *flag*, not the queue: rendering anyway
+        // would just block on currentDrawable, which is the bug being fixed.
+        // The forced state is sticky, so the next tick renders it.
+        XCTAssertEqual(
+            RenderGate.decide(forceRedraw: true, hasRenderedOnce: true,
+                              redisplayPending: false,
+                              framesInFlight: RenderGate.maxFramesInFlight),
+            .throttle)
+    }
+
+    func testCapLeavesADrawableFree() {
+        XCTAssertLessThan(RenderGate.maxFramesInFlight, 3,
+                          "CAMetalLayer.maximumDrawableCount is 3; the cap must "
+                          + "stay under it so a drawable is free when the frame "
+                          + "finally asks for one")
+        XCTAssertGreaterThanOrEqual(RenderGate.maxFramesInFlight, 2,
+                                    "fewer than two in flight serializes CPU "
+                                    + "encoding against GPU execution")
+    }
+
+    // MARK: - Recovering from a frame that presented nothing
+
+    func testAPresentedFrameClearsTheForcedRedraw() {
+        XCTAssertFalse(RenderGate.forceRedrawAfterRender(presented: true))
+    }
+
+    func testAFrameWithNoDrawableForcesTheNextTick() {
+        XCTAssertTrue(
+            RenderGate.forceRedrawAfterRender(presented: false),
+            "the frame rendered into the offscreen targets but reached no screen, "
+            + "and its redisplay flag is already consumed — without the forced "
+            + "retry the viewport would hold a stale image (#396)")
+    }
+
+    // MARK: - Tick rate
+
+    func testRayTracingHalvesTheTickRate() {
+        XCTAssertEqual(RenderGate.preferredFPS(rayTracing: false), 120,
+                       "ProMotion is still allowed when frames are cheap")
+        XCTAssertEqual(RenderGate.preferredFPS(rayTracing: true), 60,
+                       "ray-traced frames are GPU-bound well below 120 Hz, so the "
+                       + "surplus ticks only cost a PyMOL_Idle each")
+    }
+}


### PR DESCRIPTION
Fixes #396.

## The problem

The 120 Hz `CADisplayLink` render loop asked `MTKView.currentDrawable` for a drawable **before** it encoded anything. Only the final post pass writes to the drawable — the scene renders into offscreen `_sceneColor` — so with ray tracing on (GPU-bound) the main thread just parked in `nextDrawable` → `semaphore_timedwait` while input, the feedback timer and SwiftUI commits queued behind it.

Separately, the on-demand gate consumed PyMOL's redisplay flag with `GetRedisplay(inst, reset: 1)` before the drawable was acquired, so a nil drawable dropped both the frame and the request for it.

## The change

`RendererMetal::setDrawable` is split in two:

- `beginLiveFrame(w, h)` — everything that only needs the target **size** (pending MSAA rebuild, offscreen post targets, `_liveRefH`), taken from the caller's drawable dimensions rather than `drawable.texture`.
- `setPresentTarget(drawable, passDesc)` — hands over the actual `CAMetalDrawable`, called right before `endFrame`.

`PyMOLBridge_RenderMetalFrame` now takes the **view** instead of a drawable and fetches `currentDrawable` itself, after `SceneRenderMetal`, so the display server's wait overlaps this frame's CPU encoding instead of preceding it. It returns whether anything was presented. The legacy AppKit loop (`main_appkit.mm`) gets the same treatment.

Two supporting changes:

- **The redisplay flag is no longer consumed by a tick that may not render.** The new `RenderGate` peeks it (`reset: 0`); the loop clears it (`reset: 1`) only once it has committed to encoding — and clears it *before* the traversal, because PyMOL re-flags from inside `SceneRenderMetal` when queued input (a drag, a click) needs another frame, so clearing afterwards would eat the next frame of every drag. A frame that ends up with no drawable rendered offscreen but presented nothing, so it forces the next tick rather than leaving a stale image.
- **A frames-in-flight cap** (2, under `CAMetalLayer.maximumDrawableCount`'s 3) makes the loop skip a tick rather than queue frames the GPU cannot retire — that is what keeps the now-late `currentDrawable` wait short. `RendererMetal` owns the count via a shared atomic decremented in the command buffer's completed handler. The display link also drops to 60 Hz while `metal_raytrace` is on, where frames are GPU-bound far below 120 anyway.

Items 1–3 of the issue's suggested fix. Item 4 (moving encoding to a render queue) is deliberately left out.

## Measurements

Same tree, master vs this branch, on the issue's own scene and methodology: 32 objects / 57,696 atoms, RT + SSAO + shadows, `cmd.rock(1)`, `sample <pid> 5`.

| main thread | master | this branch |
|---|---|---|
| total samples | 4127 | 4041 |
| in `renderTick` | 3523 (85%) | 1560 (39%) |
| blocked in `currentDrawable` → `nextDrawable` → `semaphore_timedwait` | **1849 (45%)** | **1 (0%)** |
| CPU in `SceneRenderMetal` | 1637 (40%) | 1515 (37%) |
| GPU (`RAYMOL_GPU_TIMING`) | 6.9 fps, 140 ms/frame, 97% busy | 6.8 fps, 128–140 ms/frame, 88–97% busy |

The main thread is free 61% of the time instead of 15%, at the same frame rate. The residual `renderTick` time is now genuine CPU encoding in `SceneRenderMetal`, not a block.

## Verification

- `xcodebuild -scheme UnitTests_macOS test`: 699 tests, 0 failures — including 12 new `RenderGateTests` covering the gate's decisions, the in-flight cap, the no-drawable retry and the tick rate. The loop itself can't be unit-tested (no way to drive a `CADisplayLink`), so the whole decision lives in a pure type, matching the existing `MetalViewportResponderTests` / `KeyRouting` pattern in this target.
- On-demand gate unchanged: a static scene with RT on renders **0** frames, ~2.4% process CPU, 0% GPU. A `cmd.turn` renders exactly one frame. No runaway redraw, no stale/black viewport.
- Idle tick cost with RT on is ~1/4 of RT off (8 vs 32 main-thread samples in `renderTick` over 6 s), confirming the 60 Hz cap applies.
- Hi-res ray-traced PNG export (`PYMOL_AUTOEXPORT=...,1600,1000,1`), which shares the post targets and `_liveRefH` with the function that was split, still renders correctly at the requested resolution.
- Live viewport screenshotted with cartoon + sticks under RT: renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)