### PR TITLE
fix(tempfiles): pid-scope the six shared Python→Swift channels (#399)

### DIFF
--- a/.github/workflows/raymol-embedded-tests.yml
+++ b/.github/workflows/raymol-embedded-tests.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Run RayMol unit tests under embedded pymol
         run: |
           pymol -ckqy testing/testing.py --run \
+              testing/tests/test_raymol_tmp.py \
               testing/tests/test_appkit_measure.py \
               testing/tests/test_appkit_sequence.py \
               testing/tests/test_appkit_object_panel.py \

--- a/modules/pymol/appkit_design.py
+++ b/modules/pymol/appkit_design.py
@@ -15,10 +15,9 @@ tells you what it will do and one that waits seventeen minutes to disagree.
 """
 
 import json
-import os
-import tempfile
 
 from pymol import cmd
+from pymol import raymol_tmp
 
 
 def _generators():
@@ -105,8 +104,7 @@ def emit(target_str='', hotspots_str='', generator_id=''):
         summary, error = _target(target_str, hotspots_str, generator_id)
         payload = {'generators': _generators(), 'target': summary, 'error': error}
         blob = json.dumps(payload)
-        path = os.path.join(tempfile.gettempdir(),
-                            'pymol_design_%d.json' % os.getpid())
+        path = raymol_tmp.channel_path('pymol_design')
         with open(path, 'w') as handle:
             handle.write(blob)
         print('DESIGN_FORM:ready')

--- a/modules/pymol/appkit_inspector.py
+++ b/modules/pymol/appkit_inspector.py
@@ -367,10 +367,10 @@ def poll(objs):
     leaked into the terminal log. So write the full JSON to a temp file (same
     TMPDIR the Swift app reads) and emit only `OBJDETAIL:ready` — same pattern as
     the sequence panel."""
-    import json, os, tempfile
+    import json
+    from pymol import raymol_tmp
     try:
-        p = os.path.join(tempfile.gettempdir(),
-                         'pymol_objdetail_%d.json' % os.getpid())
+        p = raymol_tmp.channel_path('pymol_objdetail')
         with open(p, 'w') as _f:
             _f.write(json.dumps(_build(objs)))
         print('OBJDETAIL:ready')
@@ -568,7 +568,8 @@ def poll_panel():
     prefix but failed JSON decode (so the panel froze on the stale list), and the
     prefix-less continuation leaked into the console on every poll tick. Keep the
     payload off the feedback line entirely and emit only `OBJPANEL:ready`."""
-    import json, os, tempfile
+    import json
+    from pymol import raymol_tmp
     # Structure prediction's main-thread pump (#284). A prediction whose weights are
     # still downloading is submitted from HERE, because the download runs on a thread
     # that must not touch the session. Done before the object list is gathered, so a
@@ -678,8 +679,7 @@ def poll_panel():
         # filename prevents an empty instance from replacing another instance's
         # populated object list and briefly showing the empty-state overlay over
         # a rendered molecule.
-        p = os.path.join(tempfile.gettempdir(),
-                         'pymol_objpanel_%d.json' % os.getpid())
+        p = raymol_tmp.channel_path('pymol_objpanel')
         with open(p, 'w') as _f:
             _f.write(blob)
         print('OBJPANEL:ready')

--- a/modules/pymol/appkit_predict.py
+++ b/modules/pymol/appkit_predict.py
@@ -9,10 +9,9 @@ short marker PREDICT_FORM:ready rides the feedback line.
 """
 
 import json
-import os
-import tempfile
 
 from pymol import cmd
+from pymol import raymol_tmp
 
 
 def _predictors():
@@ -97,7 +96,7 @@ def emit(input_str=''):
         chains, error = _chains(input_str)
         payload = {'predictors': _predictors(), 'chains': chains, 'error': error}
         blob = json.dumps(payload)
-        p = os.path.join(tempfile.gettempdir(), 'pymol_predict_%d.json' % os.getpid())
+        p = raymol_tmp.channel_path('pymol_predict')
         with open(p, 'w') as f:
             f.write(blob)
         print('PREDICT_FORM:ready')

--- a/modules/pymol/appkit_ray_overlay.py
+++ b/modules/pymol/appkit_ray_overlay.py
@@ -13,8 +13,9 @@ Usage from Python:
 """
 
 import os
-import tempfile
 import threading
+
+from pymol import raymol_tmp
 
 try:
     import objc
@@ -151,7 +152,7 @@ def show_ray_image(cmd_module):
 
     # Save the scene image to a temporary PNG file.
     # prior=1 reads CScene::Image without re-rendering.
-    tmp_path = os.path.join(tempfile.gettempdir(), "_pymol_ray_overlay.png")
+    tmp_path = raymol_tmp.channel_path("_pymol_ray_overlay", "png")
     try:
         cmd_module.png(tmp_path, prior=1, quiet=1)
     except Exception:

--- a/modules/pymol/appkit_sequence.py
+++ b/modules/pymol/appkit_sequence.py
@@ -269,13 +269,12 @@ def poll(preview=False):
     cannot see. See `_visible_objects`.
     """
     import json
-    import os
-    import tempfile
+    from pymol import raymol_tmp
     if preview:
         names = ['__theme_preview']
     else:
         names = _visible_objects()
     data = _build(names, preview)
-    p = os.path.join(tempfile.gettempdir(), 'pymol_seq.json')
+    p = raymol_tmp.channel_path('pymol_seq')
     with open(p, 'w') as f:
         f.write(json.dumps(data))

--- a/modules/pymol/appkit_settings.py
+++ b/modules/pymol/appkit_settings.py
@@ -9,15 +9,14 @@ Setting types (pymol.setting): 1 boolean, 2 int, 3 float, 4 float3, 5 color,
 6 string.
 """
 import json
-import os
-import tempfile
 
 from pymol import cmd
+from pymol import raymol_tmp
 from pymol import setting as _setting
 
 
 def _path():
-    return os.path.join(tempfile.gettempdir(), 'pymol_settings.json')
+    return raymol_tmp.channel_path('pymol_settings')
 
 
 def catalog():

--- a/modules/pymol/metal_move.py
+++ b/modules/pymol/metal_move.py
@@ -16,17 +16,16 @@ through the object's current transform (TTT), so it tumbles with the molecule.
 The SAME frame drives both translation (drag an axis arrow) and rotation (drag a
 ring) — there is no mode switch. All manipulation is non-destructive TTT
 (cmd.translate/cmd.rotate with object=); Reset is matrix_reset. Gizmo geometry is
-written to <tmpdir>/pymol_gizmo.json, which Swift reads back synchronously.
+written to <tmpdir>/pymol_gizmo_<pid>.json, which Swift reads back synchronously.
 
 NDC convention matches metal_pick / the gesture handlers: bottom-left origin,
 +x right, +y up, in [-1, 1].
 """
 import json
 import math
-import os
-import tempfile
 
 from pymol import cmd
+from pymol import raymol_tmp
 
 # Module state --------------------------------------------------------------
 _active = None          # active object name, or None
@@ -63,7 +62,7 @@ _RING_SEG = 48
 _ELEM_MASS = {'H': 1.008, 'C': 12.011, 'N': 14.007, 'O': 15.999, 'S': 32.06,
               'P': 30.974, 'FE': 55.845, 'ZN': 65.38, 'MG': 24.305,
               'CA': 40.078, 'NA': 22.99, 'CL': 35.45, 'K': 39.098}
-_PATH = os.path.join(tempfile.gettempdir(), 'pymol_gizmo.json')
+_PATH = raymol_tmp.channel_path('pymol_gizmo')
 
 
 # --- vector helpers ---------------------------------------------------------

--- a/modules/pymol/metal_pick.py
+++ b/modules/pymol/metal_pick.py
@@ -62,12 +62,12 @@ _PRESELECT = '_preselect'
 # readout just keeps it instead of discarding it. Swift formats the text (see
 # HoverReadout.text); Python stays a dumb reporter so the formatting rules are
 # unit-testable without a live core.
-_HOVER_INFO_JSON = 'pymol_hover_info.json'
+_HOVER_INFO_STEM = 'pymol_hover_info'
 
 
 def _hover_info_path():
-    import os, tempfile
-    return os.path.join(tempfile.gettempdir(), _HOVER_INFO_JSON)
+    from pymol import raymol_tmp
+    return raymol_tmp.channel_path(_HOVER_INFO_STEM)
 
 
 def _write_hover_info(out):
@@ -807,7 +807,7 @@ def hover_preview_at(ndc_x, ndc_y, aspect, preview=1, info=0):
     over every drawn atom is the expensive part, so it must not run twice):
       preview=1  update the '_preselect' highlight   (Mouse / Hover)
       info=1     write the top-right readout payload (issue #359) to
-                 <tmpdir>/pymol_hover_info.json for Swift to format
+                 <tmpdir>/pymol_hover_info_<pid>.json for Swift to format
     The caller passes whichever its user has left on; with both off it should not
     call at all.
     """

--- a/modules/pymol/raymol_tmp.py
+++ b/modules/pymol/raymol_tmp.py
@@ -1,0 +1,25 @@
+"""Per-process paths for the tempfile channels Python uses to hand payloads to
+the native app.
+
+Several payloads are too large for PyMOL's ~1 KB feedback-line cap, so Python
+writes them to `$TMPDIR` and only the marker rides the feedback line. The file
+name must therefore be unique PER PROCESS: two RayMol instances on one machine
+(a dev build beside the installed app, or several windows launched as separate
+processes) share `$TMPDIR`, so a fixed name lets one instance read the other's
+payload — the sequence channels are written on one tick and read on the next, so
+the swap window is wide (issue #399).
+
+Python and Swift are the SAME process here (PyMOL is embedded in the app), so
+`os.getpid()` and `ProcessInfo.processInfo.processIdentifier` agree. Every stem
+passed to `channel_path` must have a twin in `TempChannel.Stem` on the Swift
+side, which is both the reader and the list `TempChannel.removeAll()` clears on
+quit.
+"""
+import os
+import tempfile
+
+
+def channel_path(stem, ext='json'):
+    """Return `<tmpdir>/<stem>_<pid>.<ext>` for this process."""
+    return os.path.join(tempfile.gettempdir(),
+                        '%s_%d.%s' % (stem, os.getpid(), ext))

--- a/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
+++ b/swiftui/PyMOLViewer.xcodeproj/project.pbxproj
@@ -22,6 +22,9 @@
 		104B27F848D308735A6D6DD2 /* MetalViewport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E9F8D36908E3216D1C8F893 /* MetalViewport.swift */; };
 		124F6E6764C7D94831B8AC7E /* AppVersionFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3F3410F7C0D3C85783B985F /* AppVersionFooter.swift */; };
 		12A3993A3E181A358E00AF0A /* HoverReadout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80137B4E6E0FA24F011D7E87 /* HoverReadout.swift */; };
+		A3990001399A399A399A0001 /* TempChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3990002399A399A399A0002 /* TempChannel.swift */; };
+		A3990003399A399A399A0003 /* TempChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3990002399A399A399A0002 /* TempChannel.swift */; };
+		A3990004399A399A399A0004 /* TempChannelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3990005399A399A399A0005 /* TempChannelTests.swift */; };
 		13B48E7F8C2A51ADAF48F4C3 /* SequencePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474D18A43D0D9A6BDD69EEFD /* SequencePanel.swift */; };
 		13C5A803C8072DE180EB23CC /* ProtenixRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7845A3EB6A6BF8A14F090062 /* ProtenixRuntime.swift */; };
 		13E8687216067D92666E3078 /* openssl-PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = CB0108E0FA1F204BE0E41F0D /* openssl-PrivacyInfo.xcprivacy */; };
@@ -342,6 +345,8 @@
 		7D3E805AC2D63B01AB7EE29C /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		7DEAB18A89F026148528C71E /* PendingJobTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingJobTests.swift; sourceTree = "<group>"; };
 		80137B4E6E0FA24F011D7E87 /* HoverReadout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverReadout.swift; sourceTree = "<group>"; };
+		A3990002399A399A399A0002 /* TempChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempChannel.swift; sourceTree = "<group>"; };
+		A3990005399A399A399A0005 /* TempChannelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempChannelTests.swift; sourceTree = "<group>"; };
 		82BCB731F0C74F642D78D450 /* PyMOLBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PyMOLBridge.h; sourceTree = "<group>"; };
 		85B66833BF167209A47B9C15 /* ThemeStudioPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStudioPanel.swift; sourceTree = "<group>"; };
 		86E93358875495F499780A00 /* MLXRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLXRuntime.swift; sourceTree = "<group>"; };
@@ -561,6 +566,7 @@
 				9E69AA2C12DC2D1583FBF8C8 /* DesignSizeGuard.swift */,
 				AA4C108E3D04FD75288859DA /* GizmoOverlay.swift */,
 				80137B4E6E0FA24F011D7E87 /* HoverReadout.swift */,
+				A3990002399A399A399A0002 /* TempChannel.swift */,
 				87825A30DE5C455B6270187F /* InferenceJob.swift */,
 				71574A2074A14803B91ED695 /* InferenceRouter.swift */,
 				3697F74BD2283492B5A7790C /* KeyRouting.swift */,
@@ -626,6 +632,7 @@
 				FFD9E3092D310E443F7CD546 /* DesignTargetSelectionTests.swift */,
 				3BF1264ED4865B293F313315 /* HoverReadoutTests.swift */,
 				A3960002396A396A396A0002 /* RenderGateTests.swift */,
+				A3990005399A399A399A0005 /* TempChannelTests.swift */,
 				AD3E224EA1BE94147B322332 /* InferenceRouterTests.swift */,
 				F43E4051E6410834AAAA4047 /* InteractionModeExitTests.swift */,
 				1FF072CB363743CAF805155E /* KeyBindingDispatchTests.swift */,
@@ -1367,6 +1374,7 @@
 				D0505F6B98C64B96BE87A753 /* DesignTargetSelectionTests.swift in Sources */,
 				FE667ADF3DAD102C12DC4DA2 /* HoverReadoutTests.swift in Sources */,
 				A3960001396A396A396A0001 /* RenderGateTests.swift in Sources */,
+				A3990004399A399A399A0004 /* TempChannelTests.swift in Sources */,
 				C98E23FB46AC666B6D1B5A72 /* InferenceRouterTests.swift in Sources */,
 				57E2333020DE9DC8910BDC3E /* InteractionModeExitTests.swift in Sources */,
 				CAC9B9F8A93BC4B71C3DB0D6 /* KeyBindingDispatchTests.swift in Sources */,
@@ -1415,6 +1423,7 @@
 				65CE08E50C85C8ACDAC92D07 /* DesignSizeGuard.swift in Sources */,
 				8C04C5D4AB27F2D9BEF79561 /* GizmoOverlay.swift in Sources */,
 				32061FAD7CD7E949C8C6A7BF /* HoverReadout.swift in Sources */,
+				A3990001399A399A399A0001 /* TempChannel.swift in Sources */,
 				59414471A1C1412AF869074D /* InferenceJob.swift in Sources */,
 				AC4CB915ECB531A4406CF387 /* InferenceRouter.swift in Sources */,
 				2C2D4B24DF4807FA1407582D /* KeyRouting.swift in Sources */,
@@ -1489,6 +1498,7 @@
 				1A580F6792CD440D91FA9F45 /* DesignSizeGuard.swift in Sources */,
 				8F71359FAD68AE5D09416C1B /* GizmoOverlay.swift in Sources */,
 				12A3993A3E181A358E00AF0A /* HoverReadout.swift in Sources */,
+				A3990003399A399A399A0003 /* TempChannel.swift in Sources */,
 				82DADD44C2ED6C0A534EBD26 /* InferenceJob.swift in Sources */,
 				966C6886E3CE816365256220 /* InferenceRouter.swift in Sources */,
 				768E23FCAB4D2B27205900B6 /* KeyRouting.swift in Sources */,

--- a/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
+++ b/swiftui/PyMOLViewer/Panels/ObjectPanel.swift
@@ -4766,8 +4766,7 @@ extension PyMOLEngine {
     /// list after e.g. `split_states`) and the continuation leaked to the log (#231).
     func parseObjectPanelFeedback(_ line: String) {
         guard line.hasPrefix("OBJPANEL:") else { return }
-        let path = (NSTemporaryDirectory() as NSString)
-            .appendingPathComponent("pymol_objpanel_\(ProcessInfo.processInfo.processIdentifier).json")
+        let path = TempChannel.path(TempChannel.Stem.objectPanel)
         guard let data = FileManager.default.contents(atPath: path) else { return }
 
         guard let payload = try? JSONDecoder().decode(PanelPayload.self, from: data) else {

--- a/swiftui/PyMOLViewer/Panels/SequencePanel.swift
+++ b/swiftui/PyMOLViewer/Panels/SequencePanel.swift
@@ -380,7 +380,7 @@ extension PyMOLEngine {
     ///            "colors": { "<idx>": [r, g, b] } }
     func parseSequencePanelFeedback(_ line: String) {
         guard line.hasPrefix("SEQPANEL:") else { return }
-        let path = NSTemporaryDirectory() + "pymol_seq.json"
+        let path = TempChannel.path(TempChannel.Stem.sequence)
         guard let data = FileManager.default.contents(atPath: path) else { return }
 
         struct Payload: Decodable {
@@ -481,7 +481,7 @@ extension PyMOLEngine {
     /// `selectedResidueKeys` for highlight sync.
     func parseSequenceSelectionFeedback(_ line: String) {
         guard line.hasPrefix("SEQSEL:") else { return }
-        let path = NSTemporaryDirectory() + "pymol_seqsel.json"
+        let path = TempChannel.path(TempChannel.Stem.sequenceSelection)
         guard let data = FileManager.default.contents(atPath: path) else { return }
         guard let keys = try? JSONDecoder().decode([String].self, from: data) else { return }
         let set = Set(keys)

--- a/swiftui/PyMOLViewer/Shared/HoverReadout.swift
+++ b/swiftui/PyMOLViewer/Shared/HoverReadout.swift
@@ -32,7 +32,7 @@ enum HoverReadout {
 
     private static let separator = " / "
 
-    /// Decode a `pymol_hover_info.json` payload.
+    /// Decode a `pymol_hover_info_<pid>.json` payload.
     ///
     /// Returns nil for BOTH "unreadable" and "the pick missed": either way there
     /// is nothing to name, and unlike the design-pick payload (where a miss must

--- a/swiftui/PyMOLViewer/Shared/PyMOLApp.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLApp.swift
@@ -17,6 +17,13 @@ final class OrientationLockDelegate: NSObject, UIApplicationDelegate {
                      supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
         return Self.mask
     }
+
+    /// Drop this process's pid-scoped tempfile channels (#399). iOS is not
+    /// guaranteed to call this before a kill, which is why the names are unique
+    /// rather than merely cleaned up — this only keeps the container tidy.
+    func applicationWillTerminate(_ application: UIApplication) {
+        TempChannel.removeAll()
+    }
 }
 #endif
 
@@ -46,6 +53,9 @@ final class RayMolAppDelegate: NSObject, NSApplicationDelegate {
     func applicationWillTerminate(_ notification: Notification) {
         PyMOLEngine.shared.runPython(
             "from pymol import predicting as _p; _p.clear_pending()")
+        // The tempfile channels are named after this pid (#399), so nothing will
+        // ever reuse them — without this they'd accumulate one set per run.
+        TempChannel.removeAll()
     }
 }
 #endif

--- a/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
+++ b/swiftui/PyMOLViewer/Shared/PyMOLEngine.swift
@@ -3005,7 +3005,7 @@ final class PyMOLEngine: ObservableObject {
     // TMPDIR), synchronously — called right after each metal_move call (the
     // longPressPick pattern). Updates the published gizmo + active object.
     private func readGizmo() {
-        let path = (NSTemporaryDirectory() as NSString).appendingPathComponent("pymol_gizmo.json")
+        let path = TempChannel.path(TempChannel.Stem.gizmo)
         guard let data = FileManager.default.contents(atPath: path),
               let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         else { return }
@@ -3039,7 +3039,7 @@ final class PyMOLEngine: ObservableObject {
 
     // Read the settings catalog JSON the bridge wrote to the temp dir.
     private func loadSettingsCatalogFile() {
-        let path = NSTemporaryDirectory() + "pymol_settings.json"
+        let path = TempChannel.path(TempChannel.Stem.settings)
         guard let data = FileManager.default.contents(atPath: path),
               let items = try? JSONDecoder().decode([SettingItem].self, from: data)
         else { return }
@@ -3137,15 +3137,16 @@ final class PyMOLEngine: ObservableObject {
     func fetchSequenceSelection() {
         guard isReady else { return }
         runPythonQuiet(
-            "import json, os, tempfile\n"
+            "import json\n"
             + "from pymol import cmd as _sc\n"
+            + "from pymol import raymol_tmp as _rt\n"
             + "_sel = []\n"
             + "try:\n"
             + "    if 'sele' in (_sc.get_names('selections') or []):\n"
             + "        _sc.iterate('sele and guide', '_sel.append(model+chr(47)+chain+chr(47)+resi)', space={'_sel': _sel})\n"
             + "except Exception:\n"
             + "    pass\n"
-            + "open(os.path.join(tempfile.gettempdir(), 'pymol_seqsel.json'), 'w').write(json.dumps(_sel))\n"
+            + "open(_rt.channel_path('\(TempChannel.Stem.sequenceSelection)'), 'w').write(json.dumps(_sel))\n"
             + "print('SEQSEL:ready')"
         )
     }
@@ -3248,8 +3249,7 @@ final class PyMOLEngine: ObservableObject {
     /// ignored: keeping the last text on screen would name a residue the cursor
     /// has already left, which is worse than showing nothing.
     private func readHoverInfo() {
-        let path = (NSTemporaryDirectory() as NSString)
-            .appendingPathComponent("pymol_hover_info.json")
+        let path = TempChannel.path(TempChannel.Stem.hoverInfo)
         let data = FileManager.default.contents(atPath: path)
         let root = data.flatMap { try? JSONSerialization.jsonObject(with: $0) } as? [String: Any]
         let text = HoverReadout.text(payload: root)
@@ -3737,8 +3737,7 @@ final class PyMOLEngine: ObservableObject {
     /// resolve. That is deliberate: this runs off a 100 ms poll, and a throw here would
     /// take the whole feedback drain down.
     func parseDesignFormFeedback() {
-        let path = (NSTemporaryDirectory() as NSString)
-            .appendingPathComponent("pymol_design_\(ProcessInfo.processInfo.processIdentifier).json")
+        let path = TempChannel.path(TempChannel.Stem.designForm)
         guard let data = FileManager.default.contents(atPath: path),
               let payload = try? JSONDecoder().decode(DesignFormPayload.self, from: data)
         else { return }
@@ -3750,8 +3749,7 @@ final class PyMOLEngine: ObservableObject {
     #endif
 
     func parsePredictFormFeedback() {
-        let path = (NSTemporaryDirectory() as NSString)
-            .appendingPathComponent("pymol_predict_\(ProcessInfo.processInfo.processIdentifier).json")
+        let path = TempChannel.path(TempChannel.Stem.predictForm)
         guard let data = FileManager.default.contents(atPath: path),
               let payload = try? JSONDecoder().decode(PredictFormPayload.self, from: data)
         else { return }
@@ -3765,8 +3763,7 @@ final class PyMOLEngine: ObservableObject {
     // sceneState. File-based to avoid the ~1KB feedback-line cap splitting the
     // payload and leaking continuation lines into the terminal log.
     func parseObjectDetailFeedback(_ line: String) {
-        let path = (NSTemporaryDirectory() as NSString)
-            .appendingPathComponent("pymol_objdetail_\(ProcessInfo.processInfo.processIdentifier).json")
+        let path = TempChannel.path(TempChannel.Stem.objectDetail)
         guard let data = FileManager.default.contents(atPath: path),
               let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         else { return }

--- a/swiftui/PyMOLViewer/Shared/TempChannel.swift
+++ b/swiftui/PyMOLViewer/Shared/TempChannel.swift
@@ -1,0 +1,58 @@
+// TempChannel.swift — per-process paths for the Python→Swift tempfile channels
+
+import Foundation
+
+/// The `$TMPDIR` files Python writes payloads into when they are too large for
+/// PyMOL's ~1 KB feedback-line cap (only the marker rides the line).
+///
+/// Every name carries this process's pid. `$TMPDIR` is shared by every RayMol on
+/// the machine — a dev build beside the installed app, or several windows
+/// launched as separate processes — so a fixed name lets one instance read
+/// another's payload (issue #399). The sequence channels are the worst case:
+/// written on one 100 ms tick and read on the next, so a second instance has a
+/// whole tick to replace the file in between; gizmo and hover are written and
+/// read synchronously, so their window is small but real.
+///
+/// PyMOL is embedded in this process, so `os.getpid()` on the Python side and
+/// `processIdentifier` here name the same file. Keep `Stem` in sync with the
+/// stems passed to `raymol_tmp.channel_path` in modules/pymol.
+enum TempChannel {
+    enum Stem {
+        static let sequence = "pymol_seq"
+        static let sequenceSelection = "pymol_seqsel"
+        static let gizmo = "pymol_gizmo"
+        static let hoverInfo = "pymol_hover_info"
+        static let settings = "pymol_settings"
+        static let rayOverlay = "_pymol_ray_overlay"
+        static let objectPanel = "pymol_objpanel"
+        static let objectDetail = "pymol_objdetail"
+        static let predictForm = "pymol_predict"
+        static let designForm = "pymol_design"
+
+        /// Every channel, for `removeAll()`. `.png` channels are listed with
+        /// their extension; the rest are JSON.
+        static let all: [(stem: String, ext: String)] = [
+            (sequence, "json"), (sequenceSelection, "json"), (gizmo, "json"),
+            (hoverInfo, "json"), (settings, "json"), (rayOverlay, "png"),
+            (objectPanel, "json"), (objectDetail, "json"),
+            (predictForm, "json"), (designForm, "json"),
+        ]
+    }
+
+    /// `<tmpdir>/<stem>_<pid>.<ext>` for this process.
+    static func path(_ stem: String, ext: String = "json") -> String {
+        return (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("\(stem)_\(ProcessInfo.processInfo.processIdentifier).\(ext)")
+    }
+
+    /// Delete this process's channel files. Called on quit so `$TMPDIR` does not
+    /// accumulate one set per run — pid-scoping makes the names unique, which
+    /// also makes them un-reusable, so nothing else ever overwrites them.
+    /// Missing files are the normal case (a channel that never fired), so
+    /// failures are ignored.
+    static func removeAll() {
+        for channel in Stem.all {
+            try? FileManager.default.removeItem(atPath: path(channel.stem, ext: channel.ext))
+        }
+    }
+}

--- a/swiftui/PyMOLViewerTests/DesignModeStateTests.swift
+++ b/swiftui/PyMOLViewerTests/DesignModeStateTests.swift
@@ -8,7 +8,7 @@ final class DesignModeStateTests: XCTestCase {
     /// _emit(), but a stale file from a real RayMol run must never be able to
     /// leak an active gizmo into a fixture.
     static let gizmoJSONPath =
-        (NSTemporaryDirectory() as NSString).appendingPathComponent("pymol_gizmo.json")
+        TempChannel.path(TempChannel.Stem.gizmo)
 
     override func setUp() {
         super.setUp()

--- a/swiftui/PyMOLViewerTests/TempChannelTests.swift
+++ b/swiftui/PyMOLViewerTests/TempChannelTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import RayMol
+
+/// The tempfile channels are shared-$TMPDIR IPC, so the property that keeps two
+/// RayMol processes apart is that every name carries this process's pid (#399).
+/// These tests pin that, and pin the `Stem.all` list `removeAll()` walks — a
+/// channel missing from it leaks a file per run.
+final class TempChannelTests: XCTestCase {
+
+    func testPathCarriesThisProcessID() {
+        let path = TempChannel.path(TempChannel.Stem.sequence)
+        XCTAssertEqual(
+            (path as NSString).lastPathComponent,
+            "pymol_seq_\(ProcessInfo.processInfo.processIdentifier).json",
+            "a pid-less name lets a second RayMol hand this one its sequence rows")
+    }
+
+    func testPathLivesInTemporaryDirectory() {
+        // Same $TMPDIR Python's tempfile.gettempdir() resolves to, which is what
+        // makes this an IPC channel rather than two unrelated files.
+        XCTAssertTrue(TempChannel.path(TempChannel.Stem.gizmo)
+                        .hasPrefix(NSTemporaryDirectory()))
+    }
+
+    func testExtensionIsOverridable() {
+        let path = TempChannel.path(TempChannel.Stem.rayOverlay, ext: "png")
+        XCTAssertEqual(
+            (path as NSString).lastPathComponent,
+            "_pymol_ray_overlay_\(ProcessInfo.processInfo.processIdentifier).png")
+    }
+
+    func testEveryStemIsListedForCleanup() {
+        let listed = Set(TempChannel.Stem.all.map { $0.stem })
+        let declared: Set<String> = [
+            TempChannel.Stem.sequence, TempChannel.Stem.sequenceSelection,
+            TempChannel.Stem.gizmo, TempChannel.Stem.hoverInfo,
+            TempChannel.Stem.settings, TempChannel.Stem.rayOverlay,
+            TempChannel.Stem.objectPanel, TempChannel.Stem.objectDetail,
+            TempChannel.Stem.predictForm, TempChannel.Stem.designForm,
+        ]
+        XCTAssertEqual(listed, declared,
+                       "a channel absent from Stem.all is never cleaned up on quit")
+        XCTAssertEqual(TempChannel.Stem.all.count, declared.count,
+                       "Stem.all must not list a channel twice")
+    }
+
+    func testRemoveAllDeletesThisProcessesChannels() throws {
+        for channel in TempChannel.Stem.all {
+            let path = TempChannel.path(channel.stem, ext: channel.ext)
+            try Data("{}".utf8).write(to: URL(fileURLWithPath: path))
+        }
+        TempChannel.removeAll()
+        for channel in TempChannel.Stem.all {
+            let path = TempChannel.path(channel.stem, ext: channel.ext)
+            XCTAssertFalse(FileManager.default.fileExists(atPath: path),
+                           "\(channel.stem) survived removeAll()")
+        }
+    }
+
+    /// removeAll() runs on quit, when a channel may never have fired — a missing
+    /// file must not be treated as an error.
+    func testRemoveAllToleratesMissingFiles() {
+        TempChannel.removeAll()
+        TempChannel.removeAll()
+    }
+}

--- a/testing/tests/test_appkit_ray_overlay.py
+++ b/testing/tests/test_appkit_ray_overlay.py
@@ -9,7 +9,6 @@ AppKit/objc/Foundation stubbed permissively before import.
 import importlib
 import os
 import sys
-import tempfile
 import types
 import unittest
 from unittest.mock import MagicMock
@@ -91,7 +90,7 @@ class OverlayTestBase(unittest.TestCase):
         ro._image_view = None
         ro._metal_view = None
         ro._event_monitor = None
-        self._tmp = os.path.join(tempfile.gettempdir(), "_pymol_ray_overlay.png")
+        self._tmp = ro.raymol_tmp.channel_path("_pymol_ray_overlay", "png")
         try:
             os.unlink(self._tmp)
         except OSError:

--- a/testing/tests/test_appkit_sequence.py
+++ b/testing/tests/test_appkit_sequence.py
@@ -25,6 +25,7 @@ if not hasattr(sys.modules["pymol"], "cmd"):
     sys.modules["pymol"].cmd = types.SimpleNamespace()
 
 from pymol import appkit_sequence as seq
+from pymol import raymol_tmp
 
 
 class FakeCmd:
@@ -237,10 +238,9 @@ class PollTest(unittest.TestCase):
 
     def _payload(self, cmd, preview=False):
         import json
-        import tempfile
         seq.cmd = cmd
         seq.poll(preview=preview)
-        p = os.path.join(tempfile.gettempdir(), "pymol_seq.json")
+        p = raymol_tmp.channel_path("pymol_seq")
         with open(p) as f:
             return json.load(f)
 
@@ -342,8 +342,7 @@ class VisibleObjectsTest(unittest.TestCase):
         seq.cmd = cmd
         seq.poll()
         import json
-        import tempfile
-        with open(os.path.join(tempfile.gettempdir(), "pymol_seq.json")) as f:
+        with open(raymol_tmp.channel_path("pymol_seq")) as f:
             data = json.load(f)
         self.assertEqual([d["name"] for d in data["objects"]], ["molB"])
 

--- a/testing/tests/test_appkit_settings.py
+++ b/testing/tests/test_appkit_settings.py
@@ -122,9 +122,13 @@ class SetValueTest(unittest.TestCase):
         self.assertTrue(any(l.startswith("SETTINGS:err") for l in _lines(buf)))
 
     def test_path_is_in_tempdir(self):
+        import os
         import tempfile
         self.assertTrue(st._path().startswith(tempfile.gettempdir()))
-        self.assertTrue(st._path().endswith("pymol_settings.json"))
+        # pid-scoped (#399): a second RayMol on the same machine must not be
+        # able to hand this instance its settings catalog.
+        self.assertTrue(st._path().endswith(
+            "pymol_settings_%d.json" % os.getpid()))
 
 
 if __name__ == "__main__":

--- a/testing/tests/test_raymol_tmp.py
+++ b/testing/tests/test_raymol_tmp.py
@@ -1,0 +1,77 @@
+"""Unit tests for pymol.raymol_tmp — headless, no PyMOL required.
+
+The tempfile channels are how Python hands the native app payloads too large for
+PyMOL's ~1 KB feedback line. Two RayMol processes share $TMPDIR, so the ONE
+property that matters is that every name carries this process's pid (issue
+#399): without it, a dev build beside the installed app reads the other's
+sequence rows, gizmo geometry or settings catalog.
+"""
+
+import os
+import sys
+import tempfile
+import types
+import unittest
+
+_MODULES_DIR = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, "modules")
+)
+if "pymol" not in sys.modules or not hasattr(sys.modules["pymol"], "__path__"):
+    _pymol_stub = types.ModuleType("pymol")
+    _pymol_stub.__path__ = [os.path.join(_MODULES_DIR, "pymol")]
+    _pymol_stub.__package__ = "pymol"
+    sys.modules["pymol"] = _pymol_stub
+
+from pymol import raymol_tmp
+
+
+class ChannelPathTest(unittest.TestCase):
+    def test_lives_in_tempdir(self):
+        p = raymol_tmp.channel_path("pymol_seq")
+        self.assertEqual(os.path.dirname(p), tempfile.gettempdir())
+
+    def test_carries_this_pid(self):
+        p = raymol_tmp.channel_path("pymol_seq")
+        self.assertEqual(os.path.basename(p),
+                         "pymol_seq_%d.json" % os.getpid())
+
+    def test_extension_is_overridable(self):
+        p = raymol_tmp.channel_path("_pymol_ray_overlay", "png")
+        self.assertEqual(os.path.basename(p),
+                         "_pymol_ray_overlay_%d.png" % os.getpid())
+
+    def test_distinct_stems_do_not_collide(self):
+        self.assertNotEqual(raymol_tmp.channel_path("pymol_seq"),
+                            raymol_tmp.channel_path("pymol_seqsel"))
+
+
+class ChannelWritersTest(unittest.TestCase):
+    """Every module that writes a channel must route through channel_path, so
+    none of them can drift back to a fixed name (which is what #399 was)."""
+
+    _WRITERS = {
+        "appkit_sequence.py": "pymol_seq",
+        "appkit_settings.py": "pymol_settings",
+        "appkit_ray_overlay.py": "_pymol_ray_overlay",
+        "appkit_inspector.py": "pymol_objpanel",
+        "appkit_predict.py": "pymol_predict",
+        "appkit_design.py": "pymol_design",
+        "metal_move.py": "pymol_gizmo",
+        "metal_pick.py": "pymol_hover_info",
+    }
+
+    def test_no_writer_builds_a_fixed_channel_name(self):
+        for name, stem in self._WRITERS.items():
+            path = os.path.join(_MODULES_DIR, "pymol", name)
+            with open(path) as f:
+                src = f.read()
+            self.assertIn("channel_path", src,
+                          "%s must build its channel path via raymol_tmp" % name)
+            self.assertNotIn("'%s.json'" % stem, src,
+                             "%s still writes a fixed, pid-less name" % name)
+            self.assertNotIn('"%s.json"' % stem, src,
+                             "%s still writes a fixed, pid-less name" % name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #399.

## What was wrong

Six Python→Swift tempfile channels used fixed names in the shared `$TMPDIR`, so two RayMol processes on one machine read each other's payloads:

| file | writer | reader |
|---|---|---|
| `pymol_seq.json` | `appkit_sequence.poll` | `parseSequencePanelFeedback` |
| `pymol_seqsel.json` | inline Python in `fetchSequenceSelection` | `parseSequenceSelectionFeedback` |
| `pymol_gizmo.json` | `metal_move` | `readGizmo` |
| `pymol_hover_info.json` | `metal_pick` | `readHoverInfo` |
| `pymol_settings.json` | `appkit_settings.catalog` | `loadSettingsCatalogFile` |
| `_pymol_ray_overlay.png` | `appkit_ray_overlay.show_ray_image` | the overlay itself |

The sequence pair is the worst case — written on one 100 ms tick, read on the next, so a second instance has a whole tick to swap the file.

## The change

All six carry the pid, as `pymol_objpanel_<pid>.json` already did. Instead of inlining the suffix ten times, each side gets one place that builds the name:

- `modules/pymol/raymol_tmp.py` → `channel_path(stem, ext='json')`
- `swiftui/PyMOLViewer/Shared/TempChannel.swift` → `TempChannel.path(_:ext:)` + `TempChannel.Stem`

The four already-pid-scoped channels move onto the same helpers, so there is a single list of channels — which is also what `TempChannel.removeAll()` walks from `applicationWillTerminate` (macOS and iOS). Without that, the now-unique names would leak one set per run: `$TMPDIR` on the review host held **166** stale `pymol_{design,predict,objpanel,objdetail}_<pid>.json` files.

`project.pbxproj` was hand-edited rather than regenerated — `xcodegen generate` shreds `RayMol.icon` into its individual SVG members.

## Tests

- `testing/tests/test_raymol_tmp.py` (new, added to the embedded-tests CI list) — pins the pid suffix and greps every writer module so no channel can drift back to a fixed name.
- `swiftui/PyMOLViewerTests/TempChannelTests.swift` (new) — pins the Swift half, the `Stem.all` cleanup list, and that `removeAll()` tolerates missing files.
- Embedded suite: 961 tests, failure set **identical to master's baseline** (9 pre-existing errors from brew-pymol's `_cmd` under the local shadow harness).
- `xcodebuild -scheme UnitTests_macOS ... test`: **705 tests, 0 failures**.

## Functional verification

Two dev instances (`RayMol-399.app`, pids 66256 / 66258) side by side:

- 1ubq in one, 4hhb in the other → `pymol_seq_66256.json` (4 KB, `[('1ubq', 134)]`) and `pymol_seq_66258.json` (23 KB, `[('4hhb', 801)]`); each window's sequence viewer and object panel showed its **own** structure.
- Settings, gizmo, hover-info and ray-overlay all wrote `*_66256.*`; the gizmo rendered in the viewport, so `readGizmo()` found the pid-scoped file.
- The pre-existing shared `pymol_seq.json` / `pymol_gizmo.json` / … were left untouched (mtimes hours old).
- On a clean quit of 66258 its files disappeared while 66256's remained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)