### PR TITLE
fix(metal-rt): ortho-aware neighbour depth in rt_composite's AO blur

### DIFF
--- a/.github/workflows/raymol-embedded-tests.yml
+++ b/.github/workflows/raymol-embedded-tests.yml
@@ -77,6 +77,7 @@ jobs:
               testing/tests/raymol/design_region.py \
               testing/tests/raymol/design_saverestore.py \
               testing/tests/raymol/metal_pick.py \
+              testing/tests/raymol/metal_shader_sources.py \
               testing/tests/raymol/scene_ttt.py \
               testing/tests/raymol/shadow_extent.py \
               testing/tests/predict \

--- a/layerGraphics/metal/RendererMetal.mm
+++ b/layerGraphics/metal/RendererMetal.mm
@@ -930,6 +930,19 @@ static float3 post_eye_pos(float2 uv, float d, float projA, float projB,
   return float3(ndcx * (-ez) / projX, ndcy * (-ez) / projY, ez);
 }
 
+// Linear eye distance (positive, toward the scene) from window depth [0,1].
+// ortho>0.5: the projection is orthographic, so eye-z is LINEAR in ndc-z
+//   (ez = (ndcz - projB)/projA with projA=proj[10], projB=proj[14]); the
+//   perspective inverse (-projB/(ndcz+projA)) would divide by a near-zero /
+//   wrong denominator and produce garbage distances.
+static float post_linear_depth(float d, float projA, float projB,
+                               float ortho = 0.0) {
+  float ndcz = 2.0 * d - 1.0;
+  float ez = (ortho > 0.5) ? ((ndcz - projB) / projA)  // ortho: linear
+                           : (-projB / (ndcz + projA)); // persp: inverse
+  return -ez;                         // distance from camera (positive)
+}
+
 // Robust eye-space surface normal from the depth buffer. Plain
 // cross(dfdx(p), dfdy(p)) uses the 2x2 quad derivative, which at a silhouette
 // straddles the depth discontinuity to the background/behind geometry: the
@@ -993,7 +1006,8 @@ static float3 post_eye_normal_smooth(depth2d<float> depthTex, sampler s, float2 
 
 // Fullscreen-triangle vertex shader + post-process fragment shaders. A single
 // library so all post pipelines share the vertex function. Compiled with the
-// shared kEyeReconSrc helpers prepended (post_eye_pos/normal/normal_smooth).
+// shared kEyeReconSrc helpers prepended (post_linear_depth/eye_pos/normal/
+// normal_smooth).
 static NSString* const kPostSrc = @R"(
 #include <metal_stdlib>
 using namespace metal;
@@ -1177,23 +1191,11 @@ struct PostU {
   float pad0;            // 16-byte multiple: the C++ mirror must be >= this size
 };
 
-// Linear eye distance (positive, toward the scene) from window depth [0,1].
-// ortho>0.5: the projection is orthographic, so eye-z is LINEAR in ndc-z
-//   (ez = (ndcz - projB)/projA with projA=proj[10], projB=proj[14]); the
-//   perspective inverse (-projB/(ndcz+projA)) would divide by a near-zero /
-//   wrong denominator and produce garbage distances.
-static float post_linear_depth(float d, float projA, float projB,
-                               float ortho = 0.0) {
-  float ndcz = 2.0 * d - 1.0;
-  float ez = (ortho > 0.5) ? ((ndcz - projB) / projA)  // ortho: linear
-                           : (-projB / (ndcz + projA)); // persp: inverse
-  return -ez;                         // distance from camera (positive)
-}
-
-// post_eye_pos / post_eye_normal / post_eye_normal_smooth are defined once in the
-// shared kEyeReconSrc block, prepended to this library (and to kRTSrc) at compile
-// time — see the newLibraryWithSource call sites. Keeping a single copy is what
-// prevents the RT library from silently losing them again (the #83/#87 regression).
+// post_linear_depth / post_eye_pos / post_eye_normal / post_eye_normal_smooth are
+// defined once in the shared kEyeReconSrc block, prepended to this library (and to
+// kRTSrc) at compile time — see the newLibraryWithSource call sites. Keeping a
+// single copy is what prevents the RT library from silently losing them again
+// (the #83/#87 regression).
 
 fragment float4 post_ssao_fog(PostVOut in [[stage_in]],
     texture2d<float> colorTex [[texture(0)]],
@@ -2190,7 +2192,15 @@ fragment float4 rt_composite(PostVOut in [[stage_in]],
       float2 uv = in.uv + float2(i, j) * texel;
       float dn = depthTex.sample(s, uv);
       if (dn >= 0.99999) continue;
-      float ezn = -u.projB / ((2.0 * dn - 1.0) + u.projA);
+      // Neighbour eye-z via the shared, ortho-aware inverse (post_linear_depth
+      // returns the POSITIVE eye distance, hence the sign flip), reconstructed
+      // the same way as pEye.z. The old inline -projB / (ndcz + projA) was the
+      // PERSPECTIVE-only inverse, so under an orthographic projection (#139) the
+      // weights compared mismatched quantities and the blur collapsed to the
+      // centre sample (raw AO speckle) or bled across silhouettes. Perspective
+      // output is unchanged up to 8-bit rounding (same inverse, now behind the
+      // helper's ortho/perspective select).
+      float ezn = -post_linear_depth(dn, u.projA, u.projB, u.projOrtho);
       float w = exp(-abs(ezn - pEye.z) / ztol);
       float2 rg = aoTex.sample(s, uv).rg;
       aoSum += rg.r * w;
@@ -2594,7 +2604,8 @@ void RendererMetal::ensureRayTracingAS()
   // (_rtCompileTried latch): a compile failure must NOT busy-recompile the source
   // every frame (that was a real perf sink while RT was broken). If it fails the RT
   // pass is skipped and the SSAO/shadow path runs — zero regression. kEyeReconSrc
-  // is prepended so rt_ao/rt_composite can call post_eye_pos/normal/normal_smooth.
+  // is prepended so rt_ao/rt_composite can call post_linear_depth/eye_pos/normal/
+  // normal_smooth.
   if (_rtReady && !_rtResolvePipeline && !_rtCompileTried) {
     _rtCompileTried = true;
     NSError* err = nil;

--- a/testing/tests/raymol/metal_shader_sources.py
+++ b/testing/tests/raymol/metal_shader_sources.py
@@ -1,0 +1,96 @@
+"""Metal shader source hygiene: cross-library helper visibility and raw-string
+termination in RendererMetal.mm.
+
+RendererMetal.mm compiles its post-processing library (kPostSrc) and its
+ray-tracing library (kRTSrc) from separate MSL string literals with
+newLibraryWithSource:, each with the shared kEyeReconSrc block prepended. Metal
+does no cross-library linking, so a helper defined only in kPostSrc is an
+undeclared identifier in kRTSrc. That is a RUNTIME shader-compile failure no
+C++ build catches: the RT pipelines are never created and metal_raytrace
+silently does nothing (PR #100 fixed exactly that after the #83/#87 shadow work
+moved post_eye_* into kPostSrc). rt_composite's depth-aware AO blur now calls
+post_linear_depth as well, so that helper has to live in the shared block too.
+
+The literals are Objective-C raw strings, @R"(...)", which end at the FIRST
+')"'. A ')"' anywhere in the shader text -- a quoted expression in a comment
+is enough -- truncates the literal and breaks the C++ compile.
+
+Pure source parsing: no GPU and no Metal toolchain, so it runs everywhere.
+
+    pymol -ckqy testing/testing.py --run tests/raymol/metal_shader_sources.py
+"""
+import os
+import re
+
+from pymol import testing
+
+SOURCE = os.path.join('layerGraphics', 'metal', 'RendererMetal.mm')
+
+_LITERAL = re.compile(r'static NSString\* const (k\w+) = @R"\((.*?)\)"(.)', re.S)
+# Hand-written helpers in these literals are post_* / rt_*; everything else that
+# looks like a call is an MSL builtin (smoothstep, sample_compare, ...).
+_DEF = re.compile(
+    r'^\s*(?:static\s+|fragment\s+|vertex\s+)?[\w:<>]+\s+((?:post|rt)_\w+)\s*\(',
+    re.M)
+_CALL = re.compile(r'\b((?:post|rt)_\w+)\s*\(')
+
+
+def shader_literals(source):
+    """{name: body} for every @R"(...)" literal in `source`.
+
+    Raises AssertionError when a literal is cut short by a ')"' inside the
+    shader text, which is what the C++ compiler would see too.
+    """
+    literals = {}
+    for match in _LITERAL.finditer(source):
+        name, body, after = match.groups()
+        if after != ';':
+            raise AssertionError(
+                '%s: raw string terminated early by \')"\' in the shader text, '
+                'near %r' % (name, body[-60:]))
+        literals[name] = body
+    return literals
+
+
+def undefined_helpers(body):
+    """post_/rt_ helpers that `body` calls but does not define."""
+    return set(_CALL.findall(body)) - set(_DEF.findall(body))
+
+
+class TestMetalShaderSources(testing.PyMOLTestCase):
+
+    def source(self):
+        root = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir,
+                            os.pardir)
+        path = os.path.normpath(os.path.join(root, SOURCE))
+        if not os.path.isfile(path):
+            # Skipped, not passed: a source-reading test that cannot find its
+            # source has checked nothing. Only reached outside a repo checkout.
+            self.skipTest('%s not present; not a repo checkout' % SOURCE)
+        with open(path) as handle:
+            return handle.read()
+
+    def testRawStringsEndWhereIntended(self):
+        literals = shader_literals(self.source())
+        for name in ('kEyeReconSrc', 'kPostSrc', 'kRTSrc'):
+            self.assertIn(name, literals)
+
+    def testEachLibraryIsSelfContained(self):
+        """Every helper a library calls is visible in shared + that library."""
+        literals = shader_literals(self.source())
+        shared = literals['kEyeReconSrc']
+        for lib in ('kPostSrc', 'kRTSrc'):
+            missing = undefined_helpers(shared + literals[lib])
+            self.assertFalse(
+                missing, '%s calls helpers it cannot see at runtime: %s'
+                % (lib, sorted(missing)))
+
+    def testRTBlurUsesTheSharedOrthoAwareDepth(self):
+        """rt_composite's bilateral AO blur must reconstruct the neighbour depth
+        with the same ortho-aware inverse as the centre sample (#139), not the
+        perspective-only formula it inlined before."""
+        rt = shader_literals(self.source())['kRTSrc']
+        composite = rt[rt.index('fragment float4 rt_composite('):]
+        self.assertIn('post_linear_depth(dn, u.projA, u.projB, u.projOrtho)',
+                      composite)
+        self.assertNotIn('-u.projB / ((2.0 * dn - 1.0) + u.projA)', composite)


### PR DESCRIPTION
## Summary

`rt_composite` (the ray-traced AO composite in `kRTSrc`, `layerGraphics/metal/RendererMetal.mm`) blurs the raw RT AO term with a 5x5 depth-aware kernel. For each neighbour it computed the eye-z with the inline **perspective-only** inverse, `-projB / (ndcz + projA)`, while the centre depth (`pEye.z`) came from the **ortho-aware** `post_eye_pos`. Under `set orthoscopic, 1` (#139) the neighbour value is garbage, so the bilateral weights compared mismatched quantities: every neighbour weight fell to ~0 and the blur collapsed to the raw Monte-Carlo sample (visible speckle), or bled across silhouettes where a wrong value happened to land close.

Pre-existing on master; not introduced by #437.

## Fix

- Neighbour depth now comes from the shared `post_linear_depth(d, projA, projB, projOrtho)` (negated: it returns the positive eye distance), the same inverse `post_ssao_fog` already uses for its neighbours.
- `post_linear_depth` lived **only in `kPostSrc`** on master, so it is moved into the shared `kEyeReconSrc` block that is prepended to both libraries. Calling it from `kRTSrc` without the move is an undeclared identifier at *runtime* shader compile, which silently disables RT (the #83/#87 class fixed in #100). Verified offline with `xcrun metal -c` on both `kEyeReconSrc+kPostSrc` and `kEyeReconSrc+kRTSrc`, plus the negative control (no move ⇒ `use of undeclared identifier 'post_linear_depth'`).
- Note: #437 also moves `post_linear_depth` into `kEyeReconSrc`; whichever lands second will see a trivial conflict in that hunk.

## Verification (host M3 Pro, hardware RT)

Two Debug apps built from this tree, differing only in `libpymol_core.a` (before = `origin/master`, after = this branch; each dylib checked for the old/new shader text). `PYMOL_AUTOEXPORT` 1200x800 exports of `test/dat/1tii.pdb` as spheres, `bg_color white`, `metal_temporal_ao 0`; RT forced via the export's `rt` flag.

| Render | before vs after |
|---|---|
| perspective, rt=0 | 0 / 960000 px differ |
| ortho, rt=0 | 0 / 960000 px differ |
| perspective, rt=1 | 8 / 960000 px differ, max channel delta 1 |
| ortho, rt=1 | 192831 px differ (20.1%), all inside the molecule's extent |

Controls: repeat renders of the same build are 0-px identical (so the identity rows are meaningful); rt=1 vs rt=0 differs on ~37% of pixels in every build/projection (RT actually engaged; the `AS rebuilt — 5684 spheres` log line confirms the acceleration structure).

The 8-pixel / 1-LSB perspective residual is fast-math codegen around the helper's ortho/perspective select: two sign formulations (`zn - (-pEye.z)` and `-zn` vs `pEye.z`) render bit-identically to each other, so it is the select, not the sign handling. It is noted in the shader comment.

Ortho blur quality, speckle metric = mean |L − gauss2(L)| over the molecule mask:

| Render | speckle |
|---|---|
| ortho rt=1 **before** | 10.14 |
| ortho rt=1 **after** | 9.17 |
| perspective rt=1 (reference) | 8.77 |
| ortho rt=0 (SSAO) | 9.72 |

The RT effect magnitude under ortho (mean delta vs rt=0) went 20.7 → 17.8, matching perspective's 18.4.

## Test

`testing/tests/raymol/metal_shader_sources.py` (added to the CI list): pure source parsing, no GPU. Asserts every `post_*`/`rt_*` helper a library calls is visible in `kEyeReconSrc` + that library, that every `@R"(...)"` literal ends at `)";` (a `)"` inside a shader comment truncates it and breaks the C++ compile — I hit this while writing the fix), and that the RT blur uses the shared ortho-aware inverse. Fails on the previous source, passes here.

Local run of the full `raymol-embedded-tests.yml` list via the Homebrew-pymol shadow harness: 766 unittest-style + 292 pytest-style tests pass. Two files could not be exercised locally and are unrelated to this change (neither touches Python or the `_cmd` binding): `raymol/shadow_extent.py` errors with `module 'pymol._cmd' has no attribute 'get_shadow_extent'` (fork-only binding absent from the upstream Homebrew `_cmd`), and `test_setting_redisplay.py` (from #430) aborts the pymol process under that binary. CI builds the fork's `_cmd`, so both run there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
