### PR TITLE
fix(seq-viewer): live-highlight residues during drag-selection (#429)

### DIFF
--- a/swiftui/PyMOLViewer/Panels/SequencePanel.swift
+++ b/swiftui/PyMOLViewer/Panels/SequencePanel.swift
@@ -93,6 +93,12 @@ struct SequencePanel: View {
     @State private var residueFrames: [String: CGRect] = [:]
     @State private var lastRange: ClosedRange<Int>? = nil
     @State private var anchorIndex: Int? = nil  // for Shift-click range
+    // Optimistic live-highlight during a drag: the selKeys currently under the
+    // sweep, unioned into the per-cell highlight test so they light up
+    // immediately, without waiting for the async PyMOL selection round-trip
+    // (issue #429). Cleared/reconciled against selectedResidueKeys when the drag
+    // ends. This is purely visual — the real 'sele' still comes from applyToggle.
+    @State private var dragSelKeys: Set<String> = []
 
     /// Flattened residue list (object order) for range/index mapping.
     private var flat: [SequenceResidue] { engine.sequences.flatMap { $0.residues } }
@@ -210,7 +216,9 @@ struct SequencePanel: View {
     }
 
     private func realResidueCell(_ r: SequenceResidue) -> some View {
-        let selected = r.isSelectable && engine.selectedResidueKeys.contains(r.selKey)
+        let selected = r.isSelectable
+            && (engine.selectedResidueKeys.contains(r.selKey)
+                || dragSelKeys.contains(r.selKey))
         return Text(r.oneLetter)
             .font(.system(size: 11, design: .monospaced))
             .foregroundColor(selected ? selectionFG : r.color)
@@ -304,13 +312,35 @@ struct SequencePanel: View {
                 guard let startIdx = residueIndex(at: value.startLocation) else { return }
                 let curIdx = residueIndex(at: value.location) ?? startIdx
                 let range = min(startIdx, curIdx)...max(startIdx, curIdx)
+                // Optimistic live highlight: light up the swept residues right
+                // now, even before the async 'sele' round-trip resolves. Updated
+                // every time the pointer enters a new cell so the visible span
+                // tracks the cursor. (issue #429)
+                dragSelKeys = Set(flat[range].filter { $0.isSelectable }.map { $0.selKey })
                 guard range != lastRange else { return }
                 lastRange = range
                 // Drag adds the swept range to the selection (additive).
                 applyToggle(residues: Array(flat[range]), add: true)
                 anchorIndex = startIdx
             }
-            .onEnded { _ in lastRange = nil }
+            .onEnded { _ in
+                lastRange = nil
+                // Reconcile the optimistic highlight against the confirmed
+                // selection: pull the real 'sele' back, then drop the local
+                // overlay once it has arrived. Deferring the clear (rather than
+                // wiping it here) avoids a one-frame flicker between the overlay
+                // disappearing and selectedResidueKeys catching up; the delayed
+                // block guarantees the overlay can never get stuck on.
+                let dragged = dragSelKeys
+                self.engine.fetchSequenceSelection()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                    // Only clear what this drag added; leave alone if a new drag
+                    // has already repopulated the set.
+                    if self.dragSelKeys == dragged {
+                        self.dragSelKeys = []
+                    }
+                }
+            }
     }
 
     private func residueIndex(at point: CGPoint) -> Int? {


### PR DESCRIPTION
Fixes #429

## Problem
In the macOS sequence viewer, dragging to select a span of residues did not highlight the background live — the selection color filled in only **after** the mouse was released.

## Root cause (confirmed)
The per-cell highlight in `SequencePanel.swift` was bound solely to the **confirmed** PyMOL selection (`engine.selectedResidueKeys`), which is only populated by an async round-trip: the drag `onChanged` dispatches a `select` command via `applyToggle`, which schedules `fetchSequenceSelection()` 0.05s later. During a fast drag that round-trip lags (and the main thread is busy with the gesture), so nothing visibly changed until the drag ended and the pipeline caught up.

## Fix
Add an **optimistic local highlight** during the drag:
- New `@State dragSelKeys: Set<String>` holds the selKeys currently under the sweep.
- `onChanged` recomputes it from the swept `range` on every update, so it tracks the cursor.
- The per-cell `selected` test unions `dragSelKeys` with `selectedResidueKeys`, so swept cells light up immediately.
- `onEnded` pulls the confirmed selection (`fetchSequenceSelection()`) and clears the overlay after a short defer — this avoids a one-frame flicker while the confirmed set catches up, and the deferred clear (guarded so a new drag can't be wiped) guarantees the overlay can never get stuck on.

The real `'sele'` behaviour (additive toggle) is unchanged. Plain click and shift-extend go through `handleClick`/`applyToggle` and are untouched; the drag gesture keeps its `minimumDistance: 8` so a plain click does not trigger it.

## Verified
- **Builds green**: rebuilt `libpymol_core.a` from this branch's source, then `xcodebuild ... PyMOLViewer_macOS -configuration Debug` → **BUILD SUCCEEDED** (the Swift compiles and the app links).
- Reviewed the click/shift/drag code paths to confirm the additive-toggle selection semantics are unchanged and the overlay clears on drag end.

## Not verified
- No interactive/on-screen run of the drag was performed in this session, so the live-highlight behaviour was validated by code inspection + a clean build, not by observing the actual sweep. There is no Swift unit test covering the `SequencePanel` drag overlay (the `test_appkit_sequence*.py` tests exercise the C++ SEQPANEL/SEQSEL backend, which this Swift-only change does not touch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)