### PR TITLE
ci(download-stats): fix 'Argument list too long' in gist update

### DIFF
--- a/.github/workflows/download-stats.yml
+++ b/.github/workflows/download-stats.yml
@@ -57,7 +57,7 @@ jobs:
           { head -n1 current.csv; tail -n +2 current.csv | grep -v "^\"${DATE}\"," || true; } > merged.csv
           cat today.csv >> merged.csv
           # PATCH the gist with the merged content.
-          jq -n --arg c "$(cat merged.csv)" \
+          jq -n --rawfile c merged.csv \
             "{files: {\"${FILE}\": {content: \$c}}}" \
             | gh api -X PATCH "/gists/${GIST_ID}" --input - --jq '.html_url'
           echo "Updated gist with $(($(wc -l < merged.csv) - 1)) total rows."


### PR DESCRIPTION
## Summary
The daily **Download stats** workflow has failed on every scheduled run since 2026-09-04 with:

```
/usr/bin/jq: Argument list too long
```

The gist CSV (~130 KB) is passed to `jq` as a single shell argument via `--arg c "$(cat merged.csv)"`. Linux caps one argument at 128 KiB, and appending a day of rows now exceeds it. The failed `jq` still piped empty input into the PATCH, so the log printed the gist URL and looked half-successful; the gist itself was not damaged, it just stopped at 2026-09-03.

## Fix
Pass the file with `--rawfile c merged.csv`, which has no size limit. One-line change.

## Verification
- Local: `jq -n --rawfile` with a 300 KB file works.
- A `workflow_dispatch` run from this branch is linked in the PR comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)