### PR TITLE
fix(macOS): repaint after every setting change (#424) and stop the undrawn movie panel squeezing the scene on 1x displays (#426)

### DIFF
--- a/.github/workflows/raymol-embedded-tests.yml
+++ b/.github/workflows/raymol-embedded-tests.yml
@@ -51,6 +51,7 @@ jobs:
               testing/tests/test_appkit_object_panel.py \
               testing/tests/test_appkit_objpanel_poll.py \
               testing/tests/test_appkit_settings.py \
+              testing/tests/test_setting_redisplay.py \
               testing/tests/test_appkit_theme_preview.py \
               testing/tests/test_appkit_command_panel.py \
               testing/tests/test_appkit_menus.py \

--- a/layer1/Ortho.cpp
+++ b/layer1/Ortho.cpp
@@ -2472,6 +2472,21 @@ void OrthoReshape(PyMOLGlobals* G, int width, int height, int force)
     block->setMargin(height - textBottom, 0, 0, 0);
     block->active = textBottom ? true : false;
 
+    // The Metal backend renders the Scene block only: the native app has its
+    // own panels for the internal GUI, feedback, movie strip and sequence
+    // viewer, and never draws the Ortho blocks. Reserving window space for
+    // them anyway shrinks the Scene block while the renderer still fills the
+    // whole drawable, so the projection aspect (Scene W/H) no longer matches
+    // the viewport and the picture is stretched vertically (#426). In practice
+    // the strip was the 15 px movie panel that any multi-state object brings
+    // in; it is a fixed pixel count, so it distorts twice as much on a 1x
+    // display as on a 2x one. Let the Scene block span the full window.
+    if (G->Renderer) {
+      sceneTop = 0;
+      sceneBottom = 0;
+      sceneRight = 0;
+    }
+
     block = SceneGetBlock(G);
     block->setMargin(sceneTop, 0, sceneBottom, sceneRight);
 

--- a/layer1/Setting.cpp
+++ b/layer1/Setting.cpp
@@ -2981,6 +2981,13 @@ void SettingGenerateSideEffects(PyMOLGlobals * G, int index, const char *sele, i
     break;
 #endif
   default:
+    // A setting with no dedicated side effect above still changes what the next
+    // frame looks like (e.g. the metal_* renderer knobs, surface_clip_front /
+    // _back): mark the scene dirty and ask for a redisplay so an on-demand
+    // draw loop repaints without waiting for a pointer event. Reps are not
+    // rebuilt and the ray-traced copy is kept — only a repaint is requested.
+    SceneDirty(G);
+    PyMOL_NeedRedisplay(G->PyMOL);
     break;
   }
 }

--- a/testing/tests/test_setting_redisplay.py
+++ b/testing/tests/test_setting_redisplay.py
@@ -1,0 +1,59 @@
+"""Every `set` must ask the viewport to repaint (#424).
+
+Runs under the embedded core:
+    pymol -ckqy testing/testing.py --run testing/tests/test_setting_redisplay.py
+
+The macOS app draws on demand: its Metal view skips the frame unless PyMOL's
+redisplay flag is raised. Settings with a dedicated side effect (fog, the
+lights, ...) raise it via SceneInvalidate, but any setting that fell through
+to `default:` in SettingGenerateSideEffects did not -- so the Effects sliders
+(metal_exposure), toggles (metal_outline) and the per-object surface clip
+sliders only showed once a mouse move over the viewport forced a frame.
+"""
+
+from pymol import cmd, testing, _cmd
+
+
+class TestSetRaisesRedisplay(testing.PyMOLTestCase):
+
+    def _clear(self):
+        _cmd._getRedisplay(cmd._COb, 1)          # read + reset
+        self.assertEqual(_cmd._getRedisplay(cmd._COb, 0), 0)
+
+    def _pending(self):
+        return _cmd._getRedisplay(cmd._COb, 0)
+
+    def testGlobalFloatWithoutSideEffectCase(self):
+        cmd.reinitialize()
+        self._clear()
+        cmd.set('metal_exposure', 1.25, quiet=1)
+        self.assertEqual(self._pending(), 1)
+
+    def testGlobalBoolWithoutSideEffectCase(self):
+        cmd.reinitialize()
+        self._clear()
+        cmd.set('metal_outline', 1, quiet=1)
+        self.assertEqual(self._pending(), 1)
+
+    def testPerObjectSetting(self):
+        cmd.reinitialize()
+        cmd.fragment('ala', 'm1')
+        self._clear()
+        cmd.set('surface_clip_front', 5.0, 'm1', quiet=1)
+        self.assertEqual(self._pending(), 1)
+
+    def testCommandLanguagePath(self):
+        # The inspector's surface sliders go through cmd.do("set ...") rather
+        # than cmd.set(); same core path, pinned separately.
+        cmd.reinitialize()
+        self._clear()
+        cmd.do('set metal_exposure, 0.8', echo=0)
+        self.assertEqual(self._pending(), 1)
+
+    def testUpdatesZeroStaysSilent(self):
+        # updates=0 is the documented "no side effects" escape hatch (session
+        # restore uses it); it must keep not raising a frame.
+        cmd.reinitialize()
+        self._clear()
+        cmd.set('metal_exposure', 1.5, quiet=1, updates=0)
+        self.assertEqual(self._pending(), 0)


### PR DESCRIPTION
Closes #424, closes #426.

## #424 — setting changes did not repaint the viewport

**Root cause.** The macOS app draws on demand: `draw(in:)` skips the frame unless PyMOL's redisplay flag is raised. `cmd.set` only raised it for settings with an explicit case in `SettingGenerateSideEffects` (fog, lights, … call `SceneInvalidate`). Everything that fell through to `default:` — the `metal_*` renderer knobs, `surface_clip_front/back`, … — changed the value silently, so the view repainted only when a pointer event forced a frame. Confirmed on the live app: after `set metal_exposure` / `set metal_outline` / per-object `set surface_clip_front` / `cmd.do("set …")` the flag read 0; after `set fog` it read 1.

**Fix.** `default:` now does `SceneDirty` + `PyMOL_NeedRedisplay`. Reps are not rebuilt and the ray-traced copy is kept — only a repaint is requested. `updates=0` still skips it. Covers every writer at once (inspector sliders/toggles, `runCommand("set …")`, MCP, scripts) instead of patching each control.

**Test.** `testing/tests/test_setting_redisplay.py` (added to the embedded-tests CI list): 4 cases fail on the unfixed core and pass on the fixed one; `updates=0` case passes on both.

## #426 — scene horizontally compressed on 1x displays

**Root cause.** Not a scale bug. With any multi-state object loaded (`movie_panel=1` default, 20-state NMR entry, predictions, trajectories), `OrthoReshape` reserves the internal movie-panel strip (`movie_panel_row_height`, 15 px) at the bottom, so PyMOL's Scene block is 15 px shorter than the Metal drawable while the renderer fills the whole drawable. Projection aspect (Scene W/H) ≠ viewport aspect → vertical stretch, i.e. "horizontal compression". The strip is a fixed pixel count, so on a 1x display it is twice the fraction of the viewport it is on 2x (983×345 for a 983×360 view vs 1966×705 for 1966×720), which is where it became visible. A single-state object shows no distortion on either display.

**Fix.** When a Metal renderer is attached (`G->Renderer`), the Scene block margins are zeroed in `OrthoReshape`: the native app never draws the Ortho blocks (internal GUI, feedback, movie panel, sequence viewer all have SwiftUI panels). Forcing `movie_panel=0` in the Metal config block would not be enough — sessions restore it.

The `?? 2.0` fallbacks in `MetalViewport.swift` are only reached with no window attached and were not involved; left as is.

**Verification (host, Debug build, 20-state 2kpp, magenta cartoon, fixed view).** `get_viewport()` now equals the drawable on both displays; the cartoon's on-screen bounding-box aspect is 2.213 on the Retina screen and 2.216 on the 1x external screen (was 2.211 vs 2.136 before). A red sphere stays 212×212 px throughout. No automated test: the condition needs a Metal renderer attached, which the embedded CLI tests cannot create.

## Checks
- Core rebuilt (`swiftui/build_macos.sh`) and macOS app built (`PyMOLViewer_macOS`, Debug) from this branch; both fixes re-verified on that build over MCP.
- Embedded CI test list (38 files) run locally under the patched core with the venv CLI build: 297 passed, 0 failed.
- No Swift changes; the iOS slice is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
